### PR TITLE
Run gRPC's `ServerInterceptor` in a blocking executor if `useBlockingTaskExecutor` is enabled.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Splitter;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -147,9 +146,9 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                        SerializationFormat serializationFormat,
                        @Nullable GrpcJsonMarshaller jsonMarshaller,
                        boolean unsafeWrapRequestBuffers,
-                       boolean useBlockingTaskExecutor,
                        ResponseHeaders defaultHeaders,
                        @Nullable GrpcStatusFunction statusFunction,
+                       @Nullable Executor blockingExecutor,
                        boolean autoCompression) {
         requireNonNull(req, "req");
         this.method = requireNonNull(method, "method");
@@ -171,8 +170,7 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         marshaller = new GrpcMessageMarshaller<>(alloc, serializationFormat, method, jsonMarshaller,
                                                  unsafeWrapRequestBuffers);
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
-        blockingExecutor = useBlockingTaskExecutor ?
-                           MoreExecutors.newSequentialExecutor(ctx.blockingTaskExecutor()) : null;
+        this.blockingExecutor = blockingExecutor;
         defaultResponseHeaders = defaultHeaders;
         this.statusFunction = statusFunction;
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -81,11 +81,11 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
                         HttpResponseWriter res, int maxRequestMessageLength, int maxResponseMessageLength,
                         ServiceRequestContext ctx, SerializationFormat serializationFormat,
                         @Nullable GrpcJsonMarshaller jsonMarshaller, boolean unsafeWrapRequestBuffers,
-                        boolean useBlockingTaskExecutor, ResponseHeaders defaultHeaders,
-                        @Nullable GrpcStatusFunction statusFunction, boolean autoCompress) {
+                        ResponseHeaders defaultHeaders, @Nullable GrpcStatusFunction statusFunction,
+                        @Nullable Executor blockingExecutor, boolean autoCompress) {
         super(req, method, simpleMethodName, compressorRegistry, decompressorRegistry, res,
               maxResponseMessageLength, ctx, serializationFormat, jsonMarshaller, unsafeWrapRequestBuffers,
-              useBlockingTaskExecutor, defaultHeaders, statusFunction, autoCompress);
+              defaultHeaders, statusFunction, blockingExecutor, autoCompress);
         requireNonNull(req, "req");
         this.method = requireNonNull(method, "method");
         this.ctx = requireNonNull(ctx, "ctx");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,11 +75,12 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
                     int maxRequestMessageLength, int maxResponseMessageLength,
                     ServiceRequestContext ctx, SerializationFormat serializationFormat,
                     @Nullable GrpcJsonMarshaller jsonMarshaller, boolean unsafeWrapRequestBuffers,
-                    boolean useBlockingTaskExecutor, ResponseHeaders defaultHeaders,
-                    @Nullable GrpcStatusFunction statusFunction, boolean autoCompress) {
+                    ResponseHeaders defaultHeaders,
+                    @Nullable GrpcStatusFunction statusFunction, @Nullable Executor blockingExecutor,
+                    boolean autoCompress) {
         super(req, method, simpleMethodName, compressorRegistry, decompressorRegistry, res,
               maxResponseMessageLength, ctx, serializationFormat, jsonMarshaller, unsafeWrapRequestBuffers,
-              useBlockingTaskExecutor, defaultHeaders, statusFunction, autoCompress);
+              defaultHeaders, statusFunction, blockingExecutor, autoCompress);
         requireNonNull(req, "req");
         this.ctx = requireNonNull(ctx, "ctx");
         final boolean grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
@@ -293,11 +293,11 @@ class StreamingServerCallTest {
                         GrpcSerializationFormats.PROTO,
                         new DefaultJsonMarshaller(MessageMarshaller.builder().build()),
                         false,
-                        false,
                         ResponseHeaders.builder(HttpStatus.OK)
                                        .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                        .build(),
                         /* exceptionMappings */ null,
+                        /* blockingExecutor */ null,
                         false);
 
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -362,11 +362,11 @@ class StreamingServerCallTest {
                 GrpcSerializationFormats.PROTO,
                 new DefaultJsonMarshaller(MessageMarshaller.builder().build()),
                 unsafeWrapRequestBuffers,
-                false,
                 ResponseHeaders.builder(HttpStatus.OK)
                                .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                .build(),
                 /* exceptionMappings */ null,
+                /* blockingExecutor */ null,
                 false);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -326,11 +326,12 @@ class UnaryServerCallTest {
                         GrpcSerializationFormats.PROTO,
                         new DefaultJsonMarshaller(MessageMarshaller.builder().build()),
                         false,
-                        false,
                         ResponseHeaders.builder(HttpStatus.OK)
                                        .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                        .build(),
-                        /* exceptionMappings */ null, /* autoCompress */ false);
+                        /* exceptionMappings */ null,
+                        /* blockingExecutor */ null,
+                        /* autoCompress */ false);
 
         final AtomicReference<SimpleRequest> requestCaptor = new AtomicReference<>();
         final AtomicBoolean completed = new AtomicBoolean();
@@ -369,10 +370,11 @@ class UnaryServerCallTest {
                 GrpcSerializationFormats.PROTO,
                 new DefaultJsonMarshaller(MessageMarshaller.builder().build()),
                 unsafeWrapRequestBuffers,
-                false,
                 ResponseHeaders.builder(HttpStatus.OK)
                                .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                .build(),
-                /* exceptionMappings */ null, /* autoCompress */ false);
+                /* exceptionMappings */ null,
+                /* blockingExecutor */ null,
+                /* autoCompress */ false);
     }
 }


### PR DESCRIPTION
Motivation:

`ServerInterceptor`s bound to a `GrpcService` run in an event loop even if
`GrpcServiceBuilder.useBlockingTaskExecutor(true)` option is specified.
See #4275 for details

Modifications:

- Use a blocking executor to run `ServerInterceptor`s

Result:

- You can now run `ServerInterceptor`s in a blocking task executor when
  `GrpcServiceBuilder.useBlockingTaskExecutor(true)` is enabled.
- Fixes #4275