### PR TITLE
Fix a bug where `Multiparts.getBoundary()` throws a `NullPointerException` when a boundary is missing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multiparts.java
@@ -18,10 +18,9 @@ package com.linecorp.armeria.common.multipart;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.Iterables;
+import java.util.List;
 
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
  * Utility methods to support multipart metadata handling.
@@ -39,12 +38,12 @@ public final class Multiparts {
         requireNonNull(contentType, "contentType");
         checkArgument(contentType.isMultipart(),
                       "Content-Type: %s (expected: multipart content type)", contentType);
-        @Nullable
-        final String boundary = Iterables.getFirst(contentType.parameters().get("boundary"), null);
-        if (boundary == null) {
+        final List<String> boundary = contentType.parameters().get("boundary");
+
+        if (boundary == null || boundary.isEmpty()) {
             throw new IllegalStateException("boundary parameter is missing on the Content-Type header");
         }
-        return boundary;
+        return boundary.get(0);
     }
 
     private Multiparts() {}

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.multipart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.MediaType;
+
+class MultipartsTest {
+
+    @Test
+    void boundary() {
+        final String boundary = "foo";
+        final MediaType multipartType = MediaType.MULTIPART_FORM_DATA.withParameter("boundary", boundary);
+        assertThat(Multiparts.getBoundary(multipartType)).isEqualTo(boundary);
+
+        assertThatThrownBy(() -> Multiparts.getBoundary(MediaType.MULTIPART_FORM_DATA))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("boundary parameter is missing on the Content-Type header");
+
+        assertThatThrownBy(() -> Multiparts.getBoundary(MediaType.JSON))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("(expected: multipart content type)");
+    }
+}


### PR DESCRIPTION
Motivation:

If a boundary in a multipart content-type header is missing,
`Multiparts.getBoundary()` should throw an `IllegalStateException` not
`NullPointerException` #4193

Modifications:

- Check the nullness of the return list for a boundary parameter.

Result:

- `Multiparts.getBoundary()` now throws a `IllegalStateExcepion` instead
  of `NullPointerException when a boundary is missing.
- Fixes #4193
