### PR TITLE
Remove pseudo headers when converting to Spring headers

### DIFF
--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponse.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponse.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
+import static com.linecorp.armeria.spring.web.reactive.ArmeriaHttpHeadersUtil.fromArmeriaHttpHeaders;
 import static java.util.Objects.requireNonNull;
 
 import org.springframework.core.io.buffer.DataBuffer;
@@ -92,7 +93,7 @@ final class ArmeriaClientHttpResponse implements ClientHttpResponse {
         if (httpHeaders != null) {
             return httpHeaders;
         }
-        this.httpHeaders = initHttpHeaders();
+        this.httpHeaders = fromArmeriaHttpHeaders(headers);
         return this.httpHeaders;
     }
 
@@ -118,11 +119,5 @@ final class ArmeriaClientHttpResponse implements ClientHttpResponse {
                                                                  .httpOnly(c.isHttpOnly())
                                                                  .build()));
         return cookies;
-    }
-
-    private HttpHeaders initHttpHeaders() {
-        final HttpHeaders httpHeaders = new HttpHeaders();
-        headers.forEach(entry -> httpHeaders.add(entry.getKey().toString(), entry.getValue()));
-        return httpHeaders;
     }
 }

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpHeadersUtil.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaHttpHeadersUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import java.util.Map.Entry;
+
+import org.springframework.http.HttpHeaders;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+
+import io.netty.util.AsciiString;
+
+final class ArmeriaHttpHeadersUtil {
+
+    static HttpHeaders fromArmeriaHttpHeaders(com.linecorp.armeria.common.HttpHeaders armeriaHeaders) {
+        final HttpHeaders springHeaders = new HttpHeaders();
+        for (Entry<AsciiString, String> e : armeriaHeaders) {
+            final AsciiString k = e.getKey();
+            final String v = e.getValue();
+
+            if (k.isEmpty()) {
+                continue;
+            }
+
+            if (k.charAt(0) != ':') {
+                springHeaders.add(k.toString(), v);
+            } else if (HttpHeaderNames.AUTHORITY.equals(k) && !armeriaHeaders.contains(HttpHeaderNames.HOST)) {
+                // Convert `:authority` to `host`.
+                springHeaders.add(HttpHeaderNames.HOST.toString(), v);
+            }
+        }
+        return springHeaders;
+    }
+
+    private ArmeriaHttpHeadersUtil() {}
+}

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpRequest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
+import static com.linecorp.armeria.spring.web.reactive.ArmeriaHttpHeadersUtil.fromArmeriaHttpHeaders;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
@@ -26,7 +27,6 @@ import javax.net.ssl.SSLSession;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpCookie;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.AbstractServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.SslInfo;
@@ -76,12 +76,6 @@ final class ArmeriaServerHttpRequest extends AbstractServerHttpRequest {
         return URI.create(scheme + "://" + authority + req.path());
     }
 
-    private static HttpHeaders fromArmeriaHttpHeaders(com.linecorp.armeria.common.HttpHeaders httpHeaders) {
-        final HttpHeaders newHttpHeaders = new HttpHeaders();
-        httpHeaders.forEach(entry -> newHttpHeaders.add(entry.getKey().toString(), entry.getValue()));
-        return newHttpHeaders;
-    }
-
     @Override
     protected MultiValueMap<String, HttpCookie> initCookies() {
         final MultiValueMap<String, HttpCookie> cookies = new LinkedMultiValueMap<>();
@@ -120,6 +114,11 @@ final class ArmeriaServerHttpRequest extends AbstractServerHttpRequest {
     @Override
     public Flux<DataBuffer> getBody() {
         return body;
+    }
+
+    @Override
+    public InetSocketAddress getLocalAddress() {
+        return ctx.localAddress();
     }
 
     @Override

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequestTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpRequestTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Map.Entry;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,6 +77,14 @@ public class ArmeriaClientHttpRequestTest {
         StepVerifier.create(httpRequest).expectComplete().verify();
 
         await().until(() -> httpRequest.whenComplete().isDone());
+
+        // Spring headers does not have pseudo headers.
+        for (Entry<String, List<String>> header : request.getHeaders().entrySet()) {
+            assertThat(header.getKey()).doesNotStartWith(":");
+        }
+        assertThat(httpRequest.headers().names())
+                .contains(HttpHeaderNames.METHOD, HttpHeaderNames.AUTHORITY,
+                          HttpHeaderNames.SCHEME, HttpHeaderNames.PATH);
     }
 
     @Test

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaClientHttpResponseTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -67,6 +69,11 @@ public class ArmeriaClientHttpResponseTest {
                     .verify();
 
         await().until(() -> httpResponse.whenComplete().isDone());
+
+        // Spring headers does not have pseudo headers.
+        for (Entry<String, List<String>> header : response.getHeaders().entrySet()) {
+            assertThat(header.getKey()).doesNotStartWith(":");
+        }
     }
 
     @Test

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaServerHttpResponseTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -109,6 +111,11 @@ class ArmeriaServerHttpResponseTest {
                     .verify();
 
         await().until(() -> httpResponse.whenComplete().isDone());
+
+        // Spring headers does not have pseudo headers.
+        for (Entry<String, List<String>> header : response.getHeaders().entrySet()) {
+            assertThat(header.getKey()).doesNotStartWith(":");
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:
We store HTTP/2 pseudo headers to the map in `HttpHeaders` with other headers.
Then, the entries of the map are copied to Spring `HttpHeaders` in Spring integration.
However, it can be a problem when the copied Spring `HttpHeaders` is converted to Netty Headers later:
https://github.com/spring-cloud/spring-cloud-gateway/blob/v3.1.3/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java#L125-L128
The validation is failed when the pseudo headers are set.

Modifications:
- Remove HTTP/2 pseudo headers when creating Spring `HttpHeaders` from Armeria `HttpHeaders`.
  - Convert `:authority` header to `HOST` header.
- Override `ServerHttpRequest.getLocalAddress()` which is added since Spring 5.2.x.

Result:
- You no longer see `IllegalArgumentException` indicating the prohibited character of a header name
  in an environment where Spring integration module and Netty client are used together.(e.g. Spring Cloud Gateway)