### PR TITLE
Add no-op subscribe

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
@@ -50,8 +50,7 @@ public final class NoopSubscriber<T> implements Subscriber<T> {
     }
 
     @Override
-    public void onError(Throwable t) {
-    }
+    public void onError(Throwable t) {}
 
     @Override
     public void onComplete() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
@@ -53,6 +53,5 @@ public final class NoopSubscriber<T> implements Subscriber<T> {
     public void onError(Throwable t) {}
 
     @Override
-    public void onComplete() {
-    }
+    public void onComplete() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NoopSubscriber.java
@@ -18,8 +18,6 @@ package com.linecorp.armeria.common.stream;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.concurrent.CompletableFuture;
-
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -31,12 +29,6 @@ import com.linecorp.armeria.internal.common.stream.StreamMessageUtil;
 public final class NoopSubscriber<T> implements Subscriber<T> {
 
     private static final NoopSubscriber<?> INSTANCE = new NoopSubscriber<>();
-
-    private CompletableFuture<Void> whenSubscribed = new CompletableFuture<>();
-
-    CompletableFuture<Void> whenSubscribed() {
-        return whenSubscribed;
-    }
 
     /**
      * Returns a singleton {@link NoopSubscriber}.
@@ -54,19 +46,14 @@ public final class NoopSubscriber<T> implements Subscriber<T> {
     @Override
     public void onNext(T item) {
         requireNonNull(item, "item");
-        if (whenSubscribed.isDone()) {
-            StreamMessageUtil.closeOrAbort(item);
-            return;
-        }
+        StreamMessageUtil.closeOrAbort(item);
     }
 
     @Override
     public void onError(Throwable t) {
-        whenSubscribed.completeExceptionally(t);
     }
 
     @Override
     public void onComplete() {
-        whenSubscribed.complete(null);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -348,12 +348,11 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<Void> whenComplete();
 
     /**
-     * Requests to start streaming data to {@link NoopSubscriber}.
+     * Drain all data using {@link NoopSubscriber}.
      *
      * <p>For example:<pre>{@code
-     * StreamMessage<Integer> source = StreamMessage.of();
-     * CompletableFuture<Void> future = source.peek(x-> {}).subscribe();
-     * assert future.isDone().equals(true);
+     * CompletableFuture<Void> cf = StreamMessage.aborted(new RuntimeException()).subscribe();
+     * assert cf.isCompletedExceptionally();
      * }</pre>
      */
     default CompletableFuture<Void> subscribe() {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -361,7 +361,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     default CompletableFuture<Void> subscribe() {
         subscribe(NoopSubscriber.get());
-        return NoopSubscriber.get().whenSubscribed();
+        return whenComplete();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -348,6 +348,20 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<Void> whenComplete();
 
     /**
+     * Requests to start streaming data to {@link NoopSubscriber}.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of();
+     * CompletableFuture<Void> future = source.peek(x-> {}).subscribe();
+     * assert future.isDone().equals(true);
+     * }</pre>
+     */
+    default CompletableFuture<Void> subscribe() {
+        subscribe(new NoopSubscriber<>());
+        return whenComplete();
+    }
+
+    /**
      * Requests to start streaming data to the specified {@link Subscriber}. If there is a problem subscribing,
      * {@link Subscriber#onError(Throwable)} will be invoked with one of the following exceptions:
      * <ul>

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -348,7 +348,7 @@ public interface StreamMessage<T> extends Publisher<T> {
     CompletableFuture<Void> whenComplete();
 
     /**
-     * Drain all data using {@link NoopSubscriber}.
+     * Drains and discards all objects in this {@link StreamMessage}.
      *
      * <p>For example:<pre>{@code
      * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -351,13 +351,17 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Drain all data using {@link NoopSubscriber}.
      *
      * <p>For example:<pre>{@code
-     * CompletableFuture<Void> cf = StreamMessage.aborted(new RuntimeException()).subscribe();
-     * assert cf.isCompletedExceptionally();
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3);
+     * List<Integer> collected = new ArrayList<>();
+     * CompletableFuture<Void> future = source.peek(collected::add).subscribe();
+     * future.join();
+     * assert collected.equals(List.of(1, 2, 3));
+     * assert future.isDone();
      * }</pre>
      */
     default CompletableFuture<Void> subscribe() {
-        subscribe(new NoopSubscriber<>());
-        return whenComplete();
+        subscribe(NoopSubscriber.get());
+        return NoopSubscriber.get().whenSubscribed();
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -318,7 +318,7 @@ class StreamMessageTest {
         final StreamMessage<HttpData> source = StreamMessage.of(httpData);
         final CompletableFuture<Void> cf = source.subscribe();
 
-        await().untilAsserted(() -> assertThat(cf.isDone()).isTrue());
+        assertThat(cf.join().isDone()).isTrue();
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -304,6 +305,13 @@ class StreamMessageTest {
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();
         }
+    }
+
+    @Test
+    void noopSubscribe() {
+        final StreamMessage<Integer> source = StreamMessage.of();
+        final CompletableFuture<Void> future = source.peek(i -> {}).subscribe();
+        await().untilAsserted(() -> assertThat(future.isDone()).isTrue());
     }
 
     private static class StreamProvider implements ArgumentsProvider {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -347,7 +347,7 @@ class StreamMessageTest {
                                                      .collect(Collectors.toList());
         final CompletableFuture<Void> cf = aborted.subscribe();
 
-        await().untilAsserted(() -> assertThat(cf.isDone()).isTrue());
+        assertThat(cf.join().isDone()).isTrue();
         assertThat(collected).isEqualTo(expected);
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -309,9 +309,12 @@ class StreamMessageTest {
 
     @Test
     void noopSubscribe() {
-        final StreamMessage<Integer> source = StreamMessage.of();
-        final CompletableFuture<Void> future = source.peek(i -> {}).subscribe();
-        await().untilAsserted(() -> assertThat(future.isDone()).isTrue());
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3);
+        final List<Integer> collected = new ArrayList<>();
+        final StreamMessage<Integer> peeked = source.peek(collected::add);
+        final CompletableFuture<Void> cf = peeked.subscribe();
+        await().untilAsserted(() -> assertThat(collected).isEqualTo(ImmutableList.of(1, 2, 3)));
+        await().untilAsserted(() -> assertThat(cf.isDone()).isTrue());
     }
 
     private static class StreamProvider implements ArgumentsProvider {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageTest.java
@@ -377,7 +377,7 @@ class StreamMessageTest {
                                                      .collect(Collectors.toList());
         final CompletableFuture<Void> cf = aborted.subscribe();
 
-        await().untilAsserted(() -> assertThat(cf.isDone()).isTrue());
+        assertThat(cf.join().isDone()).isTrue();
         assertThat(collected).isEqualTo(expected);
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();


### PR DESCRIPTION
Motivation:

Provide a method to do a no-op subscribe to a `StreamMessage` #4145

Some users may want to use `StreamMessage#peek` to perform some options, but not want the entire message to be in memory (as is done by `StreamMessage#collect`). The functionality may be similar to `Flux#subscribe`

Modifications:

- Add no-op `subscribe` to `StreamMessage`

Result:

- we can now use no-op `subscribe` for draining data from `StreamMessage`.
- Closes #4145 