### PR TITLE
Chain the AccessLogWriter if another one is previously set

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -56,22 +56,23 @@ public class RoutersBenchmark {
         SERVICES = ImmutableList.of(
                 new ServiceConfig(route1, route1,
                                   SERVICE, defaultLogName, defaultServiceName, defaultServiceNaming, 0, 0,
-                                  false, AccessLogWriter.disabled(), false, CommonPools.blockingTaskExecutor(),
-                                  true, SuccessFunction.always(), multipartUploadsLocation),
+                                  false, AccessLogWriter.disabled(), CommonPools.blockingTaskExecutor(),
+                                  SuccessFunction.always(), multipartUploadsLocation, ImmutableList.of()),
                 new ServiceConfig(route2, route2,
                                   SERVICE, defaultLogName, defaultServiceName, defaultServiceNaming, 0, 0,
-                                  false, AccessLogWriter.disabled(), false, CommonPools.blockingTaskExecutor(),
-                                  true, SuccessFunction.always(), multipartUploadsLocation)
+                                  false, AccessLogWriter.disabled(), CommonPools.blockingTaskExecutor(),
+                                  SuccessFunction.always(), multipartUploadsLocation, ImmutableList.of())
         );
         FALLBACK_SERVICE = new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), SERVICE,
                                              defaultLogName, defaultServiceName,
                                              defaultServiceNaming, 0, 0, false, AccessLogWriter.disabled(),
-                                             false, CommonPools.blockingTaskExecutor(), true,
-                                             SuccessFunction.always(), multipartUploadsLocation);
+                                             CommonPools.blockingTaskExecutor(),
+                                             SuccessFunction.always(), multipartUploadsLocation,
+                                             ImmutableList.of());
         HOST = new VirtualHost(
                 "localhost", "localhost", 0, null, SERVICES, FALLBACK_SERVICE, RejectedRouteHandler.DISABLED,
                 unused -> NOPLogger.NOP_LOGGER, defaultServiceNaming, 0, 0, false,
-                AccessLogWriter.disabled(), false, CommonPools.blockingTaskExecutor(), true);
+                AccessLogWriter.disabled(), CommonPools.blockingTaskExecutor(), ImmutableList.of());
         ROUTER = Routers.ofVirtualHost(HOST, SERVICES, RejectedRouteHandler.DISABLED);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -568,11 +568,6 @@ final class DefaultServerConfig implements ServerConfig {
     }
 
     @Override
