### PR TITLE
Make `RoutingResult.path()` correctly return the mapped path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -31,10 +31,7 @@ abstract class AbstractPathMapping implements PathMapping {
      */
     static String mappedPath(String prefix, String path) {
         int length = prefix.length();
-        if (length == 0) {
-            return path;
-        }
-        if ("/".equals(prefix)) {
+        if (length == 0 || "/".equals(prefix)) {
             return path;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractPathMapping.java
@@ -26,6 +26,25 @@ import com.linecorp.armeria.common.annotation.Nullable;
  */
 abstract class AbstractPathMapping implements PathMapping {
 
+    /**
+     * Returns the path with its prefix removed.
+     */
+    static String mappedPath(String prefix, String path) {
+        int length = prefix.length();
+        if (length == 0) {
+            return path;
+        }
+        if ("/".equals(prefix)) {
+            return path;
+        }
+
+        if (prefix.charAt(length - 1) == '/') {
+            // Make sure the mappedPath starts with '/'
+            length -= 1;
+        }
+        return path.substring(length);
+    }
+
     @Override
     public final PathMapping withPrefix(String prefix) {
         prefix = ensureAbsolutePath(prefix, "prefix");

--- a/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExactPathMapping.java
@@ -29,24 +29,30 @@ import com.linecorp.armeria.common.annotation.Nullable;
 
 final class ExactPathMapping extends AbstractPathMapping {
 
+    private final String prefix;
     private final String exactPath;
     private final List<String> paths;
 
     ExactPathMapping(String exactPath) {
+        this("", exactPath);
+    }
+
+    private ExactPathMapping(String prefix, String exactPath) {
+        this.prefix = prefix;
         this.exactPath = ensureAbsolutePath(exactPath, "exactPath");
         paths = ImmutableList.of(exactPath, exactPath);
     }
 
     @Override
     PathMapping doWithPrefix(String prefix) {
-        return new ExactPathMapping(concatPaths(prefix, exactPath));
+        return new ExactPathMapping(prefix, concatPaths(prefix, exactPath));
     }
 
     @Nullable
     @Override
     RoutingResultBuilder doApply(RoutingContext routingCtx) {
         return exactPath.equals(routingCtx.path()) ? RoutingResult.builder()
-                                                                  .path(routingCtx.path())
+                                                                  .path(mappedPath(prefix, routingCtx.path()))
                                                                   .query(routingCtx.query())
                                                    : null;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -55,6 +55,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
     private static final Splitter PATH_SPLITTER = Splitter.on('/');
 
     private final String prefix;
+
     /**
      * The original path pattern specified in the constructor.
      */
@@ -103,15 +104,6 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
         this("", pathPattern);
     }
 
-    /**
-     * Create a {@link ParameterizedPathMapping} instance from given {@code pathPattern}.
-     *
-     * @param pathPattern the {@link String} that contains path params.
-     *                    e.g. {@code /users/{name}}, {@code /users/:name}, {@code /users/{*name}} or
-     *                    {@code /users/:*name}
-     *
-     * @throws IllegalArgumentException if the {@code pathPattern} is invalid.
-     */
     private ParameterizedPathMapping(String prefix, String pathPattern) {
         this.prefix = prefix;
         requireNonNull(pathPattern, "pathPattern");

--- a/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ParameterizedPathMapping.java
@@ -54,6 +54,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
 
     private static final Splitter PATH_SPLITTER = Splitter.on('/');
 
+    private final String prefix;
     /**
      * The original path pattern specified in the constructor.
      */
@@ -99,6 +100,20 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
      * @throws IllegalArgumentException if the {@code pathPattern} is invalid.
      */
     ParameterizedPathMapping(String pathPattern) {
+        this("", pathPattern);
+    }
+
+    /**
+     * Create a {@link ParameterizedPathMapping} instance from given {@code pathPattern}.
+     *
+     * @param pathPattern the {@link String} that contains path params.
+     *                    e.g. {@code /users/{name}}, {@code /users/:name}, {@code /users/{*name}} or
+     *                    {@code /users/:*name}
+     *
+     * @throws IllegalArgumentException if the {@code pathPattern} is invalid.
+     */
+    private ParameterizedPathMapping(String prefix, String pathPattern) {
+        this.prefix = prefix;
         requireNonNull(pathPattern, "pathPattern");
 
         if (!pathPattern.startsWith("/")) {
@@ -219,7 +234,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
 
     @Override
     PathMapping doWithPrefix(String prefix) {
-        return new ParameterizedPathMapping(concatPaths(prefix, pathPattern));
+        return new ParameterizedPathMapping(prefix, concatPaths(prefix, pathPattern));
     }
 
     @Override
@@ -251,7 +266,7 @@ final class ParameterizedPathMapping extends AbstractPathMapping {
         }
 
         final RoutingResultBuilder builder = RoutingResult.builderWithExpectedNumParams(paramNameArray.length)
-                                                          .path(routingCtx.path())
+                                                          .path(mappedPath(prefix, routingCtx.path()))
                                                           .query(routingCtx.query());
 
         for (int i = 0; i < paramNameArray.length; i++) {

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -66,14 +66,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
             return null;
         }
 
-        final RoutingResultBuilder builder =
-                mapping.apply(routingCtx.overridePath(path.substring(pathPrefix.length() - 1)));
-        if (builder != null) {
-            // Replace the path.
-            builder.path(path);
-        }
-
-        return builder;
+        return mapping.apply(routingCtx.overridePath(path.substring(pathPrefix.length() - 1)));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteBuilder.java
@@ -140,7 +140,7 @@ public final class RouteBuilder {
         return pathMapping(new RegexPathMappingWithPrefix(prefix, getPathMapping(pathPattern)));
     }
 
-    static PathMapping globPathMapping(String prefix, String glob, int numGroupsToSkip) {
+    private static PathMapping globPathMapping(String prefix, String glob, int numGroupsToSkip) {
         if (glob.startsWith("/")) {
             return globPathMapping(concatPaths(prefix, glob), numGroupsToSkip);
         }

--- a/core/src/test/java/com/linecorp/armeria/server/AbstractPathMappingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbstractPathMappingTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2022 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class AbstractPathMappingTest {
+
+    @CsvSource({"/prefix, /foo", "/prefix/, /foo", ", /prefix/foo", "/, /prefix/foo"})
+    @ParameterizedTest
+    void mappedPath(String prefix, String expected) {
+        if (prefix == null) {
+            prefix = "";
+        }
+        final String path = "/prefix/foo";
+        final String mappedPath = AbstractPathMapping.mappedPath(prefix, path);
+        assertThat(mappedPath).isEqualTo(expected);
+        if (prefix.isEmpty() || "/".equals(prefix)) {
+            // Reuse the original path
+            assertThat(mappedPath).isSameAs(path);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/MappedPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/MappedPathTest.java
@@ -63,7 +63,6 @@ class MappedPathTest {
 
             sb.serviceUnder("/catch-all",
                             (SimpleHttpServiceWithRoute) Route::ofCatchAll);
-
         }
     };
 
@@ -72,7 +71,7 @@ class MappedPathTest {
             "/regex/users/0001,         /users/0001",
             "/glob/users/0002/profile,  /users/0002/profile",
             "/parameterized/users/0003, /users/0003",
-            "/prefix1/prefix2/0004,        /0004",
+            "/prefix1/prefix2/0004,     /0004",
             "/catch-all/a/n/y,          /a/n/y",
     })
     @ParameterizedTest

--- a/core/src/test/java/com/linecorp/armeria/server/MappedPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/MappedPathTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2022 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class MappedPathTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @SuppressWarnings("OverlyStrongTypeCast")
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.serviceUnder("/exact",
+                            (SimpleHttpServiceWithRoute) () -> Route.builder()
+                                                                    .path("/users/0000")
+                                                                    .build());
+
+            sb.serviceUnder("/regex",
+                            (SimpleHttpServiceWithRoute) () -> Route.builder()
+                                                                    .regex("^/users/(?<userId>[0-9]+)$")
+                                                                    .build());
+            sb.serviceUnder("/glob",
+                            (SimpleHttpServiceWithRoute) () -> Route.builder()
+                                                                    .glob("/users/**/profile")
+                                                                    .build());
+
+            sb.serviceUnder("/parameterized",
+                            (SimpleHttpServiceWithRoute) () -> Route.builder()
+                                                                    .path("/users/{userId}")
+                                                                    .build());
+
+            sb.serviceUnder("/prefix1",
+                            (SimpleHttpServiceWithRoute) () -> Route.builder()
+                                                                    .pathPrefix("/prefix2")
+                                                                    .build());
+
+            sb.serviceUnder("/catch-all",
+                            (SimpleHttpServiceWithRoute) Route::ofCatchAll);
+
+        }
+    };
+
+    @CsvSource({
+            "/exact/users/0000,         /users/0000",
+            "/regex/users/0001,         /users/0001",
+            "/glob/users/0002/profile,  /users/0002/profile",
+            "/parameterized/users/0003, /users/0003",
+            "/prefix1/prefix2/0004,        /0004",
+            "/catch-all/a/n/y,          /a/n/y",
+    })
+    @ParameterizedTest
+    void mappedPath(String path, String mappedPath) {
+        final BlockingWebClient client = server.blockingWebClient();
+        assertThat(client.get(path).contentUtf8()).isEqualTo(mappedPath);
+    }
+
+    @FunctionalInterface
+    private interface SimpleHttpServiceWithRoute extends HttpServiceWithRoutes {
+
+        Route route();
+
+        @Override
+        default Set<Route> routes() {
+            return ImmutableSet.of(route());
+        }
+
+        @Override
+        default HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(ctx.mappedPath());
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDecoratingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcDecoratingService.java
@@ -95,12 +95,17 @@ final class GrpcDecoratingService extends SimpleDecoratingHttpService implements
     }
 
     @Override
+    public Map<Route, ServerMethodDefinition<?, ?>> methodsByRoute() {
+        return delegate.methodsByRoute();
+    }
+
+    @Override
     public Set<SerializationFormat> supportedSerializationFormats() {
         return delegate.supportedSerializationFormats();
     }
 
     @Nullable
-    HttpService lookup(ServiceRequestContext ctx) {
+    private HttpService lookup(ServiceRequestContext ctx) {
         final ServerMethodDefinition<?, ?> method = lookupMethodFromAttribute ? ctx.attr(RESOLVED_GRPC_METHOD)
                                                                               : null;
         if (method == null || method.getMethodDescriptor() == null) {

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceTest.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.it.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -56,23 +59,36 @@ class GrpcDecoratingServiceTest {
         }
     };
 
-    private static String FIRST_TEST_RESULT = "";
-    private static String SECOND_TEST_RESULT = "";
+    private static final LinkedBlockingDeque<String> decorators = new LinkedBlockingDeque<>();
+
+    @BeforeEach
+    void setUp() {
+        decorators.clear();
+    }
 
     @Test
     void methodDecorators() {
         final TestServiceBlockingStub client =
                 GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
         client.unaryCall(SimpleRequest.getDefaultInstance());
-        assertThat(FIRST_TEST_RESULT)
-                .isEqualTo("FirstDecorator/MethodFirstDecorator");
+        final String first = decorators.poll();
+        final String second = decorators.poll();
+        assertThat(first).isEqualTo("FirstDecorator");
+        assertThat(second).isEqualTo("MethodFirstDecorator");
+        assertThat(decorators).isEmpty();
+    }
 
-        final TestServiceBlockingStub prefixClient = GrpcClients
-                .builder(server.httpUri())
-                .pathPrefix("/grpc")
-                .build(TestServiceBlockingStub.class);
+    @Test
+    void methodDecoratorsWithPrefix() {
+        final TestServiceBlockingStub prefixClient = GrpcClients.builder(server.httpUri())
+                                                                .responseTimeoutMillis(0)
+                                                                .pathPrefix("/grpc")
+                                                                .build(TestServiceBlockingStub.class);
         prefixClient.unaryCall(SimpleRequest.getDefaultInstance());
-        assertThat(SECOND_TEST_RESULT).isEqualTo("SecondDecorator/MethodSecondDecorator");
+        final String first = decorators.poll();
+        final String second = decorators.poll();
+        assertThat(first).isEqualTo("SecondDecorator");
+        assertThat(second).isEqualTo("MethodSecondDecorator");
     }
 
     private static class FirstDecorator implements DecoratingHttpServiceFunction {
@@ -80,7 +96,7 @@ class GrpcDecoratingServiceTest {
         public HttpResponse serve(HttpService delegate,
                                   ServiceRequestContext ctx,
                                   HttpRequest req) throws Exception {
-            FIRST_TEST_RESULT += "FirstDecorator/";
+            decorators.offer("FirstDecorator");
             return delegate.serve(ctx, req);
         }
     }
@@ -90,7 +106,7 @@ class GrpcDecoratingServiceTest {
         public HttpResponse serve(HttpService delegate,
                                   ServiceRequestContext ctx,
                                   HttpRequest req) throws Exception {
-            FIRST_TEST_RESULT += "MethodFirstDecorator";
+            decorators.offer("MethodFirstDecorator");
             return delegate.serve(ctx, req);
         }
     }
@@ -100,7 +116,7 @@ class GrpcDecoratingServiceTest {
         public HttpResponse serve(HttpService delegate,
                                   ServiceRequestContext ctx,
                                   HttpRequest req) throws Exception {
-            SECOND_TEST_RESULT += "SecondDecorator/";
+            decorators.offer("SecondDecorator");
             return delegate.serve(ctx, req);
         }
     }
@@ -110,7 +126,7 @@ class GrpcDecoratingServiceTest {
         public HttpResponse serve(HttpService delegate,
                                   ServiceRequestContext ctx,
                                   HttpRequest req) throws Exception {
-            SECOND_TEST_RESULT += "MethodSecondDecorator";
+            decorators.offer("MethodSecondDecorator");
             return delegate.serve(ctx, req);
         }
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.it.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +60,7 @@ class GrpcDecoratingServiceTest {
         }
     };
 
-    private static final LinkedBlockingDeque<String> decorators = new LinkedBlockingDeque<>();
+    private static final BlockingDeque<String> decorators = new LinkedBlockingDeque<>();
 
     @BeforeEach
     void setUp() {
@@ -89,6 +90,7 @@ class GrpcDecoratingServiceTest {
         final String second = decorators.poll();
         assertThat(first).isEqualTo("SecondDecorator");
         assertThat(second).isEqualTo("MethodSecondDecorator");
+        assertThat(decorators).isEmpty();
     }
 
     private static class FirstDecorator implements DecoratingHttpServiceFunction {


### PR DESCRIPTION
Motivation:

`RoutingResult.path()` should return a mapped path by `Route`.
Let's say a service which routes to `/users/{userId}` is prefixed
with `/api/v1`. If a request path is `/api/v1/users/1234`,
- `ServiceRequestContext.path()` is equal to `/api/v1/users/1234`
- `ServiceRequestContext.mappedPath()` should be equal to `/users/1234`

Before #4086, a prefixed path is internally mapped with
`PrefixPathMapping`. So a prefix path is correctly stripped.
https://github.com/line/armeria/blob/d336d8981f03001f5a12ecae3363e98b698bb08b/core/src/main/java/com/linecorp/armeria/server/PrefixPathMapping.java#L67
\#4086 introduced `Route.withPrefix()` and all `PathMapping`s are able
to be prefixed. Consequently, other `PathMapping` implementations such
as `ExactPathMapping`, should remove the prefix when building
`RoutingResult.path()`.

Modifications:

- Remove the prefix of a request path when a `RoutingContext` is applied
  to:
  - `ExactPathMapping`
  - `GlobPathMapping`,
  - `ParameterizedPathMapping`
  - `RegexPathMappingWithPrefix`

Result:

Fix a regression introduced by #4086