### PR TITLE
Warn the initial failure of health checks for `HealthCheckedEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/AbstractHealthCheckedEndpointGroupBuilder.java
@@ -27,11 +27,13 @@ import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientOptionsBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.AbstractDynamicEndpointGroupBuilder;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.auth.AuthToken;
@@ -224,9 +226,10 @@ public abstract class AbstractHealthCheckedEndpointGroupBuilder extends Abstract
      * Returns the {@link Function} that starts to send health check requests to the {@link Endpoint}
      * specified in a given {@link HealthCheckerContext} when invoked. The {@link Function} must update
      * the health of the {@link Endpoint} with a value between [0, 1] via
-     * {@link HealthCheckerContext#updateHealth(double)}. {@link HealthCheckedEndpointGroup} will call
-     * {@link AsyncCloseable#closeAsync()} on the {@link AsyncCloseable} returned by the {@link Function}
-     * when it needs to stop sending health check requests.
+     * {@link HealthCheckerContext#updateHealth(double, ClientRequestContext, ResponseHeaders, Throwable)}.
+     * {@link HealthCheckedEndpointGroup} will call {@link AsyncCloseable#closeAsync()} on the
+     * {@link AsyncCloseable} returned by the {@link Function} when it needs to stop sending health check
+     * requests.
      */
     protected abstract Function<? super HealthCheckerContext, ? extends AsyncCloseable> newCheckerFactory();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -172,7 +172,8 @@ final class DefaultHealthCheckerContext
             } else {
                 if (cause != null) {
                     initialCheckFuture.completeExceptionally(cause);
-                } else if (headers != null) {
+                } else {
+                    assert headers != null;
                     initialCheckFuture.completeExceptionally(new InvalidResponseException(
                             ctx + " Received an unhealthy check response. headers: " + headers));
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -31,8 +31,11 @@ import java.util.function.BiConsumer;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.InvalidResponseException;
 import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -153,10 +156,27 @@ final class DefaultHealthCheckerContext
 
     @Override
     public void updateHealth(double health) {
-        onUpdateHealth.accept(originalEndpoint,  health > 0);
+        // Should use the new 'updateHealth()' API below.
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateHealth(double health, ClientRequestContext ctx,
+                             @Nullable ResponseHeaders headers, @Nullable Throwable cause) {
+        final boolean isHealthy = health > 0;
+        onUpdateHealth.accept(originalEndpoint, isHealthy);
 
         if (!initialCheckFuture.isDone()) {
-            initialCheckFuture.complete(null);
+            if (isHealthy) {
+                initialCheckFuture.complete(null);
+            } else {
+                if (cause != null) {
+                    initialCheckFuture.completeExceptionally(cause);
+                } else if (headers != null) {
+                    initialCheckFuture.completeExceptionally(new InvalidResponseException(
+                            ctx + " Received an unhealthy check response. headers: " + headers));
+                }
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -164,7 +164,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
             contextGroup.whenInitialized().handle((unused, cause) -> {
                 if (cause != null && !initialized) {
                     if (logger.isWarnEnabled()) {
-                        logger.warn("Failed to initialize the first health check. " +
+                        logger.warn("The first health check failed for all endpoints. " +
                                     "numCandidates: {} candidates: {}",
                                     candidates.size(), truncate(candidates, 10), cause);
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -161,12 +161,25 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
             // Remove old contexts when the newly created contexts are fully initialized to smoothly transition
             // to new endpoints.
-            contextGroup.whenInitialized().thenRun(() -> {
+            contextGroup.whenInitialized().handle((unused, cause) -> {
+                if (cause != null && !initialized) {
+                    if (logger.isWarnEnabled()) {
+                        logger.warn("Failed to initialize the first health check. " +
+                                    "numCandidates: {} candidates: {}",
+                                    candidates.size(), truncate(candidates, 10), cause);
+                    }
+                }
                 initialized = true;
                 destroyOldContexts(contextGroup);
                 setEndpoints(allHealthyEndpoints());
+                return null;
             });
         }
+    }
+
+    @VisibleForTesting
+    Queue<HealthCheckContextGroup> contextGroupChain() {
+        return contextGroupChain;
     }
 
     private List<Endpoint> allHealthyEndpoints() {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
@@ -79,9 +79,9 @@ public interface HealthCheckerContext {
      *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
      * @param ctx the {@link ClientRequestContext} of the health check request.
      * @param headers the {@link ResponseHeaders} of the health check request.
-     *                {@code null} if the request is failed with an {@link Throwable}.
+     *                {@code null} if the request is failed with the {@code cause}.
      * @param cause the cause of the failed health check request.
-     *              {@code null} if the health checked request received an {@link ResponseHeaders}.
+     *              {@code null} if the health checked request received the {@code headers}.
      */
     default void updateHealth(double health, ClientRequestContext ctx,
                               @Nullable ResponseHeaders headers, @Nullable Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
@@ -66,7 +66,7 @@ public interface HealthCheckerContext {
      *               A positive value indicates the {@link Endpoint} is able to handle requests.
      *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
      *
-     * @deprecated Use {@link #updateHealth(double, ClientRequestContext, ResponseHeaders, Throwable)} instead.
+     * @deprecated Use {@link #updateHealth(double, ClientRequestContext, ResponseHeaders, Throwable)}.
      */
     @Deprecated
     void updateHealth(double health);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckerContext.java
@@ -20,8 +20,11 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
  * Provides the properties and operations required for sending health check requests.
@@ -62,6 +65,27 @@ public interface HealthCheckerContext {
      * @param health {@code 0.0} indicates the {@link Endpoint} is not able to handle any requests.
      *               A positive value indicates the {@link Endpoint} is able to handle requests.
      *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
+     *
+     * @deprecated Use {@link #updateHealth(double, ClientRequestContext, ResponseHeaders, Throwable)} instead.
      */
+    @Deprecated
     void updateHealth(double health);
+
+    /**
+     * Updates the health of the {@link Endpoint} being checked.
+     *
+     * @param health {@code 0.0} indicates the {@link Endpoint} is not able to handle any requests.
+     *               A positive value indicates the {@link Endpoint} is able to handle requests.
+     *               A value greater than {@code 1.0} will be set equal to {@code 1.0}.
+     * @param ctx the {@link ClientRequestContext} of the health check request.
+     * @param headers the {@link ResponseHeaders} of the health check request.
+     *                {@code null} if the request is failed with an {@link Throwable}.
+     * @param cause the cause of the failed health check request.
+     *              {@code null} if the health checked request received an {@link ResponseHeaders}.
+     */
+    default void updateHealth(double health, ClientRequestContext ctx,
+                              @Nullable ResponseHeaders headers, @Nullable Throwable cause) {
+        // TODO(ikhoon): Make this method abstract in Armeria 2.0
+        updateHealth(health);
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroupTest.java
@@ -25,13 +25,17 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroupTest.EndpointComparator;
 import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroupTest.MockEndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
 
 class HealthCheckContextGroupTest {
 
@@ -57,7 +61,7 @@ class HealthCheckContextGroupTest {
             // Health status is not updated yet.
             assertThat(endpointGroup.endpoints()).isEmpty();
 
-            contexts.forEach(ctx -> ctx.updateHealth(1.0));
+            contexts.forEach(ctx -> ctx.updateHealth(1.0, null, null, null));
             assertThat(endpointGroup.endpoints()).containsAll(secondGroup.endpoints());
 
             firstGroup.set(Endpoint.of("dynamic1"), Endpoint.of("dynamic2"));
@@ -68,7 +72,7 @@ class HealthCheckContextGroupTest {
 
             // If health check is finished for the new endpoints,
             // the old EndpointGroup should be removed from the healthy endpoints.
-            contexts.forEach(ctx -> ctx.updateHealth(1.0));
+            contexts.forEach(ctx -> ctx.updateHealth(1.0, null, null, null));
             assertThat(endpointGroup.endpoints()).containsAll(firstGroup.endpoints());
 
             for (int i = 0; i < contexts.size(); i++) {
@@ -124,15 +128,17 @@ class HealthCheckContextGroupTest {
             // Health status is not updated yet.
             assertThat(endpointGroup.endpoints()).isEmpty();
 
-            contexts.get(0).updateHealth(1.0);
+            contexts.get(0).updateHealth(1.0, null, null, null);
             // The initial future should be completed after all endpoints are checked.
             assertThat(endpointGroup.whenReady()).isNotDone();
 
-            contexts.get(1).updateHealth(0);
+            final ClientRequestContext mockCtx =
+                    ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/health"));
+            contexts.get(1).updateHealth(0, mockCtx, null, new AnticipatedException());
             assertThat(endpointGroup.whenReady()).isDone();
             assertThat(endpointGroup.endpoints()).containsExactly(contexts.get(0).endpoint());
 
-            contexts.get(1).updateHealth(1.0);
+            contexts.get(1).updateHealth(1.0, null, null, null);
             assertThat(endpointGroup.endpoints()).containsExactly(static1, static2);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupInitialFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupInitialFailureTest.java
@@ -1,0 +1,183 @@
+/*
+ *  Copyright 2022 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.InvalidResponseException;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HealthCheckedEndpointGroupInitialFailureTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.virtualHost("health.foo.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.of(HttpStatus.OK);
+              });
+            sb.virtualHost("health.bar.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.of(HttpStatus.OK);
+              });
+
+            sb.virtualHost("slow.foo.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.streaming();
+              });
+            sb.virtualHost("slow.bar.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.streaming();
+              });
+
+            sb.virtualHost("500.foo.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+              });
+            sb.virtualHost("500.bar.com")
+              .service("/health", (ctx, req) -> {
+                  return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+              });
+            // Make clients trigger timeouts.
+            sb.requestTimeoutMillis(0);
+        }
+    };
+
+    static ClientFactory clientFactory;
+
+    @BeforeAll
+    static void beforeAll() {
+        clientFactory = ClientFactory.builder()
+                                     .addressResolverGroupFactory(
+                                             unused -> MockAddressResolverGroup.localhost())
+                                     .build();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        clientFactory.closeAsync();
+    }
+
+    @Test
+    void allHealthy() {
+        final EndpointGroup delegate =
+                EndpointGroup.of(Endpoint.of("health.foo.com"), Endpoint.of("health.bar.com"));
+        try (HealthCheckedEndpointGroup endpointGroup = newHealthCheckedEndpointGroup(delegate)) {
+            assertThat(endpointGroup.whenReady().join()).hasSize(2);
+            assertThat(endpointGroup.contextGroupChain().size()).isOne();
+            assertThat(endpointGroup.contextGroupChain().poll().whenInitialized()).isCompleted();
+        }
+    }
+
+    @CsvSource({"slow.bar.com", "500.bar.com"})
+    @ParameterizedTest
+    void oneHealthy(String unhealthyHost) {
+        final Endpoint foo = Endpoint.of("health.foo.com");
+        final EndpointGroup delegate =
+                EndpointGroup.of(foo, Endpoint.of(unhealthyHost));
+        try (HealthCheckedEndpointGroup endpointGroup = newHealthCheckedEndpointGroup(delegate)) {
+            assertThat(endpointGroup.whenReady().join()).containsExactly(foo);
+            assertThat(endpointGroup.contextGroupChain().size()).isOne();
+            // Since there is one healthy endpoint, `whenInitialized()` should not complete with an error.
+            assertThat(endpointGroup.contextGroupChain().poll().whenInitialized()).isCompleted();
+        }
+    }
+
+    @Test
+    void allUnhealthy_responseTimeout() {
+        final EndpointGroup delegate =
+                EndpointGroup.of(Endpoint.of("slow.foo.com"), Endpoint.of("slow.bar.com"));
+        try (HealthCheckedEndpointGroup endpointGroup = newHealthCheckedEndpointGroup(delegate)) {
+            assertThat(endpointGroup.whenReady().join()).isEmpty();
+            assertThat(endpointGroup.contextGroupChain().size()).isOne();
+            final Throwable cause =
+                    catchThrowable(() -> endpointGroup.contextGroupChain().poll().whenInitialized().join());
+            assertThat(cause)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(ResponseTimeoutException.class);
+            final Throwable[] suppressed = cause.getSuppressed();
+            assertThat(suppressed).hasSize(1);
+            assertThat(suppressed[0]).isInstanceOf(ResponseTimeoutException.class);
+        }
+    }
+
+    @Test
+    void allUnhealthy_errorResponse() {
+        final EndpointGroup delegate =
+                EndpointGroup.of(Endpoint.of("500.foo.com"), Endpoint.of("500.bar.com"));
+        try (HealthCheckedEndpointGroup endpointGroup = newHealthCheckedEndpointGroup(delegate)) {
+            assertThat(endpointGroup.whenReady().join()).isEmpty();
+            assertThat(endpointGroup.contextGroupChain().size()).isOne();
+            final Throwable cause =
+                    catchThrowable(() -> endpointGroup.contextGroupChain().poll().whenInitialized().join());
+            assertThat(cause)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(InvalidResponseException.class)
+                    .hasMessageContaining("Received an unhealthy check response.");
+            final Throwable[] suppressed = cause.getSuppressed();
+            assertThat(suppressed).hasSize(1);
+            assertThat(suppressed[0]).isInstanceOf(InvalidResponseException.class)
+                    .hasMessageContaining("Received an unhealthy check response.");
+        }
+    }
+
+    @Test
+    void allUnhealthy_mixed() {
+        final EndpointGroup delegate =
+                EndpointGroup.of(Endpoint.of("slow.foo.com"), Endpoint.of("500.bar.com"));
+        try (HealthCheckedEndpointGroup endpointGroup = newHealthCheckedEndpointGroup(delegate)) {
+            assertThat(endpointGroup.whenReady().join()).isEmpty();
+            assertThat(endpointGroup.contextGroupChain().size()).isOne();
+            final Throwable cause =
+                    catchThrowable(() -> endpointGroup.contextGroupChain().poll().whenInitialized().join());
+            assertThat(cause)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(ResponseTimeoutException.class);
+            final Throwable[] suppressed = cause.getSuppressed();
+            assertThat(suppressed).hasSize(1);
+            assertThat(suppressed[0]).isInstanceOf(InvalidResponseException.class)
+                    .hasMessageContaining("Received an unhealthy check response.");
+        }
+    }
+
+    private static HealthCheckedEndpointGroup newHealthCheckedEndpointGroup(EndpointGroup delegate) {
+        return HealthCheckedEndpointGroup.builder(delegate, "/health")
+                                         .port(server.httpPort())
+                                         .clientFactory(clientFactory)
+                                         .withClientOptions(builder -> builder.responseTimeoutMillis(3000))
+                                         .build();
+    }
+}


### PR DESCRIPTION
Motivation:

Since a failed response is automatically retried with a backoff, it
makes sense to ignore unhealthy responses. However, if there is a
misconfiguration or an unexpected network disruption, users find it
difficult to detect the cause of unhealthy endpoints.
They will just see an `EmptyEndpointGroupException` like the following after
a connection timeout.
```java
Caused by: com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException:
       Unable to select endpoints from: HealthCheckedEndpointGroup{endpoints=[], numEndpoints=0, candidates=[...], numCandidates=5, selectionStrategy=class com.linecorp.armeria.client.endpoint.WeightedRoundRobinStrategy, initialized=true}
	at com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException.get(EmptyEndpointGroupException.java:39)
```

Modifications:

- Warn the failure of the initial health check if all endpoints are
  unhealthy.

Result:

`HealthCheckedEndpointGroup` now leaves a detailed error message if all
endpoints are unhealthy on the first check.
