### PR TITLE
Add max-age ServerCacheControl.DISABLED/REVALIDATE

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaders.java
@@ -92,7 +92,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
  *   <li>{@link CacheControl} and {@link ContentDisposition}
  *     <ul>
  *       <li>Converted via {@code asHeaderValue()}</li>
- *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}, {@code "form-data; name=\"fieldName\""}</li>
+ *       <li>e.g. {@code "no-cache, no-store, max-age=0, must-revalidate"},
+ *         {@code "form-data; name=\"fieldName\""}</li>
  *     </ul>
  *   </li>
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}

--- a/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
+++ b/core/src/main/java/com/linecorp/armeria/common/QueryParams.java
@@ -94,7 +94,8 @@ import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
  *   <li>{@link CacheControl} and {@link ContentDisposition}
  *     <ul>
  *       <li>Converted via {@code asHeaderValue()}</li>
- *       <li>e.g. {@code "no-cache, no-store, must-revalidate"}, {@code "form-data; name=\"fieldName\""}</li>
+ *       <li>e.g. {@code "no-cache, no-store, max-age=0, must-revalidate"},
+ *         {@code "form-data; name=\"fieldName\""}</li>
  *     </ul>
  *   </li>
  *   <li>{@link Instant}, {@link TemporalAccessor}, {@link Date} and {@link Calendar}

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -42,7 +42,7 @@ public final class ServerCacheControl extends CacheControl {
     public static final ServerCacheControl EMPTY = builder().build();
 
     /**
-     * {@code "no-cache, no-store, must-revalidate"}.
+     * {@code "no-cache, no-store, max-age=0, must-revalidate"}.
      */
     public static final ServerCacheControl DISABLED = builder().noCache()
                                                                .maxAgeSeconds(0)
@@ -51,7 +51,7 @@ public final class ServerCacheControl extends CacheControl {
                                                                .build();
 
     /**
-     * {@code "no-cache, must-revalidate"}.
+     * {@code "no-cache, max-age=0, must-revalidate"}.
      */
     public static final ServerCacheControl REVALIDATED = builder().noCache()
                                                                   .maxAgeSeconds(0)

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -45,6 +45,7 @@ public final class ServerCacheControl extends CacheControl {
      * {@code "no-cache, no-store, must-revalidate"}.
      */
     public static final ServerCacheControl DISABLED = builder().noCache()
+                                                               .maxAgeSeconds(0)
                                                                .noStore()
                                                                .mustRevalidate()
                                                                .build();
@@ -53,6 +54,7 @@ public final class ServerCacheControl extends CacheControl {
      * {@code "no-cache, must-revalidate"}.
      */
     public static final ServerCacheControl REVALIDATED = builder().noCache()
+                                                                  .maxAgeSeconds(0)
                                                                   .mustRevalidate()
                                                                   .build();
 

--- a/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpHeadersTest.java
@@ -100,7 +100,7 @@ class HttpHeadersTest {
         assertThat(headers.get(DATE)).isEqualTo(expectedDate);
         assertThat(headers.get(LAST_MODIFIED)).isEqualTo(expectedDate);
         assertThat(headers.get(IF_MODIFIED_SINCE)).isEqualTo(expectedDate);
-        assertThat(headers.get(CACHE_CONTROL)).isEqualTo("no-cache, no-store, must-revalidate");
+        assertThat(headers.get(CACHE_CONTROL)).isEqualTo("no-cache, no-store, max-age=0, must-revalidate");
         assertThat(headers.get(CONTENT_TYPE)).isEqualTo("text/plain; charset=utf-8");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/QueryParamsTest.java
@@ -99,7 +99,7 @@ class QueryParamsTest {
         assertThat(params.get("date")).isEqualTo(expectedDate);
         assertThat(params.get("instant")).isEqualTo(expectedDate);
         assertThat(params.get("calendar")).isEqualTo(expectedDate);
-        assertThat(params.get("cache-control")).isEqualTo("no-cache, no-store, must-revalidate");
+        assertThat(params.get("cache-control")).isEqualTo("no-cache, no-store, max-age=0, must-revalidate");
         assertThat(params.get("media-type")).isEqualTo("text/plain; charset=utf-8");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/ServerCacheControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ServerCacheControlTest.java
@@ -27,11 +27,11 @@ public class ServerCacheControlTest {
     public void testConstants() {
         assertThat(ServerCacheControl.EMPTY.isEmpty()).isTrue();
         assertThat(ServerCacheControl.DISABLED.asHeaderValue())
-                .isEqualTo("no-cache, no-store, must-revalidate");
+                .isEqualTo("no-cache, no-store, max-age=0, must-revalidate");
         assertThat(ServerCacheControl.IMMUTABLE.asHeaderValue())
                 .isEqualTo("max-age=31536000, public, immutable");
         assertThat(ServerCacheControl.REVALIDATED.asHeaderValue())
-                .isEqualTo("no-cache, must-revalidate");
+                .isEqualTo("no-cache, max-age=0, must-revalidate");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -155,7 +155,8 @@ class AnnotatedDocServiceTest {
         final WebClient client = WebClient.of(server.httpUri());
         final AggregatedHttpResponse res = client.get("/docs/specification.json").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache, must-revalidate");
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo("no-cache, max-age=0, must-revalidate");
         assertThatJson(res.contentUtf8()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedJson);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceAdditionalHeadersTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceAdditionalHeadersTest.java
@@ -53,6 +53,6 @@ public class FileServiceAdditionalHeadersTest {
         assertThat(res.headers().getAll(HttpHeaderNames.of("foo"))).containsExactly("1", "2");
         assertThat(res.headers().getAll(HttpHeaderNames.of("bar"))).containsExactly("3");
         assertThat(res.headers().getAll(HttpHeaderNames.CACHE_CONTROL))
-                .containsExactly("no-cache, must-revalidate");
+                .containsExactly("no-cache, max-age=0, must-revalidate");
     }
 }

--- a/graphql/src/test/java/com/linecorp/armeria/internal/server/graphql/GraphqlDocServiceTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/internal/server/graphql/GraphqlDocServiceTest.java
@@ -100,7 +100,8 @@ class GraphqlDocServiceTest {
         final WebClient client = WebClient.of(server.httpUri());
         final AggregatedHttpResponse res = client.get("/docs/specification.json").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL)).isEqualTo("no-cache, must-revalidate");
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo("no-cache, max-age=0, must-revalidate");
         assertThatJson(res.contentUtf8())
                 .when(IGNORING_ARRAY_ORDER)
                 .node("services[0].name").isEqualTo("com.linecorp.armeria.server.graphql.DefaultGraphqlService")


### PR DESCRIPTION
Motivation:

According to `Cache-Control` spec, `must-revalidate` operates together with "stale" state, and an easy (the only?) way to specify "stale" is by adding `max-age=0` to the `Cache-Control` response header.

See #4290 for more information.

Modifications:

- Added `max-age=0` to the `ServerCacheControl.DISABLED` and `ServerCacheControl.REVALIDATE` constants

Result:

- Closes #4290
- Should only have benign effect.
  Theoretically a user of Cache-Control could've used e.g. `ServerCacheControl.DISABLED.toBuilder().mustRevalidate(false).build()` and get unexpected result, but I doubt it.
