### PR TITLE
Support for response_body option of gRPC-JSON transcoding

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -109,7 +109,7 @@ abstract class AbstractHttpMessageBuilder {
 
     AbstractHttpMessageBuilder content(MediaType contentType, byte[] content) {
         requireNonNull(content, "content");
-        return content(contentType,  HttpData.wrap(content));
+        return content(contentType, HttpData.wrap(content));
     }
 
     AbstractHttpMessageBuilder content(MediaType contentType, HttpData content) {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -109,7 +109,7 @@ abstract class AbstractHttpMessageBuilder {
 
     AbstractHttpMessageBuilder content(MediaType contentType, byte[] content) {
         requireNonNull(content, "content");
-        return content(contentType, HttpData.wrap(content));
+        return content(contentType,  HttpData.wrap(content));
     }
 
     AbstractHttpMessageBuilder content(MediaType contentType, HttpData content) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
@@ -137,7 +137,8 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
                         if (t != null) {
                             res.completeExceptionally(t);
                         } else {
-                            deframeAndRespond(ctx, framedResponse, res, unframedGrpcErrorHandler, responseBodyConverter);
+                            deframeAndRespond(ctx, framedResponse, res, unframedGrpcErrorHandler,
+                                    responseBodyConverter);
                         }
                     }
                     return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -144,7 +144,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                     responseFuture.completeExceptionally(t);
                 } else {
                     ctx.setAttr(FramedGrpcService.RESOLVED_GRPC_METHOD, method);
-                    frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(), responseFuture);
+                    frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(), responseFuture, null);
                 }
             }
             return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -144,7 +144,8 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                     responseFuture.completeExceptionally(t);
                 } else {
                     ctx.setAttr(FramedGrpcService.RESOLVED_GRPC_METHOD, method);
-                    frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(), responseFuture, null);
+                    frameAndServe(unwrap(), ctx, grpcHeaders.build(),
+                            clientRequest.content(), responseFuture, null);
                 }
             }
             return null;

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -643,6 +643,16 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
+    void shouldAcceptResponseBodyValueNullValue() throws JsonProcessingException {
+        final String jsonContent = "{\"value\":\"value\", " +
+                "\"array_field\":[\"value1\",\"value2\"]}";
+        final AggregatedHttpResponse response = jsonPostRequest(webClient,
+                "/v1/echo/response_body/struct", jsonContent);
+        final JsonNode root = mapper.readTree(response.contentUtf8());
+        assertThat(root.isEmpty()).isTrue();
+    }
+
+    @Test
     void shouldAcceptResponseBodyValueNoMatch() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}" +
                 ",\"array_field\":[\"value1\",\"value2\"]}";

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -611,7 +611,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shoudAcceptResponseBodyValue() {
+    void shouldAcceptResponseBodyValue() {
         final QueryParamsBuilder query = QueryParams.builder();
         query.add("value", "value");
         final AggregatedHttpResponse response = webClient.get("/v1/echo/response_body/value?" +
@@ -621,7 +621,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shoudAcceptResponseBodyRepeated() throws JsonProcessingException {
+    void shouldAcceptResponseBodyRepeated() throws JsonProcessingException {
         final AggregatedHttpResponse response = webClient.get(
                 "/v1/echo/response_body/repeated?array_field=value1&array_field=value2")
                 .aggregate().join();
@@ -632,7 +632,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shoudAcceptResponseBodyValueStruct() throws JsonProcessingException {
+    void shouldAcceptResponseBodyValueStruct() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}," +
                 "\"array_field\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
@@ -643,7 +643,7 @@ class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shoudAcceptResponseBodyValueNoMatch() throws JsonProcessingException {
+    void shouldAcceptResponseBodyValueNoMatch() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}" +
                 ",\"array_field\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -223,7 +223,6 @@ class HttpJsonTranscodingTest {
             final GrpcService grpcService = GrpcService.builder()
                                                        .addService(new HttpJsonTranscodingTestService())
                                                        .enableHttpJsonTranscoding(true)
-
                                                        .build();
             // gRPC transcoding will not work under '/foo'.
             // You may get the following log messages when calling the following 'serviceUnder' method:
@@ -231,10 +230,8 @@ class HttpJsonTranscodingTest {
             //   but the routes will be ignored. It will be served at the route you specified: path=/foo,
             //   service=...
             sb.service(grpcService)
-                    .decorator(LoggingService.newDecorator())
-              //.requestTimeout(Duration.ZERO)
+              .requestTimeout(Duration.ZERO)
               .serviceUnder("/foo", grpcService)
-
               .serviceUnder("/docs", DocService.builder().build());
         }
     };
@@ -244,7 +241,7 @@ class HttpJsonTranscodingTest {
     final HttpJsonTranscodingTestServiceBlockingStub grpcClient =
             GrpcClients.builder(server.httpUri())
                        .build(HttpJsonTranscodingTestServiceBlockingStub.class);
-    final WebClient webClient = WebClient.builder(server.httpUri()).responseTimeout(Duration.ofMinutes(1)).build();
+    final WebClient webClient = WebClient.builder(server.httpUri()).build();
 
     @Test
     void shouldGetMessageV1ByGrpcClient() {

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import com.linecorp.armeria.server.logging.LoggingService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -617,7 +617,7 @@ class HttpJsonTranscodingTest {
         final AggregatedHttpResponse response = webClient.get("/v1/echo/response_body/value?" +
                 query.toQueryString())
                 .aggregate().join();
-        assertThat(response.contentUtf8()).isEqualTo("value");
+        assertThat(response.contentUtf8()).isEqualTo("\"value\"");
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -644,7 +644,7 @@ class HttpJsonTranscodingTest {
 
     @Test
     void shouldAcceptResponseBodyValueNullValue() throws JsonProcessingException {
-        final String jsonContent = "{\"value\":\"value\", " +
+        final String jsonContent = "{\"value\":\"value\"," +
                 "\"array_field\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
                 "/v1/echo/response_body/struct", jsonContent);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -125,7 +125,7 @@ class UnframedGrpcServiceTest {
                                                                .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
-        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of());
+        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(), null);
         assertThat(byteBuf.refCnt()).isZero();
     }
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -60,6 +60,7 @@ service HttpJsonTranscodingTestService {
   rpc EchoTimestampAndDuration(EchoTimestampAndDurationRequest) returns (EchoTimestampAndDurationResponse) {
     option (google.api.http) = {
       get: "/v1/echo/{timestamp}/{duration}"
+      response_body: "timestamp"
     };
   }
 
@@ -94,9 +95,10 @@ service HttpJsonTranscodingTestService {
   rpc EchoListValue(EchoListValueRequest) returns (EchoListValueResponse) {
     option (google.api.http) = {
       get: "/v1/echo/list_value"
-
+      response_body: "value"
       additional_bindings {
         post: "/v1/echo/list_value"
+        response_body: "value"
         body: "value"
       }
     };

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -60,7 +60,6 @@ service HttpJsonTranscodingTestService {
   rpc EchoTimestampAndDuration(EchoTimestampAndDurationRequest) returns (EchoTimestampAndDurationResponse) {
     option (google.api.http) = {
       get: "/v1/echo/{timestamp}/{duration}"
-      response_body: "timestamp"
     };
   }
 
@@ -95,10 +94,8 @@ service HttpJsonTranscodingTestService {
   rpc EchoListValue(EchoListValueRequest) returns (EchoListValueResponse) {
     option (google.api.http) = {
       get: "/v1/echo/list_value"
-      response_body: "value"
       additional_bindings {
         post: "/v1/echo/list_value"
-        response_body: "value"
         body: "value"
       }
     };

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -94,6 +94,7 @@ service HttpJsonTranscodingTestService {
   rpc EchoListValue(EchoListValueRequest) returns (EchoListValueResponse) {
     option (google.api.http) = {
       get: "/v1/echo/list_value"
+
       additional_bindings {
         post: "/v1/echo/list_value"
         body: "value"

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -128,6 +128,11 @@ service HttpJsonTranscodingTestService {
   rpc EchoRecursive2(Recursive) returns (Recursive) {
     option (google.api.http) = {
       get: "/v1/echo/recursive2"
+
+      additional_bindings {
+        post: "/v1/echo/recursive2"
+        body: "*"
+      }
     };
   }
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -128,13 +128,49 @@ service HttpJsonTranscodingTestService {
   rpc EchoRecursive2(Recursive) returns (Recursive) {
     option (google.api.http) = {
       get: "/v1/echo/recursive2"
+    };
+  }
+
+  rpc EchoResponseBodyValue(EchoResponseBodyRequest) returns (EchoResponseBodyResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/response_body/value"
+      response_body: "value"
+    };
+  }
+
+  rpc EchoResponseBodyRepeated(EchoResponseBodyRequest) returns (EchoResponseBodyResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/response_body/repeated"
+      response_body: "array_field"
+    };
+  }
+
+  rpc EchoResponseBodyStruct(EchoResponseBodyRequest) returns (EchoResponseBodyResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/response_body/struct"
+      response_body: "struct_body"
 
       additional_bindings {
-        post: "/v1/echo/recursive2"
+        post: "/v1/echo/response_body/struct"
+        response_body: "struct_body"
         body: "*"
       }
     };
   }
+
+  rpc EchoResponseBodyNoMatching(EchoResponseBodyRequest) returns (EchoResponseBodyResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/response_body/nomatch"
+      response_body: "anonymous"
+
+      additional_bindings {
+        post: "/v1/echo/response_body/nomatch"
+        response_body: "anonymous"
+        body: "*"
+      }
+    };
+  }
+
 }
 
 message GetMessageRequestV1 {
@@ -247,4 +283,20 @@ message EchoRecursiveResponse {
 message Recursive {
   string value = 1;
   Recursive nested = 2;
+}
+
+message StructBody {
+  string struct_body = 1;
+}
+
+message EchoResponseBodyRequest {
+  string value = 1;
+  StructBody struct_body = 2;
+  repeated string array_field = 3;
+}
+
+message EchoResponseBodyResponse {
+  string value = 1;
+  StructBody struct_body = 2;
+  repeated string array_field = 3;
 }


### PR DESCRIPTION
Motivation:

Sometime we need the top-level json array in request body instead of json object. And in https://github.com/googleapis/googleapis/blob/36e9ea95c12129db02c218b36f2e34a56b14d159/google/api/http.proto#L360 it already defines request_body field that support extracting top-level message.

Modifications:

-   passing a Function<HttpData, HttpData> responseBodyConverter to frameAndServe
and using it in singleSubscriber. 

Result:

- Closes #4132 

