### PR TITLE
Fix javadoc of ArmeriaSettings.java

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -65,8 +65,8 @@ import io.netty.channel.EventLoopGroup;
  *     excluded-user-agents: some-user-agent, another-user-agent
  *     min-response-size: 1KB
  *   internal-services:
- *     - port: 18080
- *     - include: docs, health, metrics
+ *     port: 18080
+ *     include: docs, health, metrics
  * }</pre>
  */
 @ConfigurationProperties(prefix = "armeria")


### PR DESCRIPTION
Motivation:

`ArmeriaSettings.internalServices` is not List type.

Result:

omitted