### PR TITLE
Skip a validation the reverse-lookup result of `127.0.0.1` for Windows

### DIFF
--- a/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTlsReverseDnsLookupTest.java
+++ b/jetty9/src/test/java/com/linecorp/armeria/server/jetty/JettyServiceTlsReverseDnsLookupTest.java
@@ -23,6 +23,8 @@ import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.common.util.OsType;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.testing.webapp.WebAppContainerMutualTlsTest;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -68,11 +70,14 @@ class JettyServiceTlsReverseDnsLookupTest extends WebAppContainerMutualTlsTest {
             // because we enabled `tlsReverseDnsLookup`.
             final String localhostName = InetAddress.getByName("127.0.0.1").getHostName();
 
-            // Make sure reverse-lookup result isn't an IP address.
-            assertThat(!NetUtil.isValidIpV4Address(localhostName) &&
-                       !NetUtil.isValidIpV6Address(localhostName))
-                    .as("Reverse DNS lookup must not return an IP address")
-                    .isTrue();
+            // XXX(ikhoon): Don't know why but Windows returns `127.0.0.1` itself as the resolved hostname.
+            if (SystemInfo.osType() != OsType.WINDOWS) {
+                // Make sure reverse-lookup result isn't an IP address.
+                assertThat(!NetUtil.isValidIpV4Address(localhostName) &&
+                           !NetUtil.isValidIpV6Address(localhostName))
+                        .as("Reverse DNS lookup must not return an IP address")
+                        .isTrue();
+            }
 
             return localhostName;
         } catch (UnknownHostException e) {


### PR DESCRIPTION
Motivation:

`JettyServiceTlsReverseDnsLookupTest.mutualTlsAttrs(SessionProtocol)`
fails on Windows. #4273 Reserse-lookup result for `127.0.0.1` is
`127.0.0.1` itself on Windows. I debugged the tests locally and figured
out the reason.
- The first lookup successfully found the hostname such as
  `DESKTOP-XXX`.
  https://github.com/openjdk/jdk/blob/b544b8b7d43907e93263db31ba3cc6d5951bcaee/src/java.base/share/classes/java/net/InetAddress.java#L810-L811
- JDK tried to get all IP addresses using the acquired hostname to
  prevent spoofing.
  https://github.com/openjdk/jdk/blob/b544b8b7d43907e93263db31ba3cc6d5951bcaee/src/java.base/share/classes/java/net/InetAddress.java#L824-L829
- The IP addresses resolved by the hostname only contain public IPs and
  `127.0.0.1` is not included in the result.
- JDK assumed that it is a spoof hostname and returned the input address
  itself instead of the reverse-lookup result.
  https://github.com/openjdk/jdk/blob/b544b8b7d43907e93263db31ba3cc6d5951bcaee/src/java.base/share/classes/java/net/InetAddress.java#L838-L841

Tested on Java 12 and 17 and all tests failed. The JVM versions
seems not to affect the result.
I guessed Windows has changed recently on the IP address resolving for
the hostname.

Modifications:

- Skip a validation the reverse-lookup result of `127.0.0.1` for Windows
  in `JettyServiceTlsReverseDnsLookupTest`

Result:

- Less noisy CI builds
- Closes #4273