### PR TITLE
Fix parsing error for BodyPart when an empty file

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -344,7 +344,7 @@ final class MimeParser {
 
             state = State.END_PART;
             done = true;
-            final ByteBuf body = in.readBytes(bodyLength);
+            final ByteBuf body = safeReadBytes(in, bodyLength);
 
             // Discard a closing boundary
             in.skipBytes(boundaryLength + 2);

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
@@ -606,6 +606,23 @@ class MimeParserTest {
     }
 
     @Test
+    void testBodyIsEmpty() {
+        final String boundary = "boundary";
+        final byte[] chunk1 = ("--" + boundary + '\n' +
+                               "Content-Id:    \t  \t\t \n" +
+                               '\n' +
+                               "--" + boundary + "--").getBytes();
+        final List<AggregatedBodyPart> parts = parse(boundary, chunk1);
+        assertThat(parts).hasSize(1);
+
+        final AggregatedBodyPart part1 = parts.get(0);
+        assertThat(part1.headers()).hasSize(2);
+        assertThat(part1.headers().get("Content-Id")).isEqualTo("");
+        assertThat(part1.headers().contentType()).isEqualTo(MediaType.PLAIN_TEXT);
+        assertThat(part1.contentUtf8()).isEmpty();
+    }
+
+    @Test
     void testParserClosed() {
         assertThatThrownBy(() -> {
             final MimeParser parser = new MimeParser(null, null, "boundary", null);

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartTest.java
@@ -134,4 +134,27 @@ public class MultipartTest {
                     .hasMessageContaining("foo");
         });
     }
+
+    @Test
+    void collectContentIsEmpty() {
+        final CompletableFuture<List<Object>> collect =
+                Multipart.of(
+                        BodyPart.of(ContentDisposition.of("form-data", "name1"),
+                                    ""),
+                        BodyPart.of(ContentDisposition.of("form-data", "name2", "hello.txt"),
+                                    "")
+                ).collect(bodyPart -> {
+                    if (bodyPart.filename() != null) {
+                        final Path path = tempDir.resolve(bodyPart.name());
+                        return bodyPart.writeTo(path).thenApply(ignore -> path);
+                    }
+                    return bodyPart.aggregate().thenApply(AggregatedHttpObject::contentUtf8);
+                });
+
+        final List<Object> bodyParts = collect.join();
+        assertThat(bodyParts.get(0)).isEqualTo("");
+        final Path path = (Path) bodyParts.get(1);
+        assertThat(path).isEqualTo(tempDir.resolve("name2"));
+        assertThat(path).content().isEqualTo("");
+    }
 }


### PR DESCRIPTION
Motivation:

In `Multipart.from(request)`, an exception is thrown when using a request with a multipart whose content is empty.


Modifications:

- When reading the body, check the body length and return `EmptyByteBuf` if empty.

Result:

- Closes #4175

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
