### PR TITLE
Do not merge -- Work In Progress - ResponseConverter Ordering Fix

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelector.java
@@ -17,6 +17,7 @@ under the License.
 package com.linecorp.armeria.internal.server.annotation;
 
 import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
@@ -31,6 +32,7 @@ import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
 import com.linecorp.armeria.server.annotation.StringResponseConverterFunction;
+
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -38,6 +40,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
+
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,138 +49,138 @@ import static com.linecorp.armeria.internal.common.util.ObjectCollectingUtil.col
 
 final class ResponseConverterFunctionSelector {
 
-  private ResponseConverterFunctionSelector() {}
+    private ResponseConverterFunctionSelector() {}
 
-  private static final Logger logger =
-      LoggerFactory.getLogger(ResponseConverterFunctionSelector.class);
+    private static final Logger logger =
+            LoggerFactory.getLogger(ResponseConverterFunctionSelector.class);
 
-  static final List<ResponseConverterFunctionProvider> responseConverterFunctionProviders =
-      ImmutableList.copyOf(ServiceLoader.load(ResponseConverterFunctionProvider.class,
-          AnnotatedService.class.getClassLoader()));
+    static final List<ResponseConverterFunctionProvider> responseConverterFunctionProviders =
+            ImmutableList.copyOf(ServiceLoader.load(ResponseConverterFunctionProvider.class,
+                                                    AnnotatedService.class.getClassLoader()));
 
-  static {
-    if (!responseConverterFunctionProviders.isEmpty()) {
-      logger.debug("Available {}s: {}", ResponseConverterFunctionProvider.class.getSimpleName(),
-          responseConverterFunctionProviders);
-    }
-  }
-
-  static ResponseConverterFunction responseConverter(
-      Method method, List<ResponseConverterFunction> responseConverters) {
-
-    final Type actualType = getActualReturnType(method);
-    final ImmutableList<ResponseConverterFunction> backingConverters =
-        ImmutableList
-            .<ResponseConverterFunction>builder()
-            .addAll(responseConverters)
-            .addAll(defaultResponseConverters)
-            .build();
-    final ResponseConverterFunction responseConverter = new CompositeResponseConverterFunction(
-        ImmutableList
-            .<ResponseConverterFunction>builder()
-            .addAll(backingConverters)
-            // It is the last converter to try to convert the result object into an HttpResponse
-            // after aggregating the published object from a Publisher or Stream.
-            .add(new AggregatedResponseConverterFunction(
-                new CompositeResponseConverterFunction(backingConverters)))
-            .build());
-
-    for (final ResponseConverterFunctionProvider provider : responseConverterFunctionProviders) {
-      final ResponseConverterFunction func =
-          provider.createResponseConverterFunction(actualType, responseConverter);
-      if (func != null) {
-        return func;
-      }
-    }
-
-    return responseConverter;
-  }
-
-  private static Type getActualReturnType(Method method) {
-    final Class<?> returnType;
-    final Type genericReturnType;
-
-    if (KotlinUtil.isKFunction(method)) {
-      returnType = KotlinUtil.kFunctionReturnType(method);
-      if (KotlinUtil.isReturnTypeNothing(method)) {
-        genericReturnType = KotlinUtil.kFunctionReturnType(method);
-      } else {
-        genericReturnType = KotlinUtil.kFunctionGenericReturnType(method);
-      }
-    } else {
-      returnType = method.getReturnType();
-      genericReturnType = method.getGenericReturnType();
-    }
-
-    if (HttpResult.class.isAssignableFrom(returnType)) {
-      final ParameterizedType type = (ParameterizedType) genericReturnType;
-      warnIfHttpResponseArgumentExists(type, type);
-      return type.getActualTypeArguments()[0];
-    } else {
-      return genericReturnType;
-    }
-  }
-
-  private static void warnIfHttpResponseArgumentExists(Type returnType, ParameterizedType type) {
-    for (final Type arg : type.getActualTypeArguments()) {
-      if (arg instanceof ParameterizedType) {
-        warnIfHttpResponseArgumentExists(returnType, (ParameterizedType) arg);
-      } else if (arg instanceof Class) {
-        final Class<?> clazz = (Class<?>) arg;
-        if (HttpResponse.class.isAssignableFrom(clazz) ||
-            AggregatedHttpResponse.class.isAssignableFrom(clazz)) {
-          logger.warn("{} in the return type '{}' may take precedence over {}.",
-              clazz.getSimpleName(), returnType, HttpResult.class.getSimpleName());
+    static {
+        if (!responseConverterFunctionProviders.isEmpty()) {
+            logger.debug("Available {}s: {}", ResponseConverterFunctionProvider.class.getSimpleName(),
+                         responseConverterFunctionProviders);
         }
-      }
-    }
-  }
-
-  /**
-   * A default {@link ResponseConverterFunction}s.
-   */
-  private static final List<ResponseConverterFunction> defaultResponseConverters =
-      ImmutableList.of(new JacksonResponseConverterFunction(),
-          new StringResponseConverterFunction(),
-          new ByteArrayResponseConverterFunction(),
-          new HttpFileResponseConverterFunction());
-
-  /**
-   * A response converter implementation which creates an {@link HttpResponse} with
-   * the objects published from a {@link Publisher} or {@link Stream}.
-   */
-  private static final class AggregatedResponseConverterFunction
-      implements ResponseConverterFunction {
-
-    private final ResponseConverterFunction responseConverter;
-
-    AggregatedResponseConverterFunction(ResponseConverterFunction responseConverter) {
-      this.responseConverter = responseConverter;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public HttpResponse convertResponse(ServiceRequestContext ctx,
-        ResponseHeaders headers,
-        @Nullable Object result,
-        HttpHeaders trailers) throws Exception {
-      final CompletableFuture<?> f;
-      if (result instanceof Publisher) {
-        f = collectFrom((Publisher<Object>) result, ctx);
-      } else if (result instanceof Stream) {
-        f = collectFrom((Stream<Object>) result, ctx.blockingTaskExecutor());
-      } else {
-        return ResponseConverterFunction.fallthrough();
-      }
+    static ResponseConverterFunction responseConverter(
+            Method method, List<ResponseConverterFunction> responseConverters) {
 
-      assert f != null;
-      return HttpResponse.from(f.thenApply(aggregated -> {
-        try {
-          return responseConverter.convertResponse(ctx, headers, aggregated, trailers);
-        } catch (Exception ex) {
-          return Exceptions.throwUnsafely(ex);
+        final Type actualType = getActualReturnType(method);
+        final ImmutableList<ResponseConverterFunction> backingConverters =
+                ImmutableList
+                        .<ResponseConverterFunction>builder()
+                        .addAll(responseConverters)
+                        .addAll(defaultResponseConverters)
+                        .build();
+        final ResponseConverterFunction responseConverter = new CompositeResponseConverterFunction(
+                ImmutableList
+                        .<ResponseConverterFunction>builder()
+                        .addAll(backingConverters)
+                        // It is the last converter to try to convert the result object into an HttpResponse
+                        // after aggregating the published object from a Publisher or Stream.
+                        .add(new AggregatedResponseConverterFunction(
+                                new CompositeResponseConverterFunction(backingConverters)))
+                        .build());
+
+        for (final ResponseConverterFunctionProvider provider : responseConverterFunctionProviders) {
+            final ResponseConverterFunction func =
+                    provider.createResponseConverterFunction(actualType, responseConverter);
+            if (func != null) {
+                return func;
+            }
         }
-      }));
+
+        return responseConverter;
     }
-  }
+
+    private static Type getActualReturnType(Method method) {
+        final Class<?> returnType;
+        final Type genericReturnType;
+
+        if (KotlinUtil.isKFunction(method)) {
+            returnType = KotlinUtil.kFunctionReturnType(method);
+            if (KotlinUtil.isReturnTypeNothing(method)) {
+                genericReturnType = KotlinUtil.kFunctionReturnType(method);
+            } else {
+                genericReturnType = KotlinUtil.kFunctionGenericReturnType(method);
+            }
+        } else {
+            returnType = method.getReturnType();
+            genericReturnType = method.getGenericReturnType();
+        }
+
+        if (HttpResult.class.isAssignableFrom(returnType)) {
+            final ParameterizedType type = (ParameterizedType) genericReturnType;
+            warnIfHttpResponseArgumentExists(type, type);
+            return type.getActualTypeArguments()[0];
+        } else {
+            return genericReturnType;
+        }
+    }
+
+    private static void warnIfHttpResponseArgumentExists(Type returnType, ParameterizedType type) {
+        for (final Type arg : type.getActualTypeArguments()) {
+            if (arg instanceof ParameterizedType) {
+                warnIfHttpResponseArgumentExists(returnType, (ParameterizedType) arg);
+            } else if (arg instanceof Class) {
+                final Class<?> clazz = (Class<?>) arg;
+                if (HttpResponse.class.isAssignableFrom(clazz) ||
+                    AggregatedHttpResponse.class.isAssignableFrom(clazz)) {
+                    logger.warn("{} in the return type '{}' may take precedence over {}.",
+                                clazz.getSimpleName(), returnType, HttpResult.class.getSimpleName());
+                }
+            }
+        }
+    }
+
+    /**
+     * A default {@link ResponseConverterFunction}s.
+     */
+    private static final List<ResponseConverterFunction> defaultResponseConverters =
+            ImmutableList.of(new JacksonResponseConverterFunction(),
+                             new StringResponseConverterFunction(),
+                             new ByteArrayResponseConverterFunction(),
+                             new HttpFileResponseConverterFunction());
+
+    /**
+     * A response converter implementation which creates an {@link HttpResponse} with
+     * the objects published from a {@link Publisher} or {@link Stream}.
+     */
+    private static final class AggregatedResponseConverterFunction
+            implements ResponseConverterFunction {
+
+        private final ResponseConverterFunction responseConverter;
+
+        AggregatedResponseConverterFunction(ResponseConverterFunction responseConverter) {
+            this.responseConverter = responseConverter;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public HttpResponse convertResponse(ServiceRequestContext ctx,
+                                            ResponseHeaders headers,
+                                            @Nullable Object result,
+                                            HttpHeaders trailers) throws Exception {
+            final CompletableFuture<?> f;
+            if (result instanceof Publisher) {
+                f = collectFrom((Publisher<Object>) result, ctx);
+            } else if (result instanceof Stream) {
+                f = collectFrom((Stream<Object>) result, ctx.blockingTaskExecutor());
+            } else {
+                return ResponseConverterFunction.fallthrough();
+            }
+
+            assert f != null;
+            return HttpResponse.from(f.thenApply(aggregated -> {
+                try {
+                    return responseConverter.convertResponse(ctx, headers, aggregated, trailers);
+                } catch (Exception ex) {
+                    return Exceptions.throwUnsafely(ex);
+                }
+            }));
+        }
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelector.java
@@ -1,0 +1,183 @@
+/*
+Copyright 2022 LINE Corporation
+
+LINE Corporation licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+ */
+
+package com.linecorp.armeria.internal.server.annotation;
+
+import com.google.common.collect.ImmutableList;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ByteArrayResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.HttpFileResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.HttpResult;
+import com.linecorp.armeria.server.annotation.JacksonResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
+import com.linecorp.armeria.server.annotation.StringResponseConverterFunction;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.linecorp.armeria.internal.common.util.ObjectCollectingUtil.collectFrom;
+
+final class ResponseConverterFunctionSelector {
+
+  private ResponseConverterFunctionSelector() {}
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(ResponseConverterFunctionSelector.class);
+
+  static final List<ResponseConverterFunctionProvider> responseConverterFunctionProviders =
+      ImmutableList.copyOf(ServiceLoader.load(ResponseConverterFunctionProvider.class,
+          AnnotatedService.class.getClassLoader()));
+
+  static {
+    if (!responseConverterFunctionProviders.isEmpty()) {
+      logger.debug("Available {}s: {}", ResponseConverterFunctionProvider.class.getSimpleName(),
+          responseConverterFunctionProviders);
+    }
+  }
+
+  static ResponseConverterFunction responseConverter(
+      Method method, List<ResponseConverterFunction> responseConverters) {
+
+    final Type actualType = getActualReturnType(method);
+    final ImmutableList<ResponseConverterFunction> backingConverters =
+        ImmutableList
+            .<ResponseConverterFunction>builder()
+            .addAll(responseConverters)
+            .addAll(defaultResponseConverters)
+            .build();
+    final ResponseConverterFunction responseConverter = new CompositeResponseConverterFunction(
+        ImmutableList
+            .<ResponseConverterFunction>builder()
+            .addAll(backingConverters)
+            // It is the last converter to try to convert the result object into an HttpResponse
+            // after aggregating the published object from a Publisher or Stream.
+            .add(new AggregatedResponseConverterFunction(
+                new CompositeResponseConverterFunction(backingConverters)))
+            .build());
+
+    for (final ResponseConverterFunctionProvider provider : responseConverterFunctionProviders) {
+      final ResponseConverterFunction func =
+          provider.createResponseConverterFunction(actualType, responseConverter);
+      if (func != null) {
+        return func;
+      }
+    }
+
+    return responseConverter;
+  }
+
+  private static Type getActualReturnType(Method method) {
+    final Class<?> returnType;
+    final Type genericReturnType;
+
+    if (KotlinUtil.isKFunction(method)) {
+      returnType = KotlinUtil.kFunctionReturnType(method);
+      if (KotlinUtil.isReturnTypeNothing(method)) {
+        genericReturnType = KotlinUtil.kFunctionReturnType(method);
+      } else {
+        genericReturnType = KotlinUtil.kFunctionGenericReturnType(method);
+      }
+    } else {
+      returnType = method.getReturnType();
+      genericReturnType = method.getGenericReturnType();
+    }
+
+    if (HttpResult.class.isAssignableFrom(returnType)) {
+      final ParameterizedType type = (ParameterizedType) genericReturnType;
+      warnIfHttpResponseArgumentExists(type, type);
+      return type.getActualTypeArguments()[0];
+    } else {
+      return genericReturnType;
+    }
+  }
+
+  private static void warnIfHttpResponseArgumentExists(Type returnType, ParameterizedType type) {
+    for (final Type arg : type.getActualTypeArguments()) {
+      if (arg instanceof ParameterizedType) {
+        warnIfHttpResponseArgumentExists(returnType, (ParameterizedType) arg);
+      } else if (arg instanceof Class) {
+        final Class<?> clazz = (Class<?>) arg;
+        if (HttpResponse.class.isAssignableFrom(clazz) ||
+            AggregatedHttpResponse.class.isAssignableFrom(clazz)) {
+          logger.warn("{} in the return type '{}' may take precedence over {}.",
+              clazz.getSimpleName(), returnType, HttpResult.class.getSimpleName());
+        }
+      }
+    }
+  }
+
+  /**
+   * A default {@link ResponseConverterFunction}s.
+   */
+  private static final List<ResponseConverterFunction> defaultResponseConverters =
+      ImmutableList.of(new JacksonResponseConverterFunction(),
+          new StringResponseConverterFunction(),
+          new ByteArrayResponseConverterFunction(),
+          new HttpFileResponseConverterFunction());
+
+  /**
+   * A response converter implementation which creates an {@link HttpResponse} with
+   * the objects published from a {@link Publisher} or {@link Stream}.
+   */
+  private static final class AggregatedResponseConverterFunction
+      implements ResponseConverterFunction {
+
+    private final ResponseConverterFunction responseConverter;
+
+    AggregatedResponseConverterFunction(ResponseConverterFunction responseConverter) {
+      this.responseConverter = responseConverter;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public HttpResponse convertResponse(ServiceRequestContext ctx,
+        ResponseHeaders headers,
+        @Nullable Object result,
+        HttpHeaders trailers) throws Exception {
+      final CompletableFuture<?> f;
+      if (result instanceof Publisher) {
+        f = collectFrom((Publisher<Object>) result, ctx);
+      } else if (result instanceof Stream) {
+        f = collectFrom((Stream<Object>) result, ctx.blockingTaskExecutor());
+      } else {
+        return ResponseConverterFunction.fallthrough();
+      }
+
+      assert f != null;
+      return HttpResponse.from(f.thenApply(aggregated -> {
+        try {
+          return responseConverter.convertResponse(ctx, headers, aggregated, trailers);
+        } catch (Exception ex) {
+          return Exceptions.throwUnsafely(ex);
+        }
+      }));
+    }
+  }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ResponseConverterFunctionSelectorTest.java
@@ -1,0 +1,75 @@
+package com.linecorp.armeria.internal.server.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.HttpResult;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+
+@SuppressWarnings("ConstantConditions")
+class ResponseConverterFunctionSelectorTest {
+
+    private static final ServiceRequestContext ctx = ServiceRequestContext.builder(
+            HttpRequest.of(HttpMethod.GET, "/")).build();
+
+    @Test
+    void prioritisesPassedInResponseConverters() throws Exception {
+        final ResponseConverterFunction converterFunction =
+                ResponseConverterFunctionSelector.responseConverter(
+                        getMethod("testEndpoint"),
+                        Collections.singletonList(new MyResponseConverterFunctionProvider())
+                );
+
+        final HttpResponse response = converterFunction.convertResponse(ctx, null, new TestClassToConvert(),
+                                                                        null);
+
+        assertThat(response.aggregate().join().contentUtf8()).isEqualTo("my_response");
+    }
+
+    @Test
+    void usesSpiResponseConverterGivenNoResponseConverterSpecified() throws Exception {
+        final ResponseConverterFunction converterFunction =
+                ResponseConverterFunctionSelector.responseConverter(
+                        getMethod("testEndpoint"),
+                        Collections.emptyList()
+                );
+
+        final HttpResponse response = converterFunction.convertResponse(ctx, null, new TestClassToConvert(),
+                                                                        null);
+
+        assertThat(response.aggregate().join().contentUtf8()).isEqualTo("testResponse");
+    }
+
+    private static Method getMethod(String methodName) throws NoSuchMethodException {
+        return TestService.class.getMethod(methodName);
+    }
+
+    private static class MyResponseConverterFunctionProvider implements ResponseConverterFunction {
+        @Override
+        public HttpResponse convertResponse(ServiceRequestContext ctx, ResponseHeaders headers,
+                                            @Nullable Object result, HttpHeaders trailers) throws Exception {
+            return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT, "my_response");
+        }
+    }
+
+    @FunctionalInterface
+    @SuppressWarnings("unused")
+    private interface TestService {
+        HttpResult<TestClassToConvert> testEndpoint();
+    }
+
+    static class TestClassToConvert {}
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/TestSpiConverter.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/TestSpiConverter.java
@@ -1,0 +1,53 @@
+package com.linecorp.armeria.internal.server.annotation;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.server.annotation.ResponseConverterFunctionSelectorTest.TestClassToConvert;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
+
+/**
+ * For use with ResponseConverterFunctionSelectorTest
+ */
+public class TestSpiConverter implements ResponseConverterFunctionProvider {
+
+  @Override
+  public @Nullable ResponseConverterFunction createResponseConverterFunction(Type responseType,
+      ResponseConverterFunction responseConverter) {
+    final Class<?> responseClass = toClass(responseType);
+    if(TestClassToConvert.class.isAssignableFrom(responseClass)) {
+      return new TestResponseConverterFunction();
+    } else {
+      return null;
+    }
+  }
+
+  private Class<?> toClass(Type type) {
+    if(type instanceof ParameterizedType) {
+      return (Class<?>) ((ParameterizedType) type).getRawType();
+    } else if (type instanceof Class<?>) {
+      return (Class<?>) type;
+    } else {
+      return null;
+    }
+  }
+
+  static class TestResponseConverterFunction implements ResponseConverterFunction {
+    @Override
+    public HttpResponse convertResponse(ServiceRequestContext ctx, ResponseHeaders headers,
+        @Nullable Object result, HttpHeaders trailers) throws Exception {
+      if(result instanceof TestClassToConvert) {
+        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT, "testResponse");
+      }
+      return ResponseConverterFunction.fallthrough();
+    }
+  }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/TestSpiConverter.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/TestSpiConverter.java
@@ -9,7 +9,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.internal.server.annotation.ResponseConverterFunctionSelectorTest.TestClassToConvert;
+import com.linecorp.armeria.internal.server.annotation.ResponseConverterFunctionSelectorTest.TestClassToConvert1;
+import com.linecorp.armeria.internal.server.annotation.ResponseConverterFunctionSelectorTest.TestClassToConvert2;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
@@ -19,35 +20,50 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider;
  */
 public class TestSpiConverter implements ResponseConverterFunctionProvider {
 
-  @Override
-  public @Nullable ResponseConverterFunction createResponseConverterFunction(Type responseType,
-      ResponseConverterFunction responseConverter) {
-    final Class<?> responseClass = toClass(responseType);
-    if(TestClassToConvert.class.isAssignableFrom(responseClass)) {
-      return new TestResponseConverterFunction();
-    } else {
-      return null;
-    }
-  }
-
-  private Class<?> toClass(Type type) {
-    if(type instanceof ParameterizedType) {
-      return (Class<?>) ((ParameterizedType) type).getRawType();
-    } else if (type instanceof Class<?>) {
-      return (Class<?>) type;
-    } else {
-      return null;
-    }
-  }
-
-  static class TestResponseConverterFunction implements ResponseConverterFunction {
     @Override
-    public HttpResponse convertResponse(ServiceRequestContext ctx, ResponseHeaders headers,
-        @Nullable Object result, HttpHeaders trailers) throws Exception {
-      if(result instanceof TestClassToConvert) {
-        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT, "testResponse");
-      }
-      return ResponseConverterFunction.fallthrough();
+    public @Nullable ResponseConverterFunction createResponseConverterFunction(Type responseType,
+                                                                               ResponseConverterFunction responseConverter) {
+        final Class<?> responseClass = toClass(responseType);
+        if (TestClassToConvert1.class.isAssignableFrom(responseClass)
+            || TestClassToConvert2.class.isAssignableFrom(responseClass)) {
+            return new TestResponseConverterFunction1(responseConverter);
+        } else {
+            return null;
+        }
     }
-  }
+
+    @SuppressWarnings({ "ConstantConditions", "ReturnOfNull" })
+    private static Class<?> toClass(Type type) {
+        if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        } else if (type instanceof Class<?>) {
+            return (Class<?>) type;
+        } else {
+            return null;
+        }
+    }
+
+    static class TestResponseConverterFunction1 implements ResponseConverterFunction {
+        ResponseConverterFunction passedInResponseConverterFunction;
+
+        TestResponseConverterFunction1(ResponseConverterFunction responseConverter) {
+            passedInResponseConverterFunction = responseConverter;
+        }
+
+        @Override
+        public HttpResponse convertResponse(ServiceRequestContext ctx, ResponseHeaders headers,
+                                            @Nullable Object result, HttpHeaders trailers) throws Exception {
+            if (result instanceof TestClassToConvert1) {
+                return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT, "testResponse");
+            }
+            if (result instanceof TestClassToConvert2) {
+                // For testing that a converter function is still passed in,
+                // because some implementations of the ResponseConverterProvider interface use the passed-in converter function
+                return passedInResponseConverterFunction.convertResponse(ctx, headers,
+                                                                         "converted_using_passed_in_converter",
+                                                                         trailers);
+            }
+            return ResponseConverterFunction.fallthrough();
+        }
+    }
 }

--- a/core/src/test/resources/META-INF/services/com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider
+++ b/core/src/test/resources/META-INF/services/com.linecorp.armeria.server.annotation.ResponseConverterFunctionProvider
@@ -1,0 +1,1 @@
+com.linecorp.armeria.internal.server.annotation.TestSpiConverter


### PR DESCRIPTION
# Work in Progress

------------------------------------------------------------

Order of ResponseConverters we tried to implement in this PR: https://github.com/line/armeria/issues/4301#issuecomment-1157123331

- Annotated ResponseConverterFunction
- Set via ServerBuilder.annotatedService() and equivalent
- Found via SPI
- Default ResponseConverterFunctions

## Failing tests:

### FlowAnnotatedServiceTest

```
[FlowAnnotatedServiceTest](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.kotlin.FlowAnnotatedServiceTest.html). [test_eventStreaming()](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.kotlin.FlowAnnotatedServiceTest.html#test_eventStreaming())
```
Test: Endpoint is effectively configured with `ServerSentEventResponseConverterFunction` via annotation (see `ProducesEventStream` annotation). ServerSentEventResponseConverterFunction = SSERCF

Behaviour of this PR: 
Uses CompositeResponseConverterFunction, which uses SSERCF to convert the output

Expectation of the test:
This test is expecting an SPI converter (`FlowResponseConverterFunction`) with SSERCF passed into it, to be prioritised over just the raw SSERCF.


### ProtobufResponseAnnotatedServiceTest
```
[ProtobufResponseAnnotatedServiceTest](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.protobuf.ProtobufResponseAnnotatedServiceTest.html). [[1] path=/protobuf/stream](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.protobuf.ProtobufResponseAnnotatedServiceTest.html#protobufStreamResponse(String)[1])
[ProtobufResponseAnnotatedServiceTest](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.protobuf.ProtobufResponseAnnotatedServiceTest.html). [[2] path=/protobuf/publisher](https://github.com/line/armeria/compare/classes/com.linecorp.armeria.server.protobuf.ProtobufResponseAnnotatedServiceTest.html#protobufStreamResponse(String)[2])
```
This test is expecting a raw `ProtobufResponseConverterFunction` to be used (current state), instead of a `CompositeResponseConverterFunction` containing a `ProtobufResponseConverterFunction` (state introduced by this PR).

Test failure is due to the expectation of an `IllegalArgumentException` (throw when the response converter used is the raw `ProtobufResponseConverterFunction`), over an `IllegalStateException` (the illegal arg ex is caught by the `CompositeResponseConverterFunction`, which rethrows an illegal state ex)




TODO
------------------------------------------------------------

Motivation:

[Explain why you're making this change and what problem you're trying to solve.
](https://github.com/line/armeria/issues/4301)

Modifications:

- List the modifications you've made in detail.

Result:

- Closes #4301 . (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