-    public boolean shutdownBlockingTaskExecutorOnStop() {
-        return false;
-    }
-
-    @Override
     public MeterRegistry meterRegistry() {
         return meterRegistry;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -92,7 +92,6 @@ final class DefaultServerConfig implements ServerConfig {
     private final Duration gracefulShutdownTimeout;
 
     private final ScheduledExecutorService blockingTaskExecutor;
-    private final boolean shutdownBlockingTaskExecutorOnStop;
 
     private final MeterRegistry meterRegistry;
 
@@ -127,7 +126,7 @@ final class DefaultServerConfig implements ServerConfig {
             long http2MaxStreamsPerConnection, int http2MaxFrameSize,
             long http2MaxHeaderListSize, int http1MaxInitialLineLength, int http1MaxHeaderSize,
             int http1MaxChunkSize, Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
-            ScheduledExecutorService blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
+            ScheduledExecutorService blockingTaskExecutor,
             MeterRegistry meterRegistry, int proxyProtocolMaxTlvSize,
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions,
@@ -176,8 +175,6 @@ final class DefaultServerConfig implements ServerConfig {
 
         requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
         this.blockingTaskExecutor = monitorBlockingTaskExecutor(blockingTaskExecutor, meterRegistry);
-
-        this.shutdownBlockingTaskExecutorOnStop = shutdownBlockingTaskExecutorOnStop;
 
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
         this.channelOptions = Collections.unmodifiableMap(
@@ -572,7 +569,7 @@ final class DefaultServerConfig implements ServerConfig {
 
     @Override
     public boolean shutdownBlockingTaskExecutorOnStop() {
-        return shutdownBlockingTaskExecutorOnStop;
+        return false;
     }
 
     @Override
@@ -650,7 +647,7 @@ final class DefaultServerConfig implements ServerConfig {
                     http2MaxStreamsPerConnection(), http2MaxFrameSize(), http2MaxHeaderListSize(),
                     http1MaxInitialLineLength(), http1MaxHeaderSize(), http1MaxChunkSize(),
                     proxyProtocolMaxTlvSize(), gracefulShutdownQuietPeriod(), gracefulShutdownTimeout(),
-                    blockingTaskExecutor(), shutdownBlockingTaskExecutorOnStop(),
+                    blockingTaskExecutor(),
                     meterRegistry(), channelOptions(), childChannelOptions(),
                     clientAddressSources(), clientAddressTrustedProxyFilter(), clientAddressFilter(),
                     clientAddressMapper(),
@@ -669,7 +666,7 @@ final class DefaultServerConfig implements ServerConfig {
             long http2MaxHeaderListSize, long http1MaxInitialLineLength, long http1MaxHeaderSize,
             long http1MaxChunkSize, int proxyProtocolMaxTlvSize,
             Duration gracefulShutdownQuietPeriod, Duration gracefulShutdownTimeout,
-            @Nullable ScheduledExecutorService blockingTaskExecutor, boolean shutdownBlockingTaskExecutorOnStop,
+            @Nullable ScheduledExecutorService blockingTaskExecutor,
             @Nullable MeterRegistry meterRegistry,
             Map<ChannelOption<?>, ?> channelOptions, Map<ChannelOption<?>, ?> childChannelOptions,
             List<ClientAddressSource> clientAddressSources,
@@ -748,8 +745,6 @@ final class DefaultServerConfig implements ServerConfig {
         if (blockingTaskExecutor != null) {
             buf.append(", blockingTaskExecutor: ");
             buf.append(blockingTaskExecutor);
-            buf.append(", shutdownBlockingTaskExecutorOnStop: ");
-            buf.append(shutdownBlockingTaskExecutorOnStop);
         }
         if (meterRegistry != null) {
             buf.append(", meterRegistry: ");

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLSession;
@@ -667,7 +666,7 @@ public final class Server implements ListenableAsyncCloseable {
 
             CompletableFutures.successfulAsList(builder.build()
                                                        .stream()
-                                                       .map(Supplier::get)
+                                                       .map(ShutdownSupport::shutdown)
                                                        .collect(toImmutableList()), cause -> null)
                               .thenRunAsync(() -> future.complete(null), config.startStopExecutor());
         }

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -50,7 +50,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.net.ssl.SSLSession;
 

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.server.ServerSslContextUtil.validateSslContext;
 import static java.util.Objects.requireNonNull;
@@ -29,7 +30,6 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -48,6 +48,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -62,7 +63,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSet.Builder;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.Flags;
@@ -76,7 +76,6 @@ import com.linecorp.armeria.common.util.StartStopSupport;
 import com.linecorp.armeria.common.util.Version;
 import com.linecorp.armeria.internal.common.PathAndQuery;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
-import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -103,7 +102,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  */
 public final class Server implements ListenableAsyncCloseable {
 
-    private static final Logger logger = LoggerFactory.getLogger(Server.class);
+    static final Logger logger = LoggerFactory.getLogger(Server.class);
 
     /**
      * Creates a new {@link ServerBuilder}.
@@ -657,45 +656,18 @@ public final class Server implements ListenableAsyncCloseable {
         private void finishDoStop(CompletableFuture<Void> future) {
             serverChannels.clear();
 
-            final Set<ScheduledExecutorService> executors =
+            final List<ShutdownSupport> shutdownSupports =
                     Stream.concat(config.virtualHosts()
                                         .stream()
-                                        .filter(VirtualHost::shutdownBlockingTaskExecutorOnStop)
-                                        .map(VirtualHost::blockingTaskExecutor),
+                                        .flatMap(v -> v.shutdownSupports().stream()),
                                   config.serviceConfigs()
                                         .stream()
-                                        .filter(ServiceConfig::shutdownBlockingTaskExecutorOnStop)
-                                        .map(ServiceConfig::blockingTaskExecutor))
-                          .collect(Collectors.toSet());
+                                        .flatMap(s -> s.shutdownSupports().stream()))
+                          .collect(toImmutableList());
 
-            if (config.shutdownBlockingTaskExecutorOnStop()) {
-                executors.add(config.blockingTaskExecutor());
-            }
-
-            shutdownExecutor(executors);
-
-            final Builder<AccessLogWriter> builder = ImmutableSet.builder();
-            config.virtualHosts()
-                  .stream()
-                  .filter(VirtualHost::shutdownAccessLogWriterOnStop)
-                  .forEach(virtualHost -> builder.add(virtualHost.accessLogWriter()));
-            config.serviceConfigs()
-                  .stream()
-                  .filter(ServiceConfig::shutdownAccessLogWriterOnStop)
-                  .forEach(serviceConfig -> builder.add(serviceConfig.accessLogWriter()));
-
-            final Set<AccessLogWriter> writers = builder.build();
-            final List<CompletableFuture<Void>> completionFutures = new ArrayList<>(writers.size());
-            writers.forEach(accessLogWriter -> {
-                final CompletableFuture<Void> shutdownFuture = accessLogWriter.shutdown();
-                shutdownFuture.exceptionally(cause -> {
-                    logger.warn("Failed to close the {}:", AccessLogWriter.class.getSimpleName(), cause);
-                    return null;
-                });
-                completionFutures.add(shutdownFuture);
-            });
-
-            CompletableFutures.successfulAsList(completionFutures, cause -> null)
+            CompletableFutures.successfulAsList(shutdownSupports.stream()
+                                                                .map(Supplier::get)
+                                                                .collect(toImmutableList()), cause -> null)
                               .thenRunAsync(() -> future.complete(null), config.startStopExecutor());
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -467,6 +467,7 @@ public final class ServerBuilder {
      */
     public ServerBuilder workerGroup(EventLoopGroup workerGroup, boolean shutdownOnStop) {
         this.workerGroup = requireNonNull(workerGroup, "workerGroup");
+        // We don't use ShutdownSupport to shutdown with other instances because we shut down workerGroup first.
         shutdownWorkerGroupOnStop = shutdownOnStop;
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -205,7 +205,6 @@ public final class ServerBuilder {
 
     ServerBuilder() {
         // Set the default host-level properties.
-        virtualHostTemplate.accessLogWriter(AccessLogWriter.disabled(), true);
         virtualHostTemplate.rejectedRouteHandler(RejectedRouteHandler.WARN);
         virtualHostTemplate.defaultServiceNaming(ServiceNaming.fullTypeName());
         virtualHostTemplate.requestTimeoutMillis(Flags.defaultRequestTimeoutMillis());
@@ -864,7 +863,7 @@ public final class ServerBuilder {
      */
     public ServerBuilder accessLogFormat(String accessLogFormat) {
         return accessLogWriter(AccessLogWriter.custom(requireNonNull(accessLogFormat, "accessLogFormat")),
-                               true);
+                               false);
     }
 
     /**
@@ -1868,8 +1867,6 @@ public final class ServerBuilder {
         }
 
         final ScheduledExecutorService blockingTaskExecutor = defaultVirtualHost.blockingTaskExecutor();
-        final boolean shutdownOnStop = defaultVirtualHost.shutdownBlockingTaskExecutorOnStop();
-
         return new DefaultServerConfig(
                 ports, setSslContextIfAbsent(defaultVirtualHost, defaultSslContext),
                 virtualHosts, workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
@@ -1878,7 +1875,7 @@ public final class ServerBuilder {
                 http2InitialStreamWindowSize, http2MaxStreamsPerConnection,
                 http2MaxFrameSize, http2MaxHeaderListSize, http1MaxInitialLineLength, http1MaxHeaderSize,
                 http1MaxChunkSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout,
-                blockingTaskExecutor, shutdownOnStop,
+                blockingTaskExecutor,
                 meterRegistry, proxyProtocolMaxTlvSize, channelOptions, newChildChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, requestIdGenerator, errorHandler, sslContexts,
@@ -1965,7 +1962,7 @@ public final class ServerBuilder {
                 maxNumConnections, idleTimeoutMillis, http2InitialConnectionWindowSize,
                 http2InitialStreamWindowSize, http2MaxStreamsPerConnection, http2MaxFrameSize,
                 http2MaxHeaderListSize, http1MaxInitialLineLength, http1MaxHeaderSize, http1MaxChunkSize,
-                proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout, null, false,
+                proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout, null,
                 meterRegistry, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -214,7 +214,13 @@ public interface ServerConfig {
 
     /**
      * Returns whether the worker {@link Executor} is shut down when the {@link Server} stops.
+     *
+     * @deprecated This method is not used anymore. The {@code blockingTaskExecutor} is shut down if
+     *             the {@code shutdownOnStop} of
+     *             {@link ServerBuilder#blockingTaskExecutor(ScheduledExecutorService, boolean)}
+     *             is set with {@code true}.
      */
+    @Deprecated
     boolean shutdownBlockingTaskExecutorOnStop();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -107,7 +107,12 @@ public interface ServerConfig {
 
     /**
      * Returns whether the worker {@link EventLoopGroup} is shut down when the {@link Server} stops.
+     *
+     * @deprecated This method will be hidden from public API. The {@link EventLoopGroup} is shut down if
+     *             the {@code shutdownOnStop} of
+     *             {@link ServerBuilder#workerGroup(EventLoopGroup, boolean)} is set to {@code true}.
      */
+    @Deprecated
     boolean shutdownWorkerGroupOnStop();
 
     /**
@@ -218,7 +223,7 @@ public interface ServerConfig {
      * @deprecated This method is not used anymore. The {@code blockingTaskExecutor} is shut down if
      *             the {@code shutdownOnStop} of
      *             {@link ServerBuilder#blockingTaskExecutor(ScheduledExecutorService, boolean)}
-     *             is set with {@code true}.
+     *             is set to {@code true}.
      */
     @Deprecated
     default boolean shutdownBlockingTaskExecutorOnStop() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -221,7 +221,9 @@ public interface ServerConfig {
      *             is set with {@code true}.
      */
     @Deprecated
-    boolean shutdownBlockingTaskExecutorOnStop();
+    default boolean shutdownBlockingTaskExecutorOnStop() {
+        return false;
+    }
 
     /**
      * Returns the {@link MeterRegistry} that collects various stats.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -107,7 +107,7 @@ public final class ServiceConfig {
         this.service = requireNonNull(service, "service");
         this.defaultLogName = defaultLogName;
         this.defaultServiceName = defaultServiceName;
-        this.defaultServiceNaming = defaultServiceNaming;
+        this.defaultServiceNaming = requireNonNull(defaultServiceNaming, "defaultServiceNaming");
         this.requestTimeoutMillis = validateRequestTimeoutMillis(requestTimeoutMillis);
         this.maxRequestLength = validateMaxRequestLength(maxRequestLength);
         this.verboseResponses = verboseResponses;
@@ -115,7 +115,7 @@ public final class ServiceConfig {
         this.transientServiceOptions = requireNonNull(transientServiceOptions, "transientServiceOptions");
         this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
         this.successFunction = requireNonNull(successFunction, "successFunction");
-        this.multipartUploadsLocation = multipartUploadsLocation;
+        this.multipartUploadsLocation = requireNonNull(multipartUploadsLocation, "multipartUploadsLocation");
         this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
 
         handlesCorsPreflight = service.as(CorsService.class) != null;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -60,15 +62,14 @@ public final class ServiceConfig {
     private final boolean verboseResponses;
 
     private final AccessLogWriter accessLogWriter;
-    private final boolean shutdownAccessLogWriterOnStop;
     private final Set<TransientServiceOption> transientServiceOptions;
     private final boolean handlesCorsPreflight;
     private final SuccessFunction successFunction;
 
     private final ScheduledExecutorService blockingTaskExecutor;
-    private final boolean shutdownBlockingTaskExecutorOnStop;
 
     private final Path multipartUploadsLocation;
+    private final List<ShutdownSupport> shutdownSupports;
 
     /**
      * Creates a new instance.
@@ -77,16 +78,14 @@ public final class ServiceConfig {
                   @Nullable String defaultServiceName, ServiceNaming defaultServiceNaming,
                   long requestTimeoutMillis, long maxRequestLength,
                   boolean verboseResponses, AccessLogWriter accessLogWriter,
-                  boolean shutdownAccessLogWriterOnStop,
                   ScheduledExecutorService blockingTaskExecutor,
-                  boolean shutdownBlockingTaskExecutorOnStop,
                   SuccessFunction successFunction,
-                  Path multipartUploadsLocation) {
+                  Path multipartUploadsLocation, List<ShutdownSupport> shutdownSupports) {
         this(null, route, mappedRoute, service, defaultLogName, defaultServiceName, defaultServiceNaming,
              requestTimeoutMillis, maxRequestLength, verboseResponses, accessLogWriter,
-             shutdownAccessLogWriterOnStop, extractTransientServiceOptions(service),
-             blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop, successFunction,
-             multipartUploadsLocation);
+             extractTransientServiceOptions(service),
+             blockingTaskExecutor, successFunction,
+             multipartUploadsLocation, shutdownSupports);
     }
 
     /**
@@ -97,12 +96,11 @@ public final class ServiceConfig {
                           @Nullable String defaultLogName, @Nullable String defaultServiceName,
                           ServiceNaming defaultServiceNaming, long requestTimeoutMillis, long maxRequestLength,
                           boolean verboseResponses, AccessLogWriter accessLogWriter,
-                          boolean shutdownAccessLogWriterOnStop,
                           Set<TransientServiceOption> transientServiceOptions,
                           ScheduledExecutorService blockingTaskExecutor,
-                          boolean shutdownBlockingTaskExecutorOnStop,
                           SuccessFunction successFunction,
-                          Path multipartUploadsLocation) {
+                          Path multipartUploadsLocation,
+                          List<ShutdownSupport> shutdownSupports) {
         this.virtualHost = virtualHost;
         this.route = requireNonNull(route, "route");
         this.mappedRoute = requireNonNull(mappedRoute, "mappedRoute");
@@ -114,12 +112,11 @@ public final class ServiceConfig {
         this.maxRequestLength = validateMaxRequestLength(maxRequestLength);
         this.verboseResponses = verboseResponses;
         this.accessLogWriter = requireNonNull(accessLogWriter, "accessLogWriter");
-        this.shutdownAccessLogWriterOnStop = shutdownAccessLogWriterOnStop;
         this.transientServiceOptions = requireNonNull(transientServiceOptions, "transientServiceOptions");
         this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
-        this.shutdownBlockingTaskExecutorOnStop = shutdownBlockingTaskExecutorOnStop;
         this.successFunction = requireNonNull(successFunction, "successFunction");
         this.multipartUploadsLocation = multipartUploadsLocation;
+        this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
 
         handlesCorsPreflight = service.as(CorsService.class) != null;
     }
@@ -155,9 +152,9 @@ public final class ServiceConfig {
         requireNonNull(virtualHost, "virtualHost");
         return new ServiceConfig(virtualHost, route, mappedRoute, service, defaultLogName, defaultServiceName,
                                  defaultServiceNaming, requestTimeoutMillis, maxRequestLength, verboseResponses,
-                                 accessLogWriter, shutdownAccessLogWriterOnStop, transientServiceOptions,
-                                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop, successFunction,
-                                 multipartUploadsLocation);
+                                 accessLogWriter, transientServiceOptions,
+                                 blockingTaskExecutor, successFunction,
+                                 multipartUploadsLocation, shutdownSupports);
     }
 
     ServiceConfig withDecoratedService(Function<? super HttpService, ? extends HttpService> decorator) {
@@ -165,18 +162,18 @@ public final class ServiceConfig {
         return new ServiceConfig(virtualHost, route, mappedRoute, service.decorate(decorator), defaultLogName,
                                  defaultServiceName, defaultServiceNaming, requestTimeoutMillis,
                                  maxRequestLength, verboseResponses,
-                                 accessLogWriter, shutdownAccessLogWriterOnStop, transientServiceOptions,
-                                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop, successFunction,
-                                 multipartUploadsLocation);
+                                 accessLogWriter, transientServiceOptions,
+                                 blockingTaskExecutor, successFunction,
+                                 multipartUploadsLocation, shutdownSupports);
     }
 
     ServiceConfig withRoute(Route route) {
         requireNonNull(route, "route");
         return new ServiceConfig(virtualHost, route, mappedRoute, service, defaultLogName, defaultServiceName,
                                  defaultServiceNaming, requestTimeoutMillis, maxRequestLength, verboseResponses,
-                                 accessLogWriter, shutdownAccessLogWriterOnStop, transientServiceOptions,
-                                 blockingTaskExecutor, shutdownBlockingTaskExecutorOnStop, successFunction,
-                                 multipartUploadsLocation);
+                                 accessLogWriter, transientServiceOptions,
+                                 blockingTaskExecutor, successFunction,
+                                 multipartUploadsLocation, shutdownSupports);
     }
 
     /**
@@ -323,10 +320,14 @@ public final class ServiceConfig {
     /**
      * Tells whether the {@link AccessLogWriter} is shut down when the {@link Server} stops.
      *
-     * @see VirtualHost#shutdownAccessLogWriterOnStop()
+     * @deprecated This method is not used anymore. The {@link AccessLogWriter} is shut down if
+     *             the {@code shutdownOnStop} of
+     *             {@link ServiceBindingBuilder#accessLogWriter(AccessLogWriter, boolean)}
+     *             is set with {@code true}.
      */
+    @Deprecated
     public boolean shutdownAccessLogWriterOnStop() {
-        return shutdownAccessLogWriterOnStop;
+        return false;
     }
 
     /**
@@ -360,10 +361,14 @@ public final class ServiceConfig {
     /**
      * Returns whether the blocking task {@link Executor} is shut down when the {@link Server} stops.
      *
-     * @see VirtualHost#shutdownBlockingTaskExecutorOnStop()
+     * @deprecated This method is not used anymore. The {@code blockingTaskExecutor} is shut down if
+     *             the {@code shutdownOnStop} of
+     *             {@link ServiceBindingBuilder#blockingTaskExecutor(ScheduledExecutorService, boolean)}
+     *             is set with {@code true}.
      */
+    @Deprecated
     public boolean shutdownBlockingTaskExecutorOnStop() {
-        return shutdownBlockingTaskExecutorOnStop;
+        return false;
     }
 
     /**
@@ -381,6 +386,10 @@ public final class ServiceConfig {
         return multipartUploadsLocation;
     }
 
+    List<ShutdownSupport> shutdownSupports() {
+        return shutdownSupports;
+    }
+
     @Override
     public String toString() {
         final ToStringHelper toStringHelper = MoreObjects.toStringHelper(this).omitNullValues();
@@ -395,11 +404,10 @@ public final class ServiceConfig {
                              .add("maxRequestLength", maxRequestLength)
                              .add("verboseResponses", verboseResponses)
                              .add("accessLogWriter", accessLogWriter)
-                             .add("shutdownAccessLogWriterOnStop", shutdownAccessLogWriterOnStop)
                              .add("blockingTaskExecutor", blockingTaskExecutor)
-                             .add("shutdownBlockingTaskExecutorOnStop", shutdownBlockingTaskExecutorOnStop)
                              .add("successFunction", successFunction)
                              .add("multipartUploadsLocation", multipartUploadsLocation)
+                             .add("shutdownSupports", shutdownSupports)
                              .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -323,7 +323,7 @@ public final class ServiceConfig {
      * @deprecated This method is not used anymore. The {@link AccessLogWriter} is shut down if
      *             the {@code shutdownOnStop} of
      *             {@link ServiceBindingBuilder#accessLogWriter(AccessLogWriter, boolean)}
-     *             is set with {@code true}.
+     *             is set to {@code true}.
      */
     @Deprecated
     public boolean shutdownAccessLogWriterOnStop() {
@@ -364,7 +364,7 @@ public final class ServiceConfig {
      * @deprecated This method is not used anymore. The {@code blockingTaskExecutor} is shut down if
      *             the {@code shutdownOnStop} of
      *             {@link ServiceBindingBuilder#blockingTaskExecutor(ScheduledExecutorService, boolean)}
-     *             is set with {@code true}.
+     *             is set to {@code true}.
      */
     @Deprecated
     public boolean shutdownBlockingTaskExecutorOnStop() {

--- a/core/src/main/java/com/linecorp/armeria/server/ShutdownSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ShutdownSupport.java
@@ -21,12 +21,11 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
-interface ShutdownSupport extends Supplier<CompletableFuture<Void>> {
+interface ShutdownSupport {
 
     static ShutdownSupport of(AccessLogWriter accessLogWriter) {
         requireNonNull(accessLogWriter, "accessLogWriter");
@@ -66,4 +65,6 @@ interface ShutdownSupport extends Supplier<CompletableFuture<Void>> {
             return UnmodifiableFuture.completedFuture(null);
         };
     }
+
+    CompletableFuture<Void> shutdown();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ShutdownSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ShutdownSupport.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.Server.logger;
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
+
+interface ShutdownSupport extends Supplier<CompletableFuture<Void>> {
+
+    static ShutdownSupport of(AccessLogWriter accessLogWriter) {
+        requireNonNull(accessLogWriter, "accessLogWriter");
+        return () -> accessLogWriter.shutdown().exceptionally(cause -> {
+            logger.warn("Failed to shutdown the {}:", accessLogWriter, cause);
+            return null;
+        });
+    }
+
+    static ShutdownSupport of(ScheduledExecutorService executor) {
+        requireNonNull(executor, "executor");
+        return () -> {
+            final ScheduledExecutorService e;
+            if (executor instanceof UnstoppableScheduledExecutorService) {
+                e = ((UnstoppableScheduledExecutorService) executor).getExecutorService();
+            } else {
+                e = executor;
+            }
+
+            e.shutdown();
+
+            boolean interrupted = false;
+            try {
+                while (!e.isTerminated()) {
+                    try {
+                        e.awaitTermination(1, TimeUnit.HOURS);
+                    } catch (InterruptedException ignore) {
+                        interrupted = true;
+                    }
+                }
+            } catch (Exception cause) {
+                logger.warn("Failed to shutdown the {}:", e, cause);
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+            return UnmodifiableFuture.completedFuture(null);
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -220,11 +220,6 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
-    public boolean shutdownBlockingTaskExecutorOnStop() {
-        return delegate.shutdownBlockingTaskExecutorOnStop();
-    }
-
-    @Override
     public MeterRegistry meterRegistry() {
         return delegate.meterRegistry();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -335,7 +335,7 @@ public final class VirtualHost {
      * @deprecated This method is not used anymore. The {@link AccessLogWriter} is shut down if
      *             the {@code shutdownOnStop} of
      *             {@link VirtualHostBuilder#accessLogWriter(AccessLogWriter, boolean)}
-     *             is set with {@code true}.
+     *             is set to {@code true}.
      */
     @Deprecated
     public boolean shutdownAccessLogWriterOnStop() {
@@ -357,7 +357,7 @@ public final class VirtualHost {
      * @deprecated This method is not used anymore. The {@code blockingTaskExecutor} is shut down if
      *             the {@code shutdownOnStop} of
      *             {@link VirtualHostBuilder#blockingTaskExecutor(ScheduledExecutorService, boolean)}
-     *             is set with {@code true}.
+     *             is set to {@code true}.
      */
     @Deprecated
     public boolean shutdownBlockingTaskExecutorOnStop() {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
@@ -38,8 +38,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -52,8 +52,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -67,8 +67,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -81,8 +81,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -95,8 +95,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -109,8 +109,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -123,8 +123,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -138,8 +138,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -152,8 +152,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -166,8 +166,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -180,8 +180,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -194,8 +194,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -209,8 +209,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -224,8 +224,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
@@ -239,8 +239,8 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
-                                  CommonPools.blockingTaskExecutor(),
+                                  null, null, ServiceNaming.fullTypeName(), 0, 0, false,
+                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
                                   Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -36,10 +38,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(HealthCheckService.class.getName());
@@ -50,10 +52,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
         assertThat(serviceName)
@@ -65,10 +67,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName() + "$TrailingDollarSign");
@@ -79,10 +81,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName() + "$TrailingDollarSign");
@@ -93,10 +95,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.fullTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getName());
@@ -107,10 +109,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(HealthCheckService.class.getSimpleName());
@@ -121,10 +123,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName)
@@ -136,10 +138,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
@@ -150,10 +152,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName() + "$TrailingDollarSign");
@@ -164,10 +166,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.simpleTypeName().serviceName(ctx);
         assertThat(serviceName).isEqualTo(ServiceNamingTest.class.getSimpleName());
@@ -178,10 +180,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), HealthCheckService.builder().build(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.shorten().serviceName(ctx);
         assertThat(serviceName).isEqualTo("c.l.a.s.h." + HealthCheckService.class.getSimpleName());
@@ -192,10 +194,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new NestedClass(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.shorten().serviceName(ctx);
         assertThat(serviceName).isEqualTo("c.l.a.s." + ServiceNamingTest.class.getSimpleName() + '$' +
@@ -207,10 +209,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.shorten().serviceName(ctx);
         assertThat(serviceName)
@@ -222,10 +224,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new TrailingDollarSign$$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.shorten().serviceName(ctx);
         assertThat(serviceName)
@@ -237,10 +239,10 @@ class ServiceNamingTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final ServiceConfig config =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), new $$$(),
-                                  null, null, null, 0, 0, false, AccessLogWriter.common(), false,
-                                  CommonPools.blockingTaskExecutor(), true,
+                                  null, null, null, 0, 0, false, AccessLogWriter.common(),
+                                  CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),
-                                  Files.newTemporaryFolder().toPath());
+                                  Files.newTemporaryFolder().toPath(), ImmutableList.of());
         when(ctx.config()).thenReturn(config);
         final String serviceName = ServiceNaming.shorten().serviceName(ctx);
         assertThat(serviceName)

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.util.Files;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -57,10 +59,10 @@ public class ServiceTest {
                                                     outer, /* defaultLogName */ null,
                                                     /* defaultServiceName */ null,
                                                     ServiceNaming.of("FooService"), 1, 1, true,
-                                                    AccessLogWriter.disabled(), false,
-                                                    CommonPools.blockingTaskExecutor(), true,
+                                                    AccessLogWriter.disabled(),
+                                                    CommonPools.blockingTaskExecutor(),
                                                     SuccessFunction.always(),
-                                                    Files.newTemporaryFolder().toPath());
+                                                    Files.newTemporaryFolder().toPath(), ImmutableList.of());
         outer.serviceAdded(cfg);
         assertThat(inner.cfg).isSameAs(cfg);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
@@ -82,7 +82,6 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
     @Test
     void testAllConfigsAreSet() {
         final boolean verboseResponse = true;
-        final boolean shutdownOnStop = true;
         final long maxRequestLength = 2 * 1024;
         final AccessLogWriter accessLogWriter = AccessLogWriter.common();
         final Duration requestTimeoutDuration = Duration.ofMillis(1000);
@@ -96,7 +95,7 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
                 .maxRequestLength(maxRequestLength)
                 .exceptionHandlers((ctx, request, cause) -> HttpResponse.of(400))
                 .pathPrefix("/path")
-                .accessLogWriter(accessLogWriter, shutdownOnStop)
+                .accessLogWriter(accessLogWriter, false)
                 .verboseResponses(verboseResponse)
                 .defaultServiceName(defaultServiceName)
                 .defaultLogName(defaultLogName)
@@ -110,7 +109,6 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
         assertThat(pathBar.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
         assertThat(pathBar.maxRequestLength()).isEqualTo(maxRequestLength);
         assertThat(pathBar.accessLogWriter()).isEqualTo(accessLogWriter);
-        assertThat(pathBar.shutdownAccessLogWriterOnStop()).isTrue();
         assertThat(pathBar.verboseResponses()).isTrue();
         assertThat(pathBar.multipartUploadsLocation()).isSameAs(multipartUploadsLocation);
         final ServiceRequestContext sctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
@@ -122,7 +120,6 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
         assertThat(pathFoo.requestTimeoutMillis()).isEqualTo(requestTimeoutDuration.toMillis());
         assertThat(pathFoo.maxRequestLength()).isEqualTo(maxRequestLength);
         assertThat(pathFoo.accessLogWriter()).isEqualTo(accessLogWriter);
-        assertThat(pathFoo.shutdownAccessLogWriterOnStop()).isTrue();
         assertThat(pathFoo.verboseResponses()).isTrue();
         assertThat(pathFoo.defaultServiceNaming().serviceName(sctx)).isEqualTo(defaultServiceName);
         assertThat(pathFoo.defaultLogName()).isEqualTo(defaultLogName);

--- a/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaServerFactory.java
+++ b/dropwizard2/src/main/java/com/linecorp/armeria/dropwizard/ArmeriaServerFactory.java
@@ -120,12 +120,13 @@ class ArmeriaServerFactory extends AbstractServerFactory {
         final MutableServletContextHandler adminContext = environment.getAdminContext();
         final HealthCheckRegistry healthChecks = environment.healthChecks();
         try {
-            final Method method = AbstractServerFactory.class.getDeclaredMethod("createAdminServlet",
-                                                                                Server.class,
-                                                                                MutableServletContextHandler.class,
-                                                                                MetricRegistry.class,
-                                                                                HealthCheckRegistry.class,
-                                                                                AdminEnvironment.class);
+            final Method method =
+                    AbstractServerFactory.class.getDeclaredMethod("createAdminServlet",
+                                                                  Server.class,
+                                                                  MutableServletContextHandler.class,
+                                                                  MetricRegistry.class,
+                                                                  HealthCheckRegistry.class,
+                                                                  AdminEnvironment.class);
             logger.debug("createAdminServlet0 resolves to dropwizard2.1 version");
             final AdminEnvironment adminEnvironment = environment.admin();
             return (Handler) method.invoke(this, server, adminContext, metrics, healthChecks, adminEnvironment);
@@ -137,11 +138,12 @@ class ArmeriaServerFactory extends AbstractServerFactory {
 
         try {
             //noinspection JavaReflectionMemberAccess - this is false warning on dropwizard2 module
-            final Method method = AbstractServerFactory.class.getDeclaredMethod("createAdminServlet",
-                                                                                Server.class,
-                                                                                MutableServletContextHandler.class,
-                                                                                MetricRegistry.class,
-                                                                                HealthCheckRegistry.class);
+            final Method method =
+                    AbstractServerFactory.class.getDeclaredMethod("createAdminServlet",
+                                                                  Server.class,
+                                                                  MutableServletContextHandler.class,
+                                                                  MetricRegistry.class,
+                                                                  HealthCheckRegistry.class);
             logger.debug("createAdminServlet0 resolves to dropwizard1 or 2.0 version");
             return (Handler) method.invoke(this, server, adminContext, metrics, healthChecks);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {

--- a/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
+++ b/thrift0.13/src/test/java/com/linecorp/armeria/it/server/GracefulShutdownIntegrationTest.java
@@ -115,6 +115,8 @@ class GracefulShutdownIntegrationTest {
 
     @BeforeEach
     void setUp() {
+        accessLogWriterCounter1.set(0);
+        accessLogWriterCounter2.set(0);
         sleepServiceCalled.set(false);
         clientFactory = ClientFactory.builder()
                                      .idleTimeoutMillis(0)
@@ -144,7 +146,7 @@ class GracefulShutdownIntegrationTest {
             totalNanos += stopTime - startTime;
         }
 
-        assertThat(accessLogWriterCounter1).hasValue(iteration);
+        assertThat(accessLogWriterCounter1).hasValue(iteration * 2);
         assertThat(accessLogWriterCounter2).hasValue(iteration);
         return baselineNanos = totalNanos / iteration;
     }


### PR DESCRIPTION
Motivation:
When users want to set multiple `AccessLogWriter`, they need to chain the `AccessLogWriter` by themselves
because the writer set later overwrite the previous one.
```java
AccessLogWriter fooWriter = ...
AccessLogWriter barWriter = ...
ServerBuilder sb1 = ...
sb1.accessLogWriter(fooWriter, false);
sb1.accessLogWriter(barWriter, true); // Not OK because fooWriter is overwritten

ServerBuilder sb2 = ...
sb2.accessLogWriter(fooWriter.andThen(barWriter), false); // OK
```
However, it's not convenient and also it's problem if users want to shut down one of the `AccessLogWriter`s when the server shuts down.
It would be nice to chain the multiple `AccessLogWriter` inside the builder and shut down the `AccessLogWriter`s only those who need it.

Modifications:
- Chain `AccessLogWriter` inside of the builders
- Introduce `ShutdownSupport`, which is a package-private class, to shut down the instances when the server stops
  - e.g. `AccessLogWriter` and `blockingTaskExecutor`

Result:
- You can now set multiple `AccessLogWriter` to `ServerBuilder` and `ServiceBindingBuilder`.
- (Deprecation) `ServiceConfig.shutdownBlockingTaskExecutorOnStop()`, `ServiceConfig.shutdownAccessLogWriterOnStop()`, `ServerConfig.shutdownBlockingTaskExecutorOnStop()` and `ServerConfig.shutdownWorkerGroupOnStop()` are deprecated.
  - They aren't used anymore.