### PR TITLE
Add HttpStatus converting util

### DIFF
--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/HttpStatusUtil.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/HttpStatusUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+public class HttpStatusUtil {
+
+    public static com.linecorp.armeria.common.HttpStatus
+    toArmeriaStatus(org.springframework.http.HttpStatus springStatus) {
+        return com.linecorp.armeria.common.HttpStatus.valueOf(springStatus.value());
+    }
+
+    public static org.springframework.http.HttpStatus
+    toSpringStatus(com.linecorp.armeria.common.HttpStatus armeriaStatus) {
+        return org.springframework.http.HttpStatus.valueOf(armeriaStatus.code());
+    }
+}

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/HttpStatusUtilTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/HttpStatusUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.web.reactive;
+
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link HttpStatusUtil}
+ */
+public class HttpStatusUtilTest {
+
+    private final Stream<Integer> statusCodes = Arrays.stream(org.springframework.http.HttpStatus.values())
+            .map(org.springframework.http.HttpStatus::value);
+
+    @Test
+    public void convertSpringStatusToArmeriaStatus() throws AssertionError {
+        statusCodes.map(org.springframework.http.HttpStatus::valueOf).forEach(
+                (springStatus) -> {
+                    int code = springStatus.value();
+                    com.linecorp.armeria.common.HttpStatus convertedStatus =
+                        HttpStatusUtil.toArmeriaStatus(springStatus);
+                    assertThat(convertedStatus.code() == code).isTrue();
+                    // default reasonPhrase is created
+                    assertNotNull(convertedStatus.reasonPhrase());
+                }
+        );
+    }
+
+    @Test
+    public void convertArmeriaStatusToSpringStatus() throws AssertionError {
+        statusCodes.map(com.linecorp.armeria.common.HttpStatus::valueOf).forEach(
+                (armeriaStatus) -> {
+                    int code = armeriaStatus.code();
+                    org.springframework.http.HttpStatus convertedStatus =
+                            HttpStatusUtil.toSpringStatus(armeriaStatus);
+                    assertThat(convertedStatus.value() == code).isTrue();
+                }
+        );
+    }
+}


### PR DESCRIPTION
Motivation:
Armeria and Spring each has their own HttpStatus. They can be converted between each other using the valueOf() method, but this method requires background information on both classes.
Provide a static util method in armeria-spring-boot2-webflux-starter for bidirectional conversion

Modifications:
- added toSpringStatus, toArmeriaStatus in com.linecorp.armeria.spring.web.reactive.HttpStatusUtil
- added tests in HttpStatusUtilTest - to be reverted if unneeded
- there was mention of custom http status at armeria [slack thread](https://line-armeria.slack.com/archives/C1NGPBUH2/p1656382677352909). It would be good to add a testcase of behavior when converting custom armeria http status to spring http status (but I failed to find out how to define one 😢 )

Result:
static convertor methods added to armeria-spring-boot2-webflux-starter library

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
