### PR TITLE
Conditional request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
@@ -170,26 +170,39 @@ public final class ConditionalRequestUtil {
         }
 
         if (dataLastModified != null) {
-            try {
-                final Long ifModifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE);
-                if (ifModifiedSince != null) {
-                    if (dataLastModified / 1000 <= ifModifiedSince / 1000) {
-                        return SKIP_METHOD_NOT_MODIFIED;
-                    }
-                }
-            } catch (Exception e) {
-                // Malformed date.
+            ETagResponse ifModifiedSinceResponse = ifModifiedSince(reqHeaders, dataLastModified);
+            if (ifModifiedSinceResponse != PERFORM_METHOD) {
+                return ifModifiedSinceResponse;
             }
-            try {
-                final Long ifUnmodifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_UNMODIFIED_SINCE);
-                if (ifUnmodifiedSince != null) {
-                    if (dataLastModified / 1000 >= ifUnmodifiedSince / 1000) {
-                        return SKIP_METHOD_NOT_MODIFIED;
-                    }
+            return ifUnmodifiedSince(reqHeaders, dataLastModified);
+        }
+        return PERFORM_METHOD;
+    }
+
+    public static ETagResponse ifUnmodifiedSince(RequestHeaders reqHeaders, Long dataLastModified) {
+        try {
+            final Long ifUnmodifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_UNMODIFIED_SINCE);
+            if (ifUnmodifiedSince != null) {
+                if (dataLastModified / 1000 >= ifUnmodifiedSince / 1000) {
+                    return SKIP_METHOD_NOT_MODIFIED;
                 }
-            } catch (Exception e) {
-                // Malformed date.
             }
+        } catch (Exception e) {
+            // Malformed date.
+        }
+        return PERFORM_METHOD;
+    }
+
+    public static ETagResponse ifModifiedSince(RequestHeaders reqHeaders, Long dataLastModified) {
+        try {
+            final Long ifModifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE);
+            if (ifModifiedSince != null) {
+                if (dataLastModified / 1000 <= ifModifiedSince / 1000) {
+                    return SKIP_METHOD_NOT_MODIFIED;
+                }
+            }
+        } catch (Exception e) {
+            // Malformed date.
         }
         return PERFORM_METHOD;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
