### PR TITLE
Add `MultipartFile` and documentation for `Multipart`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipartFile.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipartFile.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.multipart;
+
+import java.io.File;
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+final class DefaultMultipartFile implements MultipartFile {
+
+    @Nullable
+    private final String name;
+    private final String filename;
+    private final File file;
+
+    DefaultMultipartFile(@Nullable String name, String filename, File file) {
+        this.name = name;
+        this.filename = filename;
+        this.file = file;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String filename() {
+        return filename;
+    }
+
+    @Override
+    public File file() {
+        return file;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof MultipartFile)) {
+            return false;
+        }
+
+        final MultipartFile that = (MultipartFile) o;
+        return Objects.equals(name, that.name()) &&
+               filename.equals(that.filename()) &&
+               file.equals(that.file());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, filename, file);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name)
+                          .add("filename", filename)
+                          .add("file", file)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartFile.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartFile.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.multipart;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * An uploaded file received in a {@link Multipart} request.
+ */
+public interface MultipartFile {
+
+    /**
+     * Creates a new {@link MultipartFile}.
+     * @param name the name parameter of the {@code "content-disposition"}
+     * @param filename the filename parameter of the {@code "content-disposition"}
+     *                 header.
+     * @param file the file that stores the {@link BodyPart#content()}.
+     */
+    static MultipartFile of(@Nullable String name, String filename, File file) {
+        requireNonNull(file, "file");
+        requireNonNull(filename, "filename");
+        return new DefaultMultipartFile(name, filename, file);
+    }
+
+    /**
+     * Returns the {@code name} parameter of the {@code "content-disposition"} header.
+     * @see BodyPart#name()
+     */
+    @Nullable
+    String name();
+
+    /**
+     * Returns the filename parameter of the {@code "content-disposition"} header.
+     * @see BodyPart#filename()
+     */
+    String filename();
+
+    /**
+     * Returns the file that stores the {@link BodyPart#content()}.
+     */
+    File file();
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
@@ -16,29 +16,31 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
-import static java.util.Objects.requireNonNull;
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 
-import com.linecorp.armeria.common.AggregatedHttpObject;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ContentDisposition;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.MediaTypeNames;
+import com.linecorp.armeria.common.multipart.AggregatedBodyPart;
 import com.linecorp.armeria.common.multipart.BodyPart;
 import com.linecorp.armeria.common.multipart.Multipart;
+import com.linecorp.armeria.common.multipart.MultipartFile;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Consumes;
@@ -47,7 +49,8 @@ import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-public class AnnotatedServiceMultipartTest {
+class AnnotatedServiceMultipartTest {
+
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
@@ -56,53 +59,69 @@ public class AnnotatedServiceMultipartTest {
         }
     };
 
-    @Consumes("multipart/form-data")
-    public static class MyAnnotatedService {
-        @Post
-        @Path("/uploadWithFileParam")
-        public HttpResponse uploadWithFileParam(@Param File file1, @Param java.nio.file.Path path1,
-                                                @Param String param1) throws IOException {
-            return HttpResponse.from(CompletableFuture.supplyAsync(() -> {
-                try {
-                    final String file1Content = Files.asCharSource(file1, StandardCharsets.UTF_8).read();
-                    final String path1Content = Files.asCharSource(path1.toFile(), StandardCharsets.UTF_8)
-                                                     .read();
-                    return file1Content + '\n' + path1Content;
-                } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                }
-            }, ServiceRequestContext.current().blockingTaskExecutor()).thenApply(
-                    fileContent -> HttpResponse.of(fileContent + '\n' + param1)));
-        }
-
-        @Post
-        @Path("/uploadWithMultipartObject")
-        public HttpResponse uploadWithMultipartObject(Multipart multipart) {
-            return HttpResponse.from(
-                    multipart.aggregate()
-                             .thenApply(aggregated -> ImmutableList
-                                     .of(requireNonNull(aggregated.field("file1")),
-                                         requireNonNull(aggregated.field("path1")),
-                                         requireNonNull(aggregated.field("param1")))
-                                     .stream()
-                                     .map(AggregatedHttpObject::contentUtf8)
-                                     .collect(Collectors.joining("\n")))
-                             .thenApply(HttpResponse::of)
-            );
-        }
-    }
-
     @ParameterizedTest
     @ValueSource(strings = { "/uploadWithFileParam", "/uploadWithMultipartObject" })
     void testUploadFile(String path) throws Exception {
         final Multipart multipart = Multipart.of(
                 BodyPart.of(ContentDisposition.of("form-data", "file1", "foo.txt"), "foo"),
                 BodyPart.of(ContentDisposition.of("form-data", "path1", "bar.txt"), "bar"),
+                BodyPart.of(ContentDisposition.of("form-data", "multipartFile1", "qux.txt"), "qux"),
                 BodyPart.of(ContentDisposition.of("form-data", "param1"), "armeria")
 
         );
         final AggregatedHttpResponse response =
-                server.webClient().blocking().execute(multipart.toHttpRequest(path));
-        assertThat(response.contentUtf8()).isEqualTo("foo\nbar\narmeria");
+                server.blockingWebClient().execute(multipart.toHttpRequest(path));
+        assertThatJson(response.contentUtf8())
+                .isEqualTo("{\"file1\":\"foo\"," +
+                           "\"path1\":\"bar\"," +
+                           "\"multipartFile1\":\"qux.txt_qux\"," +
+                           "\"param1\":\"armeria\"}");
+    }
+
+    @Consumes(MediaTypeNames.MULTIPART_FORM_DATA)
+    private static class MyAnnotatedService {
+        @Post
+        @Path("/uploadWithFileParam")
+        public HttpResponse uploadWithFileParam(@Param File file1, @Param java.nio.file.Path path1,
+                                                @Param MultipartFile multipartFile1,
+                                                @Param String param1) throws IOException {
+            return HttpResponse.from(CompletableFuture.supplyAsync(() -> {
+                try {
+                    final String file1Content = Files.asCharSource(file1, StandardCharsets.UTF_8).read();
+                    final String path1Content = Files.asCharSource(path1.toFile(), StandardCharsets.UTF_8)
+                                                     .read();
+                    final String multipartFile1Content =
+                            Files.asCharSource(multipartFile1.file(), StandardCharsets.UTF_8)
+                                 .read();
+                    final ImmutableMap<String, String> content =
+                            ImmutableMap.of("file1", file1Content,
+                                            "path1", path1Content,
+                                            "multipartFile1",
+                                            multipartFile1.filename() + '_' + multipartFile1Content,
+                                            "param1", param1);
+                    return HttpResponse.ofJson(content);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }, ServiceRequestContext.current().blockingTaskExecutor()));
+        }
+
+        @Post
+        @Path("/uploadWithMultipartObject")
+        public HttpResponse uploadWithMultipartObject(Multipart multipart) {
+            return HttpResponse.from(multipart.aggregate().thenApply(aggregated -> {
+                final ImmutableMap<String, String> body =
+                        aggregated.names().stream().collect(toImmutableMap(Function.identity(), e -> {
+                            final AggregatedBodyPart bodyPart =
+                                    aggregated.field(e);
+                            String content = bodyPart.contentUtf8();
+                            if ("multipartFile1".equals(e)) {
+                                content = bodyPart.filename() + '_' + content;
+                            }
+                            return content;
+                        }));
+                return HttpResponse.ofJson(body);
+            }));
+        }
     }
 }

--- a/site/src/pages/docs/server-multipart.mdx
+++ b/site/src/pages/docs/server-multipart.mdx
@@ -1,0 +1,138 @@
+# Handling a multipart request
+
+Armeria provides <type://Multipart> encoder and decoder built on top of 
+[Reactive Streams](https://www.reactive-streams.org/).
+
+## Building a multipart request
+
+A <type://Multipart> consists of multiple <typeplural://BodyPart>.
+Each <type://BodyPart> is divided into a headers and a body. A <type://BodyPart> headers can be created simply 
+using <type://ContentDisposition>. You can use <type://HttpHeaders> to set a complex headers as well. 
+`String`, <type://HttpData>, or <type://StreamMessage> can be set as the body of the <type://BodyPart>.
+
+```java
+import java.nio.file.Path;
+import com.linecorp.armeria.common.ContentDisposition;
+import com.linecorp.armeria.common.multipart.BodyPart;
+
+// Create a 'Content-Disposition' header for 'name' field.
+ContentDisposition nameDisposition = 
+    ContentDisposition.of("form-data", "name");
+// Create a BodyPart with 'Content-Disposition' header and its data.
+BodyPart bodyPart1 = BodyPart.of(nameDisposition, "Meri Kim");
+
+// Create a 'Content-Disposition' header for 'image' field.
+ContentDisposition imageDisposition =
+    ContentDisposition.of("form-data", "image", "profile.png");
+Path image = Paths.get("/path/to/image");
+// Create a BodyPart with 'Content-Disposition' header and its file.
+BodyPart bodyPart2 = BodyPart.of(imageDisposition, StreamMessage.of(image));
+
+// Create a new multipart with two body parts.
+Multipart multipart = Multipart.of(bodyPart1, bodyPart2);
+```
+
+If we decode and print the <type://Multipart> created above,
+```java
+for (HttpData httpData : multipart.toStreamMessage().collect().join()) {
+  System.out.print(httpData.toStringUtf8());
+}
+```
+we will see a raw multipart data as shown below:
+```
+--ArmeriaBoundaryEsbNVr9Z66DAIYIN
+content-disposition:form-data; name="name"
+content-type:text/plain
+
+Meri Kim
+--ArmeriaBoundaryEsbNVr9Z66DAIYIN
+content-disposition:form-data; name="image"; filename="profile.png"
+content-type:application/octet-stream
+
+<binary-data>
+```
+
+## Sending a multipart request
+
+The <type://Multipart> created in this way can be converted to a <type://HttpRequest> through 
+<type://MultiPart#toHttpRequest(String)> and transmitted to a server using a <type://WebClient>.
+
+```java
+WebClient client = WebClient.of("https://armeria.dev");
+// Encode a `Multipart` into an `HttpRequest`
+HttpRequest request = multipart.toHttpRequest("/upload");
+client.execute(request).aggregate()...;
+```
+
+## Receiving a multipart request
+
+On the server side, the multipart HTTP request sent from the client can be decoded into a <type://Multipart>
+using <type://Multipart#from(HttpRequest)>.
+```java
+Server.builder()
+      .service((ctx, req) -> {
+        // Decode an `HttpRequest` into a `Multipart`
+        Multipart multipart = Multipart.from(req);
+        ...
+      })
+```
+Since <type://Multipart> does not have the actual multipart data, you can use 
+`Multipart.bodyParts().subscribe(...)` to read data little by little as needed.
+If the size of the data is not large, the data can be read after being loaded into memory through 
+<type://Multipart#aggregate()>.
+```java
+// Use Reactive Streams' Subscriber to read the data with backpressure.
+multiPart.bodyParts().subsribe(new Subsriber() {
+   ...
+});
+
+// Read the data after aggregation.
+Multipart.from(req).aggregate()
+         .thenAccept(multipart -> {
+             for (AggregatedBodyPart bodyPart : multipart.bodyParts()) {
+                 String content = bodyPart.contentUtf8();
+                 ...
+             }
+         });
+```
+
+## Using <type://@Param> annotation
+
+In Annotated service, you can directly map the body part data of `multipart/form-data` to `String`, `Path`, 
+`File`, or <type://Multipart> using `@Param` annotation.
+
+<Tip>
+
+Note that a <type://BodyPart> can be converted into a `Path`, `File` or <type://Multipart> only when 
+a <type://ContentDisposition#filename()> is specified.
+
+</Tip>
+
+```java
+import java.io.File;
+import java.nio.file.Path;
+
+import com.linecorp.armeria.common.MediaTypeNames;
+import com.linecorp.armeria.common.multipart.MultipartFile;
+import com.linecorp.armeria.server.annotation.Consumes;
+import com.linecorp.armeria.server.annotation.Post;
+
+@Consumes(MediaTypeNames.MULTIPART_FORM_DATA)
+@Post("/upload")
+public HttpResponse upload(
+    @Param String param,
+    @Param File file,
+    @Param Path path,
+    @Param MultipartFile multipartFile) {
+    // Do something with the multipart data
+    ...
+}
+```
+
+<Tip>
+
+The multipart files created by annotated service are stored into
+<type://ServerBuilder#multipartUploadsLocation(Path)> and the files are not removed automatically. 
+You should explicitly **delete** the files after use.
+
+</Tip>

--- a/site/src/pages/docs/toc.json
+++ b/site/src/pages/docs/toc.json
@@ -14,6 +14,7 @@
     "server-decorator",
     "server-grpc",
     "server-thrift",
+    "server-graphql",
     "server-docservice",
     "server-annotated-service",
     "server-http-file",
@@ -22,7 +23,7 @@
     "server-cors",
     "server-sse",
     "server-service-registration",
-    "server-graphql"
+    "server-multipart"
   ],
   "Client": [
     "client-http",


### PR DESCRIPTION
Motivation:

If a file is uploaded to a server using an annotated service,
the actual filename specified in the Content-Disposition header is lost
because a random file is created to avoid duplicate file names.

Modifications:

- Add `MultipartFile` to get the actual filename of a `BodyPart`.
- Add documentation for the usage of `Multipart`
  - How to encode and decode `Multipart` from and to `HttpRequest`
  - How to bind `multipart/form-data` in annotated services

Result:

You can now use `MultipartFile` to get the actual filename of an
uploaded file through `multipart/form-data`.
```java
@Consumes(MediaTypeNames.MULTIPART_FORM_DATA)
@Post("/upload")
public HttpResponse upload(@Param MultipartFile multipartFile) {
  // The name parameter of the "content-disposition" header
  String name = multipartFile.name();
  // The filename parameter of the "content-disposition" header
  String filename = multipartFile.filename();
  // The file that stores the part content.
  File file = multipartFile.file();
}
```
