### PR TITLE
Fix a bug where `WeightedRandomDistributionEndpointSelector` gets stuck in an infinite loop

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -75,7 +75,7 @@ final class WeightedRandomDistributionEndpointSelector {
             while (it.hasNext()) {
                 final Entry entry = it.next();
                 final int weight = entry.weight();
-                target -= entry.weight();
+                target -= weight;
                 if (target < 0) {
                     entry.increment();
                     if (entry.isFull()) {
@@ -83,9 +83,11 @@ final class WeightedRandomDistributionEndpointSelector {
                         entry.reset();
                         remaining -= weight;
                         if (remaining == 0) {
-                            // As all entry are full, reset `currentEntries` and `remaining`.
+                            // As all entries are full, reset `currentEntries` and `remaining`.
                             currentEntries.addAll(allEntries);
                             remaining = total;
+                        } else {
+                            assert remaining > 0 : remaining;
                         }
                     }
                     return entry.endpoint();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -69,8 +69,8 @@ final class WeightedRandomDistributionEndpointSelector {
         }
 
         final ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
-        long target = threadLocalRandom.nextLong(remaining);
         synchronized (currentEntries) {
+            long target = threadLocalRandom.nextLong(remaining);
             final Iterator<Entry> it = currentEntries.iterator();
             while (it.hasNext()) {
                 final Entry entry = it.next();
@@ -83,8 +83,7 @@ final class WeightedRandomDistributionEndpointSelector {
                         entry.reset();
                         remaining -= weight;
                         if (remaining == 0) {
-                            // Since all entry are full, reset `currentEntries` and
-                            // `remaining` to `total`
+                            // As all entry are full, reset `currentEntries` and `remaining`.
                             currentEntries.addAll(allEntries);
                             remaining = total;
                         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -15,10 +15,10 @@
  */
 package com.linecorp.armeria.client.endpoint;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -35,93 +35,74 @@ import com.linecorp.armeria.common.annotation.Nullable;
  */
 final class WeightedRandomDistributionEndpointSelector {
 
-    private static final AtomicLongFieldUpdater<WeightedRandomDistributionEndpointSelector>
-            currentTotalWeightUpdater =
-            AtomicLongFieldUpdater.newUpdater(
-                    WeightedRandomDistributionEndpointSelector.class, "currentTotalWeight");
-
-    private final List<Entry> entries;
-    private final long totalWeight;
-    private volatile long currentTotalWeight;
+    private final List<Entry> allEntries;
+    private final List<Entry> currentEntries;
+    private final long total;
+    private long remaining;
 
     WeightedRandomDistributionEndpointSelector(List<Endpoint> endpoints) {
-        final ImmutableList.Builder<Entry> builder = ImmutableList.builder();
+        final ImmutableList.Builder<Entry> builder = ImmutableList.builderWithExpectedSize(endpoints.size());
 
-        long totalWeight = 0;
+        long total = 0;
         for (Endpoint endpoint : endpoints) {
             if (endpoint.weight() <= 0) {
                 continue;
             }
             builder.add(new Entry(endpoint));
-            totalWeight += endpoint.weight();
+            total += endpoint.weight();
         }
-        this.totalWeight = totalWeight;
-        currentTotalWeight = totalWeight;
-        entries = builder.build();
+        this.total = total;
+        remaining = total;
+        allEntries = builder.build();
+        currentEntries = new ArrayList<>(allEntries);
     }
 
     @VisibleForTesting
     List<Entry> entries() {
-        return entries;
+        return allEntries;
     }
 
     @Nullable
     Endpoint selectEndpoint() {
-        if (entries.isEmpty()) {
+        if (allEntries.isEmpty()) {
             return null;
         }
+
         final ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
-        Endpoint selected = null;
-        for (;;) {
-            final long currentWeight = currentTotalWeight;
-            if (currentWeight == 0) {
-                // currentTotalWeight will become totalWeight as soon as it becomes 0 so we just loop again.
-                continue;
-            }
-            long nextLong = threadLocalRandom.nextLong(currentWeight);
-            // There's a chance that currentTotalWeight is changed before looping currentEntries.
-            // However, we have counters and choosing an endpoint doesn't have to be exact so no big deal.
-            // TODO(minwoox): Use binary search when the number of endpoints is greater than N.
-            for (Entry entry : entries) {
-                if (entry.isFull()) {
-                    continue;
-                }
-                final Endpoint endpoint = entry.endpoint();
-                final int weight = endpoint.weight();
-                nextLong -= weight;
-                if (nextLong < 0) {
-                    final int counter = entry.incrementAndGet();
-                    if (counter <= weight) {
-                        selected = endpoint;
-                        if (counter == weight) {
-                            decreaseCurrentTotalWeight(weight);
+        long target = threadLocalRandom.nextLong(remaining);
+        synchronized (currentEntries) {
+            final Iterator<Entry> it = currentEntries.iterator();
+            while (it.hasNext()) {
+                final Entry entry = it.next();
+                final int weight = entry.weight();
+                target -= entry.weight();
+                if (target < 0) {
+                    entry.increment();
+                    if (entry.isFull()) {
+                        it.remove();
+                        entry.reset();
+                        remaining -= weight;
+                        if (remaining == 0) {
+                            // Since all entry are full, reset `currentEntries` and
+                            // `remaining` to `total`
+                            currentEntries.addAll(allEntries);
+                            remaining = total;
                         }
                     }
-                    break;
+                    return entry.endpoint();
                 }
             }
-
-            if (selected != null) {
-                return selected;
-            }
         }
-    }
 
-    private void decreaseCurrentTotalWeight(int weight) {
-        final long totalWeight = currentTotalWeightUpdater.addAndGet(this, -1 * weight);
-        if (totalWeight == 0) {
-            // There's no chance that newWeight is lower than 0 because decreasing the weight of each entry
-            // happens only once.
-            entries.forEach(entry -> entry.set(0));
-            currentTotalWeight = this.totalWeight;
-        }
+        // Since `allEntries` is not empty, should select one Endpoint from `allEntries`.
+        throw new Error("Should never reach here");
     }
 
     @VisibleForTesting
-    static final class Entry extends AtomicInteger {
-        private static final long serialVersionUID = -1719423489992905558L;
+    static final class Entry {
 
         private final Endpoint endpoint;
+        private int counter;
 
         Entry(Endpoint endpoint) {
             this.endpoint = endpoint;
@@ -131,8 +112,26 @@ final class WeightedRandomDistributionEndpointSelector {
             return endpoint;
         }
 
+        void increment() {
+            assert counter < endpoint().weight();
+            counter++;
+        }
+
+        int weight() {
+            return endpoint().weight();
+        }
+
+        void reset() {
+            counter = 0;
+        }
+
+        @VisibleForTesting
+        int counter() {
+            return counter;
+        }
+
         boolean isFull() {
-            return get() >= endpoint.weight();
+            return counter >= endpoint.weight();
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelectorTest.java
@@ -73,7 +73,7 @@ final class WeightedRandomDistributionEndpointSelectorTest {
             for (int count = 0; count < totalWeight; count++) {
                 assertThat(selector.selectEndpoint()).isNotNull();
                 if (count == totalWeight - 1) {
-                    int sum = selector.entries().stream().mapToInt(Entry::counter).sum();
+                    final int sum = selector.entries().stream().mapToInt(Entry::counter).sum();
                     // Since all entries were full, `Entry.counter()` should be reset.
                     assertThat(sum).isEqualTo(0);
                 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelectorTest.java
@@ -65,17 +65,17 @@ final class WeightedRandomDistributionEndpointSelectorTest {
 
     @Test
     void resetEntriesWhenAllEntriesAreFull() throws InterruptedException {
-        final int concurrency = 16;
+        final int concurrency = 4;
         final CountDownLatch startLatch = new CountDownLatch(concurrency);
         final CountDownLatch checkLatch = new CountDownLatch(concurrency);
         final CountDownLatch finalLatch = new CountDownLatch(concurrency);
-        final Endpoint foo = Endpoint.of("foo.com").withWeight(1000);
-        final Endpoint bar = Endpoint.of("bar.com").withWeight(2000);
-        final Endpoint qux = Endpoint.of("qux.com").withWeight(3000);
+        final Endpoint foo = Endpoint.of("foo.com").withWeight(10);
+        final Endpoint bar = Endpoint.of("bar.com").withWeight(20);
+        final Endpoint qux = Endpoint.of("qux.com").withWeight(30);
         final List<Endpoint> endpoints = ImmutableList.of(foo, bar, qux);
         final WeightedRandomDistributionEndpointSelector
                 selector = new WeightedRandomDistributionEndpointSelector(endpoints);
-        final int totalWeight = 6000;
+        final int totalWeight = foo.weight() + bar.weight() + qux.weight();
         for (int i = 0; i < concurrency; i++) {
             CommonPools.blockingTaskExecutor().execute(() -> {
                 try {


### PR DESCRIPTION
Motivation:

I saw suspicious stack traces from the thread dump reported from LINE's
internal channel.
```java
daemon prio=5 os_prio=0 cpu=14048767.37ms elapsed=148187.24s tid=0x00007f0c710eb000 nid=0xb556 runnable  [0x00007f06fbb8d000]
  java.lang.Thread.State: RUNNABLE
       at com.linecorp.armeria.client.endpoint.WeightedRandomDistributionEndpointSelector.selectEndpoint(WeightedRandomDistributionEndpointSelector.java:87)
       at com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy$RampingUpEndpointWeightSelector.selectNow(WeightRampingUpStrategy.java:169)
       at com.linecorp.armeria.client.endpoint.DynamicEndpointGroup.selectNow(DynamicEndpointGroup.java:87)
```
Many threads in the thread dump got stuck in the same line.
It seemed that a `WeightedRandomDistributionEndpointSelector` couldn't
escape from `for` loop.

The two lines above can be a race condition.
While one thread updates `entry.counter` to 0 and before updates
`currentTotalWeight`, other threads can increase `entry.counter`.
https://github.com/line/armeria/blob/5b384fbe27e7e6f9225d6db91cbb684d09dfbb5e/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java#L93
https://github.com/line/armeria/blob/5b384fbe27e7e6f9225d6db91cbb684d09dfbb5e/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java#L115
It can make all entries are full and `currentTotalWeight` is positive.
If the two conditions are met, the `for` loop runs forever.
https://github.com/line/armeria/blob/5b384fbe27e7e6f9225d6db91cbb684d09dfbb5e/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java#L75-L88

Modifications:

- Use `synchronized` to access `currentEntries` and atomically update
  `currentEntries`
- Remove a full `Entry` from `currentEntries` to avoid useless iterations.

Result:

You no longer see an infinite loop when selecting an `Endpoint` using
`EndpointSelectionStrategy.rampingUp()`.