### PR TITLE
Correctly throw `WriteTimeoutException` for requests without content

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java
@@ -258,7 +258,6 @@ final class HttpRequestSubscriber implements Subscriber<HttpObject>, ChannelFutu
     @Override
     public void onComplete() {
         isSubscriptionCompleted = true;
-        cancelTimeout();
 
         if (state != State.DONE) {
             write(HttpData.empty(), true);


### PR DESCRIPTION
Motivation:

`WriteTimeoutException` is defined as an exception thrown if the first message write doesn't complete within a specified time. This specification holds for requests with bodies.

However, requests without bodies never throw a `WriteTimeoutException` because:

1) Requests without bodies complete their stream immediately

https://github.com/line/armeria/blob/5a2c7202aa17b6e43a90808e2a27fdf69df18417/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java#L141-L148

2) This in turn, cancels the write timeout immediately

https://github.com/line/armeria/blob/5a2c7202aa17b6e43a90808e2a27fdf69df18417/core/src/main/java/com/linecorp/armeria/client/HttpRequestSubscriber.java#L261

Modifications:

- Remove the call to `HttpRequestSubscriber#cancelTimeout` when the subscription on the request is complete.

Result:

- Closes #4255

Verified the following test passes:
https://github.com/jrhee17/armeria/blob/13c2c60e60b6109531b363d55d09ab6af7de432c/core/src/test/java/com/linecorp/armeria/client/TimeoutTest.java

Also created a PR which helps simulate slow writes as a follow-up:
https://github.com/line/armeria/pull/4260

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
