### PR TITLE
Move a misplaced test file

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InternalReflectionUtilsTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InternalReflectionUtilsTest.java
@@ -45,7 +45,6 @@ class InternalReflectionUtilsTest {
                 methods.put(methodName, method);
             }
         }
-        System.out.println(methods);
         assertThat(methods.get("unaryCall").getDeclaringClass()).isEqualTo(AbstractTestServiceImpl.class);
         assertThat(methods.get("emptyCall").getDeclaringClass()).isEqualTo(TestServiceImpl.class);
     }


### PR DESCRIPTION
Motivation:

`InternalReflectionUtilsTest` was located in `test/proto/...`.

Modifications:

- Move `InternalReflectionUtilsTest` under `test/java/...`

Result:

Test `InternalReflectionUtilsTest` with CI jobs.
