### PR TITLE
Fix while streaming retrofit not request upstream on demand

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -176,9 +176,10 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
         callbackExecutor.execute(() -> {
             try {
                 callback.onResponse(armeriaCall, responseBuilder
-                        .body(ResponseBody.create(Strings.isNullOrEmpty(contentType) ?
+                        .body(ResponseBody.create(content,
+                                                  Strings.isNullOrEmpty(contentType) ?
                                                   null : MediaType.parse(contentType),
-                                                  contentLength, content))
+                                                  contentLength))
                         .build());
             } catch (IOException e) {
                 callback.onFailure(armeriaCall, e);

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
@@ -63,6 +63,12 @@ final class PipeBuffer {
         return source;
     }
 
+    boolean exhausted() {
+        synchronized (buffer) {
+            return buffer.exhausted();
+        }
+    }
+
     private final class PipeSource implements Source {
         final Timeout timeout = new Timeout();
 

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/StreamingCallSubscriber.java
@@ -62,7 +62,9 @@ final class StreamingCallSubscriber extends AbstractSubscriber {
             safeOnResponse(Okio.buffer(new ForwardingSource(pipeBuffer.source()) {
                 @Override
                 public long read(Buffer sink, long byteCount) throws IOException {
-                    request(1);
+                    if (pipeBuffer.exhausted()) {
+                        request(1);
+                    }
                     return super.read(sink, byteCount);
                 }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryLargeStreamTest.java
@@ -80,12 +80,12 @@ public class ArmeriaCallFactoryLargeStreamTest {
                                 }
                                 sentCount += 1;
 
+                                // Sent more than 512MB
                                 if ((sentCount - 1) * 10_000 > 1024 * 1024 * 512) {
                                     s.onComplete();
                                     return;
                                 }
                             }
-
                         }
 
                         @Override


### PR DESCRIPTION
Motivation:

Recognized that Armeria-retrofit's streaming mode sometimes requests more data from the heap even though there is still data in the buffer.

Modifications:

- Check if buffer exhausted before request next item
- Fix deprecated api of `ResponseBody.create`
- Fix test not using streaming mode

Result:

- Armeria retrofit will request upstream on demand
