### PR TITLE
Fix the test failure of `GrpcServiceLogNameTest.logName()`

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
@@ -95,14 +96,15 @@ class GrpcServiceLogNameTest {
         rootLogger.detachAppender(appender);
     }
 
-    @Test
+    // TODO(ikhoon): Revert after CI build passes
+    @RepeatedTest(100)
     void logName() {
         final TestServiceBlockingStub client =
                 GrpcClients.builder(server.httpUri().resolve("/grpc/"))
                            .build(TestServiceBlockingStub.class);
         client.emptyCall(Empty.newBuilder().build());
 
-        final RequestLog log = capturedCtx.log().partial();
+        final RequestLog log = capturedCtx.log().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo(TestServiceGrpc.SERVICE_NAME);
         assertThat(log.name()).isEqualTo("EmptyCall");
         assertThat(log.fullName()).isEqualTo(TestServiceGrpc.getEmptyCallMethod().getFullMethodName());
@@ -115,7 +117,7 @@ class GrpcServiceLogNameTest {
                            .build(TestServiceBlockingStub.class);
         client.emptyCall(Empty.newBuilder().build());
 
-        final RequestLog log = capturedCtx.log().partial();
+        final RequestLog log = capturedCtx.log().whenComplete().join();
         assertThat(log.serviceName()).isEqualTo("DefaultServiceName");
         assertThat(log.name()).isEqualTo("DefaultName");
         assertThat(log.fullName()).isEqualTo("DefaultServiceName/DefaultName");

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Executors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java
@@ -96,8 +96,7 @@ class GrpcServiceLogNameTest {
         rootLogger.detachAppender(appender);
     }
 
-    // TODO(ikhoon): Revert after CI build passes
-    @RepeatedTest(100)
+    @Test
     void logName() {
         final TestServiceBlockingStub client =
                 GrpcClients.builder(server.httpUri().resolve("/grpc/"))


### PR DESCRIPTION
Motivation:

`GrpcServiceLogNameTest.logName()` accesses `RequestLog.name()` using 
`RequestLogAccess.partial()` that unsafely accesses `RequestLog` without waiting for the completion event.
https://github.com/line/armeria/blob/49054ad7f22a7f2d64faaeb694674b0df09ad165/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceLogNameTest.java#L105

I thought the `.partial()` was safe if `RequestLog.name()` was set before a response completed.
However, the hypothesis was wrong. `RequestLog.name()` could be set even after the write of a response is completed.
`RequestLog.name()` can be set while executing `.endRequest()`.
https://github.com/line/armeria/blob/daae15d426ffb2581fdff9f10f16ec69f90b7a36/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java#L1041-L1046
; that could be called after write for response has completed. 
https://github.com/line/armeria/blob/871d87297e4d051241589cb1ae95641cbc83f880/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java#L167-L180


Modifications:

- Use `whenComplete().join()` to get `RequestLog` from `RequestLogAccess`.

Result:

- Clean up flaky tests.
- Closes #4333