### PR TITLE
Introduce a way to retrieve the innermost wrapped object of `Unwrappable` easily

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
@@ -23,7 +23,6 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.util.Unwrappable;
 
 final class DefaultBlockingWebClient implements BlockingWebClient {
 
@@ -86,7 +85,7 @@ final class DefaultBlockingWebClient implements BlockingWebClient {
     }
 
     @Override
-    public Unwrappable unwrapAll() {
+    public Object unwrapAll() {
         return delegate.unwrapAll();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 final class DefaultBlockingWebClient implements BlockingWebClient {
 
@@ -82,5 +83,10 @@ final class DefaultBlockingWebClient implements BlockingWebClient {
     @Override
     public HttpClient unwrap() {
         return delegate.unwrap();
+    }
+
+    @Override
+    public Unwrappable unwrapAll() {
+        return delegate.unwrapAll();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.Scheme;
-import com.linecorp.armeria.common.util.Unwrappable;
 
 final class DefaultRestClient implements RestClient {
 
@@ -79,7 +78,7 @@ final class DefaultRestClient implements RestClient {
     }
 
     @Override
-    public Unwrappable unwrapAll() {
+    public Object unwrapAll() {
         return delegate.unwrapAll();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.Scheme;
+import com.linecorp.armeria.common.util.Unwrappable;
 
 final class DefaultRestClient implements RestClient {
 
@@ -75,5 +76,10 @@ final class DefaultRestClient implements RestClient {
     @Override
     public HttpClient unwrap() {
         return delegate.unwrap();
+    }
+
+    @Override
+    public Unwrappable unwrapAll() {
+        return delegate.unwrapAll();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,12 +45,8 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public Unwrappable unwrap(boolean once) {
-        if (once) {
-            return unwrap();
-        } else {
-            return delegate.unwrap(once);
-        }
+    public Unwrappable unwrapAll() {
+        return delegate.unwrapAll();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,7 +45,7 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public Unwrappable unwrapAll() {
+    public Object unwrapAll() {
         return delegate.unwrapAll();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,7 +45,7 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public Unwrappable root() {
+    public <U extends Unwrappable> U root() {
         return delegate.root();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,7 +45,7 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public <U extends Unwrappable> U root() {
+    public Unwrappable root() {
         return delegate.root();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,8 +45,12 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public Unwrappable root() {
-        return delegate.root();
+    public Unwrappable unwrap(boolean all) {
+        if (all) {
+            return delegate.unwrap(all);
+        } else {
+            return unwrap();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,6 +45,11 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
+    public Unwrappable root() {
+        return delegate.root();
+    }
+
+    @Override
     public String toString() {
         final String simpleName = getClass().getSimpleName();
         final String name = simpleName.isEmpty() ? getClass().getName() : simpleName;

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -45,11 +45,11 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
     }
 
     @Override
-    public Unwrappable unwrap(boolean all) {
-        if (all) {
-            return delegate.unwrap(all);
-        } else {
+    public Unwrappable unwrap(boolean once) {
+        if (once) {
             return unwrap();
+        } else {
+            return delegate.unwrap(once);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -87,4 +87,11 @@ public interface Unwrappable {
     default Unwrappable unwrap() {
         return this;
     }
+
+    /**
+     * TBU.
+     */
+    default Unwrappable root() {
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -89,10 +89,10 @@ public interface Unwrappable {
     }
 
     /**
-     * Unwraps this object and returns the object being decorated. If {@code all} is true,
-     * then the innermost wrapped object is returned. If {@code all} is false, then the behavior is identical
-     * to {@link Unwrappable#unwrap()}. If this {@link Unwrappable} is the innermost
-     * object, this method returns itself. For example:
+     * Unwraps this object and returns the object being decorated. If {@code once} is false,
+     * then the innermost wrapped object is returned. If {@code once} is true, then the behavior is identical
+     * to {@link Unwrappable#unwrap()} and the object being decorated is returned.
+     * If this {@link Unwrappable} is the innermost object, this method returns itself. For example:
      * <pre>{@code
      * class Foo implements Unwrappable {}
      *
@@ -109,19 +109,19 @@ public interface Unwrappable {
      * }
      *
      * final Foo foo = new Foo();
-     * foo.unwrap(true) == foo;
      * foo.unwrap(false) == foo;
+     * foo.unwrap(true) == foo;
      *
      * final Bar<Foo> bar = new Bar<>(foo);
-     * bar.unwrap(true) == foo;
      * bar.unwrap(false) == foo;
+     * bar.unwrap(true) == foo;
      *
      * final Qux<Bar<Foo>> qux = new Qux<>(bar);
-     * qux.unwrap(true) == foo;
-     * qux.unwrap(false) == bar;
+     * qux.unwrap(false) == foo;
+     * qux.unwrap(true) == bar;
      * }</pre>
      */
-    default Unwrappable unwrap(boolean all) {
+    default Unwrappable unwrap(boolean once) {
         return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.util;
 import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * Provides a way to unwrap an object in decorator pattern, similar to down-casting in an inheritance pattern.
@@ -117,6 +118,7 @@ public interface Unwrappable {
      * assert qux.unwrapAll() == foo;
      * }</pre>
      */
+    @UnstableApi
     default Unwrappable unwrapAll() {
         Unwrappable unwrapped = this;
         while (true) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -118,6 +118,13 @@ public interface Unwrappable {
      * }</pre>
      */
     default Unwrappable unwrapAll() {
-        return unwrap();
+        Unwrappable unwrapped = this;
+        while (true) {
+            final Unwrappable inner = unwrapped.unwrap();
+            if (inner == unwrapped) {
+                return inner;
+            }
+            unwrapped = inner;
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -89,9 +89,34 @@ public interface Unwrappable {
     }
 
     /**
-     * TBU.
+     * Returns the innermost object decorated by this object. If this {@link Unwrappable} is the innermost
+     * object, this method returns itself. For example:
+     * <pre>{@code
+     * class Foo implements Unwrappable {}
+     *
+     * class Bar<T extends Unwrappable> extends AbstractUnwrappable<T> {
+     *     Bar(T delegate) {
+     *         super(delegate);
+     *     }
+     * }
+     *
+     * class Qux<T extends Unwrappable> extends AbstractUnwrappable<T> {
+     *     Qux(T delegate) {
+     *         super(delegate);
+     *     }
+     * }
+     *
+     * Foo foo = new Foo();
+     * assert foo.root() == foo;
+     *
+     * Bar<Foo> bar = new Bar<>(foo);
+     * assert bar.root() == foo;
+     *
+     * Qux<Bar<Foo>> qux = new Qux<>(bar);
+     * assert qux.root() == foo;
+     * }</pre>
      */
-    default <U extends Unwrappable> U root() {
-        return (U) this;
+    default Unwrappable root() {
+        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -119,7 +119,7 @@ public interface Unwrappable {
      * }</pre>
      */
     @UnstableApi
-    default Unwrappable unwrapAll() {
+    default Object unwrapAll() {
         Unwrappable unwrapped = this;
         while (true) {
             final Unwrappable inner = unwrapped.unwrap();

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -106,17 +106,18 @@ public interface Unwrappable {
      *     }
      * }
      *
-     * final Foo foo = new Foo();
-     * foo.unwrapAll() == foo;
+     * Foo foo = new Foo();
+     * assert foo.unwrapAll() == foo;
      *
-     * final Bar<Foo> bar = new Bar<>(foo);
-     * bar.unwrapAll() == foo;
+     * Bar<Foo> bar = new Bar<>(foo);
+     * assert bar.unwrapAll() == foo;
      *
-     * final Qux<Bar<Foo>> qux = new Qux<>(bar);
-     * qux.unwrapAll() == foo;
+     * Qux<Bar<Foo>> qux = new Qux<>(bar);
+     * assert qux.unwrap() == bar;
+     * assert qux.unwrapAll() == foo;
      * }</pre>
      */
     default Unwrappable unwrapAll() {
-        return this;
+        return unwrap();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -89,7 +89,9 @@ public interface Unwrappable {
     }
 
     /**
-     * Returns the innermost object decorated by this object. If this {@link Unwrappable} is the innermost
+     * Unwraps this object and returns the object being decorated. If {@code all} is true,
+     * then the innermost wrapped object is returned. If {@code all} is false, then the behavior is identical
+     * to {@link Unwrappable#unwrap()}. If this {@link Unwrappable} is the innermost
      * object, this method returns itself. For example:
      * <pre>{@code
      * class Foo implements Unwrappable {}
@@ -106,17 +108,20 @@ public interface Unwrappable {
      *     }
      * }
      *
-     * Foo foo = new Foo();
-     * assert foo.root() == foo;
+     * final Foo foo = new Foo();
+     * foo.unwrap(true) == foo;
+     * foo.unwrap(false) == foo;
      *
-     * Bar<Foo> bar = new Bar<>(foo);
-     * assert bar.root() == foo;
+     * final Bar<Foo> bar = new Bar<>(foo);
+     * bar.unwrap(true) == foo;
+     * bar.unwrap(false) == foo;
      *
-     * Qux<Bar<Foo>> qux = new Qux<>(bar);
-     * assert qux.root() == foo;
+     * final Qux<Bar<Foo>> qux = new Qux<>(bar);
+     * qux.unwrap(true) == foo;
+     * qux.unwrap(false) == bar;
      * }</pre>
      */
-    default Unwrappable root() {
+    default Unwrappable unwrap(boolean all) {
         return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -91,7 +91,7 @@ public interface Unwrappable {
     /**
      * TBU.
      */
-    default Unwrappable root() {
-        return this;
+    default <U extends Unwrappable> U root() {
+        return (U) this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Unwrappable.java
@@ -89,9 +89,7 @@ public interface Unwrappable {
     }
 
     /**
-     * Unwraps this object and returns the object being decorated. If {@code once} is false,
-     * then the innermost wrapped object is returned. If {@code once} is true, then the behavior is identical
-     * to {@link Unwrappable#unwrap()} and the object being decorated is returned.
+     * Unwraps this object and returns the innermost object being decorated.
      * If this {@link Unwrappable} is the innermost object, this method returns itself. For example:
      * <pre>{@code
      * class Foo implements Unwrappable {}
@@ -109,19 +107,16 @@ public interface Unwrappable {
      * }
      *
      * final Foo foo = new Foo();
-     * foo.unwrap(false) == foo;
-     * foo.unwrap(true) == foo;
+     * foo.unwrapAll() == foo;
      *
      * final Bar<Foo> bar = new Bar<>(foo);
-     * bar.unwrap(false) == foo;
-     * bar.unwrap(true) == foo;
+     * bar.unwrapAll() == foo;
      *
      * final Qux<Bar<Foo>> qux = new Qux<>(bar);
-     * qux.unwrap(false) == foo;
-     * qux.unwrap(true) == bar;
+     * qux.unwrapAll() == foo;
      * }</pre>
      */
-    default Unwrappable unwrap(boolean once) {
+    default Unwrappable unwrapAll() {
         return this;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -45,6 +45,9 @@ class AbstractUnwrappableTest {
 
         final Qux<Bar<Foo>> qux = new Qux<>(bar);
         assertThat(qux.unwrapAll()).isSameAs(foo);
+
+        final Baz baz = new Baz(qux);
+        assertThat(baz.unwrapAll()).isSameAs(foo);
     }
 
     private static final class Foo implements Unwrappable {}
@@ -52,6 +55,20 @@ class AbstractUnwrappableTest {
     private static final class Bar<T extends Unwrappable> extends AbstractUnwrappable<T> {
         Bar(T delegate) {
             super(delegate);
+        }
+    }
+
+    private static final class Baz implements Unwrappable {
+
+        private final Unwrappable delegate;
+
+        Baz(Unwrappable delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Unwrappable unwrap() {
+            return delegate.unwrap();
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -38,13 +38,16 @@ class AbstractUnwrappableTest {
     @Test
     void testUnwrapAll() {
         final Foo foo = new Foo();
-        assertThat(foo.root()).isSameAs(foo);
+        assertThat(foo.unwrap(true)).isSameAs(foo);
+        assertThat(foo.unwrap(false)).isSameAs(foo);
 
         final Bar<Foo> bar = new Bar<>(foo);
-        assertThat(bar.root()).isSameAs(foo);
+        assertThat(bar.unwrap(true)).isSameAs(foo);
+        assertThat(bar.unwrap(false)).isSameAs(foo);
 
         final Qux<Bar<Foo>> qux = new Qux<>(bar);
-        assertThat(qux.root()).isSameAs(foo);
+        assertThat(qux.unwrap(true)).isSameAs(foo);
+        assertThat(qux.unwrap(false)).isSameAs(bar);
     }
 
     private static final class Foo implements Unwrappable {}

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -35,6 +35,15 @@ class AbstractUnwrappableTest {
         assertThat(qux.unwrap().unwrap()).isSameAs(foo);
     }
 
+    @Test
+    void testUnwrapAll() {
+        final Foo foo = new Foo();
+        final Bar<Foo> bar = new Bar<>(foo);
+        final Qux<Bar<Foo>> qux = new Qux<>(bar);
+
+        assertThat(qux.root()).isSameAs(foo);
+    }
+
     private static final class Foo implements Unwrappable {}
 
     private static final class Bar<T extends Unwrappable> extends AbstractUnwrappable<T> {

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -38,11 +38,13 @@ class AbstractUnwrappableTest {
     @Test
     void testUnwrapAll() {
         final Foo foo = new Foo();
-        final Bar<Foo> bar = new Bar<>(foo);
-        final Qux<Bar<Foo>> qux = new Qux<>(bar);
+        assertThat(foo.root()).isSameAs(foo);
 
-        final Foo root = qux.root();
-        assertThat(root).isSameAs(foo);
+        final Bar<Foo> bar = new Bar<>(foo);
+        assertThat(bar.root()).isSameAs(foo);
+
+        final Qux<Bar<Foo>> qux = new Qux<>(bar);
+        assertThat(qux.root()).isSameAs(foo);
     }
 
     private static final class Foo implements Unwrappable {}

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -38,16 +38,16 @@ class AbstractUnwrappableTest {
     @Test
     void testUnwrapAll() {
         final Foo foo = new Foo();
-        assertThat(foo.unwrap(true)).isSameAs(foo);
         assertThat(foo.unwrap(false)).isSameAs(foo);
+        assertThat(foo.unwrap(true)).isSameAs(foo);
 
         final Bar<Foo> bar = new Bar<>(foo);
-        assertThat(bar.unwrap(true)).isSameAs(foo);
         assertThat(bar.unwrap(false)).isSameAs(foo);
+        assertThat(bar.unwrap(true)).isSameAs(foo);
 
         final Qux<Bar<Foo>> qux = new Qux<>(bar);
-        assertThat(qux.unwrap(true)).isSameAs(foo);
-        assertThat(qux.unwrap(false)).isSameAs(bar);
+        assertThat(qux.unwrap(false)).isSameAs(foo);
+        assertThat(qux.unwrap(true)).isSameAs(bar);
     }
 
     private static final class Foo implements Unwrappable {}

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -38,16 +38,13 @@ class AbstractUnwrappableTest {
     @Test
     void testUnwrapAll() {
         final Foo foo = new Foo();
-        assertThat(foo.unwrap(false)).isSameAs(foo);
-        assertThat(foo.unwrap(true)).isSameAs(foo);
+        assertThat(foo.unwrapAll()).isSameAs(foo);
 
         final Bar<Foo> bar = new Bar<>(foo);
-        assertThat(bar.unwrap(false)).isSameAs(foo);
-        assertThat(bar.unwrap(true)).isSameAs(foo);
+        assertThat(bar.unwrapAll()).isSameAs(foo);
 
         final Qux<Bar<Foo>> qux = new Qux<>(bar);
-        assertThat(qux.unwrap(false)).isSameAs(foo);
-        assertThat(qux.unwrap(true)).isSameAs(bar);
+        assertThat(qux.unwrapAll()).isSameAs(foo);
     }
 
     private static final class Foo implements Unwrappable {}

--- a/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/util/AbstractUnwrappableTest.java
@@ -41,7 +41,8 @@ class AbstractUnwrappableTest {
         final Bar<Foo> bar = new Bar<>(foo);
         final Qux<Bar<Foo>> qux = new Qux<>(bar);
 
-        assertThat(qux.root()).isSameAs(foo);
+        final Foo root = qux.root();
+        assertThat(root).isSameAs(foo);
     }
 
     private static final class Foo implements Unwrappable {}

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -184,4 +184,6 @@ private final class DefaultScalaRestClient(delegate: RestClient) extends ScalaRe
   override def options(): ClientOptions = delegate.options()
 
   override def unwrap(): HttpClient = delegate.unwrap().asInstanceOf[HttpClient]
+
+  override def unwrapAll(): Unwrappable = delegate.unwrapAll();
 }

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -21,6 +21,7 @@ import com.linecorp.armeria.client.endpoint.EndpointGroup
 import com.linecorp.armeria.common.annotation.UnstableApi
 import com.linecorp.armeria.common.util.Unwrappable
 import com.linecorp.armeria.common.{HttpMethod, Scheme}
+
 import java.net.URI
 import java.util.Objects.requireNonNull
 
@@ -185,5 +186,5 @@ private final class DefaultScalaRestClient(delegate: RestClient) extends ScalaRe
 
   override def unwrap(): HttpClient = delegate.unwrap().asInstanceOf[HttpClient]
 
-  override def unwrapAll(): Unwrappable = delegate.unwrapAll();
+  override def unwrapAll(): Object = delegate.unwrapAll();
 }


### PR DESCRIPTION
Motivation:

Currently, it is possible to retrieve the root `Unwrappable` if one knows the type using `Unwrappable#as(Class<?>)`.
However, sometimes users may just want to retrieve the underlying root type quickly without caring what type the object actually is.

One such example of this case may be when one simply wants to check for equality of the underlying type.
https://github.com/line/armeria/blob/8b0225ec63e231428276f30b92f8357eb7876b03/core/src/main/java/com/linecorp/armeria/common/ThreadLocalRequestContextStorage.java#L49

One may want to check whether the underlying `RequestContext` is equal in the above scenario.

Another option I think we have is to add a "root"-esque API to `RequestContext`.
I think this is also a good idea, at the risk of ABI compatibility if we decide to generalize this API in the future.

Modifications:

- Add a `Unwrappable#unwrap(boolean all)` API.
    - If `all == false`, the behavior is identical to `Unwrappable#unwrap()`
    - If `all == true`, the innermost object is returned

Result:

- Users can extract the innermost wrapped object conveniently

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