@@ -25,7 +25,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.math.LongMath;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -174,7 +173,6 @@ public final class ConditionalRequestUtil {
             try {
                 final Long ifModifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE);
                 if (ifModifiedSince != null) {
-                    @SuppressWarnings("UnstableApiUsage")
                     if (dataLastModified / 1000 <= ifModifiedSince / 1000) {
                         return SKIP_METHOD_NOT_MODIFIED;
                     }
@@ -185,7 +183,7 @@ public final class ConditionalRequestUtil {
             try {
                 final Long ifUnmodifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_UNMODIFIED_SINCE);
                 if (ifUnmodifiedSince != null) {
-                    if (dataLastModified / 1000 >= ifModifiedSince / 1000) {
+                    if (dataLastModified / 1000 >= ifUnmodifiedSince / 1000) {
                         return SKIP_METHOD_NOT_MODIFIED;
                     }
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtil.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.conditional;
+
+import static com.linecorp.armeria.server.conditional.ETag.parseHeader;
+import static com.linecorp.armeria.server.conditional.ETagResponse.PERFORM_METHOD;
+import static com.linecorp.armeria.server.conditional.ETagResponse.SKIP_METHOD_NOT_MODIFIED;
+import static com.linecorp.armeria.server.conditional.ETagResponse.SKIP_METHOD_PRECONDITION_FAILED;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.math.LongMath;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * This class helps with handling of Conditional Requests as per
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2732">RFC 7232</a>.
+ */
+public final class ConditionalRequestUtil {
+    private ConditionalRequestUtil() {}
+
+    @VisibleForTesting
+    static boolean strongComparison(List<ETag> eTags, ETag dataETag) {
+        if (dataETag.isWeak()) {
+            return false;
+        }
+        for (ETag eTag : eTags) {
+            if (eTag.isStrong() && eTag.getETag().equals(dataETag.getETag())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @VisibleForTesting
+    static boolean weakComparison(List<ETag> requestETags, ETag dataETag) {
+        for (ETag eTag : requestETags) {
+            if (eTag.getETag().equals(dataETag.getETag())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Performs an If-Match.
+     * @param requestETags The parsed If-None-Match header.
+     * @param dataETag The ETag of the current data. If the resource doesn't exists, this is null.
+     *      This is mostly used to make sure PUT operations don't overwrite existing data.
+     * @return true if the method should be performed (ie. NOT just return 304 Not Modified).
+     */
+    public static ETagResponse ifMatch(List<ETag> requestETags, @Nullable ETag dataETag) {
+        requireNonNull(requestETags, "requestETags cannot be null");
+        // Making sure that it's the same instance
+        if (requestETags == ETag.ASTERISK_ETAG) {
+            if (dataETag != null) {
+                return PERFORM_METHOD;
+            } else {
+                return SKIP_METHOD_PRECONDITION_FAILED;
+            }
+        }
+        if (dataETag == null) {
+            return PERFORM_METHOD;
+        }
+        // If-Match requires strong match which can never match weak tags
+        if (strongComparison(requestETags, dataETag)) {
+            return SKIP_METHOD_PRECONDITION_FAILED;
+        }
+        return PERFORM_METHOD;
+    }
+
+    /**
+     * Performs an If-Match.
+     * @param header The If-None-Match header.
+     * @param dataETag The ETag of the current data. If the resource doesn't exists, this is null.
+     *      This is mostly used to make sure PUT operations don't overwrite existing data.
+     * @return true if the method should be performed (ie. NOT just return 304 Not Modified).
+     */
+    public static ETagResponse ifMatch(@Nullable String header, @Nullable ETag dataETag) {
+        final List<ETag> requestETags = parseHeader(header);
+        if (requestETags != null) {
+            return ifMatch(requestETags, dataETag);
+        }
+        return PERFORM_METHOD;
+    }
+
+    /**
+     * Performs an If-None-Match.
+     * @param requestETags The parsed If-None-Match header.
+     * @param dataETag The ETag of the current data. If the resource doesn't exists, this is null.
+     *      This is mostly used to make sure PUT operations don't overwrite existing data.
+     * @return true if the method should be performed (ie. NOT just return 304 Not Modified).
+     */
+    public static ETagResponse ifNoneMatch(List<ETag> requestETags, @Nullable ETag dataETag) {
+        requireNonNull(requestETags, "requestETags cannot be null");
+        // Making sure that it's the same instance
+        if (requestETags == ETag.ASTERISK_ETAG) {
+            if (dataETag != null) {
+                return SKIP_METHOD_NOT_MODIFIED;
+            } else {
+                return PERFORM_METHOD;
+            }
+        }
+        if (dataETag != null) {
+            if (weakComparison(requestETags, dataETag)) {
+                return SKIP_METHOD_NOT_MODIFIED;
+            }
+        }
+        return PERFORM_METHOD;
+    }
+
+    /**
+     * Performs an If-None-Match.
+     * @param header The If-None-Match header.
+     * @param dataETag The ETag of the current data. If the resource doesn't exists, this is null.
+     *      This is mostly used to make sure PUT operations don't overwrite existing data.
+     * @return true if the method should be performed (ie. NOT just return 304 Not Modified).
+     */
+    public static ETagResponse ifNoneMatch(@Nullable String header, @Nullable ETag dataETag) {
+        final List<ETag> requestETags = parseHeader(header);
+        if (requestETags != null) {
+            return ifNoneMatch(requestETags, dataETag);
+        }
+        return PERFORM_METHOD;
+    }
+
+    /**
+     * Processes a request doing If-Match, If-None-Match and If-Modified-Since.
+     * @param reqHeaders The RequestHeaders object of the request.
+     * @param dataETag The ETag of the current data. If the resource doesn't exists, this is null.
+     *      This is mostly used to make sure PUT operations don't overwrite existing data.
+     * @return HttpStatus to return. PRECONDITION_FAILED for when If-Match matches.
+     */
+    public static ETagResponse conditionalRequest(RequestHeaders reqHeaders,
+                                                  @Nullable ETag dataETag,
+                                                  @Nullable Long dataLastModified) {
+        requireNonNull(reqHeaders, "reqHeaders cannot be null");
+        final List<ETag> ifMatchHeader = parseHeader(reqHeaders.get(HttpHeaderNames.IF_MATCH));
+        if (ifMatchHeader != null && ifMatch(ifMatchHeader, dataETag) == SKIP_METHOD_PRECONDITION_FAILED) {
+            return SKIP_METHOD_PRECONDITION_FAILED;
+        }
+        final String ifNoneMatchHeader = reqHeaders.get(HttpHeaderNames.IF_NONE_MATCH);
+        if (ifNoneMatchHeader != null) {
+            final ETagResponse ifNoneMatchResponse = ifNoneMatch(ifNoneMatchHeader, dataETag);
+            if (ifNoneMatchResponse == SKIP_METHOD_NOT_MODIFIED) {
+                return SKIP_METHOD_NOT_MODIFIED;
+            } else {
+                // Handle 'if-modified-since' header, only if 'if-none-match' does not exist.
+                // ie return here, because if-modified-since is definitive.
+                return PERFORM_METHOD;
+            }
+        }
+
+        if (dataLastModified != null) {
+            try {
+                final Long ifModifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_MODIFIED_SINCE);
+                if (ifModifiedSince != null) {
+                    @SuppressWarnings("UnstableApiUsage")
+                    final long ifModifiedSinceMillis = LongMath.saturatedAdd(ifModifiedSince, 999);
+                    if (dataLastModified <= ifModifiedSinceMillis) {
+                        return SKIP_METHOD_NOT_MODIFIED;
+                    }
+                }
+            } catch (Exception e) {
+                // Malformed date.
+            }
+            try {
+                final Long ifUnmodifiedSince = reqHeaders.getTimeMillis(HttpHeaderNames.IF_UNMODIFIED_SINCE);
+                if (ifUnmodifiedSince != null) {
+                    @SuppressWarnings("UnstableApiUsage")
+                    // TODO Reviewers, is this correct?
+                    final long ifModifiedSinceMillis = LongMath.saturatedSubtract(ifUnmodifiedSince, 999);
+                    if (dataLastModified >= ifModifiedSinceMillis) {
+                        return SKIP_METHOD_NOT_MODIFIED;
+                    }
+                }
+            } catch (Exception e) {
+                // Malformed date.
+            }
+        }
+        return PERFORM_METHOD;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.conditional;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * An Entity Tag as used in <a href="https://datatracker.ietf.org/doc/html/rfc2732">RFC 7232</a>.
+ */
+public final class ETag {
+    public static final List<ETag> ASTERISK_ETAG =
+            ImmutableList.of(
+                    new ETag("*", false)
+            );
+
+    private static final Pattern ETAG_REGEX = Pattern.compile("(W/|)\"([^\"]*)\"");
+
+    private final String eTag;
+    private final boolean weak;
+
+    /**
+     * Create an Entity tag instance.
+     * @param eTag The data.
+     * @param weak The weak state.
+     */
+    public ETag(String eTag, boolean weak) {
+        Preconditions.checkArgument(validateEtag(eTag), "Invalid ETag: '%s'", eTag);
+        this.eTag = eTag;
+        this.weak = weak;
+    }
+
+    @Override
+    public String toString() {
+        return asHeaderValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ETag)) {
+            return false;
+        }
+        final ETag eTag = (ETag) o;
+        return weak == eTag.weak && Objects.equal(this.eTag, eTag.eTag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(eTag, weak);
+    }
+
+    /**
+     * Getter.
+     * @return the Entity Tag.
+     */
+    public String getETag() {
+        return eTag;
+    }
+
+    /**
+     * Getter.
+     * @return Weak state.
+     */
+    public boolean isWeak() {
+        return weak;
+    }
+
+    /**
+     * Getter.
+     * @return The inverse of Weak state.
+     */
+    public boolean isStrong() {
+        return !weak;
+    }
+
+    /**
+     * Convert into header value.
+     * @return Make a string suitable for debugging and adding to headers.
+     */
+    public String asHeaderValue() {
+        final StringBuilder builder = new StringBuilder();
+        if (weak) {
+            builder.append("W/");
+        }
+        return builder
+                .append('\"')
+                .append(eTag)
+                .append('\"')
+                .toString();
+    }
+
+    /**
+     * Validate that the Entity Tag does not contain any illegal characters.
+     * @param etag the Entity Tag.
+     * @return true if it validates clean.
+     */
+    public static boolean validateEtag(String etag) {
+        for (int i = 0; i < etag.length(); i++) {
+            final char value = etag.charAt(i);
+            // 0x21, 0x23-0x74 and 0x7f-0xff in US-ASCII is allowed.
+            // That means it's easier to check for what's _disallowed_ as
+            // all unicode characters are allowed.
+            if (value <= 0x20 || value == 0x22 || value == 0x7f) {
+                // Parsing error - throw Exception instead?
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Splits the If-Not-Modified header into multiple Entity Tags.
+     * Format is according to RFC2732
+     * <pre>
+     *  If-Match = "*" / 1#entity-tag
+     *  If-None-Match = "*" / 1#entity-tag
+     *      entity-tag = [ weak ] opaque-tag
+     *      weak       = %x57.2F ; "W/", case-sensitive
+     *      opaque-tag = DQUOTE *etagc DQUOTE
+     *      etagc      = %x21 / %x23-7E / obs-text
+     *              ; VCHAR except double quotes, plus obs-text
+     * </pre>
+     * @param header the If-Not-Modified or If-Match header of the request
+     * @return list of entity tags or null on parsing error
+     */
+    @Nullable
+    public static List<ETag> parseHeader(@Nullable String header) {
+        if (header == null) {
+            return ImmutableList.of();
+        }
+        if ("*".equals(header)) {
+            return ETag.ASTERISK_ETAG;
+        }
+
+        final Builder<ETag> results = ImmutableList.builder();
+        final Matcher matcher = ETAG_REGEX.matcher(header);
+        int expectedPos = 0;
+        while (matcher.find()) {
+            final String divider = header.substring(expectedPos, matcher.start()).trim();
+            if (!divider.isEmpty() && !",".equals(divider)) {
+                // Parsing error - throw Exception instead?
+                return null;
+            }
+            final boolean weak = "W/".equals(matcher.group(1));
+            results.add(new ETag(matcher.group(2), weak));
+            expectedPos = matcher.end();
+        }
+        final String trailer = header.substring(expectedPos).trim();
+        if (!trailer.isEmpty()) {
+            // Parsing error - throw Exception instead?
+            return null;
+        }
+        return results.build();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
@@ -135,7 +135,7 @@ public final class ETag {
 
     /**
      * Splits the If-Not-Modified header into multiple Entity Tags.
-     * Format is according to RFC2732
+     * Format is according to RFC7232
      * <pre>
      *  If-Match = "*" / 1#entity-tag
      *  If-None-Match = "*" / 1#entity-tag

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
@@ -38,17 +38,17 @@ public final class ETag {
 
     private static final Pattern ETAG_REGEX = Pattern.compile("(W/|)\"([^\"]*)\"");
 
-    private final String eTag;
+    private final String opaqueTag;
     private final boolean weak;
 
     /**
      * Create an Entity tag instance.
-     * @param eTag The data.
+     * @param opaqueTag The data.
      * @param weak The weak state.
      */
-    public ETag(String eTag, boolean weak) {
-        Preconditions.checkArgument(validateEtag(eTag), "Invalid ETag: '%s'", eTag);
-        this.eTag = eTag;
+    public ETag(String opaqueTag, boolean weak) {
+        Preconditions.checkArgument(validateEtag(opaqueTag), "Invalid opaque tag: '%s'", opaqueTag);
+        this.opaqueTag = opaqueTag;
         this.weak = weak;
     }
 
@@ -66,12 +66,12 @@ public final class ETag {
             return false;
         }
         final ETag eTag = (ETag) o;
-        return weak == eTag.weak && Objects.equal(this.eTag, eTag.eTag);
+        return weak == eTag.weak && Objects.equal(this.opaqueTag, eTag.opaqueTag);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(eTag, weak);
+        return Objects.hashCode(opaqueTag, weak);
     }
 
     /**
@@ -79,7 +79,7 @@ public final class ETag {
      * @return the Entity Tag.
      */
     public String getETag() {
-        return eTag;
+        return opaqueTag;
     }
 
     /**
@@ -109,7 +109,7 @@ public final class ETag {
         }
         return builder
                 .append('\"')
-                .append(eTag)
+                .append(opaqueTag)
                 .append('\"')
                 .toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ETag.java
@@ -151,7 +151,7 @@ public final class ETag {
     @Nullable
     public static List<ETag> parseHeader(@Nullable String header) {
         if (header == null) {
-            return ImmutableList.of();
+            return null;
         }
         if ("*".equals(header)) {
             return ETag.ASTERISK_ETAG;

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/ETagResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/ETagResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.conditional;
+
+/**
+ * The evaluation result of a conditional request rule.
+ */
+public enum ETagResponse {
+    /** Must perform method. */
+    PERFORM_METHOD,
+    /**
+     * Must NOT perform the method.
+     * Mostly for GET/HEAD.
+     */
+    SKIP_METHOD_NOT_MODIFIED,
+    /**
+     * Must NOT perform the method.
+     * Mostly for PUT/POST/DELETE.
+     * May return 200 OK if the state sent is identical
+     * to the current state on record.
+     */
+    SKIP_METHOD_PRECONDITION_FAILED,
+}

--- a/core/src/main/java/com/linecorp/armeria/server/conditional/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/conditional/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Conditional Request request helpers as per
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2732">RFC 7232</a>.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.server.conditional;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
@@ -37,8 +37,9 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
 
 class ConditionalRequestUtilTest {
-    private static final Long LONG_TIME_AGO = Instant.parse("2007-12-03T10:15:30.00Z").toEpochMilli();
-    private static final Long NOT_SO_LONG_TIME_AGO = Instant.parse("2008-12-03T10:15:30.00Z").toEpochMilli();
+    private static final Long NOW = Instant.parse("1994-10-29T19:43:31.00Z").toEpochMilli();
+    private static final Long LONG_TIME_AGO = Instant.parse("1994-10-29T16:43:31.00Z").toEpochMilli();
+    private static final Long FUTURE = Instant.parse("2008-12-03T10:15:30.00Z").toEpochMilli();
 
     /*
      * Comparison table:
@@ -110,7 +111,7 @@ class ConditionalRequestUtilTest {
                               .add(IF_NONE_MATCH, "\"foobar\"")
                               .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
                               .build();
-        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", true), NOT_SO_LONG_TIME_AGO))
+        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", true), NOW))
                 .isSameAs(SKIP_METHOD_NOT_MODIFIED);
         assertThat(conditionalRequest(reqHeaders, new ETag("foo", true), LONG_TIME_AGO))
                 .isSameAs(PERFORM_METHOD);
@@ -119,7 +120,7 @@ class ConditionalRequestUtilTest {
                 RequestHeaders.builder(HttpMethod.GET, "/")
                               .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
                               .build();
-        assertThat(conditionalRequest(reqHeaders2, new ETag("foobar", true), NOT_SO_LONG_TIME_AGO))
+        assertThat(conditionalRequest(reqHeaders2, new ETag("foobar", true), NOW))
                 .isSameAs(PERFORM_METHOD);
         assertThat(conditionalRequest(reqHeaders2, new ETag("foo", true), LONG_TIME_AGO))
                 .isSameAs(SKIP_METHOD_NOT_MODIFIED);
@@ -137,17 +138,17 @@ class ConditionalRequestUtilTest {
                 RequestHeaders.builder(HttpMethod.GET, "/")
                               .add(IF_NONE_MATCH, "\"foobar\"")
                               .add(IF_MATCH, "\"foo\"")
-                              .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
+                              .addTimeMillis(IF_MODIFIED_SINCE, NOW)
                               .build();
 
-        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", false), NOT_SO_LONG_TIME_AGO))
+        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", false), FUTURE))
                 .isSameAs(SKIP_METHOD_PRECONDITION_FAILED);
-        assertThat(conditionalRequest(reqHeaders, new ETag("foo", false), LONG_TIME_AGO))
+        assertThat(conditionalRequest(reqHeaders, new ETag("foo", false), NOW))
                 .isSameAs(PERFORM_METHOD);
 
         // Either of these are acceptable. It really depends on the evaluation-order between
         // If-Match and If-None-Match.
-        assertThat(conditionalRequest(reqHeaders, new ETag("fxx", false), LONG_TIME_AGO))
+        assertThat(conditionalRequest(reqHeaders, new ETag("fxx", false), NOW))
                 .isIn(SKIP_METHOD_PRECONDITION_FAILED, SKIP_METHOD_NOT_MODIFIED);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
@@ -72,15 +72,15 @@ class ConditionalRequestUtilTest {
     @Test
     void testIfMatch() {
         assertThat(ConditionalRequestUtil.ifMatch("W/\"1\"", new ETag("1", true)))
-                .isSameAs(ETagResponse.PERFORM_METHOD);
-        assertThat(ConditionalRequestUtil.ifMatch("*", new ETag("1", true)))
+                .isSameAs(ETagResponse.SKIP_METHOD_PRECONDITION_FAILED);
+        assertThat(ConditionalRequestUtil.ifMatch("*", new ETag("1", false)))
                 .isSameAs(ETagResponse.PERFORM_METHOD);
         assertThat(ConditionalRequestUtil.ifMatch("*", null))
                 .isSameAs(ETagResponse.SKIP_METHOD_PRECONDITION_FAILED);
         assertThat(ConditionalRequestUtil.ifMatch("\"1\"", new ETag("1", true)))
-                .isSameAs(ETagResponse.PERFORM_METHOD);
-        assertThat(ConditionalRequestUtil.ifMatch("\"1\"", new ETag("1", false)))
                 .isSameAs(ETagResponse.SKIP_METHOD_PRECONDITION_FAILED);
+        assertThat(ConditionalRequestUtil.ifMatch("\"1\"", new ETag("1", false)))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/conditional/ConditionalRequestUtilTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.conditional;
+
+import static com.linecorp.armeria.common.HttpHeaderNames.IF_MATCH;
+import static com.linecorp.armeria.common.HttpHeaderNames.IF_MODIFIED_SINCE;
+import static com.linecorp.armeria.common.HttpHeaderNames.IF_NONE_MATCH;
+import static com.linecorp.armeria.server.conditional.ConditionalRequestUtil.conditionalRequest;
+import static com.linecorp.armeria.server.conditional.ConditionalRequestUtil.strongComparison;
+import static com.linecorp.armeria.server.conditional.ConditionalRequestUtil.weakComparison;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.RequestHeaders;
+
+class ConditionalRequestUtilTest {
+    private static final Long LONG_TIME_AGO = Instant.parse("2007-12-03T10:15:30.00Z").toEpochMilli();
+    private static final Long NOT_SO_LONG_TIME_AGO = Instant.parse("2008-12-03T10:15:30.00Z").toEpochMilli();
+
+    /*
+     * Comparison table:
+     * ETag 1       ETag 2      Strong Comparison   Weak Comparison
+     * W/"1"        W/"1"       no match            match
+     * W/"1"        W/"2"       no match            no match
+     * W/"1"        "1"         no match            match
+     * "1"          "1"         match               match
+     */
+    @Test
+    void testWeakComparison() {
+        assertThat(weakComparison(ImmutableList.of(new ETag("1", true)), new ETag("1", true)))
+                .isTrue();
+        assertThat(weakComparison(ImmutableList.of(new ETag("1", true)), new ETag("2", true)))
+                .isFalse();
+        assertThat(weakComparison(ImmutableList.of(new ETag("1", false)), new ETag("1", true)))
+                .isTrue();
+        assertThat(weakComparison(ImmutableList.of(new ETag("1", false)), new ETag("1", false)))
+                .isTrue();
+    }
+
+    @Test
+    void testStrongComparison() {
+        assertThat(strongComparison(ImmutableList.of(new ETag("1", true)), new ETag("1", true)))
+                .isFalse();
+        assertThat(strongComparison(ImmutableList.of(new ETag("1", true)), new ETag("2", true)))
+                .isFalse();
+        assertThat(strongComparison(ImmutableList.of(new ETag("1", false)), new ETag("1", true)))
+                .isFalse();
+        assertThat(strongComparison(ImmutableList.of(new ETag("1", false)), new ETag("1", false)))
+                .isTrue();
+    }
+
+    @Test
+    void testIfMatch() {
+        assertThat(ConditionalRequestUtil.ifMatch("W/\"1\"", new ETag("1", true)))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+        assertThat(ConditionalRequestUtil.ifMatch("*", new ETag("1", true)))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+        assertThat(ConditionalRequestUtil.ifMatch("*", null))
+                .isSameAs(ETagResponse.SKIP_METHOD_PRECONDITION_FAILED);
+        assertThat(ConditionalRequestUtil.ifMatch("\"1\"", new ETag("1", true)))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+        assertThat(ConditionalRequestUtil.ifMatch("\"1\"", new ETag("1", false)))
+                .isSameAs(ETagResponse.SKIP_METHOD_PRECONDITION_FAILED);
+    }
+
+    @Test
+    void testIfNoneMatch() {
+        assertThat(ConditionalRequestUtil.ifNoneMatch("W/\"1\"", new ETag("1", true)))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+        assertThat(ConditionalRequestUtil.ifNoneMatch("*", new ETag("1", true)))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+        assertThat(ConditionalRequestUtil.ifNoneMatch("*", null))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+        assertThat(ConditionalRequestUtil.ifNoneMatch("\"1\"", new ETag("1", true)))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+        assertThat(ConditionalRequestUtil.ifNoneMatch("\"1\"", new ETag("1", false)))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+    }
+
+    /**
+     * Make sure that if-none-match always trumps if-modified-since.
+     */
+    @Test
+    void testIfNoneMatchIfModifiedSinceEvaluationOrderConditionalRequest() {
+        final RequestHeaders reqHeaders =
+                RequestHeaders.builder(HttpMethod.GET, "/")
+                              .add(IF_NONE_MATCH, "\"foobar\"")
+                              .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
+                              .build();
+        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", true), NOT_SO_LONG_TIME_AGO))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+        assertThat(conditionalRequest(reqHeaders, new ETag("foo", true), LONG_TIME_AGO))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+
+        final RequestHeaders reqHeaders2 =
+                RequestHeaders.builder(HttpMethod.GET, "/")
+                              .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
+                              .build();
+        assertThat(conditionalRequest(reqHeaders2, new ETag("foobar", true), NOT_SO_LONG_TIME_AGO))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+        assertThat(conditionalRequest(reqHeaders2, new ETag("foo", true), LONG_TIME_AGO))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+    }
+
+    /**
+     * I'm not sure about the evaluation order. They are really not meant to be used for even
+     * the same methods, even less in the same request, so this is the less well defined part of
+     * the RFC. They do however both state that the method MUST NOT be performed when they respectively
+     * evaluate to false (SKIP_METHOD_XXXXX).
+     */
+    @Test
+    void testIfNoneMatchIfMatchEvaluationOrderConditionalRequest() {
+        final RequestHeaders reqHeaders =
+                RequestHeaders.builder(HttpMethod.GET, "/")
+                              .add(IF_NONE_MATCH, "\"foobar\"")
+                              .add(IF_MATCH, "\"foobar\"")
+                              .addTimeMillis(IF_MODIFIED_SINCE, LONG_TIME_AGO)
+                              .build();
+
+        assertThat(conditionalRequest(reqHeaders, new ETag("foobar", true), NOT_SO_LONG_TIME_AGO))
+                .isSameAs(ETagResponse.SKIP_METHOD_NOT_MODIFIED);
+        assertThat(conditionalRequest(reqHeaders, new ETag("foo", true), LONG_TIME_AGO))
+                .isSameAs(ETagResponse.PERFORM_METHOD);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/conditional/ETagTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/conditional/ETagTest.java
@@ -53,7 +53,7 @@ class ETagTest {
     @Test
     void asteriskParsing() {
         AssertionsForClassTypes.assertThat(ETag.parseHeader(null))
-                               .isEqualTo(ImmutableList.of());
+                               .isNull();
         AssertionsForClassTypes.assertThat(ETag.parseHeader("*"))
                                .isSameAs(ETag.ASTERISK_ETAG);
         AssertionsForClassTypes.assertThat(ETag.parseHeader("\"*\""))

--- a/core/src/test/java/com/linecorp/armeria/server/conditional/ETagTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/conditional/ETagTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.conditional;
+
+import static com.linecorp.armeria.server.conditional.ETag.validateEtag;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class ETagTest {
+
+    @Test
+    void asHeaderValue() {
+        assertThat(new ETag("foobar", true).asHeaderValue()).isEqualTo("W/\"foobar\"");
+        assertThat(new ETag("foobar", false).asHeaderValue()).isEqualTo("\"foobar\"");
+    }
+
+    @Test
+    void testValidateEtag() {
+        assertThatThrownBy(() -> new ETag(" ", true))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(validateEtag("!"))
+                .isTrue();
+        assertThat(validateEtag("Foo!Foo#»☺$+~"))
+                .isTrue();
+        assertThat(validateEtag("\""))
+                .isFalse();
+        assertThat(validateEtag("\u007f"))
+                .isFalse();
+        assertThat(validateEtag("\u0080"))
+                .isTrue();
+    }
+
+    @Test
+    void asteriskParsing() {
+        AssertionsForClassTypes.assertThat(ETag.parseHeader(null))
+                               .isEqualTo(ImmutableList.of());
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("*"))
+                               .isSameAs(ETag.ASTERISK_ETAG);
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"*\""))
+                               .isNotSameAs(ETag.ASTERISK_ETAG)
+                               .isEqualTo(ImmutableList.of(new ETag("*", false)));
+    }
+
+    void quoting() {
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"missingEndingQuote"))
+                               .isNull();
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("missingInitialQuote\""))
+                               .isNull();
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"foo\""))
+                               .isEqualTo(ImmutableList.of(new ETag("foo", false)));
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("W/\"foo\""))
+                               .isEqualTo(ImmutableList.of(new ETag("foo", true)));
+    }
+
+    @Test
+    void multiple() {
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"foo\", W/\"bar\""))
+                               .isEqualTo(ImmutableList.of(new ETag("foo", false), new ETag("bar", true)));
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"foo\", W/\"bar\", \"barbar\""))
+                               .isEqualTo(ImmutableList.of(new ETag("foo", false),
+                                                           new ETag("bar", true),
+                                                           new ETag("barbar", false)));
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"foo\", W/\"bar\", \"barbar\"junk"))
+                               .isNull();
+        AssertionsForClassTypes.assertThat(ETag.parseHeader("\"foo\", junkW/\"bar\", \"barbar\""))
+                               .isNull();
+    }
+}


### PR DESCRIPTION
RFC 7232 Conditional Requests

https://datatracker.ietf.org/doc/html/rfc7232

If-Match, If-None-Match, If-Unmodified-Since, If-Modified-Since

Motivation:

It would be useful to have vetted and tested functionality that does Entity Tags and date checks in the Armeria API that would also be useful for Armeria internally.

Modifications:

- [X] Added Conditional Request functionality
- [X] Modified AbstractHttpFile to use the above functionality
- [X] ~Modify HttpCheckService to use the above functionality~ The logic there is extremely specific and although it should according to spec handle `*` it would just make no sense in that context.
- [X] ~Modify HttpHealthChecker to use the above functionality~ Just sets, never reads the IF_NONE_MATCH. Red herring.
- [X] Expose If-Modified-Since & If-Unmodified-Since
- [ ] Test for If-Unmodified-Since
- [ ] _Maybe_ implement If-Range for completeness


Result:

- No issue for this
- Expose a hopefully useful interface that implements the Conditional Request which contains a lot of pitfalls, not in the least in the parsing of the If-Match and If-None-Match headers.
