### PR TITLE
Fix a bug where duplicate healthy endpoints are set to `HealthCheckedEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -137,9 +137,9 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
             final AtomicBoolean initialized = new AtomicBoolean();
             endpointGroup.addListener(newEndpoints -> {
-                final List<Endpoint> dedupEndpoints =
-                        new ArrayList<>(deduplicateEndpoints(newEndpoints).values());
                 if (initialized.compareAndSet(false, true)) {
+                    final List<Endpoint> dedupEndpoints =
+                            new ArrayList<>(deduplicateEndpoints(newEndpoints).values());
                     endpointSelector = new WeightedRandomDistributionEndpointSelector(dedupEndpoints);
                     endpointsFinishedRampingUp.addAll(dedupEndpoints);
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -19,9 +19,9 @@ import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
@@ -184,7 +184,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     }
 
     private List<Endpoint> allHealthyEndpoints() {
-        final Set<Endpoint> allHealthyEndpoints = new HashSet<>();
+        final List<Endpoint> allHealthyEndpoints = new ArrayList<>();
         synchronized (contextGroupChain) {
             final HealthCheckContextGroup newGroup = contextGroupChain.getLast();
             for (Endpoint candidate : newGroup.candidates()) {
@@ -206,7 +206,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 }
             }
         }
-        return ImmutableList.copyOf(allHealthyEndpoints);
+        return allHealthyEndpoints;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -15,12 +15,13 @@
  */
 package com.linecorp.armeria.client.endpoint.healthcheck;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
@@ -105,7 +106,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     @VisibleForTesting
     final HealthCheckStrategy healthCheckStrategy;
 
-    private final Queue<HealthCheckContextGroup> contextGroupChain = new ArrayDeque<>(4);
+    private final Deque<HealthCheckContextGroup> contextGroupChain = new ArrayDeque<>(4);
 
     // Should not use NonBlockingHashSet whose remove operation does not clear the reference of the value
     // from the internal array. The remaining value is revived if a new value having the same hash code is
@@ -183,11 +184,29 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     }
 
     private List<Endpoint> allHealthyEndpoints() {
+        final Set<Endpoint> allHealthyEndpoints = new HashSet<>();
         synchronized (contextGroupChain) {
-            return contextGroupChain.stream().flatMap(group -> group.candidates().stream())
-                                    .filter(healthyEndpoints::contains)
-                                    .collect(toImmutableList());
+            final HealthCheckContextGroup newGroup = contextGroupChain.getLast();
+            for (Endpoint candidate : newGroup.candidates()) {
+                if (healthyEndpoints.contains(candidate)) {
+                    allHealthyEndpoints.add(candidate);
+                }
+            }
+
+            for (HealthCheckContextGroup oldGroup : contextGroupChain) {
+                if (oldGroup == newGroup) {
+                    break;
+                }
+                for (Endpoint candidate : oldGroup.candidates()) {
+                    if (!allHealthyEndpoints.contains(candidate) && healthyEndpoints.contains(candidate)) {
+                        // Add old Endpoints that do not exist in newGroup. When the first check for newGroup is
+                        // completed, the old Endpoints will be removed.
+                        allHealthyEndpoints.add(candidate);
+                    }
+                }
+            }
         }
+        return ImmutableList.copyOf(allHealthyEndpoints);
     }
 
     @Nullable

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupIntegrationTest.java
@@ -213,6 +213,7 @@ class HealthCheckedEndpointGroupIntegrationTest {
             endpointGroup.newMeterBinder("baz").bindTo(registry);
 
             assertThat(endpointGroup.endpoints())
+                    .hasSize(3)
                     .containsOnly(Endpoint.of("127.0.0.1", portOne));
 
             assertThat(MoreMeters.measureAll(registry))

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -25,9 +25,11 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -315,6 +317,42 @@ class HealthCheckedEndpointGroupTest {
                                                     ClientOptions.of(), checkFactory,
                                                     HealthCheckStrategy.all())) {
             assertThat(counter.get()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void shouldDeduplicateOldEndpoints() {
+        final Function<? super HealthCheckerContext, ? extends AsyncCloseable> checkFactory = ctx -> {
+            ctx.updateHealth(HEALTHY, null, null, null);
+            return AsyncCloseableSupport.of();
+        };
+
+        final Endpoint candidate1 = Endpoint.of("candidate1");
+        final Endpoint candidate2 = Endpoint.of("candidate2");
+        final Endpoint candidate3 = Endpoint.of("candidate3");
+        final MockEndpointGroup delegate = new MockEndpointGroup();
+        delegate.set(candidate1, candidate2);
+
+        try (HealthCheckedEndpointGroup endpointGroup =
+                     new HealthCheckedEndpointGroup(delegate, true,
+                                                    SessionProtocol.HTTP, 80,
+                                                    DEFAULT_HEALTH_CHECK_RETRY_BACKOFF,
+                                                    ClientOptions.of(), checkFactory,
+                                                    HealthCheckStrategy.all())) {
+            final BlockingQueue<List<Endpoint>> healthyEndpointsList = new LinkedTransferQueue<>();
+            endpointGroup.addListener(healthyEndpointsList::add, true);
+            delegate.set(candidate1, candidate3);
+            final HealthCheckContextGroup contextGroup = endpointGroup.contextGroupChain().poll();
+            assertThat(contextGroup.candidates()).containsExactly(candidate1, candidate3);
+            assertThat(contextGroup.whenInitialized()).isDone();
+            assertThat(healthyEndpointsList).hasSize(3);
+            final List<Endpoint> first = healthyEndpointsList.poll();
+            assertThat(first).containsExactly(candidate1, candidate2);
+            final List<Endpoint> second = healthyEndpointsList.poll();
+            // `candidate1` should be deduplicated.
+            assertThat(second).containsExactly(candidate1, candidate2, candidate3);
+            final List<Endpoint> third = healthyEndpointsList.poll();
+            assertThat(third).containsExactly(candidate1, candidate3);
         }
     }
 


### PR DESCRIPTION
Motivation:

I got a report from @eisig that `EndpointSelectionStrategy.rampingUp()`
did not work with `HealthCheckedEndpointGroup`.
Slack thread: https://line-armeria.slack.com/archives/C1NGPBUH2/p1650438670771329?thread_ts=1650324855.491319&cid=C1NGPBUH2

The bug will be reproducible by the following steps:
- If new `Endpoint`s are added to a `DynamicEndpointGroup` which
  `HealthCheckEndointGroup` delegates to, a new context group is added to
  `contextGroupChain`.
https://github.com/line/armeria/blob/1ec5a6828c6b8245dec738519b6f543a7878e349/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java#L160
- The old context chain will be moved when the first check of the new context
  group has been completed.
https://github.com/line/armeria/blob/1ec5a6828c6b8245dec738519b6f543a7878e349/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java#L164-L173
- While two contexts are alive, `allHealthyEndpoints()` returns all
  healthy endpoints in both the old one and the new one.
- Consequently, `WeightRampingUpStrategy` sees duplicate endpoints and it
  tries to merge the weight of duplicate endpoints. As all weights of
  `Endpoint`s has changed, ramping up will start over.

Modifications:

- Deduplicate healthy endpoints when collecting from `contextGroupChain`
  - The healthy endpoints in old context groups will be ignored if they
    already exist in the new/latest context group.

Result:

A ramping up `EndpointSelectionStrategy` now correctly works with
`HealthCheckedEndpointGroup`.