### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
     // If you want to change `org.jetbrains.kotlin.jvm` version,
     // you also need to change `org.jetbrains.kotlin:kotlin-allopen` version in `dependencies.yml`.
-    id 'org.jetbrains.kotlin.jvm' version '1.6.20' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.7.0' apply false
     id 'org.jlleitschuh.gradle.ktlint' version '10.1.0' apply false
 
     id 'net.ltgt.errorprone' version '2.0.2' apply false

--- a/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
@@ -302,6 +302,7 @@ public final class BlockingWebClientRequestPreparation
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public BlockingWebClientRequestPreparation content(@FormatString String format, Object... content) {
         delegate.content(format, content);
         return this;
@@ -309,6 +310,7 @@ public final class BlockingWebClientRequestPreparation
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public BlockingWebClientRequestPreparation content(MediaType contentType, @FormatString String format,
                                                        Object... content) {
         delegate.content(contentType, format, content);

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -240,6 +240,7 @@ public final class FutureTransformingRequestPreparation<T>
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public FutureTransformingRequestPreparation<T> content(@FormatString String format, Object... content) {
         delegate.content(format, content);
         return this;
@@ -247,6 +248,7 @@ public final class FutureTransformingRequestPreparation<T>
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public FutureTransformingRequestPreparation<T> content(MediaType contentType, @FormatString String format,
                                                            Object... content) {
         delegate.content(contentType, format, content);

--- a/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
@@ -157,6 +157,7 @@ public class TransformingRequestPreparation<T, R> implements RequestPreparationS
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public TransformingRequestPreparation<T, R> content(String format, Object... content) {
         delegate.content(format, content);
         return this;
@@ -164,6 +165,7 @@ public class TransformingRequestPreparation<T, R> implements RequestPreparationS
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public TransformingRequestPreparation<T, R> content(MediaType contentType, String format,
                                                         Object... content) {
         delegate.content(contentType, format, content);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -417,12 +417,14 @@ public final class WebClientRequestPreparation extends AbstractHttpRequestBuilde
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public WebClientRequestPreparation content(@FormatString String format, Object... content) {
         return (WebClientRequestPreparation) super.content(format, content);
     }
 
     @Override
     @FormatMethod
+    @SuppressWarnings("FormatStringAnnotation")
     public WebClientRequestPreparation content(MediaType contentType, @FormatString String format,
                                                Object... content) {
         return (WebClientRequestPreparation) super.content(contentType, format, content);

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -113,8 +113,7 @@ final class MimeParser {
     /**
      * The publisher that emits body part contents.
      */
-    @Nullable
-    private MultipartDecoder.BodyPartPublisher bodyPartPublisher;
+    private MultipartDecoder.@Nullable BodyPartPublisher bodyPartPublisher;
 
     /**
      * Read and process body parts until we see the terminating boundary line.

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -180,7 +180,7 @@ final class AccessLogFormats {
 
     private static AccessLogComponent newAccessLogComponent(char token,
                                                             @Nullable String variable,
-                                                            @Nullable Condition.Builder condBuilder) {
+                                                            Condition.@Nullable Builder condBuilder) {
         final AccessLogType type = AccessLogType.find(token);
         checkArgument(type != null, "Unexpected token character: '%s'", token);
         if (type.variableRequirement() == VariableRequirement.YES) {

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -816,8 +816,7 @@ class HttpClientIntegrationTest {
     })
     class JettyInteropTest {
 
-        @Nullable
-        org.eclipse.jetty.server.Server jetty;
+        org.eclipse.jetty.server.@Nullable Server jetty;
 
         @BeforeAll
         void startJetty() throws Exception {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -2,16 +2,17 @@
 # NB: Update NOTICE.txt and add/remove LICENSE.*.txt when adding/removing a dependency.
 #
 
+# Find the corresponding links of Javadoc below and update them when you update boms.
 boms:
-  - com.fasterxml.jackson:jackson-bom:2.13.2.1
-  - io.dropwizard.metrics:metrics-bom:4.2.9
+  - com.fasterxml.jackson:jackson-bom:2.13.3
+  - io.dropwizard.metrics:metrics-bom:4.2.10
   # Ensure that we use the same Protobuf version as what gRPC depends on.
   # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
   #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
-  - io.grpc:grpc-bom:1.45.1
-  - io.micrometer:micrometer-bom:1.8.5
-  - io.netty:netty-bom:4.1.76.Final
-  - io.zipkin.brave:brave-bom:5.13.8
+  - io.grpc:grpc-bom:1.47.0
+  - io.micrometer:micrometer-bom:1.9.1
+  - io.netty:netty-bom:4.1.78.Final
+  - io.zipkin.brave:brave-bom:5.13.9
   - org.eclipse.jetty:jetty-bom:9.4.46.v20220331
   - org.junit:junit-bom:5.8.2
 
@@ -50,13 +51,13 @@ com.expediagroup:
 com.fasterxml.jackson.core:
   jackson-annotations:
     javadocs:
-    - https://fasterxml.github.io/jackson-annotations/javadoc/2.12/
+    - https://fasterxml.github.io/jackson-annotations/javadoc/2.13/
   jackson-core:
     javadocs:
-    - https://fasterxml.github.io/jackson-core/javadoc/2.12/
+    - https://fasterxml.github.io/jackson-core/javadoc/2.13/
   jackson-databind:
     javadocs:
-    - https://fasterxml.github.io/jackson-databind/javadoc/2.12/
+    - https://fasterxml.github.io/jackson-databind/javadoc/2.13/
 
 # Don't upgrade Caffeine to 3.x that requires Java 11.
 com.github.ben-manes.caffeine:
@@ -74,22 +75,23 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '3.2.1' }
+  gradle-node-plugin: { version: '3.4.0' }
 
+# This is only used for gRPC test module.
 com.google.api:
-  gax-grpc: { version: '2.16.0' }
+  gax-grpc: { version: '2.18.2' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 # This is only used for examples/context-propagation/dagger
 com.google.dagger:
-  dagger: { version: &DAGGER_VERSION '2.41' }
+  dagger: { version: &DAGGER_VERSION '2.42' }
   dagger-compiler: { version: *DAGGER_VERSION }
   dagger-producers: { version: *DAGGER_VERSION }
 
 com.google.errorprone:
-  error_prone_core: { version: &ERRORPRONE_VERSION '2.13.1' }
+  error_prone_core: { version: &ERRORPRONE_VERSION '2.14.0' }
   error_prone_annotations: { version: *ERRORPRONE_VERSION }
 
 com.google.guava:
@@ -127,6 +129,7 @@ com.google.j2objc:
 # Ensure that we use the same Protobuf version as what gRPC depends on.
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
 #      (Switch to the right tag and look for 'protobufVersion' and 'protocVersion'.)
+#      e.g. https://github.com/grpc/grpc-java/blob/v1.47.0/build.gradle
 com.google.protobuf:
   protobuf-java: { version: &PROTOBUF_VERSION '3.19.2' }
   protobuf-java-util:
@@ -137,10 +140,10 @@ com.google.protobuf:
   protoc: { version: *PROTOBUF_VERSION }
 
 com.graphql-java:
-  graphql-java: { version: '18.0' }
+  graphql-java: { version: '18.2' }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.2.1' }
+  proguard-gradle: { version: '7.2.2' }
 
 # Akka is used only for testing in it:grpcweb module.
 com.lightbend.akka.grpc:
@@ -153,13 +156,13 @@ com.netflix.eureka:
 
 # DGS is used only for testing in it:dgs module.
 com.netflix.graphql.dgs:
-  graphql-dgs-client: { version: '4.9.25' }
+  graphql-dgs-client: { version: '5.0.4' }
 
 com.pszymczyk.consul:
   embedded-consul: { version: '2.2.1' }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '10.1' }
+  checkstyle: { version: '10.3.1' }
 
 com.salesforce.servicelibs:
   reactor-grpc: { version: &REACTVIVE_GRPC_VERSION '1.2.3' }
@@ -175,7 +178,7 @@ com.spotify:
 
 # OkHttp is used only for testing in it:okhttp module.
 com.squareup.okhttp3:
-  okhttp: { version: &OKHTTP_VERSION '4.9.3' }
+  okhttp: { version: &OKHTTP_VERSION '4.10.0' }
   okhttp-tls: { version: *OKHTTP_VERSION }
 
 com.squareup.retrofit2:
@@ -186,7 +189,7 @@ com.squareup.retrofit2:
   converter-jackson: { version: *RETROFIT2_VERSION }
 
 com.thesamet.scalapb:
-  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.10' }
+  scalapb-runtime_2.12: { version: &SCALAPB_VERSION '0.11.11' }
   scalapb-runtime_2.13: { version: *SCALAPB_VERSION }
   scalapb-runtime_3: { version: *SCALAPB_VERSION }
   scalapb-runtime-grpc_2.12: { version: *SCALAPB_VERSION }
@@ -205,7 +208,7 @@ com.typesafe.akka:
 # Finagle is used only for testing in zookeeper module.
 com.twitter:
   finagle-serversets_2.13:
-    version: '22.3.0'
+    version: '22.4.0'
 
 cz.alenkacz:
   gradle-scalafmt: { version: '1.16.2' }
@@ -229,7 +232,7 @@ io.dropwizard:
 io.dropwizard.metrics:
   metrics-core:
     javadocs:
-    - https://metrics.dropwizard.io/4.1.0/apidocs/
+    - https://metrics.dropwizard.io/4.2.10/apidocs/
 
 io.grpc:
   grpc-core:
@@ -252,16 +255,16 @@ io.grpc:
     - io.netty:netty-handler-proxy
     - io.netty:netty-transport
     - io.netty:netty-tcnative-boringssl-static
-  grpc-kotlin-stub: { version: &GRPC_KOTLIN_VERSION '1.2.1' }
+  grpc-kotlin-stub: { version: &GRPC_KOTLIN_VERSION '1.3.0' }
   protoc-gen-grpc-kotlin: { version: *GRPC_KOTLIN_VERSION }
 
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.8.4/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.9.1/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.8.4/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.9.1/
   micrometer-spring-legacy:
     javadocs:
     - https://www.javadoc.io/doc/io.micrometer/micrometer-spring-legacy/1.3.9/
@@ -271,7 +274,7 @@ io.micrometer:
 
 # This is only used for ScalaPB test
 io.monix:
-  monix-reactive_2.12: { version: &MONIX_VERSION '3.4.0' }
+  monix-reactive_2.12: { version: &MONIX_VERSION '3.4.1' }
   monix-reactive_2.13: { version: *MONIX_VERSION }
   monix-reactive_3: { version: *MONIX_VERSION }
 
@@ -281,11 +284,11 @@ io.netty:
     - https://netty.io/4.1/api/
 
 io.netty.incubator:
-  netty-incubator-transport-native-io_uring: { version: '0.0.13.Final' }
+  netty-incubator-transport-native-io_uring: { version: '0.0.14.Final' }
 
 io.projectreactor:
   reactor-core:
-    version: &REACTOR_VERSION '3.4.17'
+    version: &REACTOR_VERSION '3.4.19'
     javadocs:
     - https://projectreactor.io/docs/core/release/api/
   reactor-test: { version: *REACTOR_VERSION }
@@ -295,7 +298,7 @@ io.projectreactor.kotlin:
 
 io.prometheus:
   simpleclient_common:
-    version: '0.15.0'
+    version: '0.16.0'
     javadocs:
     - https://prometheus.github.io/client_java/
 
@@ -307,7 +310,7 @@ io.reactivex.rxjava2:
 
 io.reactivex.rxjava3:
   rxjava:
-    version: '3.1.4'
+    version: '3.1.5'
     javadocs:
       - http://reactivex.io/RxJava/3.x/javadoc/
 
@@ -356,7 +359,7 @@ me.champeau.jmh:
   jmh-gradle-plugin: { version: '0.6.6' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.34.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.35.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.shibboleth.utilities:
@@ -396,7 +399,7 @@ org.apache.httpcomponents:
 
 org.apache.kafka:
   kafka-clients:
-    version: '3.1.0'
+    version: '3.2.0'
     javadocs:
     - https://kafka.apache.org/30/javadoc/
 
@@ -430,7 +433,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.22.0' }
+  assertj-core: { version: '3.23.1' }
 
 org.awaitility:
   awaitility: { version: '4.2.0' }
@@ -480,12 +483,13 @@ org.eclipse.jetty.alpn:
 
 # Groovy is only used for testing consul
 org.codehaus.groovy:
-  groovy-xml: { version: '3.0.10' }
+  groovy-xml: { version: '3.0.11' }
 
 org.hamcrest:
   hamcrest: { version: &HAMCREST_VERSION '2.2' }
   hamcrest-library: { version: *HAMCREST_VERSION }
 
+# Validator is only used for examples and testings in Spring
 org.hibernate.validator:
   hibernate-validator: { version: '6.2.3.Final' }
 
@@ -499,27 +503,27 @@ org.jctools:
 # If you want to change `org.jetbrains.kotlin:kotlin-allopen` version,
 # you also need to change `org.jetbrains.kotlin.jvm` version in `build.gradle`.
 org.jetbrains.kotlin:
-  kotlin-allopen: { version: &KOTLIN_VERSION '1.6.20' }
+  kotlin-allopen: { version: &KOTLIN_VERSION '1.7.0' }
   kotlin-reflect: { version: *KOTLIN_VERSION }
 
 org.jetbrains.kotlinx:
-  kotlinx-coroutines-core: { version: &KOTLIN_COROUTINE_VERSION '1.6.1' }
+  kotlinx-coroutines-core: { version: &KOTLIN_COROUTINE_VERSION '1.6.3' }
   kotlinx-coroutines-jdk8: { version: *KOTLIN_COROUTINE_VERSION }
   # kotlinx-coroutines-reactor is only used for testing :it:spring:boot2-kotlin
   kotlinx-coroutines-reactor: { version: *KOTLIN_COROUTINE_VERSION }
   kotlinx-coroutines-rx2: { version: *KOTLIN_COROUTINE_VERSION }
 
 org.jlleitschuh.gradle:
-  ktlint-gradle: { version: '10.2.1' }
+  ktlint-gradle: { version: '10.3.0' }
 
 org.jooq:
   joor: { version: '0.9.14' }
 
 org.jsoup:
-  jsoup: { version: '1.14.3' }
+  jsoup: { version: '1.15.1' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '4.4.0' }
+  mockito-core: { version: &MOCKITO_VERSION '4.6.1' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
@@ -540,7 +544,7 @@ org.opensaml:
   opensaml-soap-impl: { version: *OPENSAML_VERSION }
 
 org.reactivestreams:
-  reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.3' }
+  reactive-streams: { version: &REACTIVE_STREAMS_VERSION '1.0.4' }
   reactive-streams-tck:
     version: *REACTIVE_STREAMS_VERSION
     exclusions:
@@ -590,11 +594,11 @@ org.slf4j:
   slf4j-simple: { version: *SLF4J_VERSION }
 
 org.springframework:
-  spring-web: { version: '5.3.19' }
+  spring-web: { version: '5.3.21' }
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.6.6'
+    version: &SPRING_BOOT_VERSION '2.7.1'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-actuator-autoconfigure: { version: *SPRING_BOOT_VERSION }
@@ -614,7 +618,7 @@ org.testng:
   testng: { version: '7.5' }
 
 org.junit-pioneer:
-  junit-pioneer: { version : '1.6.1'}
+  junit-pioneer: { version : '1.7.1'}
 
 org.xerial.snappy:
   snappy-java: { version: '1.1.8.4' }
@@ -628,9 +632,9 @@ xml-apis:
 
 com.github.vladimir-bukhtoyarov:
   bucket4j-core:
-    version: '7.4.0'
+    version: '7.5.0'
     javadocs:
-    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.4.0/
+    - https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.5.0/
 
 org.jboss.resteasy:
   resteasy-core-spi:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -519,6 +519,7 @@ org.jlleitschuh.gradle:
 org.jooq:
   joor: { version: '0.9.14' }
 
+# JSoup is only used for Gradle script and SAML testing.
 org.jsoup:
   jsoup: { version: '1.15.1' }
 

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -56,7 +56,7 @@ configure(projectsWithFlags('java')) {
                     }
                     if (project.ext.hasFlag('kotlin-grpc')) {
                         kotlinGrpc {
-                            artifact = "io.grpc:protoc-gen-grpc-kotlin:${managedVersions['io.grpc:protoc-gen-grpc-kotlin']}:jdk7@jar"
+                            artifact = "io.grpc:protoc-gen-grpc-kotlin:${managedVersions['io.grpc:protoc-gen-grpc-kotlin']}:jdk8@jar"
                         }
                     }
 

--- a/it/server/build.gradle
+++ b/it/server/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     testImplementation project(':grpc')
+    testImplementation 'com.squareup.okhttp:okhttp:2.7.5'
     testImplementation 'io.grpc:grpc-core'
     testImplementation 'io.grpc:grpc-interop-testing'
     testImplementation 'io.grpc:grpc-okhttp'

--- a/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -177,8 +177,8 @@ public final class JettyService implements HttpService {
     private Server server;
     @Nullable
     private ArmeriaConnector connector;
-    @Nullable
-    private com.linecorp.armeria.server.Server armeriaServer;
+
+    private com.linecorp.armeria.server.@Nullable Server armeriaServer;
     private boolean startedServer;
 
     private JettyService(@Nullable String hostname, boolean tlsReverseDnsLookup,
@@ -399,8 +399,8 @@ public final class JettyService implements HttpService {
 
         private final ServiceRequestContext ctx;
         private final HttpResponseWriter res;
-        @Nullable
-        MetaData.Response info;
+
+        MetaData.@Nullable Response info;
 
         ArmeriaHttpTransport(ServiceRequestContext ctx, HttpResponseWriter res) {
             this.ctx = ctx;
@@ -408,7 +408,7 @@ public final class JettyService implements HttpService {
         }
 
         @Override
-        public void send(@Nullable MetaData.Response info, boolean head,
+        public void send(MetaData.@Nullable Response info, boolean head,
                          @Nullable ByteBuffer content, boolean lastContent, Callback callback) {
             if (ctx.isTimedOut()) {
                 // Silently discard the write request in case of timeout to match the behavior of Jetty.
@@ -474,7 +474,7 @@ public final class JettyService implements HttpService {
         }
 
         @Nullable
-        private HttpHeaders toResponseTrailers(@Nullable MetaData.Response info) {
+        private HttpHeaders toResponseTrailers(MetaData.@Nullable Response info) {
             if (jResGetTrailerSupplier == null) {
                 return null;
             }

--- a/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/ManagedTomcatService.java
+++ b/tomcat9/src/main/java/com/linecorp/armeria/server/tomcat/ManagedTomcatService.java
@@ -46,8 +46,7 @@ final class ManagedTomcatService extends TomcatService {
     private final ServerListener configurator;
     private static final Set<String> activeEngines = new HashSet<>();
 
-    @Nullable
-    private org.apache.catalina.Server server;
+    private org.apache.catalina.@Nullable Server server;
     @Nullable
     private Server armeriaServer;
     @Nullable

--- a/zookeeper3/src/main/java/com/linecorp/armeria/common/zookeeper/AbstractCuratorFrameworkBuilder.java
+++ b/zookeeper3/src/main/java/com/linecorp/armeria/common/zookeeper/AbstractCuratorFrameworkBuilder.java
@@ -49,8 +49,8 @@ public class AbstractCuratorFrameworkBuilder {
     @Nullable
     private final CuratorFramework client;
     private final String znodePath;
-    @Nullable
-    private final CuratorFrameworkFactory.Builder clientBuilder;
+
+    private final CuratorFrameworkFactory.@Nullable Builder clientBuilder;
     @Nullable
     private final ImmutableList.Builder<Consumer<? super Builder>> customizers;
 


### PR DESCRIPTION
- Brave 5.13.8 -> 5.13.9
- Bucket4J 7.4.0 -> 7.5.0
- Dropwizard metrics 4.2.9 -> 4.2.10
- gRPC 1.45.1 -> 1.47.0
- grpc-kotlin-stub 1.2.1 -> 1.3.0
- Jackson 2.13.2.1 -> 2.13.3
- JSoup 1.14.3 -> 1.15.1
- Kotlinx 1.6.1 -> 1.6.3
- Micrometer 1.8.5 -> 1.9.1
- Netty 4.1.76.Final -> 4.1.78.Final
- Netty incubator 0.0.13.Final -> 0.0.14.Final
- Project Reactor 3.4.17 -> 3.4.19
- Prometheus simpleclient 0.15.0 -> 0.16.0
- Reactive Streams 1.0.3 -> 1.0.4
- RxJava 3.1.4 -> 3.1.5
- scalapb-runtime_2.12 0.11.10 -> 0.11.11
- Spring Boot 2.6.6 -> 2.7.1
- Spring Web 5.3.19 -> 5.3.21
- Build
  - AssertJ 3.22.0 -> 3.23.1
  - Checkstyle 10.1 -> 10.3.1
  - Dagger 2.41 -> 2.42
  - Error prone 2.13.1 -> 2.14.0
  - Finagle 22.3.0 -> 22.4.0
  - gradle-node-plugin 3.2.1 -> 3.4.0
  - gax-grpc 2.16.0 -> 1.18.2
  - GraphQL DGS 4.9.25 -> 5.0.4
  - Groovy 3.0.10 -> 3.0.11
  - Json Unit 2.34.0 -> 2.35.0
  - junit-pioneer 1.6.1 -> 1.7.1
  - Kafka clients 3.1.0 -> 3.2.0
  - Kotlin AllOpen 1.6.20 -> 1.7.0
  - ktlint-gradle 10.2.1 -> 10.3.0
  - Mockito 4.4.0 -> 4.6.1
  - Monix 3.4.0 -> 3.4.1
  - OkHttp 4.9.3 -> 4.10.0
  - Proguard 7.2.1 -> 7.2.2