### PR TITLE
Add AnnotatedServiceConfigSetters, Replace Interface

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceBindingBuilder.java
@@ -61,7 +61,7 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
  *
  * @see ServiceBindingBuilder
  */
-public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetters {
+public final class AnnotatedServiceBindingBuilder implements AnnotatedServiceConfigSetters {
 
     private final ServerBuilder serverBuilder;
     private final DefaultServiceConfigSetters defaultServiceConfigSetters = new DefaultServiceConfigSetters();
@@ -82,6 +82,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * Sets the path prefix to be used for this {@link AnnotatedServiceBindingBuilder}.
      * @param pathPrefix string representing the path prefix.
      */
+    @Override
     public AnnotatedServiceBindingBuilder pathPrefix(String pathPrefix) {
         this.pathPrefix = requireNonNull(pathPrefix, "pathPrefix");
         return this;
@@ -90,6 +91,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link ExceptionHandlerFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder exceptionHandlers(
             ExceptionHandlerFunction... exceptionHandlerFunctions) {
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
@@ -100,6 +102,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link ExceptionHandlerFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder exceptionHandlers(
             Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions) {
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
@@ -110,6 +113,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link ResponseConverterFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder responseConverters(
             ResponseConverterFunction... responseConverterFunctions) {
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
@@ -120,6 +124,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link ResponseConverterFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder responseConverters(
             Iterable<? extends ResponseConverterFunction> responseConverterFunctions) {
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
@@ -130,6 +135,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link RequestConverterFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder requestConverters(
             RequestConverterFunction... requestConverterFunctions) {
         requireNonNull(requestConverterFunctions, "requestConverterFunctions");
@@ -140,6 +146,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
     /**
      * Adds the given {@link RequestConverterFunction}s to this {@link AnnotatedServiceBindingBuilder}.
      */
+    @Override
     public AnnotatedServiceBindingBuilder requestConverters(
             Iterable<? extends RequestConverterFunction> requestConverterFunctions) {
         requireNonNull(requestConverterFunctions, "requestConverterFunctions");
@@ -153,6 +160,7 @@ public final class AnnotatedServiceBindingBuilder implements ServiceConfigSetter
      * service uses blocking logic, you should either execute such logic in a separate thread using something
      * like {@link Executors#newCachedThreadPool()} or enable this setting.
      */
+    @Override
     public AnnotatedServiceBindingBuilder useBlockingTaskExecutor(boolean useBlockingTaskExecutor) {
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AnnotatedServiceConfigSetters.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+
+interface AnnotatedServiceConfigSetters extends ServiceConfigSetters {
+
+    AnnotatedServiceConfigSetters pathPrefix(String pathPrefix);
+
+    AnnotatedServiceConfigSetters exceptionHandlers(ExceptionHandlerFunction... exceptionHandlerFunctions);
+
+    AnnotatedServiceConfigSetters exceptionHandlers(
+            Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions);
+
+    AnnotatedServiceConfigSetters responseConverters(ResponseConverterFunction... responseConverterFunctions);
+
+    AnnotatedServiceConfigSetters responseConverters(
+            Iterable<? extends ResponseConverterFunction> responseConverterFunctions);
+
+    AnnotatedServiceConfigSetters requestConverters(RequestConverterFunction... requestConverterFunctions);
+
+    AnnotatedServiceConfigSetters requestConverters(
+            Iterable<? extends RequestConverterFunction> requestConverterFunctions);
+
+    AnnotatedServiceConfigSetters useBlockingTaskExecutor(boolean useBlockingTaskExecutor);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilder.java
@@ -63,7 +63,7 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
  * @see VirtualHostBuilder
  * @see AnnotatedServiceBindingBuilder
  */
-public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceConfigSetters {
+public final class VirtualHostAnnotatedServiceBindingBuilder implements AnnotatedServiceConfigSetters {
 
     private final DefaultServiceConfigSetters defaultServiceConfigSetters = new DefaultServiceConfigSetters();
     private final VirtualHostBuilder virtualHostBuilder;
@@ -84,6 +84,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Sets the path prefix to be used for this {@link VirtualHostAnnotatedServiceBindingBuilder}.
      * @param pathPrefix string representing the path prefix.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder pathPrefix(String pathPrefix) {
         this.pathPrefix = requireNonNull(pathPrefix, "pathPrefix");
         return this;
@@ -93,6 +94,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link ExceptionHandlerFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder exceptionHandlers(
             ExceptionHandlerFunction... exceptionHandlerFunctions) {
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
@@ -104,6 +106,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link ExceptionHandlerFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder exceptionHandlers(
             Iterable<? extends ExceptionHandlerFunction> exceptionHandlerFunctions) {
         requireNonNull(exceptionHandlerFunctions, "exceptionHandlerFunctions");
@@ -115,6 +118,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link ResponseConverterFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder responseConverters(
             ResponseConverterFunction... responseConverterFunctions) {
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
@@ -126,6 +130,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link ResponseConverterFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder responseConverters(
             Iterable<? extends ResponseConverterFunction> responseConverterFunctions) {
         requireNonNull(responseConverterFunctions, "responseConverterFunctions");
@@ -137,6 +142,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link RequestConverterFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder requestConverters(
             RequestConverterFunction... requestConverterFunctions) {
         requireNonNull(requestConverterFunctions, "requestConverterFunctions");
@@ -148,6 +154,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * Adds the given {@link RequestConverterFunction}s to this
      * {@link VirtualHostAnnotatedServiceBindingBuilder}.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder requestConverters(
             Iterable<? extends RequestConverterFunction> requestConverterFunctions) {
         requireNonNull(requestConverterFunctions, "requestConverterFunctions");
@@ -161,6 +168,7 @@ public final class VirtualHostAnnotatedServiceBindingBuilder implements ServiceC
      * service uses blocking logic, you should either execute such logic in a separate thread using something
      * like {@link Executors#newCachedThreadPool()} or enable this setting.
      */
+    @Override
     public VirtualHostAnnotatedServiceBindingBuilder useBlockingTaskExecutor(boolean useBlockingTaskExecutor) {
         this.useBlockingTaskExecutor = useBlockingTaskExecutor;
         return this;


### PR DESCRIPTION
Motivation:

Manage `AnnotatedServiceBindingBuilder` and `VirtualHostAnnotatedServiceBindingBuilder` as a common interface

Modifications:

- Add `AnnotatedServiceConfigSetters` interface
- Add the common builder methods in `AnnotatedServiceBindingBuilder` and `VirtualHostAnnotatedServiceBindingBuilder` to `AnnotatedServiceConfigSetters` interface
- Replace `ServiceConfigSetters` in `AnnotatedServiceBindingBuilder` and `VirtualHostAnnotatedServiceBindingBuilder` with `AnnotatedServiceConfigSetters`
- Add `@Override` in `AnnotatedServiceBindingBuilder` and `VirtualHostAnnotatedServiceBindingBuilder` 

Result:

- Closes #4205. (If this resolves the issue.)

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
