### PR TITLE
Add `RestClient` for Java, Kotlin Coroutine and Scala

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
@@ -50,7 +50,7 @@ import io.netty.util.AttributeKey;
  */
 @UnstableApi
 public final class BlockingWebClientRequestPreparation
-        implements RequestPreparationSetters<AggregatedHttpResponse> {
+        implements WebRequestPreparationSetters<AggregatedHttpResponse> {
 
     private final WebClientRequestPreparation delegate;
 
@@ -350,6 +350,12 @@ public final class BlockingWebClientRequestPreparation
     public BlockingWebClientRequestPreparation headers(
             Iterable<? extends Entry<? extends CharSequence, String>> headers) {
         delegate.headers(headers);
+        return this;
+    }
+
+    @Override
+    public BlockingWebClientRequestPreparation trailer(CharSequence name, Object value) {
+        delegate.trailer(name, value);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.Scheme;
+
+final class DefaultRestClient implements RestClient {
+
+    static final RestClient DEFAULT = new DefaultRestClient(WebClient.of());
+
+    private final WebClient delegate;
+
+    DefaultRestClient(WebClient delegate) {
+        requireNonNull(delegate, "delegate");
+        this.delegate = delegate;
+    }
+
+    @Override
+    public RestClientPreparation path(HttpMethod method, String path) {
+        requireNonNull(method, "method");
+        requireNonNull(path, "path");
+        return new RestClientPreparation(delegate, method, path);
+    }
+
+    @Override
+    public Scheme scheme() {
+        return delegate.scheme();
+    }
+
+    @Override
+    public EndpointGroup endpointGroup() {
+        return delegate.endpointGroup();
+    }
+
+    @Override
+    public String absolutePathRef() {
+        return delegate.absolutePathRef();
+    }
+
+    @Override
+    public URI uri() {
+        return delegate.uri();
+    }
+
+    @Override
+    public Class<?> clientType() {
+        return delegate.clientType();
+    }
+
+    @Override
+    public ClientOptions options() {
+        return delegate.options();
+    }
+
+    @Override
+    public HttpClient unwrap() {
+        return delegate.unwrap();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -40,6 +40,8 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
 
     @Nullable
     private BlockingWebClient blockingWebClient;
+    @Nullable
+    private RestClient restClient;
 
     DefaultWebClient(ClientBuilderParams params, HttpClient delegate, MeterRegistry meterRegistry) {
         super(params, delegate, meterRegistry,
@@ -128,6 +130,14 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
             return blockingWebClient;
         }
         return blockingWebClient = new DefaultBlockingWebClient(this);
+    }
+
+    @Override
+    public RestClient asRestClient() {
+        if (restClient != null) {
+            return restClient;
+        }
+        return restClient = RestClient.of(this);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -49,7 +49,7 @@ import io.netty.util.AttributeKey;
  */
 @UnstableApi
 public final class FutureTransformingRequestPreparation<T>
-        implements RequestPreparationSetters<CompletableFuture<T>> {
+        implements WebRequestPreparationSetters<CompletableFuture<T>> {
 
     private static final Logger logger = LoggerFactory.getLogger(FutureTransformingRequestPreparation.class);
 
@@ -288,6 +288,12 @@ public final class FutureTransformingRequestPreparation<T>
     public FutureTransformingRequestPreparation<T> headers(
             Iterable<? extends Entry<? extends CharSequence, String>> headers) {
         delegate.headers(headers);
+        return this;
+    }
+
+    @Override
+    public FutureTransformingRequestPreparation<T> trailer(CharSequence name, Object value) {
+        delegate.trailer(name, value);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
@@ -21,12 +21,14 @@ import java.time.Duration;
 import com.linecorp.armeria.common.HttpMessageSetters;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.PathAndQueryParamSetters;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.netty.util.AttributeKey;
 
 /**
  * Sets properties for building an {@link HttpRequest} and {@link RequestOptions}.
  */
+@UnstableApi
 public interface RequestPreparationSetters extends PathAndQueryParamSetters, HttpMessageSetters,
                                                    RequestOptionsSetters {
 

--- a/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
@@ -18,21 +18,22 @@ package com.linecorp.armeria.client;
 
 import java.time.Duration;
 
-import com.linecorp.armeria.common.HttpRequestSetters;
+import com.linecorp.armeria.common.HttpMessageSetters;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.PathAndQueryParamSetters;
 
 import io.netty.util.AttributeKey;
 
-interface RequestPreparationSetters<T> extends HttpRequestSetters, RequestOptionsSetters {
-
-    /**
-     * Builds and executes the request.
-     */
-    T execute();
+/**
+ * Sets properties for building an {@link HttpRequest} and {@link RequestOptions}.
+ */
+public interface RequestPreparationSetters extends PathAndQueryParamSetters, HttpMessageSetters,
+                                                   RequestOptionsSetters {
 
     /**
      * Sets the specified {@link RequestOptions} that could overwrite the previously configured values such as
      * {@link #responseTimeout(Duration)}, {@link #writeTimeout(Duration)}, {@link #maxResponseLength(long)}
      * and {@link #attr(AttributeKey, Object)}.
      */
-    RequestPreparationSetters<T> requestOptions(RequestOptions requestOptions);
+    RequestPreparationSetters requestOptions(RequestOptions requestOptions);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestPreparationSetters.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import io.netty.util.AttributeKey;
 
 /**
- * Sets properties for building an {@link HttpRequest} and {@link RequestOptions}.
+ * provides the setters for building an {@link HttpRequest} and {@link RequestOptions}.
  */
 @UnstableApi
 public interface RequestPreparationSetters extends PathAndQueryParamSetters, HttpMessageSetters,

--- a/core/src/main/java/com/linecorp/armeria/client/RestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClient.java
@@ -27,8 +27,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
- * A client designed for calling <a href="https://restfulapi.net/">RESTful APIs</a>
- * conveniently.
+ * A client designed for calling <a href="https://restfulapi.net/">RESTful APIs</a> conveniently.
  */
 @UnstableApi
 public interface RestClient extends ClientBuilderParams, Unwrappable {

--- a/core/src/main/java/com/linecorp/armeria/client/RestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClient.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.util.Unwrappable;
 /**
  * A <a href="https://restfulapi.net/">REST</a> client.
  * This client is designed to easily exchange RESTful APIs.
- * If you want to handle a non-JSON or streaming response, please use {@link WebClient}.
  */
 @UnstableApi
 public interface RestClient extends ClientBuilderParams, Unwrappable {

--- a/core/src/main/java/com/linecorp/armeria/client/RestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClient.java
@@ -27,8 +27,8 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
- * A <a href="https://restfulapi.net/">REST</a> client.
- * This client is designed to easily exchange RESTful APIs.
+ * A client designed for calling <a href="https://restfulapi.net/">RESTful APIs</a>
+ * conveniently.
  */
 @UnstableApi
 public interface RestClient extends ClientBuilderParams, Unwrappable {

--- a/core/src/main/java/com/linecorp/armeria/client/RestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClient.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.Unwrappable;
+
+/**
+ * A <a href="https://restfulapi.net/">REST</a> client.
+ * This client is designed to easily exchange RESTful APIs.
+ * If you want to handle a non-JSON or streaming response, please use {@link WebClient}.
+ */
+@UnstableApi
+public interface RestClient extends ClientBuilderParams, Unwrappable {
+
+    /**
+     * Returns a {@link RestClient} without a base URI using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
+     */
+    static RestClient of() {
+        return DefaultRestClient.DEFAULT;
+    }
+
+    /**
+     * Returns a new {@link RestClient} with the specified {@link WebClient}.
+     */
+    static RestClient of(WebClient webClient) {
+        requireNonNull(webClient, "webClient");
+
+        if (webClient == WebClient.of()) {
+            return of();
+        }
+        return new DefaultRestClient(webClient);
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@code uri} using the default options.
+     *
+     * @param uri the URI of the server endpoint
+     *
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(String uri) {
+        return builder(uri).build();
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@link URI} using the default options.
+     *
+     * @param uri the {@link URI} of the server endpoint
+     *
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(URI uri) {
+        return builder(uri).build();
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@code protocol} using the default {@link ClientFactory} and the default
+     * {@link ClientOptions}.
+     *
+     * @param protocol the session protocol of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(String protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} using the default {@link ClientFactory} and the default
+     * {@link ClientOptions}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(SessionProtocol protocol, EndpointGroup endpointGroup) {
+        return builder(protocol, endpointGroup).build();
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@code protocol} and {@code path} using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
+     *
+     * @param protocol the session protocol of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(String protocol, EndpointGroup endpointGroup, String path) {
+        return builder(protocol, endpointGroup, path).build();
+    }
+
+    /**
+     * Returns a new {@link RestClient} that connects to the specified {@link EndpointGroup} with
+     * the specified {@link SessionProtocol} and {@code path} using the default {@link ClientFactory} and
+     * the default {@link ClientOptions}.
+     *
+     * @param protocol the {@link SessionProtocol} of the {@link EndpointGroup}
+     * @param endpointGroup the server {@link EndpointGroup}
+     * @param path the path to the endpoint
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClient of(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
+        return builder(protocol, endpointGroup, path).build();
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created without a base {@link URI}.
+     */
+    static RestClientBuilder builder() {
+        return new RestClientBuilder();
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified base {@code uri}.
+     *
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(String uri) {
+        return builder(URI.create(requireNonNull(uri, "uri")));
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified base {@link URI}.
+     *
+     * @throws IllegalArgumentException if the {@code uri} is not valid or its scheme is not one of the values
+     *                                  in {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(URI uri) {
+        return new RestClientBuilder(uri);
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified {@code protocol}
+     * and base {@link EndpointGroup}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(String protocol, EndpointGroup endpointGroup) {
+        return builder(SessionProtocol.of(requireNonNull(protocol, "protocol")), endpointGroup);
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified {@link SessionProtocol}
+     * and base {@link EndpointGroup}.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return new RestClientBuilder(protocol, endpointGroup, null);
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified {@code protocol}.
+     * base {@link EndpointGroup} and path.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(String protocol, EndpointGroup endpointGroup, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
+        return builder(SessionProtocol.of(protocol), endpointGroup, path);
+    }
+
+    /**
+     * Returns a new {@link RestClientBuilder} created with the specified {@link SessionProtocol},
+     * base {@link EndpointGroup} and path.
+     *
+     * @throws IllegalArgumentException if the {@code protocol} is not one of the values in
+     *                                  {@link SessionProtocol#httpValues()} or
+     *                                  {@link SessionProtocol#httpsValues()}.
+     */
+    static RestClientBuilder builder(SessionProtocol protocol, EndpointGroup endpointGroup, String path) {
+        requireNonNull(protocol, "protocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(path, "path");
+        return new RestClientBuilder(protocol, endpointGroup, path);
+    }
+
+    /**
+     * Sets an {@link HttpMethod#GET} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Customer>> response =
+     *     restClient.get("/api/v1/customers/{customerId}")
+     *               .pathParam("customerId", "0000001")
+     *               .execute(Customer.class);
+     * }</pre>
+     */
+    default RestClientPreparation get(String path) {
+        return path(HttpMethod.GET, path);
+    }
+
+    /**
+     * Sets an {@link HttpMethod#POST} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Result>> response =
+     *     restClient.post("/api/v1/customers")
+     *               .contentJson(new Customer(...))
+     *               .execute(Result.class);
+     * }</pre>
+     */
+    default RestClientPreparation post(String path) {
+        return path(HttpMethod.POST, path);
+    }
+
+    /**
+     * Sets an {@link HttpMethod#PUT} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Result>> response =
+     *     restClient.put("/api/v1/customers")
+     *               .contentJson(new Customer(...))
+     *               .execute(Result.class);
+     * }</pre>
+     */
+    default RestClientPreparation put(String path) {
+        return path(HttpMethod.PUT, path);
+    }
+
+    /**
+     * Sets an {@link HttpMethod#PATCH} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Result>> response =
+     *     restClient.patch("/api/v1/customers")
+     *               .contentJson(new Customer(...))
+     *               .execute(Result.class);
+     * }</pre>
+     */
+    default RestClientPreparation patch(String path) {
+        return path(HttpMethod.PATCH, path);
+    }
+
+    /**
+     * Sets an {@link HttpMethod#DELETE} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Result>> response =
+     *     restClient.delete("/api/v1/customers")
+     *               .pathParam("customerId", "0000001")
+     *               .execute(Result.class);
+     * }</pre>
+     */
+    default RestClientPreparation delete(String path) {
+        return path(HttpMethod.DELETE, path);
+    }
+
+    /**
+     * Sets the {@link HttpMethod} and the {@code path} and returns a fluent request builder.
+     * <pre>{@code
+     * RestClient restClient = RestClient.of("...");
+     * CompletableFuture<ResponseEntity<Customer>> response =
+     *     restClient.path(HttpMethod.GET, "/api/v1/customers/{customerId}")
+     *               .pathParam("customerId", "0000001")
+     *               .execute(Customer.class);
+     * }</pre>
+     */
+    RestClientPreparation path(HttpMethod method, String path);
+
+    @Override
+    HttpClient unwrap();
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -38,7 +38,6 @@ import com.linecorp.armeria.common.auth.OAuth2Token;
 /**
  * Creates a new <a href="https://restfulapi.net/">REST</a> client that connects to the specified {@link URI}
  * using the builder pattern. This client is designed to easily exchange RESTful APIs.
- * If you want to handle a non-JSON or streaming response, please use {@link WebClient}.
  *
  * <p>Use the factory methods in {@link RestClient} if you do not have many options to
  * override. Please refer to {@link ClientBuilder} for how decorators and HTTP headers are configured.

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.redirect.RedirectConfig;
+import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.OAuth1aToken;
+import com.linecorp.armeria.common.auth.OAuth2Token;
+
+/**
+ * Creates a new <a href="https://restfulapi.net/">REST</a> client that connects to the specified {@link URI}
+ * using the builder pattern. This client is designed to easily exchange RESTful APIs.
+ * If you want to handle a non-JSON or streaming response, please use {@link WebClient}.
+ *
+ * <p>Use the factory methods in {@link RestClient} if you do not have many options to
+ * override. Please refer to {@link ClientBuilder} for how decorators and HTTP headers are configured.
+ */
+@UnstableApi
+public final class RestClientBuilder extends AbstractWebClientBuilder {
+
+    /**
+     * Creates a new instance.
+     */
+    RestClientBuilder() {}
+
+    /**
+     * Creates a new instance.
+     *
+     * @throws IllegalArgumentException if the scheme of the uri is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    RestClientBuilder(URI uri) {
+        super(uri);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @throws IllegalArgumentException if the {@code sessionProtocol} is not one of the fields
+     *                                  in {@link SessionProtocol}
+     */
+    RestClientBuilder(SessionProtocol sessionProtocol, EndpointGroup endpointGroup, @Nullable String path) {
+        super(sessionProtocol, endpointGroup, path);
+    }
+
+    /**
+     * Returns a newly-created web client based on the properties of this builder.
+     *
+     * @throws IllegalArgumentException if the scheme of the {@code uri} specified in
+     *                                  {@link RestClient#builder(String)} or
+     *                                  {@link RestClient#builder(URI)} is not an HTTP scheme
+     */
+    public RestClient build() {
+        return new DefaultRestClient(buildWebClient());
+    }
+
+    // Override the return type of the chaining methods in the superclass.
+
+    @Deprecated
+    @Override
+    public RestClientBuilder rpcDecorator(Function<? super RpcClient, ? extends RpcClient> decorator) {
+        return (RestClientBuilder) super.rpcDecorator(decorator);
+    }
+
+    @Deprecated
+    @Override
+    public RestClientBuilder rpcDecorator(DecoratingRpcClientFunction decorator) {
+        return (RestClientBuilder) super.rpcDecorator(decorator);
+    }
+
+    @Override
+    public RestClientBuilder options(ClientOptions options) {
+        return (RestClientBuilder) super.options(options);
+    }
+
+    @Override
+    public RestClientBuilder options(ClientOptionValue<?>... options) {
+        return (RestClientBuilder) super.options(options);
+    }
+
+    @Override
+    public RestClientBuilder options(Iterable<ClientOptionValue<?>> options) {
+        return (RestClientBuilder) super.options(options);
+    }
+
+    @Override
+    public <T> RestClientBuilder option(ClientOption<T> option, T value) {
+        return (RestClientBuilder) super.option(option, value);
+    }
+
+    @Override
+    public <T> RestClientBuilder option(ClientOptionValue<T> optionValue) {
+        return (RestClientBuilder) super.option(optionValue);
+    }
+
+    @Override
+    public RestClientBuilder factory(ClientFactory factory) {
+        return (RestClientBuilder) super.factory(factory);
+    }
+
+    @Override
+    public RestClientBuilder writeTimeout(Duration writeTimeout) {
+        return (RestClientBuilder) super.writeTimeout(writeTimeout);
+    }
+
+    @Override
+    public RestClientBuilder writeTimeoutMillis(long writeTimeoutMillis) {
+        return (RestClientBuilder) super.writeTimeoutMillis(writeTimeoutMillis);
+    }
+
+    @Override
+    public RestClientBuilder responseTimeout(Duration responseTimeout) {
+        return (RestClientBuilder) super.responseTimeout(responseTimeout);
+    }
+
+    @Override
+    public RestClientBuilder responseTimeoutMillis(long responseTimeoutMillis) {
+        return (RestClientBuilder) super.responseTimeoutMillis(responseTimeoutMillis);
+    }
+
+    @Override
+    public RestClientBuilder maxResponseLength(long maxResponseLength) {
+        return (RestClientBuilder) super.maxResponseLength(maxResponseLength);
+    }
+
+    @Override
+    public RestClientBuilder requestIdGenerator(Supplier<RequestId> requestIdGenerator) {
+        return (RestClientBuilder) super.requestIdGenerator(requestIdGenerator);
+    }
+
+    @Override
+    public RestClientBuilder successFunction(SuccessFunction successFunction) {
+        return (RestClientBuilder) super.successFunction(successFunction);
+    }
+
+    @Override
+    public RestClientBuilder endpointRemapper(
+            Function<? super Endpoint, ? extends EndpointGroup> endpointRemapper) {
+        return (RestClientBuilder) super.endpointRemapper(endpointRemapper);
+    }
+
+    @Override
+    public RestClientBuilder decorator(
+            Function<? super HttpClient, ? extends HttpClient> decorator) {
+        return (RestClientBuilder) super.decorator(decorator);
+    }
+
+    @Override
+    public RestClientBuilder decorator(DecoratingHttpClientFunction decorator) {
+        return (RestClientBuilder) super.decorator(decorator);
+    }
+
+    @Override
+    public RestClientBuilder clearDecorators() {
+        return (RestClientBuilder) super.clearDecorators();
+    }
+
+    @Override
+    public RestClientBuilder addHeader(CharSequence name, Object value) {
+        return (RestClientBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public RestClientBuilder addHeaders(
+            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (RestClientBuilder) super.addHeaders(headers);
+    }
+
+    @Override
+    public RestClientBuilder setHeader(CharSequence name, Object value) {
+        return (RestClientBuilder) super.setHeader(name, value);
+    }
+
+    @Override
+    public RestClientBuilder setHeaders(
+            Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
+        return (RestClientBuilder) super.setHeaders(headers);
+    }
+
+    @Override
+    public RestClientBuilder auth(BasicToken token) {
+        return (RestClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public RestClientBuilder auth(OAuth1aToken token) {
+        return (RestClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public RestClientBuilder auth(OAuth2Token token) {
+        return (RestClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public RestClientBuilder auth(AuthToken token) {
+        return (RestClientBuilder) super.auth(token);
+    }
+
+    @Override
+    public RestClientBuilder followRedirects() {
+        return (RestClientBuilder) super.followRedirects();
+    }
+
+    @Override
+    public RestClientBuilder followRedirects(RedirectConfig redirectConfig) {
+        return (RestClientBuilder) super.followRedirects(redirectConfig);
+    }
+
+    @Override
+    public RestClientBuilder contextCustomizer(
+            Consumer<? super ClientRequestContext> contextCustomizer) {
+        return (RestClientBuilder) super.contextCustomizer(contextCustomizer);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
+
+import org.reactivestreams.Publisher;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.errorprone.annotations.FormatMethod;
+
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.JacksonObjectMapperProvider;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * Prepares and executes a new {@link HttpRequest} for {@link RestClient}.
+ */
+@UnstableApi
+public final class RestClientPreparation implements RequestPreparationSetters {
+
+    private final WebClientRequestPreparation delegate;
+
+    RestClientPreparation(WebClient client, HttpMethod method, String path) {
+        delegate = client.prepare();
+        delegate.method(method);
+        delegate.path(path);
+    }
+
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     *
+     * @see JacksonObjectMapperProvider
+     */
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz) {
+        requireNonNull(clazz, "clazz");
+        @SuppressWarnings("ThreadJoinLoop")
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz).execute();
+        return cast(response);
+    }
+
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     */
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, mapper).execute();
+        return cast(response);
+    }
+
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     *
+     * @see JacksonObjectMapperProvider
+     */
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef) {
+        requireNonNull(typeRef, "typeRef");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef).execute();
+        return cast(response);
+    }
+
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     */
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            ObjectMapper mapper) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, mapper).execute();
+        return cast(response);
+    }
+
+    /**
+     * Sends the HTTP request and converts the {@link HttpResponse} using the {@link ResponseAs}.
+     */
+    public <T> T execute(ResponseAs<HttpResponse, T> responseAs) {
+        requireNonNull(responseAs, "responseAs");
+        return delegate.as(responseAs).execute();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object any) {
+        return (T) any;
+    }
+
+    @Override
+    public RestClientPreparation pathParam(String name, Object value) {
+        delegate.pathParam(name, value);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation pathParams(Map<String, ?> pathParams) {
+        delegate.pathParams(pathParams);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation disablePathParams() {
+        delegate.disablePathParams();
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation queryParam(String name, Object value) {
+        delegate.queryParam(name, value);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation queryParams(
+            Iterable<? extends Entry<? extends String, String>> queryParams) {
+        delegate.queryParams(queryParams);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(String content) {
+        delegate.content(content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(MediaType contentType, CharSequence content) {
+        delegate.content(contentType, content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(MediaType contentType, String content) {
+        delegate.content(contentType, content);
+        return this;
+    }
+
+    @Override
+    @FormatMethod
+    public RestClientPreparation content(String format, Object... content) {
+        delegate.content(format, content);
+        return this;
+    }
+
+    @Override
+    @FormatMethod
+    public RestClientPreparation content(MediaType contentType, String format, Object... content) {
+        delegate.content(contentType, format, content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(MediaType contentType, byte[] content) {
+        delegate.content(contentType, content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(MediaType contentType, HttpData content) {
+        delegate.content(contentType, content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation content(MediaType contentType, Publisher<? extends HttpData> content) {
+        delegate.content(contentType, content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation contentJson(Object content) {
+        delegate.contentJson(content);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation header(CharSequence name, Object value) {
+        delegate.header(name, value);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation headers(Iterable<? extends Entry<? extends CharSequence, String>> headers) {
+        delegate.headers(headers);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation trailer(CharSequence name, Object value) {
+        delegate.trailer(name, value);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation trailers(Iterable<? extends Entry<? extends CharSequence, String>> trailers) {
+        delegate.trailers(trailers);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation cookie(Cookie cookie) {
+        delegate.cookie(cookie);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation cookies(Iterable<? extends Cookie> cookies) {
+        delegate.cookies(cookies);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation responseTimeout(Duration responseTimeout) {
+        delegate.responseTimeout(responseTimeout);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation responseTimeoutMillis(long responseTimeoutMillis) {
+        delegate.responseTimeoutMillis(responseTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation writeTimeout(Duration writeTimeout) {
+        delegate.writeTimeout(writeTimeout);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation writeTimeoutMillis(long writeTimeoutMillis) {
+        delegate.writeTimeoutMillis(writeTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation maxResponseLength(long maxResponseLength) {
+        delegate.maxResponseLength(maxResponseLength);
+        return this;
+    }
+
+    @Override
+    public <V> RestClientPreparation attr(AttributeKey<V> key, @Nullable V value) {
+        delegate.attr(key, value);
+        return this;
+    }
+
+    @Override
+    public RestClientPreparation requestOptions(RequestOptions requestOptions) {
+        delegate.requestOptions(requestOptions);
+        return this;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -64,7 +64,6 @@ public final class RestClientPreparation implements RequestPreparationSetters {
      */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz) {
         requireNonNull(clazz, "clazz");
-        @SuppressWarnings("ThreadJoinLoop")
         final CompletableFuture<? extends ResponseEntity<? extends T>> response =
                 delegate.asJson(clazz).execute();
         return cast(response);

--- a/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
@@ -42,12 +42,12 @@ import io.netty.util.AttributeKey;
  * transforms an {@link HttpResponse} into the {@code T} type object.
  */
 @UnstableApi
-public class TransformingRequestPreparation<T, R> implements RequestPreparationSetters<R> {
+public class TransformingRequestPreparation<T, R> implements WebRequestPreparationSetters<R> {
 
-    private final RequestPreparationSetters<T> delegate;
+    private final WebRequestPreparationSetters<T> delegate;
     private ResponseAs<T, R> responseAs;
 
-    TransformingRequestPreparation(RequestPreparationSetters<T> delegate, ResponseAs<T, R> responseAs) {
+    TransformingRequestPreparation(WebRequestPreparationSetters<T> delegate, ResponseAs<T, R> responseAs) {
         this.delegate = delegate;
         this.responseAs = responseAs;
     }
@@ -206,6 +206,12 @@ public class TransformingRequestPreparation<T, R> implements RequestPreparationS
     public TransformingRequestPreparation<T, R> headers(
             Iterable<? extends Entry<? extends CharSequence, String>> headers) {
         delegate.headers(headers);
+        return this;
+    }
+
+    @Override
+    public TransformingRequestPreparation<T, R> trailer(CharSequence name, Object value) {
+        delegate.trailer(name, value);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -598,6 +598,14 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
     @UnstableApi
     BlockingWebClient blocking();
 
+    /**
+     * Returns a {@link RestClient} that connects to the same {@link URI} with this {@link WebClient}.
+     */
+    @UnstableApi
+    default RestClient toRestClient() {
+        return RestClient.of(this);
+    }
+
     @Override
     HttpClient unwrap();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -602,9 +602,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      * Returns a {@link RestClient} that connects to the same {@link URI} with this {@link WebClient}.
      */
     @UnstableApi
-    default RestClient toRestClient() {
-        return RestClient.of(this);
-    }
+    RestClient asRestClient();
 
     @Override
     HttpClient unwrap();

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -79,11 +79,13 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
 
     // Override the return type of the chaining methods in the superclass.
 
+    @Deprecated
     @Override
     public WebClientBuilder rpcDecorator(Function<? super RpcClient, ? extends RpcClient> decorator) {
         return (WebClientBuilder) super.rpcDecorator(decorator);
     }
 
+    @Deprecated
     @Override
     public WebClientBuilder rpcDecorator(DecoratingRpcClientFunction decorator) {
         return (WebClientBuilder) super.rpcDecorator(decorator);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -50,8 +50,8 @@ import io.netty.util.AttributeKey;
 /**
  * Prepares and executes a new {@link HttpRequest} for {@link WebClient}.
  */
-public final class WebClientRequestPreparation extends AbstractHttpRequestBuilder
-        implements RequestPreparationSetters<HttpResponse> {
+public final class WebClientRequestPreparation
+        extends AbstractHttpRequestBuilder implements WebRequestPreparationSetters<HttpResponse> {
 
     private final WebClient client;
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebRequestPreparationSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebRequestPreparationSetters.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestMethodSetters;
+
+/**
+ * Sets properties for building an {@link HttpRequest} using {@link WebClientRequestPreparation}.
+ */
+interface WebRequestPreparationSetters<T> extends RequestPreparationSetters, RequestMethodSetters {
+
+    /**
+     * Builds and executes the request.
+     */
+    T execute();
+}

--- a/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/BackoffWrapper.java
@@ -22,6 +22,9 @@ import com.linecorp.armeria.common.util.AbstractUnwrappable;
  */
 public class BackoffWrapper extends AbstractUnwrappable<Backoff> implements Backoff {
 
+    /**
+     * Creates an {@link BackoffWrapper} with the specified {@code delegate}.
+     */
     protected BackoffWrapper(Backoff delegate) {
         super(delegate);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -29,12 +29,14 @@ import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.internal.common.JacksonUtil;
 
 /**
  * A skeletal builder implementation for {@link HttpMessage}.
  */
 @SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
+@UnstableApi
 public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -48,6 +48,9 @@ public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
     @Nullable
     private HttpHeadersBuilder httpTrailers;
 
+    /**
+     * Creates a new instance.
+     */
     protected AbstractHttpMessageBuilder() {}
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -157,7 +157,7 @@ public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
     }
 
     @Override
-    public HttpMessageSetters trailer(CharSequence name, Object value) {
+    public AbstractHttpMessageBuilder trailer(CharSequence name, Object value) {
         requireNonNull(name, "name");
         requireNonNull(value, "value");
         if (httpTrailers == null) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.Locale;
+import java.util.Map.Entry;
+
+import org.reactivestreams.Publisher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Sets properties for building an {@link HttpMessage}.
+ */
+@UnstableApi
+public interface HttpMessageSetters {
+
+    /**
+     * Sets the content as UTF_8 for this message.
+     */
+    HttpMessageSetters content(String content);
+
+    /**
+     * Sets the content for this message.
+     */
+    HttpMessageSetters content(MediaType contentType, CharSequence content);
+
+    /**
+     * Sets the content for this message.
+     */
+    HttpMessageSetters content(MediaType contentType, String content);
+
+    /**
+     * Sets the content as UTF_8 for this message. The {@code content} is formatted by
+     * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
+     */
+    @FormatMethod
+    HttpMessageSetters content(@FormatString String format, Object... content);
+
+    /**
+     * Sets the content for this message. The {@code content} is formatted by
+     * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
+     */
+    @FormatMethod
+    HttpMessageSetters content(MediaType contentType, @FormatString String format,
+                               Object... content);
+
+    /**
+     * Sets the content for this message. The {@code content} will be wrapped using
+     * {@link HttpData#wrap(byte[])}, so any changes made to {@code content} will be reflected in the request.
+     */
+    HttpMessageSetters content(MediaType contentType, byte[] content);
+
+    /**
+     * Sets the content for this message.
+     */
+    HttpMessageSetters content(MediaType contentType, HttpData content);
+
+    /**
+     * Sets the {@link Publisher} for this message.
+     */
+    HttpMessageSetters content(MediaType contentType, Publisher<? extends HttpData> content);
+
+    /**
+     * Sets the content for this message. The {@code content} is converted into JSON format
+     * using the default {@link ObjectMapper}.
+     */
+    HttpMessageSetters contentJson(Object content);
+
+    /**
+     * Adds a header for this message.
+     */
+    HttpMessageSetters header(CharSequence name, Object value);
+
+    /**
+     * Adds multiple headers for this message.
+     *
+     * @see HttpHeaders
+     */
+    HttpMessageSetters headers(
+            Iterable<? extends Entry<? extends CharSequence, String>> headers);
+
+    /**
+     * Adds an HTTP trailer for this message.
+     */
+    HttpMessageSetters trailer(CharSequence name, Object value);
+
+    /**
+     * Adds HTTP trailers for this message.
+     */
+    HttpMessageSetters trailers(
+            Iterable<? extends Entry<? extends CharSequence, String>> trailers);
+
+    /**
+     * Sets a cookie for this message.
+     *
+     * @see Cookie
+     */
+    HttpMessageSetters cookie(Cookie cookie);
+
+    /**
+     * Sets multiple cookies for this message.
+     *
+     * @see Cookies
+     */
+    HttpMessageSetters cookies(Iterable<? extends Cookie> cookies);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
@@ -34,7 +34,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 public interface HttpMessageSetters {
 
     /**
-     * Sets the content as UTF_8 for this message.
+     * Sets the content as UTF-8 for this message.
      */
     HttpMessageSetters content(String content);
 
@@ -49,7 +49,7 @@ public interface HttpMessageSetters {
     HttpMessageSetters content(MediaType contentType, String content);
 
     /**
-     * Sets the content as UTF_8 for this message. The {@code content} is formatted by
+     * Sets the content as UTF-8 for this message. The {@code content} is formatted by
      * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
      */
     @FormatMethod

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 public interface HttpRequestSetters extends RequestMethodSetters, PathAndQueryParamSetters, HttpMessageSetters {
 
     /**
-     * Sets the content as UTF_8 for this request.
+     * Sets the content as UTF-8 for this request.
      */
     @Override
     HttpRequestSetters content(String content);
@@ -53,7 +53,7 @@ public interface HttpRequestSetters extends RequestMethodSetters, PathAndQueryPa
     HttpRequestSetters content(MediaType contentType, String content);
 
     /**
-     * Sets the content as UTF_8 for this request. The {@code content} is formatted by
+     * Sets the content as UTF-8 for this request. The {@code content} is formatted by
      * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
      */
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -29,79 +29,31 @@ import com.google.errorprone.annotations.FormatString;
 /**
  * Sets properties for building an {@link HttpRequest}.
  */
-public interface HttpRequestSetters {
-
-    /**
-     * Shortcut to set GET method and path.
-     */
-    HttpRequestSetters get(String path);
-
-    /**
-     * Shortcut to set POST method and path.
-     */
-    HttpRequestSetters post(String path);
-
-    /**
-     * Shortcut to set PUT method and path.
-     */
-    HttpRequestSetters put(String path);
-
-    /**
-     * Shortcut to set DELETE method and path.
-     */
-    HttpRequestSetters delete(String path);
-
-    /**
-     * Shortcut to set PATCH method and path.
-     */
-    HttpRequestSetters patch(String path);
-
-    /**
-     * Shortcut to set OPTIONS method and path.
-     */
-    HttpRequestSetters options(String path);
-
-    /**
-     * Shortcut to set HEAD method and path.
-     */
-    HttpRequestSetters head(String path);
-
-    /**
-     * Shortcut to set TRACE method and path.
-     */
-    HttpRequestSetters trace(String path);
-
-    /**
-     * Sets the method for this request.
-     *
-     * @see HttpMethod
-     */
-    HttpRequestSetters method(HttpMethod method);
-
-    /**
-     * Sets the path for this request.
-     */
-    HttpRequestSetters path(String path);
+public interface HttpRequestSetters extends RequestMethodSetters, PathAndQueryParamSetters, HttpMessageSetters {
 
     /**
      * Sets the content as UTF_8 for this request.
      */
+    @Override
     HttpRequestSetters content(String content);
 
     /**
      * Sets the content for this request.
      */
+    @Override
     HttpRequestSetters content(MediaType contentType, CharSequence content);
 
     /**
      * Sets the content for this request.
      */
+    @Override
     HttpRequestSetters content(MediaType contentType, String content);
 
     /**
      * Sets the content as UTF_8 for this request. The {@code content} is formatted by
      * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
      */
+    @Override
     @FormatMethod
     HttpRequestSetters content(@FormatString String format, Object... content);
 
@@ -109,30 +61,35 @@ public interface HttpRequestSetters {
      * Sets the content for this request. The {@code content} is formatted by
      * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
      */
+    @Override
     @FormatMethod
     HttpRequestSetters content(MediaType contentType, @FormatString String format,
-                                      Object... content);
+                               Object... content);
 
     /**
      * Sets the content for this request. The {@code content} will be wrapped using
      * {@link HttpData#wrap(byte[])}, so any changes made to {@code content} will be reflected in the request.
      */
+    @Override
     HttpRequestSetters content(MediaType contentType, byte[] content);
 
     /**
      * Sets the content for this request.
      */
+    @Override
     HttpRequestSetters content(MediaType contentType, HttpData content);
 
     /**
      * Sets the {@link Publisher} for this request.
      */
+    @Override
     HttpRequestSetters content(MediaType contentType, Publisher<? extends HttpData> content);
 
     /**
      * Sets the content for this request. The {@code content} is converted into JSON format
      * using the default {@link ObjectMapper}.
      */
+    @Override
     HttpRequestSetters contentJson(Object content);
 
     /**
@@ -144,6 +101,7 @@ public interface HttpRequestSetters {
      *            .build();
      * }</pre>
      */
+    @Override
     HttpRequestSetters header(CharSequence name, Object value);
 
     /**
@@ -157,12 +115,14 @@ public interface HttpRequestSetters {
      *
      * @see HttpHeaders
      */
+    @Override
     HttpRequestSetters headers(
             Iterable<? extends Entry<? extends CharSequence, String>> headers);
 
     /**
      * Sets HTTP trailers for this request.
      */
+    @Override
     HttpRequestSetters trailers(
             Iterable<? extends Entry<? extends CharSequence, String>> trailers);
 
@@ -175,6 +135,7 @@ public interface HttpRequestSetters {
      *            .build(); // GET `/bar`
      * }</pre>
      */
+    @Override
     HttpRequestSetters pathParam(String name, Object value);
 
     /**
@@ -186,12 +147,14 @@ public interface HttpRequestSetters {
      *            .build(); // GET `/1/2`
      * }</pre>
      */
+    @Override
     HttpRequestSetters pathParams(Map<String, ?> pathParams);
 
     /**
      * Disables path parameters substitution. If path parameter is not disabled and a parameter's, specified
      * using {@code {}} or {@code :}, value is not found, an {@link IllegalStateException} is thrown.
      */
+    @Override
     HttpRequestSetters disablePathParams();
 
     /**
@@ -203,6 +166,7 @@ public interface HttpRequestSetters {
      *            .build(); // GET `/endpoint?foo=bar`
      * }</pre>
      */
+    @Override
     HttpRequestSetters queryParam(String name, Object value);
 
     /**
@@ -216,6 +180,7 @@ public interface HttpRequestSetters {
      *
      * @see QueryParams
      */
+    @Override
     HttpRequestSetters queryParams(Iterable<? extends Entry<? extends String, String>> queryParams);
 
     /**
@@ -229,6 +194,7 @@ public interface HttpRequestSetters {
      *
      * @see Cookie
      */
+    @Override
     HttpRequestSetters cookie(Cookie cookie);
 
     /**
@@ -243,5 +209,6 @@ public interface HttpRequestSetters {
      *
      * @see Cookies
      */
+    @Override
     HttpRequestSetters cookies(Iterable<? extends Cookie> cookies);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -26,9 +26,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.FormatString;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * Sets properties for building an {@link HttpRequest}.
  */
+@UnstableApi
 public interface HttpRequestSetters extends RequestMethodSetters, PathAndQueryParamSetters, HttpMessageSetters {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
@@ -121,7 +121,7 @@ public final class HttpResponseBuilder extends AbstractHttpMessageBuilder {
     }
 
     /**
-     * Sets the content as UTF_8 for this response.
+     * Sets the content as UTF-8 for this response.
      */
     @Override
     public HttpResponseBuilder content(String content) {
@@ -145,7 +145,7 @@ public final class HttpResponseBuilder extends AbstractHttpMessageBuilder {
     }
 
     /**
-     * Sets the content as UTF_8 for this response. The {@code content} is formatted by
+     * Sets the content as UTF-8 for this response. The {@code content} is formatted by
      * {@link String#format(Locale, String, Object...)} with {@linkplain Locale#ENGLISH English locale}.
      */
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
@@ -238,6 +238,41 @@ public final class HttpResponseBuilder extends AbstractHttpMessageBuilder {
         return (HttpResponseBuilder) super.trailers(trailers);
     }
 
+    /**
+     * Sets a cookie for this response. For example:
+     * <pre>{@code
+     * HttpResponse.builder()
+     *             .ok()
+     *             .cookie(Cookie.ofSecure("cookie", "foo"))
+     *             .build();
+     * }</pre>
+     *
+     * @see Cookie
+     */
+    @Override
+    public HttpResponseBuilder cookie(Cookie cookie) {
+        responseHeadersBuilder.cookie(cookie);
+        return this;
+    }
+
+    /**
+     * Sets multiple cookies for this response.
+     * <pre>{@code
+     * HttpResponse.builder()
+     *             .ok()
+     *             .cookies(Cookies.ofSecure(Cookie.ofSecure("cookie1", "foo"),
+     *                                       Cookie.ofSecure("cookie2", "bar")))
+     *             .build();
+     * }</pre>
+     *
+     * @see Cookies
+     */
+    @Override
+    public HttpResponseBuilder cookies(Iterable<? extends Cookie> cookies) {
+        responseHeadersBuilder.cookies(cookies);
+        return this;
+    }
+
     @Override
     HttpHeadersBuilder headersBuilder() {
         return responseHeadersBuilder;

--- a/core/src/main/java/com/linecorp/armeria/common/PathAndQueryParamSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PathAndQueryParamSetters.java
@@ -22,7 +22,7 @@ import java.util.Map.Entry;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
- * Sets properties for building a path and a query string.
+ * Provides the setters for building a path and a query string.
  */
 @UnstableApi
 public interface PathAndQueryParamSetters {

--- a/core/src/main/java/com/linecorp/armeria/common/PathAndQueryParamSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PathAndQueryParamSetters.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Sets properties for building a path and a query string.
+ */
+@UnstableApi
+public interface PathAndQueryParamSetters {
+
+    /**
+     * Sets a path param for this message.
+     */
+    PathAndQueryParamSetters pathParam(String name, Object value);
+
+    /**
+     * Sets multiple path params for this message.
+     */
+    PathAndQueryParamSetters pathParams(Map<String, ?> pathParams);
+
+    /**
+     * Disables path parameters substitution. If path parameter is not disabled and a parameter's, specified
+     * using {@code {}} or {@code :}, value is not found, an {@link IllegalStateException} is thrown.
+     */
+    PathAndQueryParamSetters disablePathParams();
+
+    /**
+     * Adds a query param for this message.
+     */
+    PathAndQueryParamSetters queryParam(String name, Object value);
+
+    /**
+     * Adds multiple query params for this message.
+     */
+    PathAndQueryParamSetters queryParams(Iterable<? extends Entry<? extends String, String>> queryParams);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/RequestMethodSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestMethodSetters.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.common;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
- * Sets properties for building a {@link HttpMethod} and a request path.
+ * Provide the setters for building a {@link HttpMethod} and a request path.
  */
 @UnstableApi
 public interface RequestMethodSetters {

--- a/core/src/main/java/com/linecorp/armeria/common/RequestMethodSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestMethodSetters.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Sets properties for building a {@link HttpMethod} and a request path.
+ */
+@UnstableApi
+public interface RequestMethodSetters {
+
+    /**
+     * Sets GET method and path.
+     */
+    RequestMethodSetters get(String path);
+
+    /**
+     * Sets POST method and path.
+     */
+    RequestMethodSetters post(String path);
+
+    /**
+     * Sets PUT method and path.
+     */
+    RequestMethodSetters put(String path);
+
+    /**
+     * Sets DELETE method and path.
+     */
+    RequestMethodSetters delete(String path);
+
+    /**
+     * Sets PATCH method and path.
+     */
+    RequestMethodSetters patch(String path);
+
+    /**
+     * Sets OPTIONS method and path.
+     */
+    RequestMethodSetters options(String path);
+
+    /**
+     * Sets HEAD method and path.
+     */
+    RequestMethodSetters head(String path);
+
+    /**
+     * Sets TRACE method and path.
+     */
+    RequestMethodSetters trace(String path);
+
+    /**
+     * Sets the method for this request.
+     *
+     * @see HttpMethod
+     */
+    RequestMethodSetters method(HttpMethod method);
+
+    /**
+     * Sets the path for this request.
+     */
+    RequestMethodSetters path(String path);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/AbstractMetricCollectingBuilder.java
@@ -36,6 +36,9 @@ public abstract class AbstractMetricCollectingBuilder {
     @Nullable
     private BiPredicate<? super RequestContext, ? super RequestLog> successFunction;
 
+    /**
+     * Creates a new instance with the specified {@link MeterIdPrefixFunction}.
+     */
     protected AbstractMetricCollectingBuilder(MeterIdPrefixFunction meterIdPrefixFunction) {
         this.meterIdPrefixFunction = requireNonNull(meterIdPrefixFunction, "meterIdPrefixFunction");
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/SettableIntSupplier.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/SettableIntSupplier.java
@@ -42,10 +42,13 @@ public class SettableIntSupplier implements IntSupplier {
     /**
      * Creates a new instance with the specified {@code initialValue}.
      */
-    public static <T> SettableIntSupplier of(int initialValue) {
+    public static SettableIntSupplier of(int initialValue) {
         return new SettableIntSupplier(initialValue);
     }
 
+    /**
+     * Creates a new instance with the specified {@code initialValue}.
+     */
     protected SettableIntSupplier(int initialValue) {
         value = initialValue;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocStringExtractor.java
@@ -55,6 +55,10 @@ public abstract class DocStringExtractor {
 
     private final String path;
 
+    /**
+     * Creates a new {@link DocStringExtractor} with the specified {@code defaultPath} and {@code
+     * pathPropertyName}.
+     */
     protected DocStringExtractor(String defaultPath, String pathPropertyName) {
         path = computePath(defaultPath, pathPropertyName);
     }

--- a/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+++ b/core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
@@ -875,6 +875,7 @@ biz.tr
 biz.tt
 biz.ua
 biz.vn
+biz.wf
 biz.zm
 bizen.okayama.jp
 bj
@@ -1079,6 +1080,7 @@ bu.no
 budejju.no
 bugatti
 build
+builder.code.com
 builders
 building.museum
 builtwithdark.com
@@ -1930,6 +1932,7 @@ deta.app
 deta.dev
 detroit.museum
 dev
+dev-builder.code.com
 dev-myqnapcloud.com
 dev.br
 dev.static.land
@@ -5503,6 +5506,7 @@ name.mv
 name.my
 name.na
 name.ng
+name.pm
 name.pr
 name.qa
 name.tj
@@ -7171,6 +7175,8 @@ sch.qa
 sch.sa
 sch.so
 sch.ss
+sch.tf
+sch.wf
 sch.zm
 schaeffler
 schlesisches.museum
@@ -7635,6 +7641,7 @@ steam.museum
 steiermark.museum
 steigen.no
 steinkjer.no
+stg-builder.code.com
 sth.ac.at
 stjohn.museum
 stjordal.no

--- a/core/src/test/java/com/linecorp/armeria/client/RestClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RestClientTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.reflections.ReflectionUtils;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
@@ -78,8 +80,6 @@ class RestClientTest {
                                              content);
                     return HttpResponse.ofJson(restResponse);
                 }
-
-                ;
             });
         }
     };
@@ -162,7 +162,7 @@ class RestClientTest {
             return Stream.of(RestClient.of(server.httpUri()),
                              RestClient.of(server.webClient()),
                              RestClient.of("http://127.0.0.1:" + server.httpPort()),
-                             server.webClient().toRestClient(),
+                             server.webClient().asRestClient(),
                              RestClient.builder(server.httpUri())
                                        .decorator(LoggingClient.newDecorator())
                                        .build())
@@ -171,16 +171,17 @@ class RestClientTest {
     }
 
     static final class RestResponse {
-        private String id;
-        private String method;
-        private String query;
-        private String header;
-        private String cookie;
-        private String content;
+        private final String id;
+        private final String method;
+        private final String query;
+        private final String header;
+        private final String cookie;
+        private final String content;
 
-        RestResponse() {}
-
-        RestResponse(String id, String method, String query, String header, String cookie, String content) {
+        @JsonCreator
+        RestResponse(@JsonProperty("id") String id, @JsonProperty("method") String method,
+                     @JsonProperty("query") String query, @JsonProperty("header") String header,
+                     @JsonProperty("cookie") String cookie, @JsonProperty("content") String content) {
             this.id = id;
             this.method = method;
             this.query = query;
@@ -193,48 +194,24 @@ class RestClientTest {
             return id;
         }
 
-        public void setId(String id) {
-            this.id = id;
-        }
-
         public String getMethod() {
             return method;
-        }
-
-        public void setMethod(String method) {
-            this.method = method;
         }
 
         public String getQuery() {
             return query;
         }
 
-        public void setQuery(String query) {
-            this.query = query;
-        }
-
         public String getHeader() {
             return header;
-        }
-
-        public void setHeader(String header) {
-            this.header = header;
         }
 
         public String getCookie() {
             return cookie;
         }
 
-        public void setCookie(String cookie) {
-            this.cookie = cookie;
-        }
-
         public String getContent() {
             return content;
-        }
-
-        public void setContent(String content) {
-            this.content = content;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/RestClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RestClientTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.reflections.ReflectionUtils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RestClientTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/rest/{id}", (ctx, req) -> {
+                return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                    final RestResponse restResponse =
+                            new RestResponse(ctx.pathParam("id"),
+                                             req.method().toString(),
+                                             ctx.queryParam("query"),
+                                             req.headers().get("x-header"),
+                                             Iterables.getFirst(req.headers().cookies(), null).value(),
+                                             agg.contentUtf8());
+                    return HttpResponse.ofJson(restResponse);
+                }));
+            });
+        }
+    };
+
+    @ArgumentsSource(RestClientProvider.class)
+    @ParameterizedTest
+    void restApi(RestClient restClient) {
+        RestClientPreparation preparation = null;
+        // HTTP methods used for REST APIs
+        // See: https://restfulapi.net/http-methods/
+        for (HttpMethod method : ImmutableList.of(HttpMethod.GET, HttpMethod.POST, HttpMethod.PUT,
+                                                  HttpMethod.DELETE, HttpMethod.PATCH)) {
+            switch (method) {
+                case GET:
+                    preparation = restClient.get("/rest/{id}");
+                    break;
+                case POST:
+                    preparation = restClient.post("/rest/{id}");
+                    break;
+                case PUT:
+                    preparation = restClient.put("/rest/{id}");
+                    break;
+                case PATCH:
+                    preparation = restClient.patch("/rest/{id}");
+                    break;
+                case DELETE:
+                    preparation = restClient.delete("/rest/{id}");
+                    break;
+            }
+            assert preparation != null;
+            final RestResponse response =
+                    preparation.content("content")
+                               .header("x-header", "header-value")
+                               .cookie(Cookie.ofSecure("cookie", "cookie-value"))
+                               .pathParam("id", "1")
+                               .queryParam("query", "query-value")
+                               .execute(RestResponse.class)
+                               .join()
+                               .content();
+
+            assertThat(response.getId()).isEqualTo("1");
+            assertThat(response.getMethod()).isEqualTo(method.toString());
+            assertThat(response.getQuery()).isEqualTo("query-value");
+            assertThat(response.getHeader()).isEqualTo("header-value");
+            assertThat(response.getCookie()).isEqualTo("cookie-value");
+            assertThat(response.getContent()).isEqualTo("content");
+        }
+    }
+
+    @Test
+    void returnType_RestClientPreparation() throws NoSuchMethodException {
+        for (final Method method : ReflectionUtils.getMethods(RequestPreparationSetters.class)) {
+            if ("execute".equals(method.getName())) {
+                continue;
+            }
+            final Method overridden =
+                    RestClientPreparation.class.getMethod(method.getName(), method.getParameterTypes());
+            assertThat(overridden.getReturnType())
+                    .as("method : " + overridden)
+                    .isEqualTo(RestClientPreparation.class);
+        }
+    }
+
+    @Test
+    void returnType_RestClientBuilder() throws NoSuchMethodException {
+        for (final Method method : ReflectionUtils.getMethods(AbstractWebClientBuilder.class,
+                                                              m -> Modifier.isPublic(m.getModifiers()))) {
+            final Method overridden =
+                    RestClientBuilder.class.getMethod(method.getName(), method.getParameterTypes());
+            assertThat(overridden.getReturnType())
+                    .as("method : " + overridden)
+                    .isEqualTo(RestClientBuilder.class);
+        }
+    }
+
+    private static class RestClientProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(RestClient.of(server.httpUri()),
+                             RestClient.of(server.webClient()),
+                             RestClient.of("http://127.0.0.1:" + server.httpPort()),
+                             server.webClient().toRestClient(),
+                             RestClient.builder(server.httpUri())
+                                       .decorator(LoggingClient.newDecorator())
+                                       .build())
+                         .map(Arguments::of);
+        }
+    }
+
+    static final class RestResponse {
+        private String id;
+        private String method;
+        private String query;
+        private String header;
+        private String cookie;
+        private String content;
+
+        RestResponse() {}
+
+        RestResponse(String id, String method, String query, String header, String cookie, String content) {
+            this.id = id;
+            this.method = method;
+            this.query = query;
+            this.header = header;
+            this.cookie = cookie;
+            this.content = content;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public void setMethod(String method) {
+            this.method = method;
+        }
+
+        public String getQuery() {
+            return query;
+        }
+
+        public void setQuery(String query) {
+            this.query = query;
+        }
+
+        public String getHeader() {
+            return header;
+        }
+
+        public void setHeader(String header) {
+            this.header = header;
+        }
+
+        public String getCookie() {
+            return cookie;
+        }
+
+        public void setCookie(String cookie) {
+            this.cookie = cookie;
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+    }
+}
+

--- a/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/DefaultMediaTypeResolverTest.java
@@ -34,15 +34,15 @@ public class DefaultMediaTypeResolverTest {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png", null))).isTrue();
         assertThat(MediaType.PDF.is(RESOLVER.guessFromPath("document.pdf", null))).isTrue();
         assertThat(MediaType.WEBP.is(RESOLVER.guessFromPath("image.webp", null))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", null))).isTrue();
     }
 
     @Test
     public void preCompressed() {
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("image.png.gz", "gzip"))).isTrue();
         assertThat(MediaType.PNG.is(RESOLVER.guessFromPath("/static/image.png.br", "brotli"))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", "identity"))).isTrue();
-        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.gz", null))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", "identity"))).isTrue();
+        assertThat(MediaType.OCTET_STREAM.is(RESOLVER.guessFromPath("image.png.bin", null))).isTrue();
     }
 
     @Test

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InternalReflectionUtilsTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InternalReflectionUtilsTest.java
@@ -45,7 +45,6 @@ class InternalReflectionUtilsTest {
                 methods.put(methodName, method);
             }
         }
-        System.out.println(methods);
         assertThat(methods.get("unaryCall").getDeclaringClass()).isEqualTo(AbstractTestServiceImpl.class);
         assertThat(methods.get("emptyCall").getDeclaringClass()).isEqualTo(TestServiceImpl.class);
     }

--- a/junit4/src/main/java/com/linecorp/armeria/testing/junit4/server/ServerRule.java
+++ b/junit4/src/main/java/com/linecorp/armeria/testing/junit4/server/ServerRule.java
@@ -28,6 +28,7 @@ import org.junit.rules.TestRule;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -313,7 +314,7 @@ public abstract class ServerRule extends ExternalResource {
      */
     @UnstableApi
     public BlockingWebClient blockingWebClient() {
-        return delegate.webClient().blocking();
+        return delegate.blockingWebClient();
     }
 
     /**
@@ -323,6 +324,24 @@ public abstract class ServerRule extends ExternalResource {
     @UnstableApi
     public BlockingWebClient blockingWebClient(Consumer<WebClientBuilder> webClientCustomizer) {
         requireNonNull(webClientCustomizer, "webClientCustomizer");
-        return delegate.webClient(webClientCustomizer).blocking();
+        return delegate.blockingWebClient(webClientCustomizer);
+    }
+
+    /**
+     * Returns the {@link RestClient} configured by {@link #configureWebClient(WebClientBuilder)}.
+     */
+    @UnstableApi
+    public RestClient restClient() {
+        return delegate.restClient();
+    }
+
+    /**
+     * Returns a newly created {@link RestClient} configured by
+     * {@link #configureWebClient(WebClientBuilder)} and then the specified customizer.
+     */
+    @UnstableApi
+    public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
+        requireNonNull(webClientCustomizer, "webClientCustomizer");
+        return delegate.restClient(webClientCustomizer);
     }
 }

--- a/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
+++ b/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
@@ -384,7 +384,7 @@ public abstract class ServerRuleDelegate {
      */
     @UnstableApi
     public RestClient restClient() {
-        return webClient().toRestClient();
+        return webClient().asRestClient();
     }
 
     /**
@@ -394,7 +394,7 @@ public abstract class ServerRuleDelegate {
     @UnstableApi
     public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
         requireNonNull(webClientCustomizer, "webClientCustomizer");
-        return webClient(webClientCustomizer).toRestClient();
+        return webClient(webClientCustomizer).asRestClient();
     }
 
     private void ensureStarted() {

--- a/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
+++ b/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
@@ -26,13 +26,16 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -348,7 +351,7 @@ public abstract class ServerRuleDelegate {
     }
 
     /**
-     * Returna a newly created {@link WebClient} configured by {@link #configureWebClient(WebClientBuilder)}
+     * Returns a newly created {@link WebClient} configured by {@link #configureWebClient(WebClientBuilder)}
      * and then the specified customizer.
      */
     public WebClient webClient(Consumer<WebClientBuilder> webClientCustomizer) {
@@ -356,6 +359,42 @@ public abstract class ServerRuleDelegate {
         final WebClientBuilder builder = webClientBuilder();
         webClientCustomizer.accept(builder);
         return builder.build();
+    }
+
+    /**
+     * Returns the {@link BlockingWebClient} configured by {@link #configureWebClient(WebClientBuilder)}.
+     */
+    @UnstableApi
+    public BlockingWebClient blockingWebClient() {
+        return webClient().blocking();
+    }
+
+    /**
+     * Returns a newly created {@link BlockingWebClient} configured by
+     * {@link #configureWebClient(WebClientBuilder)} and then the specified customizer.
+     */
+    @UnstableApi
+    public BlockingWebClient blockingWebClient(Consumer<WebClientBuilder> webClientCustomizer) {
+        requireNonNull(webClientCustomizer, "webClientCustomizer");
+        return webClient(webClientCustomizer).blocking();
+    }
+
+    /**
+     * Returns the {@link RestClient} configured by {@link #configureWebClient(WebClientBuilder)}.
+     */
+    @UnstableApi
+    public RestClient restClient() {
+        return webClient().toRestClient();
+    }
+
+    /**
+     * Returns a newly created {@link RestClient} configured by
+     * {@link #configureWebClient(WebClientBuilder)} and then the specified customizer.
+     */
+    @UnstableApi
+    public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
+        requireNonNull(webClientCustomizer, "webClientCustomizer");
+        return webClient(webClientCustomizer).toRestClient();
     }
 
     private void ensureStarted() {

--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/ServerExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/ServerExtension.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -338,7 +339,7 @@ public abstract class ServerExtension extends AbstractAllOrEachExtension {
      */
     @UnstableApi
     public BlockingWebClient blockingWebClient() {
-        return delegate.webClient().blocking();
+        return delegate.blockingWebClient();
     }
 
     /**
@@ -348,7 +349,25 @@ public abstract class ServerExtension extends AbstractAllOrEachExtension {
     @UnstableApi
     public BlockingWebClient blockingWebClient(Consumer<WebClientBuilder> webClientCustomizer) {
         requireNonNull(webClientCustomizer, "webClientCustomizer");
-        return delegate.webClient(webClientCustomizer).blocking();
+        return delegate.blockingWebClient(webClientCustomizer);
+    }
+
+    /**
+     * Returns the {@link RestClient} configured by {@link #configureWebClient(WebClientBuilder)}.
+     */
+    @UnstableApi
+    public RestClient restClient() {
+        return delegate.restClient();
+    }
+
+    /**
+     * Returns a newly created {@link RestClient} configured by
+     * {@link #configureWebClient(WebClientBuilder)} and then the specified customizer.
+     */
+    @UnstableApi
+    public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
+        requireNonNull(webClientCustomizer, "webClientCustomizer");
+        return delegate.restClient(webClientCustomizer);
     }
 
     /**

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kotlin
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.linecorp.armeria.client.RestClientPreparation
+import com.linecorp.armeria.common.JacksonObjectMapperProvider
+import com.linecorp.armeria.common.ResponseEntity
+import kotlinx.coroutines.future.await
+
+/**
+ * Sends the HTTP request and converts the JSON response body as the `T` object using the default
+ * [ObjectMapper].
+ *
+ * @see JacksonObjectMapperProvider
+ */
+suspend inline fun <reified T> RestClientPreparation.execute(): ResponseEntity<T> {
+    return execute(object : TypeReference<T>(){}).await()
+}
+
+/**
+ * Sends the HTTP request and converts the JSON response body as the `T` object using the specified
+ * [ObjectMapper].
+ */
+suspend inline fun <reified T> RestClientPreparation.execute(mapper: ObjectMapper): ResponseEntity<T> {
+    return execute(object : TypeReference<T>(){}, mapper).await()
+}

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.future.await
  * @see JacksonObjectMapperProvider
  */
 suspend inline fun <reified T> RestClientPreparation.execute(): ResponseEntity<T> {
-    return execute(object : TypeReference<T>(){}).await()
+    return execute(object : TypeReference<T>() {}).await()!!
 }
 
 /**
@@ -38,5 +38,5 @@ suspend inline fun <reified T> RestClientPreparation.execute(): ResponseEntity<T
  * [ObjectMapper].
  */
 suspend inline fun <reified T> RestClientPreparation.execute(mapper: ObjectMapper): ResponseEntity<T> {
-    return execute(object : TypeReference<T>(){}, mapper).await()
+    return execute(object : TypeReference<T>() {}, mapper).await()!!
 }

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClientTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClientTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kotlin
+
+import com.linecorp.armeria.common.AggregatedHttpRequest
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.server.ServerBuilder
+import com.linecorp.armeria.server.ServiceRequestContext
+import com.linecorp.armeria.testing.junit5.server.ServerExtension
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class RestClientTest {
+
+    @Test
+    fun get() {
+        runBlocking {
+            val restClient = server.restClient()
+            val response =
+                restClient
+                    .get("/rest/{id}")
+                    .pathParam("id", "1")
+                    .execute<RestResponse>()
+            val content: RestResponse = response.content()
+            assertThat(content.id).isEqualTo("1")
+            assertThat(content.method).isEqualTo("GET")
+            assertThat(content.content).isEqualTo("")
+        }
+    }
+
+    @Test
+    fun post() {
+        runBlocking {
+            val restClient = server.restClient()
+            val response =
+                restClient
+                    .post("/rest/{id}")
+                    .pathParam("id", "1")
+                    .contentJson("content")
+                    .execute<RestResponse>()
+            val content: RestResponse = response.content()
+            assertThat(content.id).isEqualTo("1")
+            assertThat(content.method).isEqualTo("POST")
+            assertThat(content.content).isEqualTo("\"content\"")
+        }
+    }
+
+    companion object {
+        @RegisterExtension
+        var server: ServerExtension = object : ServerExtension() {
+            override fun configure(sb: ServerBuilder) {
+                sb.service("/rest/{id}") { ctx: ServiceRequestContext, req: HttpRequest ->
+                    HttpResponse.from(req.aggregate().thenApply { agg: AggregatedHttpRequest ->
+                        val restResponse =
+                            RestResponse(
+                                ctx.pathParam("id")!!,
+                                req.method().toString(),
+                                agg.contentUtf8()
+                            )
+                        HttpResponse.ofJson(restResponse)
+                    })
+                }
+            }
+        }
+    }
+}
+
+data class RestResponse(val id: String, val method: String, val content: String)

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.scala
+
+import com.linecorp.armeria.client._
+import com.linecorp.armeria.client.endpoint.EndpointGroup
+import com.linecorp.armeria.common.annotation.UnstableApi
+import com.linecorp.armeria.common.util.Unwrappable
+import com.linecorp.armeria.common.{HttpMethod, Scheme}
+import java.net.URI
+import java.util.Objects.requireNonNull
+
+/**
+ * A [[https://restfulapi.net/ REST]] client for Scala.
+ * This client is designed to easily exchange RESTful APIs.
+ * If you want to handle a non-JSON or streaming response, please use `WebClient`.
+ */
+@UnstableApi
+trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
+
+  /**
+   * Sets the `path` with `HttpMethod.GET` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Customer]] =
+   *   restClient.get("/api/v1/customers/{customerId}")
+   *             .pathParam("customerId", "0000001")
+   *             .execute[Customer]()
+   * }}}
+   */
+  def get(pathPattern: String): ScalaRestClientPreparation = path(HttpMethod.GET, pathPattern)
+
+  /**
+   * Sets the `path` with `HttpMethod.POST` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Result]] =
+   *   restClient.post("/api/v1/customers")
+   *             .contentJson(new Customer(...))
+   *             .execute[Result]()
+   * }}}
+   */
+  def post(pathPattern: String): ScalaRestClientPreparation = path(HttpMethod.POST, pathPattern)
+
+  /**
+   * Sets the `path` with `HttpMethod.PUT` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Result]] =
+   *   restClient.put("/api/v1/customers")
+   *             .contentJson(new Customer(...))
+   *             .execute[Result]()
+   * }}}
+   */
+  def put(pathPattern: String): ScalaRestClientPreparation = path(HttpMethod.PUT, pathPattern)
+
+  /**
+   * Sets the `path` with `HttpMethod.PATCH` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Result]] =
+   *   restClient.patch("/api/v1/customers")
+   *             .contentJson(new Customer(...))
+   *             .execute[Result]()
+   * }}}
+   */
+  def patch(pathPattern: String): ScalaRestClientPreparation = path(HttpMethod.PATCH, pathPattern)
+
+  /**
+   * Sets the `path` an `HttpMethod.DELETE` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Result]] =
+   *   restClient.delete("/api/v1/customers")
+   *             .contentJson(new Customer(...))
+   *             .execute[Result]()
+   * }}}
+   */
+  def delete(pathPattern: String): ScalaRestClientPreparation = path(HttpMethod.DELETE, pathPattern)
+
+  /**
+   * Sets the `HttpMethod` and the `path` and returns a fluent request builder.
+   * {{{
+   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val response: Future[ResponseEntity[Customer]] =
+   *   restClient.path(HttpMethod.GET, "/api/v1/customers/{customerId}")
+   *             .pathParam("customerId", "0000001")
+   *             .execute[Customer]()
+   * }}}
+   */
+  def path(method: HttpMethod, path: String): ScalaRestClientPreparation
+}
+
+/**
+ * A [[https://restfulapi.net/ REST]] client for Scala.
+ * If you want to create a `ScalaRestClient`` with various options, create a `WebClient`` first
+ * and convert it into a ScalaRestClient} via `WebClient.toScalaRestClient` or `ScalaRestClient(WebClient)`.
+ * {{{
+ * val webClient: WebClient =
+ *   WebClient.builder("https://api.example.com")
+ *     .responseTimeout(Duration.ofSeconds(10))
+ *     .decorator(LoggingClient.newDecorator())
+ *     ...
+ *     .build()
+ *
+ * // Use the extension method
+ * import com.linecorp.armeria.scala.implicits._
+ * val restClient: ScalaRestClient = webClient.toScalaRestClient()
+ *
+ * // Or explicitly call the factory method
+ * val restClient: ScalaRestClient = ScalaRestClient(webClient)
+ * }}}
+ */
+@UnstableApi
+object ScalaRestClient {
+
+  private val DEFAULT = new DefaultScalaRestClient(RestClient.of())
+
+  /**
+   * Returns a `ScalaRestClient` without a base URI using the default `ClientFactory` and
+   * the default `ClientOptions`.
+   */
+  def apply(): ScalaRestClient = DEFAULT
+
+  /**
+   * Returns a new `ScalaRestClient` that connects to the specified `uri` using the default options.
+   *
+   * @param uri the URI of the server endpoint
+   * @throws IllegalArgumentException if the `uri` is not valid or its scheme is not one of the values
+   *                                  in `SessionProtocol.httpValues()` or `SessionProtocol.httpsValues()`.
+   */
+  def apply(uri: String): ScalaRestClient = apply(WebClient.of(uri))
+
+  /**
+   * Returns a new `ScalaRestClient` that connects to the specified `URI` using the default options.
+   *
+   * @param uri the `URI` of the server endpoint
+   * @throws IllegalArgumentException if the `uri` is not valid or its scheme is not one of the values
+   *                                  in `SessionProtocol.httpValues()` or `SessionProtocol.httpsValues()`.
+   */
+  def apply(uri: URI): ScalaRestClient = apply(WebClient.of(uri))
+
+  /**
+   * Returns a new `ScalaRestClient` with the specified `WebClient`.
+   */
+  def apply(webClient: WebClient): ScalaRestClient =
+    if (webClient eq WebClient.of()) {
+      DEFAULT
+    } else {
+      new DefaultScalaRestClient(RestClient.of(webClient))
+    }
+}
+
+private final class DefaultScalaRestClient(delegate: RestClient) extends ScalaRestClient {
+
+  override def path(method: HttpMethod, path: String): ScalaRestClientPreparation = {
+    requireNonNull(method, "method")
+    requireNonNull(path, "path")
+    new ScalaRestClientPreparation(delegate.path(method, path))
+  }
+
+  override def scheme(): Scheme = delegate.scheme()
+
+  override def endpointGroup(): EndpointGroup = delegate.endpointGroup()
+
+  override def absolutePathRef(): String = delegate.absolutePathRef()
+
+  override def uri(): URI = delegate.uri()
+
+  override def clientType(): Class[_] = delegate.clientType()
+
+  override def options(): ClientOptions = delegate.options()
+
+  override def unwrap(): HttpClient = delegate.unwrap().asInstanceOf[HttpClient]
+}

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -25,8 +25,7 @@ import java.net.URI
 import java.util.Objects.requireNonNull
 
 /**
- * A [[https://restfulapi.net/ REST]] client for Scala.
- * This client is designed to easily exchange RESTful APIs.
+ * A client designed for calling [[https://restfulapi.net/ RESTful APIs]] conveniently.
  */
 @UnstableApi
 trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
@@ -34,7 +33,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `path` with `HttpMethod.GET` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Customer]] =
    *   restClient.get("/api/v1/customers/{customerId}")
    *             .pathParam("customerId", "0000001")
@@ -46,7 +45,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `path` with `HttpMethod.POST` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Result]] =
    *   restClient.post("/api/v1/customers")
    *             .contentJson(new Customer(...))
@@ -58,7 +57,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `path` with `HttpMethod.PUT` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Result]] =
    *   restClient.put("/api/v1/customers")
    *             .contentJson(new Customer(...))
@@ -70,7 +69,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `path` with `HttpMethod.PATCH` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Result]] =
    *   restClient.patch("/api/v1/customers")
    *             .contentJson(new Customer(...))
@@ -82,7 +81,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `path` an `HttpMethod.DELETE` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Result]] =
    *   restClient.delete("/api/v1/customers")
    *             .contentJson(new Customer(...))
@@ -94,7 +93,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
   /**
    * Sets the `HttpMethod` and the `path` and returns a fluent request builder.
    * {{{
-   * val restClient: ScalaRestClient = ScalaRestClient()
+   * val restClient: ScalaRestClient = ScalaRestClient("https://rest.example.com")
    * val response: Future[ResponseEntity[Customer]] =
    *   restClient.path(HttpMethod.GET, "/api/v1/customers/{customerId}")
    *             .pathParam("customerId", "0000001")
@@ -107,7 +106,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
 /**
  * A [[https://restfulapi.net/ REST]] client for Scala.
  * If you want to create a `ScalaRestClient` with various options, create a `WebClient` first
- * and convert it into a ScalaRestClient} via `WebClient.toScalaRestClient` or `ScalaRestClient(WebClient)`.
+ * and convert it into a `ScalaRestClient` via `WebClient.asScalaRestClient()` or `ScalaRestClient(WebClient)`.
  * {{{
  * val webClient: WebClient =
  *   WebClient.builder("https://api.example.com")
@@ -118,7 +117,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
  *
  * // Use the extension method
  * import com.linecorp.armeria.scala.implicits._
- * val restClient: ScalaRestClient = webClient.toScalaRestClient()
+ * val restClient: ScalaRestClient = webClient.asScalaRestClient()
  *
  * // Or explicitly call the factory method
  * val restClient: ScalaRestClient = ScalaRestClient(webClient)

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -27,7 +27,6 @@ import java.util.Objects.requireNonNull
 /**
  * A [[https://restfulapi.net/ REST]] client for Scala.
  * This client is designed to easily exchange RESTful APIs.
- * If you want to handle a non-JSON or streaming response, please use `WebClient`.
  */
 @UnstableApi
 trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
@@ -107,7 +106,7 @@ trait ScalaRestClient extends ClientBuilderParams with Unwrappable {
 
 /**
  * A [[https://restfulapi.net/ REST]] client for Scala.
- * If you want to create a `ScalaRestClient`` with various options, create a `WebClient`` first
+ * If you want to create a `ScalaRestClient` with various options, create a `WebClient` first
  * and convert it into a ScalaRestClient} via `WebClient.toScalaRestClient` or `ScalaRestClient(WebClient)`.
  * {{{
  * val webClient: WebClient =

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.scala
+
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, JavaTypeable}
+import com.linecorp.armeria.client.{RequestOptions, RequestPreparationSetters, RestClientPreparation}
+import com.linecorp.armeria.common.annotation.UnstableApi
+import com.linecorp.armeria.common.{Cookie, HttpData, MediaType, ResponseEntity}
+import com.linecorp.armeria.scala.implicits._
+import io.netty.util.AttributeKey
+import java.lang.{Iterable => JIterable}
+import java.time.Duration
+import java.util.{Map => JMap}
+import org.reactivestreams.Publisher
+import scala.collection.immutable
+import scala.concurrent.Future
+
+/**
+ * Prepares and executes a new `HttpRequest` for `ScalaRestClient`.
+ */
+@UnstableApi
+final class ScalaRestClientPreparation private[scala] (delegate: RestClientPreparation)
+    extends RequestPreparationSetters {
+
+  /**
+   * Sends the HTTP request and converts the JSON response body as the `A` object using the default
+   * `ClassTagExtensions`.
+   */
+  def execute[A: JavaTypeable](): Future[ResponseEntity[A]] =
+    delegate.execute[Future[ResponseEntity[A]]](ScalaResponseAs.json[A])
+
+  /**
+   * Sends the HTTP request and converts the JSON response body as the `A` object using the specified
+   * `ClassTagExtensions`.
+   */
+  def execute[A: JavaTypeable](mapper: ClassTagExtensions): Future[ResponseEntity[A]] =
+    delegate.execute(ScalaResponseAs.json[A](mapper))
+
+  override def requestOptions(requestOptions: RequestOptions): ScalaRestClientPreparation = {
+    delegate.requestOptions(requestOptions)
+    this
+  }
+
+  override def pathParam(name: String, value: Any): ScalaRestClientPreparation = {
+    delegate.pathParam(name, value)
+    this
+  }
+
+  override def pathParams(pathParams: JMap[String, _]): ScalaRestClientPreparation = {
+    delegate.pathParams(pathParams)
+    this
+  }
+
+  /**
+   * Sets multiple path params for this request.
+   */
+  def pathParams(pathParams: Map[String, Any]): ScalaRestClientPreparation = {
+    delegate.pathParams(pathParams.asJava)
+    this
+  }
+
+  override def disablePathParams(): ScalaRestClientPreparation = {
+    delegate.disablePathParams()
+    this
+  }
+
+  override def queryParam(name: String, value: Any): ScalaRestClientPreparation = {
+    delegate.queryParam(name, value)
+    this
+  }
+
+  override def queryParams(
+      queryParams: JIterable[_ <: JMap.Entry[_ <: String, String]]): ScalaRestClientPreparation = {
+    delegate.queryParams(queryParams)
+    this
+  }
+
+  /**
+   * Sets multiple query params for this request.
+   */
+  def queryParams(queryParams: Map[String, String]): ScalaRestClientPreparation = {
+    queryParams.foreach { case (k, v) => queryParam(k, v) }
+    this
+  }
+
+  override def responseTimeout(responseTimeout: Duration): ScalaRestClientPreparation = {
+    delegate.responseTimeout(responseTimeout)
+    this
+  }
+
+  override def responseTimeoutMillis(responseTimeoutMillis: Long): ScalaRestClientPreparation = {
+    delegate.responseTimeoutMillis(responseTimeoutMillis)
+    this
+  }
+
+  override def writeTimeout(writeTimeout: Duration): ScalaRestClientPreparation = {
+    delegate.writeTimeout(writeTimeout)
+    this
+  }
+
+  override def writeTimeoutMillis(writeTimeoutMillis: Long): ScalaRestClientPreparation = {
+    delegate.writeTimeoutMillis(writeTimeoutMillis)
+    this
+  }
+
+  override def maxResponseLength(maxResponseLength: Long): ScalaRestClientPreparation = {
+    delegate.maxResponseLength(maxResponseLength)
+    this
+  }
+
+  override def attr[V](key: AttributeKey[V], value: V): ScalaRestClientPreparation = {
+    delegate.attr(key, value)
+    this
+  }
+
+  override def content(content: String): ScalaRestClientPreparation = {
+    delegate.content(content)
+    this
+  }
+
+  override def content(contentType: MediaType, content: CharSequence): ScalaRestClientPreparation = {
+    delegate.content(contentType, content)
+    this
+  }
+
+  override def content(contentType: MediaType, content: String): ScalaRestClientPreparation = {
+    delegate.content(contentType, content)
+    this
+  }
+
+  override def content(format: String, content: Object*): ScalaRestClientPreparation = {
+    delegate.content(format, content)
+    this
+  }
+
+  override def content(contentType: MediaType, format: String, content: Object*): ScalaRestClientPreparation = {
+    delegate.content(contentType, format, content)
+    this
+  }
+
+  override def content(contentType: MediaType, content: Array[Byte]): ScalaRestClientPreparation = {
+    delegate.content(contentType, content)
+    this
+  }
+
+  override def content(contentType: MediaType, content: HttpData): ScalaRestClientPreparation = {
+    delegate.content(contentType, content)
+    this
+  }
+
+  override def content(
+      contentType: MediaType,
+      content: Publisher[_ <: HttpData]): ScalaRestClientPreparation = {
+    delegate.content(contentType, content)
+    this
+  }
+
+  override def contentJson(content: AnyRef): ScalaRestClientPreparation = {
+    delegate.contentJson(content)
+    this
+  }
+
+  override def header(name: CharSequence, value: Any): ScalaRestClientPreparation = {
+    delegate.header(name, value)
+    this
+  }
+
+  override def headers(
+      headers: JIterable[_ <: JMap.Entry[_ <: CharSequence, String]]): ScalaRestClientPreparation = {
+    delegate.headers(headers)
+    this
+  }
+
+  /**
+   * Adds multiple headers for this request.
+   */
+  def headers(headers: Map[_ <: CharSequence, String]): ScalaRestClientPreparation = {
+    headers.foreach { case (k, v) => header(k, v) }
+    this
+  }
+
+  override def trailer(name: CharSequence, value: Any): ScalaRestClientPreparation = {
+    delegate.trailer(name, value)
+    this
+  }
+
+  override def trailers(
+      trailers: JIterable[_ <: JMap.Entry[_ <: CharSequence, String]]): ScalaRestClientPreparation = {
+    delegate.trailers(trailers)
+    this
+  }
+
+  /**
+   * Adds multiple trailers for this request.
+   */
+  def trailers(trailers: Map[_ <: CharSequence, String]): ScalaRestClientPreparation = {
+    trailers.foreach { case (k, v) => trailer(k, v) }
+    this
+  }
+
+  override def cookie(cookie: Cookie): ScalaRestClientPreparation = {
+    delegate.cookie(cookie)
+    this
+  }
+
+  override def cookies(cookies: JIterable[_ <: Cookie]): ScalaRestClientPreparation = {
+    delegate.cookies(cookies)
+    this
+  }
+
+  /**
+   * Adds multiple `Cookie`s for this request.
+   */
+  def cookies(cookies: immutable.Seq[Cookie]): ScalaRestClientPreparation = {
+    delegate.cookies(cookies.asJava)
+    this
+  }
+}

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
@@ -17,9 +17,14 @@
 package com.linecorp.armeria.client.scala
 
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, JavaTypeable}
-import com.linecorp.armeria.client.{RequestOptions, RequestPreparationSetters, RestClientPreparation}
+import com.linecorp.armeria.client.{
+  RequestOptions,
+  RequestPreparationSetters,
+  ResponseAs,
+  RestClientPreparation
+}
 import com.linecorp.armeria.common.annotation.UnstableApi
-import com.linecorp.armeria.common.{Cookie, HttpData, MediaType, ResponseEntity}
+import com.linecorp.armeria.common.{Cookie, HttpData, HttpResponse, MediaType, ResponseEntity}
 import com.linecorp.armeria.scala.implicits._
 import io.netty.util.AttributeKey
 import java.lang.{Iterable => JIterable}
@@ -49,6 +54,14 @@ final class ScalaRestClientPreparation private[scala] (delegate: RestClientPrepa
    */
   def execute[A: JavaTypeable](mapper: ClassTagExtensions): Future[ResponseEntity[A]] =
     delegate.execute(ScalaResponseAs.json[A](mapper))
+
+  /**
+   * Sends the HTTP request and converts the `HttpResponse` using the `ResponseAs`.
+   * `ScalaResponseAs` provides converters for well-known types.
+   */
+  def execute[T](responseAs: ResponseAs[HttpResponse, T]): T = {
+    delegate.execute(responseAs)
+  }
 
   override def requestOptions(requestOptions: RequestOptions): ScalaRestClientPreparation = {
     delegate.requestOptions(requestOptions)

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/scala/ClientConversions.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/scala/ClientConversions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 LINE Corporation
+ * Copyright 2022 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,24 +13,25 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria
 
+package com.linecorp.armeria.scala
+
+import com.linecorp.armeria.client.WebClient
+import com.linecorp.armeria.client.scala.ScalaRestClient
 import com.linecorp.armeria.common.annotation.UnstableApi
+import scala.language.implicitConversions
 
-/**
- * Provides a collection of utilities for using Armeria in a project written in Scala.
- * Read [[https://armeria.dev/docs/advanced-scala]] for more information.
- */
-package object scala {
+@UnstableApi
+trait ClientConversions {
+
+  implicit final def restClientOps(webClient: WebClient): RestClientOps =
+    new RestClientOps(webClient)
+}
+
+final class RestClientOps(private val webClient: WebClient) extends AnyVal {
 
   /**
-   * Provides a collection of useful extension methods and implicit conversions for using Armeria
-   * in a project written in Scala. Read [[https://armeria.dev/docs/advanced-scala]] for more information.
+   * Returns a `ScalaRestClient` that connects to the same `URI` with this `WebClient`.
    */
-  @UnstableApi
-  object implicits
-      extends CommonConversions
-      with ClientConversions
-      with CollectionConverters
-      with ServerConversions
+  def toScalaRestClient(): ScalaRestClient = ScalaRestClient(webClient)
 }

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/scala/ClientConversions.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/scala/ClientConversions.scala
@@ -33,5 +33,5 @@ final class RestClientOps(private val webClient: WebClient) extends AnyVal {
   /**
    * Returns a `ScalaRestClient` that connects to the same `URI` with this `WebClient`.
    */
-  def toScalaRestClient(): ScalaRestClient = ScalaRestClient(webClient)
+  def asScalaRestClient(): ScalaRestClient = ScalaRestClient(webClient)
 }

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.scala
+
+import com.google.common.collect.Iterables
+import com.linecorp.armeria.common.{Cookie, HttpResponse, ResponseEntity}
+import com.linecorp.armeria.scala.implicits._
+import com.linecorp.armeria.server.{ServerBuilder, ServerSuite}
+import munit.FunSuite
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+class RestClientSuite extends FunSuite with ServerSuite {
+  override protected def configureServer: ServerBuilder => Unit = { sb =>
+    sb.service(
+      "/rest/{id}",
+      (ctx, req) => {
+        req
+          .aggregate()
+          .thenApply[HttpResponse](agg => {
+            HttpResponse.ofJson(RestResponse(ctx.pathParam("id"), agg.contentUtf8()))
+          })
+          .toHttpResponse
+      }
+    ).service(
+      "/rest/complex/{id}",
+      (ctx, req) => {
+        req
+          .aggregate()
+          .thenApply[HttpResponse](agg => {
+            HttpResponse.ofJson(ComplexResponse(
+              id = ctx.pathParam("id"),
+              method = ctx.method().toString,
+              query = ctx.queryParam("query"),
+              header = req.headers.get("x-header"),
+              trailer = agg.trailers().get("x-trailer"),
+              cookie = Iterables.getFirst(req.headers.cookies, null).value(),
+              content = agg.contentUtf8()
+            ))
+          })
+          .toHttpResponse
+      }
+    )
+  }
+
+  test("should create ScalaRestClient with implicit class") {
+    val restClient = server.webClient().toScalaRestClient()
+    val future: Future[ResponseEntity[RestResponse]] =
+      restClient
+        .get("/rest/{id}")
+        .pathParam("id", 1)
+        .execute[RestResponse]()
+    val content = Await.result(future, Duration.Inf).content()
+    assertEquals(content.id, "1")
+  }
+
+  test("should create ScalaRestClient with factory method") {
+    val restClient = ScalaRestClient(server.webClient())
+    val future: Future[ResponseEntity[RestResponse]] =
+      restClient
+        .get("/rest/{id}")
+        .pathParam("id", 1)
+        .execute[RestResponse]()
+    val content = Await.result(future, Duration.Inf).content()
+    assertEquals(content.id, "1")
+  }
+
+  test("complex input") {
+    val restClient = server.webClient().toScalaRestClient()
+    val future =
+      restClient
+        .post("/rest/complex/{id}")
+        .content("content")
+        .headers(Map("x-header" -> "header-value"))
+        .trailers(Map("x-trailer" -> "trailer-value"))
+        .cookies(List(Cookie.ofSecure("cookie", "cookie-value")))
+        .pathParams(Map("id" -> "1"))
+        .queryParams(Map("query" -> "query-value"))
+        .execute[ComplexResponse]()
+
+    val content = Await.result(future, Duration.Inf).content()
+    assertEquals(content.id, "1")
+    assertEquals(content.method, "POST")
+    assertEquals(content.query, "query-value")
+    assertEquals(content.header, "header-value")
+    assertEquals(content.trailer, "trailer-value")
+    assertEquals(content.cookie, "cookie-value")
+    assertEquals(content.content, "content")
+  }
+}
+
+case class RestResponse(id: String, content: String)
+
+case class ComplexResponse(
+    id: String,
+    method: String,
+    query: String,
+    header: String,
+    trailer: String,
+    cookie: String,
+    content: String);

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
@@ -73,7 +73,7 @@ class RestClientSuite extends FunSuite with ServerSuite {
   }
 
   test("should create ScalaRestClient with implicit class") {
-    val restClient = server.webClient().toScalaRestClient()
+    val restClient = server.webClient().asScalaRestClient()
     val future: Future[ResponseEntity[RestResponse]] =
       restClient
         .get("/rest/{id}")
@@ -95,7 +95,7 @@ class RestClientSuite extends FunSuite with ServerSuite {
   }
 
   test("complex input") {
-    val restClient = server.webClient().toScalaRestClient()
+    val restClient = server.webClient().asScalaRestClient()
     val future =
       restClient
         .post("/rest/complex/{id}")

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
@@ -40,7 +40,7 @@ class RestClientSuite extends FunSuite with ServerSuite {
         @Path("/rest/{id}")
         def restApi(@Param id: String, content: String): RestResponse = RestResponse(id, content)
       },
-      Array.empty: _*
+      Array.emptyObjectArray: _*
     )
 
     sb.annotatedService(
@@ -68,7 +68,7 @@ class RestClientSuite extends FunSuite with ServerSuite {
           )
         }
       },
-      Array.empty: _*
+      Array.emptyObjectArray: _*
     )
   }
 
@@ -139,4 +139,4 @@ case class ComplexResponse(
     header: String,
     trailer: String,
     cookie: String,
-    content: String);
+    content: String)

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
@@ -18,16 +18,10 @@ package com.linecorp.armeria.client.scala
 
 import com.google.common.collect.Iterables
 import com.linecorp.armeria.client.RequestPreparationSetters
-import com.linecorp.armeria.common.{
-  AggregatedHttpRequest,
-  AggregatedHttpResponse,
-  Cookie,
-  HttpResponse,
-  ResponseEntity
-}
+import com.linecorp.armeria.common.{AggregatedHttpRequest, Cookie, ResponseEntity}
 import com.linecorp.armeria.scala.implicits._
 import com.linecorp.armeria.server.annotation._
-import com.linecorp.armeria.server.{ServerBuilder, ServerSuite, ServiceRequestContext}
+import com.linecorp.armeria.server.{ServerBuilder, ServerSuite}
 import munit.FunSuite
 import org.reflections.ReflectionUtils
 import scala.concurrent.duration.Duration
@@ -35,16 +29,20 @@ import scala.concurrent.{Await, Future}
 
 class RestClientSuite extends FunSuite with ServerSuite {
   override protected def configureServer: ServerBuilder => Unit = { sb =>
-    sb.annotatedService(new {
-      @Get
-      @Post
-      @Put
-      @Delete
-      @Patch
-      @ProducesJson
-      @Path("/rest/{id}")
-      def restApi(@Param id: String, content: String): RestResponse = RestResponse(id, content)
-    })
+    sb.annotatedService(
+      new {
+        @Get
+        @Post
+        @Put
+        @Delete
+        @Patch
+        @ProducesJson
+        @Path("/rest/{id}")
+        def restApi(@Param id: String, content: String): RestResponse = RestResponse(id, content)
+      },
+      Array.empty: _*
+    )
+
     sb.annotatedService(
       new {
         @Get
@@ -69,7 +67,8 @@ class RestClientSuite extends FunSuite with ServerSuite {
             content = agg.contentUtf8()
           )
         }
-      }
+      },
+      Array.empty: _*
     )
   }
 
@@ -125,7 +124,7 @@ class RestClientSuite extends FunSuite with ServerSuite {
         if ("execute" != method.getName) {
           val overridden = classOf[ScalaRestClientPreparation]
             .getMethod(method.getName, method.getParameterTypes: _*)
-          assert(overridden.getReturnType.isInstanceOf[Class[ScalaRestClientPreparation]])
+          assert(overridden.getReturnType == classOf[ScalaRestClientPreparation])
         }
       })
   }

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -208,7 +208,9 @@
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
     </module>
-    <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+    </module>
     <module name="MissingJavadocPackage"/>
     <module name="MissingJavadocType"/>
     <module name="JavadocParagraph"/>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7999,11 +7999,11 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/ejs": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dependencies": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       },
       "bin": {
         "ejs": "bin/cli.js"
@@ -9706,11 +9706,30 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/filename-reserved-regex": {
@@ -14411,11 +14430,11 @@
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "node_modules/jake": {
-      "version": "10.8.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dependencies": {
-        "async": "0.9.x",
+        "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
@@ -14442,9 +14461,9 @@
       }
     },
     "node_modules/jake/node_modules/async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/jake/node_modules/chalk": {
       "version": "4.1.2",
@@ -31922,11 +31941,11 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "ejs": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "requires": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       }
     },
     "electron-to-chromium": {
@@ -33191,11 +33210,29 @@
       }
     },
     "filelist": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "filename-reserved-regex": {
@@ -36654,11 +36691,11 @@
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jake": {
-      "version": "10.8.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "requires": {
-        "async": "0.9.x",
+        "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
@@ -36673,9 +36710,9 @@
           }
         },
         "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
         },
         "chalk": {
           "version": "4.1.2",

--- a/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/ThriftProtocolFactoryProvider.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/common/thrift/ThriftProtocolFactoryProvider.java
@@ -36,6 +36,9 @@ public abstract class ThriftProtocolFactoryProvider {
         final SerializationFormat serializationFormat;
         final TProtocolFactory tProtocolFactory;
 
+        /**
+         * Create an {@link Entry} with the specified {@link SerializationFormat} and {@link TProtocolFactory}.
+         */
         public Entry(SerializationFormat serializationFormat, TProtocolFactory tProtocolFactory) {
             this.serializationFormat = requireNonNull(serializationFormat, "serializationFormat");
             this.tProtocolFactory = requireNonNull(tProtocolFactory, "tProtocolFactory");


### PR DESCRIPTION
Motivation:

`WebClient` and `WebClientPreparation` has powerful and fluent features.
RESTful API is classic but it is still the dominant protocol for sharing
web resources.
The `WebClient` is able to handle not only REST responses but also
a stream response and a file response.
The API design of `WebClient`, in turn, is not optimized for REST API.
See #4250 

Modifications:

- Add `RestClient` for exchange RESTful APIs.
  - It assume that the response has a JSON body.
- Add `RestClientBuilder` so as to fluently build a `RestClient`.
- Refactor the intefaces for request preparations to accommodate
  `RestClientPreparation`.
  - Method and path setters are extracted to `RequestMethodSetters`.
  - Query and path param setters are moved to `PathAndQueryParamSetters`
  - Added `HttpMessageSetters` for setting `HttpMessage` properties.
- Add `execute()` extension methods for Kotlin Coroutine.
- Add `ScalaRestClient` for Scala.
  - Tried to add extension methods using an implicit class but Scala
    compiler failed to find the overloaded method which has a generic
    parameter.
- Provide a extension method to convert a `WebClient` to
  `ScalaRestClient`.
- Add `restClient()` to `ServerExtension` and `ServerRule`.

Result:

You can now easily send and receive RESTful APIs using `RestClient`
- Java
  ```java
  RestClient restClient = RestClient.of("...");
  CompletableFuture<ResponseEntity<Customer>> response =
      restClient.get("/api/v1/customers/{customerId}")
                .pathParam("customerId", "0000001")
                .execute(Customer.class);
  ```
- Kotlin
  ```kt
  val restClient: RestClient = RestClient.of("...");
  val response: ResponseEntity<Customer> =
     restClient
       .get("/api/v1/customers/{customerId}")
       .pathParam("customerId", "0000001")
       .execute<Customer>()  // a suspend function
  ```
- Scala
  ```scala
  val restClient: ScalaRestClient = ScalaRestClient("...")
  val response: Future[ResponseEntity[Result]] =
    restClient.post("/api/v1/customers")
              .contentJson(new Customer(...))
              .execute[Result]()
  ```
