### PR TITLE
Fix failing `DefaultMediaTypeResolverTest` tests

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
@@ -34,20 +34,14 @@ public class DefaultMediaTypeResolverTest {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png", null))).isTrue();
         assertThat(MediaType.PDF.is(RESOLVER.guessFromPath("document.pdf", null))).isTrue();
         assertThat(MediaType.WEBP.is(RESOLVER.guessFromPath("image.webp", null))).isTrue();
-        final MediaType mediaType = RESOLVER.guessFromPath("image.png.gz", null);
-        assertThat(mediaType.type()).isEqualTo("application");
-        assertThat(mediaType.subtype()).isEqualTo("octet-stream");
-        assertThat(MediaType.OCTET_STREAM.is(mediaType)).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
     }
 
     @Test
     public void preCompressed() {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("image.png.gz", "gzip"))).isTrue();
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
-        final MediaType mediaType = RESOLVER.guessFromPath("image.png.gz", "identity");
-        assertThat(mediaType.type()).isEqualTo("application");
-        assertThat(mediaType.subtype()).isEqualTo("octet-stream");
-        assertThat(MediaType.OCTET_STREAM.is(mediaType)).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", "identity"))).isTrue();
         assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
@@ -34,15 +34,15 @@ public class DefaultMediaTypeResolverTest {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png", null))).isTrue();
         assertThat(MediaType.PDF.is(RESOLVER.guessFromPath("document.pdf", null))).isTrue();
         assertThat(MediaType.WEBP.is(RESOLVER.guessFromPath("image.webp", null))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", null))).isTrue();
     }
 
     @Test
     public void preCompressed() {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("image.png.gz", "gzip"))).isTrue();
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", "identity"))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", "identity"))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", null))).isTrue();
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
@@ -34,14 +34,20 @@ public class DefaultMediaTypeResolverTest {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png", null))).isTrue();
         assertThat(MediaType.PDF.is(RESOLVER.guessFromPath("document.pdf", null))).isTrue();
         assertThat(MediaType.WEBP.is(RESOLVER.guessFromPath("image.webp", null))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
+        final MediaType mediaType = RESOLVER.guessFromPath("image.png.gz", null);
+        assertThat(mediaType.type()).isEqualTo("application");
+        assertThat(mediaType.subtype()).isEqualTo("octet-stream");
+        assertThat(MediaType.OCTET_STREAM.is(mediaType)).isTrue();
     }
 
     @Test
     public void preCompressed() {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("image.png.gz", "gzip"))).isTrue();
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", "identity"))).isTrue();
+        final MediaType mediaType = RESOLVER.guessFromPath("image.png.gz", "identity");
+        assertThat(mediaType.type()).isEqualTo("application");
+        assertThat(mediaType.subtype()).isEqualTo("octet-stream");
+        assertThat(MediaType.OCTET_STREAM.is(mediaType)).isTrue();
         assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
     }
 


### PR DESCRIPTION
Motivation:

- https://bugs.openjdk.java.net/browse/JDK-8273655
- https://github.com/openjdk/jdk/commit/65ed0a742e65fe7e661e8da2adea6cd41992869e
- JDK has modified the default `content-types.properties` mappings recently, causing failures in some tests.
- https://github.com/line/armeria/actions/runs/2291723521

Modifications:

- Use `.bin` over `.gz` for some tests

Result:

- CI passes for more recent jdk versions

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
