### PR TITLE
Recover HttpResponse according to a specific exception class

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -976,7 +976,7 @@ public interface HttpResponse extends Response, HttpMessage {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         final StreamMessage<HttpObject> stream = recover(cause -> {
-            if (!cause.getClass().isAssignableFrom(causeClass)) {
+            if (!causeClass.isAssignableFrom(cause.getClass())) {
                 return Exceptions.throwUnsafely(cause);
             }
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -963,6 +963,18 @@ public interface HttpResponse extends Response, HttpMessage {
      * notRecovered.aggregate().join();
      *
      * HttpResponse response = HttpResponse.ofFailure(new IllegalStateException("Oops..."));
+     * // Use the shortcut recover method as a chain.
+     * HttpResponse recoverChain =
+     *     response.recover(RuntimeException.class, cause -> {
+     *         final IllegalArgumentException ex = new IllegalArgumentException("Oops2...");
+     *         // If a failed response is returned from the first chain
+     *         return HttpResponse.ofFailure(ex);
+     *     })
+     *     // If the shortcut exception type is correct, catch and recover in the second chain.
+     *     .recover(IllegalArgumentException.class, cause -> HttpResponse.of("fallback"));
+     * recoverChain.aggregate().join();
+     *
+     * HttpResponse response = HttpResponse.ofFailure(new IllegalStateException("Oops..."));
      * // If the exception type does not match
      * HttpResponse mismatchRecovered =
      *     response.recover(IllegalArgumentException.class, cause -> HttpResponse.of("Fallback"));

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -939,8 +939,8 @@ public interface HttpResponse extends Response, HttpMessage {
         return of(new RecoverableStreamMessage<>(this, function, /* allowResuming */ false));
     }
 
-    default HttpResponse recover(Class<? extends Throwable> causeClass,
-                                 Function<? super Throwable, ? extends HttpResponse> function) {
+    default <T extends Throwable> HttpResponse recover(Class<T> causeClass,
+                                                       Function<? super T, ? extends HttpResponse> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         final StreamMessage<HttpObject> stream = recover(cause -> {
@@ -948,7 +948,7 @@ public interface HttpResponse extends Response, HttpMessage {
                 return Exceptions.throwUnsafely(cause);
             }
             try {
-                final HttpResponse recoveredResponse = function.apply(cause);
+                final HttpResponse recoveredResponse = function.apply((T) cause);
                 requireNonNull(recoveredResponse, "recoveredResponse");
                 return recoveredResponse;
             } catch (Throwable t) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -976,7 +976,7 @@ public interface HttpResponse extends Response, HttpMessage {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recover(cause -> {
-            if (!causeClass.isAssignableFrom(cause.getClass())) {
+            if (!causeClass.isInstance(cause)) {
                 return Exceptions.throwUnsafely(cause);
             }
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -966,7 +966,7 @@ public interface HttpResponse extends Response, HttpMessage {
      * // If the exception type does not match
      * HttpResponse misMatchRecovered =
      *     response.recover(IllegalArgumentException.class, cause -> HttpResponse.of("Fallback"));
-     * // In this case, CompletionException is returned. (can't recover exception)
+     * // In this case, CompletionException is thrown. (can't recover exception)
      * misMatchRecovered.aggregate().join();
      * }</pre>
      */
@@ -975,7 +975,7 @@ public interface HttpResponse extends Response, HttpMessage {
                                                        Function<? super T, ? extends HttpResponse> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
-        final StreamMessage<HttpObject> stream = recover(cause -> {
+        return recover(cause -> {
             if (!causeClass.isAssignableFrom(cause.getClass())) {
                 return Exceptions.throwUnsafely(cause);
             }
@@ -987,6 +987,5 @@ public interface HttpResponse extends Response, HttpMessage {
                 return Exceptions.throwUnsafely(t);
             }
         });
-        return of(stream);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -969,7 +969,7 @@ public interface HttpResponse extends Response, HttpMessage {
      * // In this case, CompletionException is returned. (can't recover exception)
      * misMatchRecovered.aggregate().join();
      * }</pre>
-     * */
+     */
     @UnstableApi
     default <T extends Throwable> HttpResponse recover(Class<T> causeClass,
                                                        Function<? super T, ? extends HttpResponse> function) {

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -33,7 +33,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.linecorp.armeria.common.util.Exceptions;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -52,6 +51,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.AbortedHttpResponse;
 import com.linecorp.armeria.internal.common.DefaultHttpResponse;
 import com.linecorp.armeria.internal.common.DefaultSplitHttpResponse;
@@ -939,16 +939,16 @@ public interface HttpResponse extends Response, HttpMessage {
         return of(new RecoverableStreamMessage<>(this, function, /* allowResuming */ false));
     }
 
-	default HttpResponse recover(Class<? extends Throwable> causeClass,
-								 Function<? super Throwable, ? extends HttpResponse> function) {
-		requireNonNull(causeClass, "causeClass");
-		requireNonNull(function, "function");
-		final StreamMessage<HttpObject> stream = recover(cause -> {
-			if(cause.getClass().equals(causeClass)) {
-				return function.apply(cause);
-			}
-			return Exceptions.throwUnsafely(cause);
-		});
-		return of(stream);
-	}
+    default HttpResponse recover(Class<? extends Throwable> causeClass,
+                                 Function<? super Throwable, ? extends HttpResponse> function) {
+        requireNonNull(causeClass, "causeClass");
+        requireNonNull(function, "function");
+        final StreamMessage<HttpObject> stream = recover(cause -> {
+            if (cause.getClass().equals(causeClass)) {
+                return function.apply(cause);
+            }
+            return Exceptions.throwUnsafely(cause);
+        });
+        return of(stream);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -940,10 +940,9 @@ public interface HttpResponse extends Response, HttpMessage {
     }
 
     /**
-     * Recovers an {@link HttpResponse} exception to the specified {@link Throwable} class.
-     * when any error occurs before a {@link ResponseHeaders} is written.
-     * Note that the failed {@link HttpResponse} cannot be recovered from an error if
-     * a {@link ResponseHeaders} was written already
+     * Recovers a failed {@link HttpResponse} by switching to a returned fallback {@link HttpResponse}
+     * when the thrown {@link Throwable} is the same type or a subtype of the
+     * specified {@code causeClass}.
      *
      * <p>Example:<pre>{@code
      * HttpResponse response = HttpResponse.ofFailure(new IllegalStateException("Oops..."));

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -964,10 +964,10 @@ public interface HttpResponse extends Response, HttpMessage {
      *
      * HttpResponse response = HttpResponse.ofFailure(new IllegalStateException("Oops..."));
      * // If the exception type does not match
-     * HttpResponse misMatchRecovered =
+     * HttpResponse mismatchRecovered =
      *     response.recover(IllegalArgumentException.class, cause -> HttpResponse.of("Fallback"));
      * // In this case, CompletionException is thrown. (can't recover exception)
-     * misMatchRecovered.aggregate().join();
+     * mismatchRecovered.aggregate().join();
      * }</pre>
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -791,6 +791,23 @@ public interface StreamMessage<T> extends Publisher<T> {
      * DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
      * stream.write(1);
      * stream.write(2);
+     * stream.write(3);
+     * stream.close(new IllegalStateException("test exception"));
+     * // Use the shortcut recover method as a chain.
+     * StreamMessage<Integer> recoverChain =
+     *     stream.recoverAndResume(RuntimeException.class, cause -> {
+     *         final IllegalArgumentException ex = new IllegalArgumentException("oops..");
+     *         // If a aborted StreamMessage returned from the first chain
+     *         return StreamMessage.aborted(ex);
+     *     })
+     *     // If the shortcut exception type is correct, catch and recover in the second chain.
+     *     .recoverAndResume(IllegalArgumentException.class, cause -> StreamMessage.of(4, 5));
+     *
+     * recoverChain.collect().join();
+     *
+     * DefaultStreamMessage<Integer> stream = new DefaultStreamMessage<>();
+     * stream.write(1);
+     * stream.write(2);
      * stream.close(ClosedStreamException.get());
      * // If the exception type does not match
      * StreamMessage<Integer> mismatchRecovered =

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -798,7 +798,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * // In this case, CompletionException is returned. (can't recover exception)
      * misMatchRecovered.collect().join();
      * }</pre>
-     * */
+     */
     @UnstableApi
     default <E extends Throwable> StreamMessage<T> recoverAndResume(Class<E> causeClass,
             Function<? super E, ? extends StreamMessage<T>> function) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -806,7 +806,7 @@ public interface StreamMessage<T> extends Publisher<T> {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recoverAndResume(cause -> {
-            if (!causeClass.isAssignableFrom(cause.getClass())) {
+            if (!causeClass.isInstance(cause)) {
                 return Exceptions.throwUnsafely(cause);
             }
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -805,7 +805,7 @@ public interface StreamMessage<T> extends Publisher<T> {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         final StreamMessage<T> stream = recoverAndResume(cause -> {
-            if (!cause.getClass().isAssignableFrom(causeClass)) {
+            if (!causeClass.isAssignableFrom(cause.getClass())) {
                 return Exceptions.throwUnsafely(cause);
             }
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -793,11 +793,11 @@ public interface StreamMessage<T> extends Publisher<T> {
      * stream.write(2);
      * stream.close(ClosedStreamException.get());
      * // If the exception type does not match
-     * StreamMessage<Integer> misMatchRecovered =
+     * StreamMessage<Integer> mismatchRecovered =
      *     stream.recoverAndResume(IllegalStateException.class, cause -> StreamMessage.of(3, 4));
      *
      * // In this case, CompletionException is thrown. (can't recover exception)
-     * misMatchRecovered.collect().join();
+     * mismatchRecovered.collect().join();
      * }</pre>
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -774,7 +774,7 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Recovers failed {@link StreamMessage} for the specified {@link Throwable} and resumes by subscribing
+     * Recovers a failed {@link StreamMessage} for the specified {@link Throwable} and resumes by subscribing
      * to a returned fallback {@link StreamMessage} when any error occurs.
      *
      * <p>Example:<pre>{@code

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
@@ -276,25 +276,25 @@ class RecoverableStreamMessageTest {
                 .hasCauseInstanceOf(ClosedStreamException.class);
     }
 
-	@Test
-	void shortcutRecoverableHttpResponse() {
-		final HttpResponse failedResponse = HttpResponse.ofFailure(new IllegalStateException("test exception"));
-		final HttpResponse recovered =
-			failedResponse.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
-		final AggregatedHttpResponse response = recovered.aggregate().join();
-		assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
-		assertThat(response.contentUtf8()).isEqualTo("fallback");
+    @Test
+    void shortcutRecoverableHttpResponse() {
+        final HttpResponse failedResponse = HttpResponse.ofFailure(new IllegalStateException("test exception"));
+        final HttpResponse recovered =
+            failedResponse.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
+        final AggregatedHttpResponse response = recovered.aggregate().join();
+        assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("fallback");
 
-		final HttpResponseWriter failedResponse2 = HttpResponse.streaming();
-		failedResponse2.write(ResponseHeaders.of(HttpStatus.OK));
-		final HttpResponse transformed =
-			failedResponse2.mapHeaders(headers -> {
-				throw new IllegalStateException("test exception");
-			});
-		final HttpResponse recovered2 =
-			transformed.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
-		final AggregatedHttpResponse response2 = recovered2.aggregate().join();
-		assertThat(response2.headers().status()).isEqualTo(HttpStatus.OK);
-		assertThat(response.contentUtf8()).isEqualTo("fallback");
-	}
+        final HttpResponseWriter failedResponse2 = HttpResponse.streaming();
+        failedResponse2.write(ResponseHeaders.of(HttpStatus.OK));
+        final HttpResponse transformed =
+            failedResponse2.mapHeaders(headers -> {
+                throw new IllegalStateException("test exception");
+            });
+        final HttpResponse recovered2 =
+            transformed.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
+        final AggregatedHttpResponse response2 = recovered2.aggregate().join();
+        assertThat(response2.headers().status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).isEqualTo("fallback");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
@@ -114,7 +114,7 @@ class RecoverableStreamMessageTest {
         assertThatThrownBy(() -> recoverable.collect().join())
             .isInstanceOf(CompletionException.class)
             .hasCauseInstanceOf(CompositeException.class)
-            .extracting("cause")
+            .getCause()
             .extracting("exceptions", ITERABLE)
             .element(0)
             .isInstanceOf(ClosedStreamException.class);
@@ -375,7 +375,7 @@ class RecoverableStreamMessageTest {
         assertThatThrownBy(() -> incorrectRecover.aggregate().join())
             .isInstanceOf(CompletionException.class)
             .hasCauseInstanceOf(CompositeException.class)
-            .extracting("cause")
+            .getCause()
             .extracting("exceptions", ITERABLE)
             .element(0)
             .isInstanceOf(NullPointerException.class);
@@ -387,7 +387,7 @@ class RecoverableStreamMessageTest {
         assertThatThrownBy(() -> incorrectRecover2.aggregate().join())
             .isInstanceOf(CompletionException.class)
             .hasCauseInstanceOf(CompositeException.class)
-            .extracting("cause")
+            .getCause()
             .extracting("exceptions", ITERABLE)
             .element(0)
             .isInstanceOf(IllegalStateException.class);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/RecoverableStreamMessageTest.java
@@ -275,4 +275,26 @@ class RecoverableStreamMessageTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ClosedStreamException.class);
     }
+
+	@Test
+	void shortcutRecoverableHttpResponse() {
+		final HttpResponse failedResponse = HttpResponse.ofFailure(new IllegalStateException("test exception"));
+		final HttpResponse recovered =
+			failedResponse.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
+		final AggregatedHttpResponse response = recovered.aggregate().join();
+		assertThat(response.headers().status()).isEqualTo(HttpStatus.OK);
+		assertThat(response.contentUtf8()).isEqualTo("fallback");
+
+		final HttpResponseWriter failedResponse2 = HttpResponse.streaming();
+		failedResponse2.write(ResponseHeaders.of(HttpStatus.OK));
+		final HttpResponse transformed =
+			failedResponse2.mapHeaders(headers -> {
+				throw new IllegalStateException("test exception");
+			});
+		final HttpResponse recovered2 =
+			transformed.recover(IllegalStateException.class, cause -> HttpResponse.of("fallback"));
+		final AggregatedHttpResponse response2 = recovered2.aggregate().join();
+		assertThat(response2.headers().status()).isEqualTo(HttpStatus.OK);
+		assertThat(response.contentUtf8()).isEqualTo("fallback");
+	}
 }


### PR DESCRIPTION
### Motivation:

If it is not a global exception handler, users may be interested in recovering an exception.
So, we can add a shortcut method for those requirements.
For example
```java
HttpResponse failed = HttpResponse.ofFailure(new IllegalStateException("Oops..."));
failed.recover(IllegalArgumentException.class, 
               cause -> HttpResponse.of(HttpStatus.BAD_REQUEST))
      .recover(IllegalStateException.class, 
               cause -> HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR))
      .recover(....)
```
Users may be to want recover shortcut specific exception class type.

### Modifications:

- Add `recover()` shortcut method in `HttpResponse`

### Result:

- Close #4279
- You can now map a specific exception to an <type://HttpResponse>.
  ```java
  HttpResponse recovered =
      response.recover(IllegalStateException.class,
                       cause -> HttpResponse.of("Fallback"));
  ```
