### PR TITLE
Fix bugs while converting `StreamMessage` to `InputStream`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
@@ -138,6 +138,7 @@ final class StreamMessageInputStream<T> extends InputStream {
             try {
                 final HttpData result = httpDataConverter.apply(item);
                 if (result.isEmpty()) {
+                    result.close();
                     request();
                     return;
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
@@ -130,7 +130,12 @@ final class StreamMessageInputStream<T> extends InputStream {
                  return;
             }
             try {
-                byteBufsInputStream.add(httpDataConverter.apply(item).byteBuf());
+                final HttpData result = httpDataConverter.apply(item);
+                if (result.isEmpty()) {
+                    request();
+                    return;
+                }
+                byteBufsInputStream.add(result.byteBuf());
             } catch (Throwable ex) {
                 StreamMessageUtil.closeOrAbort(item, ex);
                 upstream.cancel();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
@@ -56,7 +56,7 @@ final class StreamMessageInputStream<T> extends InputStream {
     public int read() throws IOException {
         ensureOpen();
         ensureSubscribed();
-        subscriber.request();
+        maybeRequest();
         return byteBufsInputStream().read();
     }
 
@@ -64,7 +64,7 @@ final class StreamMessageInputStream<T> extends InputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         ensureOpen();
         ensureSubscribed();
-        subscriber.request();
+        maybeRequest();
         return byteBufsInputStream().read(b, off, len);
     }
 
@@ -95,6 +95,12 @@ final class StreamMessageInputStream<T> extends InputStream {
             subscribed = true;
             source.subscribe(subscriber, executor);
             subscriber.whenSubscribed.join();
+        }
+    }
+
+    private void maybeRequest() throws IOException {
+        if (available() == 0) {
+            subscriber.request();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
@@ -158,6 +158,7 @@ public final class ByteBufsInputStream extends InputStream {
             return;
         }
         if (!buffers.add(buffer)) {
+            buffer.release();
             throw new IllegalStateException("Unable to add new buffer");
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
@@ -150,6 +150,7 @@ public final class ByteBufsInputStream extends InputStream {
     public void add(ByteBuf buffer) {
         requireNonNull(buffer, "buffer");
         if (eos.get()) {
+            buffer.release();
             throw new IllegalStateException("Already closed");
         }
         if (!buffers.add(buffer)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStream.java
@@ -153,6 +153,10 @@ public final class ByteBufsInputStream extends InputStream {
             buffer.release();
             throw new IllegalStateException("Already closed");
         }
+        if (!buffer.isReadable()) {
+            buffer.release();
+            return;
+        }
         if (!buffers.add(buffer)) {
             throw new IllegalStateException("Unable to add new buffer");
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageInputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageInputStreamTest.java
@@ -34,6 +34,7 @@ import com.google.common.primitives.Bytes;
 import com.linecorp.armeria.common.HttpData;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -56,11 +57,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -82,11 +79,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -111,11 +104,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -155,11 +144,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertDoesNotThrow(inputStream::close);
@@ -213,11 +198,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(inputStream.read());
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isEqualTo(1);
@@ -250,11 +231,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -283,11 +260,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -310,11 +283,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -342,11 +311,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -374,11 +339,7 @@ class StreamMessageInputStreamTest {
             result.writeByte(read);
         }
 
-        final int readableBytes = result.readableBytes();
-        final byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
@@ -392,7 +353,7 @@ class StreamMessageInputStreamTest {
         streamMessage2.write("78");
         final AtomicBoolean consumed = new AtomicBoolean();
         streamMessage2.whenConsumed().thenRun(() -> {
-            consumed.getAndSet(true);
+            consumed.set(true);
             streamMessage2.close();
         });
         final InputStream inputStream = StreamMessage
@@ -404,34 +365,27 @@ class StreamMessageInputStreamTest {
             result.writeByte(inputStream.read());
         }
 
-        int readableBytes = result.readableBytes();
-        byte[] actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        byte[] actual = ByteBufUtil.getBytes(result);
+        result.clear();
         assertThat(actual).isEqualTo(ImmutableList.of("12")
                                                   .stream()
                                                   .map(String::getBytes)
                                                   .reduce(Bytes::concat).get());
-        assertThat(inputStream.available()).isEqualTo(0);
-        assertThat(consumed.get()).isFalse();
+        assertThat(inputStream.available()).isZero();
+        assertThat(consumed).isFalse();
 
         int read;
         while ((read = inputStream.read()) != -1) {
             result.writeByte(read);
         }
 
-        readableBytes = result.readableBytes();
-        actual = new byte[readableBytes];
-        for (int i = 0; i < readableBytes; i++) {
-            actual[i] = result.readByte();
-        }
+        actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(ImmutableList.of("34", "56", "78")
                                                   .stream()
                                                   .map(String::getBytes)
                                                   .reduce(Bytes::concat).get());
         assertThat(inputStream.available()).isZero();
-        assertThat(consumed.get()).isTrue();
+        await().untilTrue(consumed);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStreamTest.java
@@ -31,6 +31,7 @@ import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.ImmutableList;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 class ByteBufsInputStreamTest {
@@ -88,6 +90,45 @@ class ByteBufsInputStreamTest {
         assertThat(stream.available()).isEqualTo(0);
 
         assertThat(resultStrings.size()).isEqualTo(5);
+        assertThat(String.join(",", resultStrings)).isEqualTo(String.join("", strings));
+        assertThat(resultStrings.get(0)).isEqualTo("first");
+        assertThat(resultStrings.get(1)).isEqualTo("second");
+        assertThat(resultStrings.get(2)).isEqualTo("third");
+        assertThat(resultStrings.get(3)).isEqualTo("fourth");
+        assertThat(resultStrings.get(4)).isEqualTo("fifth");
+    }
+
+    @Test
+    void testAdd_ignoreEmptyByteBuf() {
+        final List<String> strings1 = ImmutableList.of("first,", "second,");
+        final List<String> strings2 = ImmutableList.of("third,fourth", ",fifth");
+        final ByteBuf empty = Unpooled.buffer();
+
+        final ByteBufsInputStream stream = new ByteBufsInputStream();
+        assertThat(stream.isEos()).isFalse();
+        assertThat(stream.available()).isEqualTo(0);
+        strings1.forEach(s -> stream.add(Unpooled.wrappedBuffer(s.getBytes(StandardCharsets.UTF_8))));
+        stream.add(empty);
+        strings2.forEach(s -> stream.add(Unpooled.wrappedBuffer(s.getBytes(StandardCharsets.UTF_8))));
+        stream.setEos();
+
+        final Scanner scanner = new Scanner(stream).useDelimiter(",");
+        final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
+        while (scanner.hasNext()) {
+            final String s = scanner.next();
+            System.out.println(s);
+            resultBuilder.add(s);
+        }
+
+        final List<String> resultStrings = resultBuilder.build();
+
+        assertThat(stream.isEos()).isTrue();
+        assertThat(stream.available()).isEqualTo(0);
+
+        assertThat(resultStrings.size()).isEqualTo(5);
+        final List<String> strings = Stream
+                .concat(strings1.stream(), strings2.stream())
+                .collect(Collectors.toList());
         assertThat(String.join(",", resultStrings)).isEqualTo(String.join("", strings));
         assertThat(resultStrings.get(0)).isEqualTo("first");
         assertThat(resultStrings.get(1)).isEqualTo("second");

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/ByteBufsInputStreamTest.java
@@ -53,7 +53,6 @@ class ByteBufsInputStreamTest {
         final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
         while (scanner.hasNext()) {
             final String s = scanner.next();
-            System.out.println(s);
             resultBuilder.add(s);
         }
         final List<String> resultStrings = resultBuilder.build();
@@ -80,7 +79,6 @@ class ByteBufsInputStreamTest {
         final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
         while (scanner.hasNext()) {
             final String s = scanner.next();
-            System.out.println(s);
             resultBuilder.add(s);
         }
 
@@ -116,7 +114,6 @@ class ByteBufsInputStreamTest {
         final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
         while (scanner.hasNext()) {
             final String s = scanner.next();
-            System.out.println(s);
             resultBuilder.add(s);
         }
 
@@ -231,7 +228,6 @@ class ByteBufsInputStreamTest {
             final ImmutableList.Builder<String> resultBuilder = ImmutableList.builder();
             while (scanner.hasNext()) {
                 final String s = scanner.next();
-                System.out.println(s);
                 resultBuilder.add(s);
             }
             return resultBuilder.build();


### PR DESCRIPTION
**Related Bug Issue** #4268 

### Motivation:
We found some bugs on `StreamMessageInputStream`
1. If `httpDataConverter` returns `HttpData.empty()`, `StreamMessageInputStreamSubscriber` should request the next element to the upstream to produce bytes but currently doesn't request any element
2. `StreamMessageInputStream` could call `subscriber.request()` even if `byteBufsInputStream` has enough data


### Modifications:
- If `httpDataConverter` returns `HttpData.empty()`, `StreamMessageInputStreamSubscriber` requests the next element to the upstream
- `StreamMessageInputStream` calls `subscriber.request()` only when `byteBufsInputStream` has not enough data

### Result:
- Fix two bugs on `StreamMessageInputStream`
- ✅ Close #4268 issue
