### PR TITLE
Use temurin instead of adopt

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -52,14 +52,14 @@ jobs:
       name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
     - id: setup-jdk-17
       name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '17'
 
     - if: ${{ matrix.on != 'self-hosted' }}
@@ -158,7 +158,7 @@ jobs:
         name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Run the linters
@@ -192,7 +192,7 @@ jobs:
         name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Restore the cache
@@ -231,7 +231,7 @@ jobs:
         name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Run flaky tests

--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Restore Gradle Cache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ jobs:
         name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Restore the cache


### PR DESCRIPTION
Motivation:

https://github.com/line/armeria/runs/6621970139?check_suite_focus=true

Recently an error is being returned from cloudflare when installing java causing unnecessary noise.
Hopefully, `adoptium.net` doesn't have this issue.

It is better that we migrate anyways as per their recommendation:
![Screen Shot 2022-05-27 at 6 04 49 PM](https://user-images.githubusercontent.com/8510579/170668349-d476a08a-7554-40f5-8dbd-d00a7ee3fed0.png)


Modifications:

- Modify to use temurin for github actions runners (not self-hosted)

Result:

- Hopefully less flaky tests/actions

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
