### PR TITLE
Add metrics for TLS handshakes / Reduce TLS certificate expiry metrics cardinality

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -174,6 +174,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         } catch (Throwable t) {
             promise.tryFailure(t);
             ctx.close();
+            return;
         } finally {
             if (p.context(this) != null) {
                 p.remove(this);

--- a/core/src/main/java/com/linecorp/armeria/server/CertificateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CertificateUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLSession;
+
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x500.style.IETFUtils;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+final class CertificateUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(CertificateUtil.class);
+
+    private static final LoadingCache<X509Certificate, String> commonNameCache =
+            Caffeine.newBuilder()
+                    .weakKeys()
+                    .build(cert -> {
+                        try {
+                            final X500Name x500Name = new JcaX509CertificateHolder(cert).getSubject();
+                            final RDN cn = x500Name.getRDNs(BCStyle.CN)[0];
+                            return IETFUtils.valueToString(cn.getFirst().getValue());
+                        } catch (Exception e) {
+                            logger.warn("Failed to get the common name from a certificate: {}", cert, e);
+                            return null;
+                        }
+                    });
+
+    @Nullable
+    static String getCommonName(SSLSession session) {
+        final Certificate[] certs = session.getLocalCertificates();
+        if (certs == null || certs.length == 0) {
+            return null;
+        }
+        return getCommonName(certs[0]);
+    }
+
+    @Nullable
+    static String getCommonName(Certificate certificate) {
+        if (!(certificate instanceof X509Certificate)) {
+            return null;
+        }
+        return commonNameCache.get((X509Certificate) certificate);
+    }
+
+    private CertificateUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTlsHandshakeMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTlsHandshakeMetricsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+class ServerTlsHandshakeMetricsTest {
+
+    private static final MeterRegistry meterRegistry = PrometheusMeterRegistries.newRegistry();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.meterRegistry(meterRegistry);
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @BeforeEach
+    void clearMetrics() {
+        meterRegistry.clear();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "H1, TLSv1.2, h1",
+            "H1, TLSv1.3, h1",
+            "H2, TLSv1.2, h2",
+            "H2, TLSv1.3, h2"
+    })
+    void handshakeSuccess(SessionProtocol sessionProtocol, String tlsProtocol, String expectedProtocol) {
+        try (ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .tlsNoVerify()
+                                  .tlsCustomizer(sslCtxBuilder -> sslCtxBuilder.protocols(tlsProtocol))
+                                  .build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.uri(sessionProtocol))
+                             .factory(clientFactory)
+                             .build()
+                             .blocking();
+
+            client.get("/");
+
+            // Should record only one handshake.
+            await().untilAsserted(() -> {
+                assertThat(meterRegistry.find("armeria.server.tls.handshakes")
+                                        .counters()).hasSize(1);
+            });
+
+            // ... and it should be successful.
+            assertThat(meterRegistry.find("armeria.server.tls.handshakes")
+                                    .tag("result", "success")
+                                    .counters()).hasSize(1);
+
+            // ... and it should be 1 with the correct tags.
+            final Counter counter =
+                    meterRegistry.find("armeria.server.tls.handshakes")
+                                 .tag("cipher.suite", value -> value.startsWith("TLS_"))
+                                 .tag("common.name", server.server().defaultHostname())
+                                 .tag("protocol", expectedProtocol)
+                                 .tag("result", "success")
+                                 .tag("tls.protocol", tlsProtocol)
+                                 .counter();
+            assertThat(counter)
+                    .withFailMessage("Failed to find the matching TLS handshake counter: %s",
+                                     MoreMeters.measureAll(meterRegistry))
+                    .isNotNull();
+            assertThat(counter.count()).isOne();
+        }
+    }
+
+    @Test
+    void handshakeFailure() {
+        // Make a request that will fail due to a certificate trust issue.
+        // Note that our server uses a self-signed certificate and the client will not trust it.
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        assertThatThrownBy(() -> client.get("/"))
+                .isInstanceOf(UnprocessedRequestException.class)
+                .hasCauseInstanceOf(SSLHandshakeException.class);
+
+        // Should record only one handshake.
+        await().untilAsserted(() -> {
+            assertThat(meterRegistry.find("armeria.server.tls.handshakes")
+                                    .counters()).hasSize(1);
+        });
+
+        // ... and it should be failed.
+        assertThat(meterRegistry.find("armeria.server.tls.handshakes")
+                                .tag("result", "failure")
+                                .counters()).hasSize(1);
+
+        // ... and it should be 1 with the expected tags.
+        final Counter counter =
+                meterRegistry.find("armeria.server.tls.handshakes")
+                             .tag("cipher.suite", "")
+                             .tag("common.name", server.server().defaultHostname())
+                             .tag("protocol", "")
+                             .tag("result", "failure")
+                             .tag("tls.protocol", "")
+                             .counter();
+        assertThat(counter)
+                .withFailMessage("Failed to find the matching TLS handshake counter: %s",
+                                 MoreMeters.measureAll(meterRegistry))
+                .isNotNull();
+        assertThat(counter.count()).isOne();
+    }
+}


### PR DESCRIPTION
Motivation:

- A user would want to keep the counter of TLS handshake success/failure.
- The TLS certificate expiry metrics we added at #4109 uses hostname
  instead of hostname pattern, potentially increasing the cardinality of
  the metrics.

Modifications:

- Added `CertificateUtil` which extracts and caches the common name of
  X.509 certificates.
- Added TLS handshake metrics to `HttpServerPipelineConfigurator`.
- Cleaned up the TLS handshake exception handling in
  `HttpServerPipelineConfigurator` once again.
- The TLS certificate expiry metrics now use `hostname.pattern` instead
  of `hostname` for reduced cardinality.
- Changed the name of TLS certificate expiry metrics from
  `armeria.server.certificate.*` to `armeria.server.tls.certificate.*`
  for consistency.
- Renamed `CertificationMetricsTest` to `ServerTlsCertificateMetricsTest`
- Miscellaneous:
  - Do not call `Bootstrap.connect()` when pipeline configuration fails
    in `HttpClientPipelineConfigurator`, because it will fail immediately
    with a noisy `IllegalStateException`.
    - This doesn't change the outcome but just prevents the exception
      from being triggered and logged unnecessarily internally.

Result:

- A user can now monitor the TLS handshake results via metric collector.
- (breaking) TLS certificate expiry metrics were renamed from
  `armeria.server.certificate.*` to `armeria.server.tls.certificate.*`
  for consistency.
- (breaking) Reduced cardinality for TLS certificate expiry metrics by
  using a hostname pattern instead of a hostname as a label.
- Fixed a noisy warning log message about double-completion of future
  which occurs when a user misconfigured a `ClientFactory`.