### PR TITLE
Fix a bug where a DNS resolution is failed with a search domain starting with a dot

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolver.java
@@ -59,9 +59,9 @@ final class SearchDomainDnsResolver extends AbstractUnwrappable<DnsResolver> imp
                                 }
                                 final String normalized;
                                 if (searchDomain.charAt(0) != '.') {
-                                    normalized = '.' + searchDomain;
+                                    normalized = '.' + searchDomain + '.';
                                 } else {
-                                    normalized = searchDomain;
+                                    normalized = searchDomain + '.';
                                 }
                                 try {
                                     // Try to create a sample DnsQuestion to validate the search domain.
@@ -163,8 +163,7 @@ final class SearchDomainDnsResolver extends AbstractUnwrappable<DnsResolver> imp
                     // share the cache key.
                     return newQuestion(orignalName + '.');
                 } else {
-                    final String searchDomain = searchDomains.get(0);
-                    return newQuestion(orignalName + searchDomain + '.');
+                    return newQuestion(orignalName + searchDomains.get(0));
                 }
             }
 
@@ -174,7 +173,7 @@ final class SearchDomainDnsResolver extends AbstractUnwrappable<DnsResolver> imp
             }
 
             if (nextSearchDomainPos < searchDomains.size()) {
-                return newQuestion(orignalName + searchDomains.get(nextSearchDomainPos) + '.');
+                return newQuestion(orignalName + searchDomains.get(nextSearchDomainPos));
             }
             if (nextSearchDomainPos == searchDomains.size() && !shouldStartWithHostname) {
                 // Use hostname as is so that RefreshingAddressResolver and CachingDnsResolver

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2022 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.internal.client.dns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+
+class SearchDomainDnsResolverTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void searchDomainStartingWithDot() {
+        final ByteArrayDnsRecord record = new ByteArrayDnsRecord("example.com", DnsRecordType.A,
+                                                                 1, new byte[] { 10, 0, 1, 1 });
+        final Queue<DnsQuestion> questions = new LinkedBlockingQueue<>();
+        final DnsResolver mockResolver = new DnsResolver() {
+
+            @Override
+            public CompletableFuture<List<DnsRecord>> resolve(DnsQuestionContext ctx, DnsQuestion question) {
+                questions.add(question);
+                if ("example.com.".equals(question.name())) {
+                    return UnmodifiableFuture.completedFuture(ImmutableList.of(record));
+                } else {
+                    return UnmodifiableFuture.exceptionallyCompletedFuture(new AnticipatedException());
+                }
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        final ImmutableList<String> searchDomains = ImmutableList.of("armeria.io", "..invalid.com",
+                                                                     ".armeria.dev");
+        final DnsQuestionContext context = new DnsQuestionContext(eventLoop.get(), 10000);
+        final DnsQuestionWithoutTrailingDot question =
+                DnsQuestionWithoutTrailingDot.of("example.com", DnsRecordType.A);
+        final SearchDomainDnsResolver resolver = new SearchDomainDnsResolver(mockResolver, searchDomains, 2);
+        final CompletableFuture<List<DnsRecord>> result = resolver.resolve(context, question);
+
+        assertThat(result.join()).contains(record);
+        assertThat(questions).hasSize(3);
+        // Should not send a search domain query with '..invalid.com'
+        System.out.println(questions);
+        assertThat(questions).containsExactly(
+                DnsQuestionWithoutTrailingDot.of("example.com", "example.com.armeria.io.", DnsRecordType.A),
+                DnsQuestionWithoutTrailingDot.of("example.com", "example.com.armeria.dev.", DnsRecordType.A),
+                DnsQuestionWithoutTrailingDot.of("example.com", "example.com.", DnsRecordType.A));
+        context.cancel();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
@@ -62,8 +62,7 @@ class SearchDomainDnsResolverTest {
             public void close() {}
         };
 
-        final ImmutableList<String> searchDomains = ImmutableList.of("armeria.io", "..invalid.com",
-                                                                     ".armeria.dev");
+        final List<String> searchDomains = ImmutableList.of(".", "armeria.io", "..invalid.com", ".armeria.dev");
         final DnsQuestionContext context = new DnsQuestionContext(eventLoop.get(), 10000);
         final DnsQuestionWithoutTrailingDot question =
                 DnsQuestionWithoutTrailingDot.of("example.com", DnsRecordType.A);

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainDnsResolverTest.java
@@ -73,7 +73,6 @@ class SearchDomainDnsResolverTest {
         assertThat(result.join()).contains(record);
         assertThat(questions).hasSize(3);
         // Should not send a search domain query with '..invalid.com'
-        System.out.println(questions);
         assertThat(questions).containsExactly(
                 DnsQuestionWithoutTrailingDot.of("example.com", "example.com.armeria.io.", DnsRecordType.A),
                 DnsQuestionWithoutTrailingDot.of("example.com", "example.com.armeria.dev.", DnsRecordType.A),

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainTest.java
@@ -69,6 +69,24 @@ class SearchDomainTest {
     }
 
     @Test
+    void startsWithDot() {
+        final String hostname = "foo.com";
+        final DnsQuestion original = DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.A);
+        final ImmutableList<String> searchDomains = ImmutableList.of(".armeria.io", ".armeria.com",
+                                                                     ".armeria.org", ".armeria.dev");
+        final SearchDomainQuestionContext ctx = new SearchDomainQuestionContext(original, searchDomains, 1);
+        final DnsQuestion firstQuestion = ctx.nextQuestion();
+        assertThat(firstQuestion.name()).isEqualTo(hostname + '.');
+        for (String searchDomain : searchDomains) {
+            final DnsQuestion expected =
+                    DnsQuestionWithoutTrailingDot.of(hostname, hostname + searchDomain + '.',
+                                                     DnsRecordType.A);
+            assertThat(ctx.nextQuestion()).isEqualTo(expected);
+        }
+        assertThat(ctx.nextQuestion()).isNull();
+    }
+
+    @Test
     void noSearchDomain() {
         final DnsQuestion original = DnsQuestionWithoutTrailingDot.of("foo.com", DnsRecordType.A);
         final SearchDomainQuestionContext ctx =

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/SearchDomainTest.java
@@ -35,14 +35,14 @@ class SearchDomainTest {
     @ParameterizedTest
     void startsWithHostname(String hostname, int ndots) {
         final DnsQuestion original = DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.A);
-        final ImmutableList<String> searchDomains = ImmutableList.of("armeria.io", "armeria.com",
-                                                                     "armeria.org", "armeria.dev");
+        final ImmutableList<String> searchDomains = ImmutableList.of(".armeria.io", ".armeria.com",
+                                                                     ".armeria.org", ".armeria.dev");
         final SearchDomainQuestionContext ctx = new SearchDomainQuestionContext(original, searchDomains, ndots);
         final DnsQuestion firstQuestion = ctx.nextQuestion();
         assertThat(firstQuestion.name()).isEqualTo(hostname + '.');
         for (String searchDomain : searchDomains) {
             final DnsQuestion expected =
-                    DnsQuestionWithoutTrailingDot.of(hostname, hostname + '.' + searchDomain + '.',
+                    DnsQuestionWithoutTrailingDot.of(hostname, hostname + searchDomain + '.',
                                                      DnsRecordType.A);
             assertThat(ctx.nextQuestion()).isEqualTo(expected);
         }
@@ -53,36 +53,20 @@ class SearchDomainTest {
     @ParameterizedTest
     void endsWithHostname(String hostname, int ndots) {
         final DnsQuestion original = DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.A);
-        final ImmutableList<String> searchDomains = ImmutableList.of("armeria.io", "armeria.com",
-                                                                     "armeria.org", "armeria.dev");
-        final SearchDomainQuestionContext ctx = new SearchDomainQuestionContext(original, searchDomains, ndots);
-        for (String searchDomain : searchDomains) {
-            final DnsQuestion expected =
-                    DnsQuestionWithoutTrailingDot.of(hostname, hostname + '.' + searchDomain + '.',
-                                                     DnsRecordType.A);
-            assertThat(ctx.nextQuestion()).isEqualTo(expected);
-        }
-
-        final DnsQuestion lastQuestion = ctx.nextQuestion();
-        assertThat(lastQuestion.name()).isEqualTo(hostname + '.');
-        assertThat(ctx.nextQuestion()).isNull();
-    }
-
-    @Test
-    void startsWithDot() {
-        final String hostname = "foo.com";
-        final DnsQuestion original = DnsQuestionWithoutTrailingDot.of(hostname, DnsRecordType.A);
+        // Since a dot is prepended to search domains by `SearchDomainDnsResolver`, should use a search
+        // domain starting with a dot for testing `SearchDomainQuestionContext`.
         final ImmutableList<String> searchDomains = ImmutableList.of(".armeria.io", ".armeria.com",
                                                                      ".armeria.org", ".armeria.dev");
-        final SearchDomainQuestionContext ctx = new SearchDomainQuestionContext(original, searchDomains, 1);
-        final DnsQuestion firstQuestion = ctx.nextQuestion();
-        assertThat(firstQuestion.name()).isEqualTo(hostname + '.');
+        final SearchDomainQuestionContext ctx = new SearchDomainQuestionContext(original, searchDomains, ndots);
         for (String searchDomain : searchDomains) {
             final DnsQuestion expected =
                     DnsQuestionWithoutTrailingDot.of(hostname, hostname + searchDomain + '.',
                                                      DnsRecordType.A);
             assertThat(ctx.nextQuestion()).isEqualTo(expected);
         }
+
+        final DnsQuestion lastQuestion = ctx.nextQuestion();
+        assertThat(lastQuestion.name()).isEqualTo(hostname + '.');
         assertThat(ctx.nextQuestion()).isNull();
     }
 


### PR DESCRIPTION
Motivation:

If a search domain starts with a dot(`.`), a DNS resolution failed with
an `IllegalArgumentException`.
```
Caused by: java.lang.IllegalArgumentException: Empty label is not a legal name
	at java.base/java.net.IDN.toASCIIInternal(IDN.java:284)
	at java.base/java.net.IDN.toASCII(IDN.java:123)
	at java.base/java.net.IDN.toASCII(IDN.java:152)
	at com.linecorp.armeria.internal.client.dns.DnsQuestionWithoutTrailingDot.<init>(DnsQuestionWithoutTrailingDot.java:53)
	at com.linecorp.armeria.internal.client.dns.DnsQuestionWithoutTrailingDot.of(DnsQuestionWithoutTrailingDot.java:48)
	at com.linecorp.armeria.internal.client.dns.SearchDomainDnsResolver$SearchDomainQuestionContext.newQuestion(SearchDomainDnsResolver.java:153)
	at com.linecorp.armeria.internal.client.dns.SearchDomainDnsResolver$SearchDomainQuestionContext.nextQuestion0(SearchDomainDnsResolver.java:132)
	at com.linecorp.armeria.internal.client.dns.SearchDomainDnsResolver$SearchDomainQuestionContext.nextQuestion(SearchDomainDnsResolver.java:112)
	at com.linecorp.armeria.internal.client.dns.SearchDomainDnsResolver.resolve(SearchDomainDnsResolver.java:48)
	at com.linecorp.armeria.internal.client.dns.HostsFileDnsResolver.resolve(HostsFileDnsResolver.java:130)
	at com.linecorp.armeria.internal.client.dns.DefaultDnsResolver.lambda$resolveAll$2(DefaultDnsResolver.java:122)
```

Modifications:

- Optionally append a dot if a search domain does not start with a dot.

Result:

- The search domain DNS resolver correctly resolves a search domain that
  starts with a dot.
- Fixes #4195