### PR TITLE
Provide a way to add multiple QueryParams with a single key when using WebClient.prepare()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -228,7 +228,7 @@ public abstract class AbstractHttpRequestBuilder
         if (this.queryParams == null) {
             this.queryParams = QueryParams.builder();
         }
-        this.queryParams.set(queryParams);
+        this.queryParams.add(queryParams);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -217,7 +217,7 @@ public abstract class AbstractHttpRequestBuilder
         if (queryParams == null) {
             queryParams = QueryParams.builder();
         }
-        queryParams.setObject(name, value);
+        queryParams.addObject(name, value);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -206,7 +206,7 @@ public interface HttpRequestSetters {
     HttpRequestSetters queryParam(String name, Object value);
 
     /**
-     * Sets multiple query params for this request. For example:
+     * Adds multiple query params for this request. For example:
      * <pre>{@code
      * HttpRequest.builder()
      *            .get("/endpoint")

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -195,7 +195,7 @@ public interface HttpRequestSetters {
     HttpRequestSetters disablePathParams();
 
     /**
-     * Sets a query param for this request. For example:
+     * Adds a query param for this request. For example:
      * <pre>{@code
      * HttpRequest.builder()
      *            .get("/endpoint")

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -62,6 +62,18 @@ class WebClientBuilderTest {
     }
 
     @Test
+    void repeatQueryParams() {
+        final String response = WebClient.of("http://127.0.0.1:" + server.httpPort())
+                                         .prepare()
+                                         .get("/echo-path")
+                                         .queryParam("bar", 1)
+                                         .queryParam("bar", 2)
+                                         .execute()
+                                         .aggregate().join().contentUtf8();
+        assertThat(response).isEqualTo("/echo-path?bar=1&bar=2");
+    }
+
+    @Test
     void uriWithNonePlusProtocol() {
         final WebClient client = WebClient.builder("none+https://google.com/").build();
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientBuilderTest.java
@@ -62,18 +62,6 @@ class WebClientBuilderTest {
     }
 
     @Test
-    void repeatQueryParams() {
-        final String response = WebClient.of("http://127.0.0.1:" + server.httpPort())
-                                         .prepare()
-                                         .get("/echo-path")
-                                         .queryParam("bar", 1)
-                                         .queryParam("bar", 2)
-                                         .execute()
-                                         .aggregate().join().contentUtf8();
-        assertThat(response).isEqualTo("/echo-path?bar=1&bar=2");
-    }
-
-    @Test
     void uriWithNonePlusProtocol() {
         final WebClient client = WebClient.builder("none+https://google.com/").build();
         assertThat(client.uri().toString()).isEqualTo("https://google.com/");

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -261,10 +261,12 @@ class HttpRequestBuilderTest {
         }
 
         final HttpRequest req = builder.get("/")
-                                           .queryParam("foo", "bar")
-                                           .queryParams(QueryParams.of("from", 0, "limit", 10))
-                                           .build();
-        assertThat(req.path()).isEqualTo("/?foo=bar&from=0&limit=10");
+                                       .queryParam("name", "foo")
+                                       .queryParam("name", "bar")
+                                       .queryParams(QueryParams.of("from", "foo", "limit", 10))
+                                       .queryParams(QueryParams.of("from", "bar", "limit", 20))
+                                       .build();
+        assertThat(req.path()).isEqualTo("/?name=foo&name=bar&from=foo&limit=10&from=bar&limit=20");
         assertThat(req).isInstanceOf(EmptyFixedHttpRequest.class);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestBuilderTest.java
@@ -432,7 +432,7 @@ class HttpRequestBuilderTest {
                       .cookie(Cookie.ofSecure("cookie", "value"))
                       .content(MediaType.PLAIN_TEXT_UTF_8, "test");
         request = requestBuilder.build();
-        assertThat(request.path()).isEqualTo("/resource1/resource2/resource4/foo-2/3?q=bar&f=10");
+        assertThat(request.path()).isEqualTo("/resource1/resource2/resource4/foo-2/3?q=foo&q=bar&f=10");
         assertThat(request.headers().contains("x-header-1", "5678")).isTrue();
         assertThat(request.headers().contains("x-header-2", "value")).isTrue();
         assertThat(request.headers().contains(COOKIE, "cookie=value")).isTrue();


### PR DESCRIPTION
Related #4160
Motivation:
- I summarize the well-documented [issue](https://github.com/line/armeria/issues/4160#issue-1174939262) by @jrhee17 
    - Some users may want to add multiple query param values for a single key.
    - However, `WebClient.prepare().queryParam()` perform a `QueryParamsBuilder#setObject` by default, making it difficult to execute such a query programmatically.
    
    ```
    WebClient.prepare()
             .get("/")
             .queryParam("id", 1)
             .queryParam("id", 2)
             .queryParam("id", 3)
             .execute();
    ```

Modifications:
- Use addObject() instead of setObject() in `AbstractHttpRequestBuilder.queryParam()`
- Use add() instead of set() in `AbstractHttpRequestBuilder.queryParams()`

Result:
- Users can add multiple query param values with a single key when using `WebClient.prepare()`
- Users can use either queryParam() or queryParams() as needed.