### PR TITLE
Enforce UTF-8 when running CI

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  LC_ALL: "en_US.UTF-8"
+
 jobs:
   build:
     if: github.repository == 'line/armeria'

--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 10 * * *'
 
+env:
+  LC_ALL: "en_US.UTF-8"
+
 jobs:
   update-psl:
     if: github.repository == 'line/armeria'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - armeria-*
 
+env:
+  LC_ALL: "en_US.UTF-8"
+
 jobs:
   publish:
     name: Publish final artifacts


### PR DESCRIPTION
Motivation:

`core:processTestResources` fails with the following exception:

```
Caused by: org.gradle.internal.execution.fingerprint.InputFingerprinter$InputFileFingerprintingException: Cannot fingerprint input file property 'rootSpec$1': Failed to create MD5 hash for file '/home1/www/actions-runner/_work/armeria/armeria/core/src/test/resources/com/linecorp/armeria/server/file/bar/??.txt' as it does not exist.
	at org.gradle.internal.execution.fingerprint.impl.DefaultInputFingerprinter$InputCollectingVisitor.visitInputFileProperty(DefaultInputFingerprinter.java:141)
...
Caused by: java.io.FileNotFoundException: /home1/www/actions-runner/_work/armeria/armeria/core/src/test/resources/com/linecorp/armeria/server/file/bar/??.txt (No such file or directory)
```

Modifications:

- Add `LC_ALL` environment variable to UTF-8 when running CI

Result:

- CI runs correctly