### PR TITLE
Add Koltlin nullable type support to `AnnotatedService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -1255,7 +1255,7 @@ final class AnnotatedValueResolver {
                     return true;
                 }
             }
-            return false;
+            return KotlinUtil.isMarkedNullable(typeElement);
         }
 
         @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -1249,13 +1249,20 @@ final class AnnotatedValueResolver {
         }
 
         private boolean isNullable() {
+            boolean hasNullableAnnotation = false;
+
             for (Annotation a : annotatedElement.getAnnotations()) {
                 final String annotationTypeName = a.annotationType().getName();
                 if (annotationTypeName.endsWith(".Nullable")) {
-                    return true;
+                    hasNullableAnnotation = true;
+                    break;
                 }
             }
-            return KotlinUtil.isMarkedNullable(typeElement);
+            final boolean isMarkedNullable = KotlinUtil.isMarkedNullable(typeElement);
+            if (hasNullableAnnotation && isMarkedNullable) {
+                warnRedundantUse("@Nullable", "?(Kotlin nullable type)");
+            }
+            return hasNullableAnnotation || isMarkedNullable;
         }
 
         @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -1128,12 +1128,23 @@ final class AnnotatedValueResolver {
             checkArgument(resolver != null, "'resolver' should be specified");
 
             final boolean isOptional = type == Optional.class;
-            final boolean isNullable = isNullable();
+            final boolean isAnnotatedNullable = isAnnotatedNullable(typeElement);
+            final boolean isMarkedNullable = KotlinUtil.isMarkedNullable(typeElement);
+            final boolean isNullable = isAnnotatedNullable || isMarkedNullable;
             final Type originalParameterizedType = parameterizedTypeOf(typeElement);
             final Type unwrappedParameterizedType = isOptional ? unwrapOptional(originalParameterizedType)
                                                                : originalParameterizedType;
+
+            // Used only for warning message.
+            final String nullableRepresentation =
+                    isMarkedNullable && !isAnnotatedNullable ? "?(Kotlin nullable type)"
+                                                             : "@Nullable";
+
+            if (isAnnotatedNullable && isMarkedNullable) {
+                warnRedundantUse("@Nullable", "?(Kotlin nullable type)");
+            }
             if (isOptional && isNullable) {
-                warnRedundantUse("Optional", "@Nullable");
+                warnRedundantUse("Optional", nullableRepresentation);
             }
 
             final boolean shouldExist;
@@ -1146,7 +1157,7 @@ final class AnnotatedValueResolver {
                     if (isOptional) {
                         warnRedundantUse("@Default", "Optional");
                     } else if (isNullable) {
-                        warnRedundantUse("@Default", "@Nullable");
+                        warnRedundantUse("@Default", nullableRepresentation);
                     }
 
                     shouldExist = false;
@@ -1175,7 +1186,7 @@ final class AnnotatedValueResolver {
                 if (isOptional) {
                     warnRedundantUse("a path variable", "Optional");
                 } else {
-                    warnRedundantUse("a path variable", "@Nullable");
+                    warnRedundantUse("a path variable", nullableRepresentation);
                 }
             }
 
@@ -1248,23 +1259,6 @@ final class AnnotatedValueResolver {
             logger.warn(buf.toString());
         }
 
-        private boolean isNullable() {
-            boolean hasNullableAnnotation = false;
-
-            for (Annotation a : annotatedElement.getAnnotations()) {
-                final String annotationTypeName = a.annotationType().getName();
-                if (annotationTypeName.endsWith(".Nullable")) {
-                    hasNullableAnnotation = true;
-                    break;
-                }
-            }
-            final boolean isMarkedNullable = KotlinUtil.isMarkedNullable(typeElement);
-            if (hasNullableAnnotation && isMarkedNullable) {
-                warnRedundantUse("@Nullable", "?(Kotlin nullable type)");
-            }
-            return hasNullableAnnotation || isMarkedNullable;
-        }
-
         @Nullable
         private Class<?> getContainerType(Type parameterizedType) {
             final Class<?> rawType = toRawType(parameterizedType);
@@ -1320,6 +1314,16 @@ final class AnnotatedValueResolver {
                         "Unsupported or invalid parameter type: " + parameterizedType, cause);
             }
             return toRawType(elementType);
+        }
+
+        private static boolean isAnnotatedNullable(AnnotatedElement annotatedElement) {
+            for (Annotation a : annotatedElement.getAnnotations()) {
+                final String annotationTypeName = a.annotationType().getName();
+                if (annotationTypeName.endsWith(".Nullable")) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -65,6 +66,9 @@ final class KotlinUtil {
     @Nullable
     private static final Method K_FUNCTION_GENERIC_RETURN_TYPE;
 
+    @Nullable
+    private static final Method IS_MARKED_NULLABLE;
+
     static {
         MethodHandle callKotlinSuspendingMethod = null;
         final String internalCommonPackageName = RequestContextUtil.class.getPackage().getName();
@@ -92,6 +96,7 @@ final class KotlinUtil {
         Method isReturnTypeNothing = null;
         Method kFunctionReturnType = null;
         Method kFunctionGenericReturnType = null;
+        Method isMarkedNullable = null;
         try {
             final Class<?> kotlinUtilClass =
                     getClass(internalCommonPackageName + ".kotlin.ArmeriaKotlinUtil");
@@ -102,6 +107,7 @@ final class KotlinUtil {
             isReturnTypeNothing = kotlinUtilClass.getMethod("isReturnTypeNothing", Method.class);
             kFunctionReturnType = kotlinUtilClass.getMethod("kFunctionReturnType", Method.class);
             kFunctionGenericReturnType = kotlinUtilClass.getMethod("kFunctionGenericReturnType", Method.class);
+            isMarkedNullable = kotlinUtilClass.getMethod("isMarkedNullable", AnnotatedElement.class);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             // ignore
         } finally {
@@ -111,6 +117,7 @@ final class KotlinUtil {
             IS_RETURN_TYPE_NOTHING = isReturnTypeNothing;
             K_FUNCTION_RETURN_TYPE = kFunctionReturnType;
             K_FUNCTION_GENERIC_RETURN_TYPE = kFunctionGenericReturnType;
+            IS_MARKED_NULLABLE = isMarkedNullable;
         }
 
         boolean isKotlinReflectionPresent = false;
@@ -241,6 +248,15 @@ final class KotlinUtil {
             return (Type) K_FUNCTION_GENERIC_RETURN_TYPE.invoke(null, method);
         } catch (Exception e) {
             return Exceptions.throwUnsafely(e);
+        }
+    }
+
+    static boolean isMarkedNullable(AnnotatedElement typeElement) {
+        try {
+            return IS_MARKED_NULLABLE != null &&
+                   (boolean) IS_MARKED_NULLABLE.invoke(null, typeElement);
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/KotlinUtil.java
@@ -233,6 +233,9 @@ final class KotlinUtil {
         }
     }
 
+    /**
+     * {@link Method#getReturnType} equivalent for Kotlin functions.
+     */
     static Class<?> kFunctionReturnType(Method method) {
         assert K_FUNCTION_RETURN_TYPE != null;
         try {
@@ -242,6 +245,9 @@ final class KotlinUtil {
         }
     }
 
+    /**
+     * {@link Method#getGenericReturnType} equivalent for Kotlin functions.
+     */
     static Type kFunctionGenericReturnType(Method method) {
         assert K_FUNCTION_GENERIC_RETURN_TYPE != null;
         try {
@@ -251,6 +257,9 @@ final class KotlinUtil {
         }
     }
 
+    /**
+     * Returns true if the typeElement can be converted to KType and is marked nullable.
+     */
     static boolean isMarkedNullable(AnnotatedElement typeElement) {
         try {
             return IS_MARKED_NULLABLE != null &&

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaKotlinUtil.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaKotlinUtil.kt
@@ -64,22 +64,22 @@ internal fun isReturnTypeNothing(method: Method): Boolean {
 }
 
 /**
- * [Method.getReturnType] equivalent for kotlin suspending function.
+ * [Method.getReturnType] equivalent for Kotlin functions.
  */
 internal fun kFunctionReturnType(method: Method): Class<*> =
     requireNotNull(method.kotlinFunction) { "method is not a kotlin function" }
         .returnType.jvmErasure.java
 
 /**
- * [Method.getGenericReturnType] equivalent for kotlin suspending function.
+ * [Method.getGenericReturnType] equivalent for Kotlin functions.
  */
 internal fun kFunctionGenericReturnType(method: Method): Type =
     requireNotNull(method.kotlinFunction) { "method is not a kotlin function" }
         .returnType.javaType
 
-internal fun isMarkedNullable(field: Field): Boolean =
-    field.kotlinProperty?.returnType?.isMarkedNullable ?: false
-
+/**
+ * Returns true if the [element]'s type is marked nullable.
+ */
 internal fun isMarkedNullable(element: AnnotatedElement): Boolean {
     return when (element) {
         is Field -> element.kotlinProperty?.returnType?.isMarkedNullable ?: false
@@ -89,8 +89,10 @@ internal fun isMarkedNullable(element: AnnotatedElement): Boolean {
             when (executable) {
                 is Method -> executable
                     .kotlinFunction
+                    // Should be `valueParameters` to exclude the `this` instance and
+                    // the extension receiver parameter.
                     ?.valueParameters
-                    ?.get(i) // this parameter
+                    ?.get(i)
                     ?.type
                     ?.isMarkedNullable
                     ?: false

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server.kotlin
+
+import com.linecorp.armeria.common.AggregatedHttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.HttpStatus
+import com.linecorp.armeria.common.QueryParams
+import com.linecorp.armeria.common.annotation.Nullable
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.ServiceRequestContext
+import com.linecorp.armeria.server.annotation.Get
+import com.linecorp.armeria.server.annotation.Param
+import com.linecorp.armeria.server.annotation.RequestConverter
+import com.linecorp.armeria.server.annotation.RequestConverterFunction
+import com.linecorp.armeria.testing.junit5.server.ServerExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.lang.reflect.ParameterizedType
+
+class NullableTypeSupportTest {
+    @ParameterizedTest
+    @ValueSource(strings = [
+        "/value-resolver/of-query-param",
+        "/value-resolver/of-request-converter",
+        "/value-resolver/of-bean-constructor",
+        "/value-resolver/of-bean-field",
+        "/value-resolver/of-bean-method"
+    ])
+    fun test_valueResolverOfBeanConstructor(testPath: String) {
+        testNullableParameters("/nullable-type/$testPath")
+
+        // Check for backward-compatibility
+        testNullableParameters("/nullable-annot/$testPath")
+    }
+
+    private fun testNullableParameters(testPath: String) {
+        val client = server.blockingWebClient()
+
+        with(client.get(testPath, QueryParams.of("a", "a"))) {
+            assertThat(status()).isEqualTo(HttpStatus.OK)
+            assertThat(contentUtf8()).isEqualTo("a: a, b: null")
+        }
+        with(client.get(testPath, QueryParams.of("a", "a", "b", "b"))) {
+            assertThat(status()).isEqualTo(HttpStatus.OK)
+            assertThat(contentUtf8()).isEqualTo("a: a, b: b")
+        }
+        with(client.get(testPath, QueryParams.of("b", "b"))) {
+            assertThat(status()).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+        with(client.get(testPath)) {
+            assertThat(status()).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val server = object : ServerExtension() {
+            override fun configure(sb: ServerBuilder) {
+                sb.apply {
+                    sb.annotatedService("/nullable-type/value-resolver", object {
+                        @Get("/of-query-param")
+                        fun ofQueryParam(@Param a: String, @Param b: String?) =
+                            HttpResponse.of("a: ${a}, b: ${b}")
+
+                        @Get("/of-request-converter")
+                        @RequestConverter(FooBarRequestConverter::class)
+                        fun ofRequestConverter(foo: Foo, bar: Bar?) =
+                            HttpResponse.of("a: ${foo.value}, b: ${bar?.value}")
+
+                        @Get("/of-bean-constructor")
+                        fun ofBeanConstructor(baz: Baz) =
+                            HttpResponse.of("a: ${baz.a}, b: ${baz.b}")
+
+                        @Get("/of-bean-field")
+                        fun ofBeanField(qux: Qux) =
+                            HttpResponse.of("a: ${qux.a}, b: ${qux.b}")
+
+                        @Get("/of-bean-method")
+                        fun ofBeanMethod(quux: Quux) =
+                            HttpResponse.of("a: ${quux.a}, b: ${quux.b}")
+                    })
+                    sb.annotatedService("/nullable-annot/value-resolver", object {
+                        @Get("/of-query-param")
+                        fun ofQueryParam(@Param a: String, @Nullable @Param b: String?) =
+                            HttpResponse.of("a: $a, b: $b")
+
+                        @Get("/of-request-converter")
+                        @RequestConverter(FooBarRequestConverter::class)
+                        fun ofRequestConverter(foo: Foo, @Nullable bar: Bar?) =
+                            HttpResponse.of("a: ${foo.value}, b: ${bar?.value}")
+
+                        @Get("/of-bean-constructor")
+                        fun ofBeanConstructor(baz: Baz0) =
+                            HttpResponse.of("a: ${baz.a}, b: ${baz.b}")
+
+                        @Get("/of-bean-field")
+                        fun ofBeanField(qux: Qux0) =
+                            HttpResponse.of("a: ${qux.a}, b: ${qux.b}")
+
+                        @Get("/of-bean-method")
+                        fun ofBeanMethod(quux: Quux0) =
+                            HttpResponse.of("a: ${quux.a}, b: ${quux.b}")
+                    })
+                }
+            }
+        }
+
+        data class Foo(
+            val value: String
+        )
+
+        data class Bar(
+            val value: String
+        )
+
+        class Baz(@Param("a") val a: String, @Param("b") val b: String?)
+
+        class Baz0(@Param("a") val a: String, @Nullable @Param("b") val b: String?)
+
+        class Qux {
+            @Param("a") lateinit var a: String
+            @Param("b") var b: String? = null
+        }
+
+        class Qux0 {
+            @Param("a") lateinit var a: String
+            @Nullable @Param("b") var b: String? = null
+        }
+
+        class Quux {
+            lateinit var a: String
+            var b: String? = null
+
+            fun setter(@Param("a") a: String, @Param("b") b: String?) {
+                this.a = a
+                this.b = b
+            }
+        }
+
+        class Quux0 {
+            lateinit var a: String
+            var b: String? = null
+
+            fun setter(@Param("a") a: String, @Nullable @Param("b") b: String?) {
+                this.a = a
+                this.b = b
+            }
+        }
+
+        class FooBarRequestConverter : RequestConverterFunction {
+            override fun convertRequest(
+                ctx: ServiceRequestContext,
+                request: AggregatedHttpRequest,
+                expectedResultType: Class<*>,
+                expectedParameterizedResultType: ParameterizedType?
+            ): Any? {
+                if (expectedResultType.isAssignableFrom(Foo::class.java)) {
+                    return ctx.queryParam("a")?.let { Foo(it) }
+                }
+                if (expectedResultType.isAssignableFrom(Bar::class.java)) {
+                    return ctx.queryParam("b")?.let { Bar(it) }
+                }
+                throw RequestConverterFunction.fallthrough()
+            }
+        }
+    }
+}

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
@@ -29,7 +29,6 @@ import com.linecorp.armeria.server.annotation.RequestConverter
 import com.linecorp.armeria.server.annotation.RequestConverterFunction
 import com.linecorp.armeria.testing.junit5.server.ServerExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -79,7 +78,7 @@ class NullableTypeSupportTest {
                     sb.annotatedService("/nullable-type/value-resolver", object {
                         @Get("/of-query-param")
                         fun ofQueryParam(@Param a: String, @Param b: String?) =
-                            HttpResponse.of("a: ${a}, b: ${b}")
+                            HttpResponse.of("a: $a, b: $b")
 
                         @Get("/of-request-converter")
                         @RequestConverter(FooBarRequestConverter::class)

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
@@ -75,7 +75,7 @@ class NullableTypeSupportTest {
         val server = object : ServerExtension() {
             override fun configure(sb: ServerBuilder) {
                 sb.apply {
-                    sb.annotatedService("/nullable-type/value-resolver", object {
+                    annotatedService("/nullable-type/value-resolver", object {
                         @Get("/of-query-param")
                         fun ofQueryParam(@Param a: String, @Param b: String?) =
                             HttpResponse.of("a: $a, b: $b")

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
@@ -133,6 +133,7 @@ class NullableTypeSupportTest {
 
         class Baz(@Param("a") val a: String, @Param("b") val b: String?)
 
+        // Check for backward-compatibility
         class Baz0(@Param("a") val a: String, @Nullable @Param("b") val b: String?)
 
         class Qux {
@@ -155,6 +156,7 @@ class NullableTypeSupportTest {
             }
         }
 
+        // Check for backward-compatibility
         class Quux0 {
             lateinit var a: String
             var b: String? = null

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/NullableTypeSupportTest.kt
@@ -43,7 +43,7 @@ class NullableTypeSupportTest {
         "/value-resolver/of-bean-field",
         "/value-resolver/of-bean-method"
     ])
-    fun test_valueResolverOfBeanConstructor(testPath: String) {
+    fun test_nullableParameters(testPath: String) {
         testNullableParameters("/nullable-type/$testPath")
 
         // Check for backward-compatibility


### PR DESCRIPTION
Motivation:

`AnnotatedService` requires `@Nullable` annotations for nullable resolved values even when it is used with Kotlin which offers nice null-safety with nullable types.

Modifications:

- Add `isMarkedNullable` method to `KotlinUtil`.
- Make `AnnotatedValueResolver#Builder` detect Kotlin nullable types of `Field` and `Parameter` and allow null values for them.

Result:
- Now you don't need to add `@Nullable` annotations to nullable arguments & fields in `AnnotatedService` if they are Kotlin nullable types(`?`).
- Closes #4144

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
