### PR TITLE
Enforce `okhttp` dependency version to `3.14.9`

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -176,7 +176,9 @@ com.spotify:
       to: com.linecorp.armeria.internal.shaded.futures
   futures-extra: { version: '4.3.1' }
 
-# OkHttp is used only for testing in it:okhttp module.
+# The OkHttp version is aligned with Retrofit's transitive version
+# to avoid unexpected conflicts. This is a temporary measure that
+# will be improved with better dependency version management in the future.
 com.squareup.okhttp3:
   okhttp: { version: &OKHTTP_VERSION '3.14.9' }
   okhttp-tls: { version: *OKHTTP_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -178,7 +178,7 @@ com.spotify:
 
 # OkHttp is used only for testing in it:okhttp module.
 com.squareup.okhttp3:
-  okhttp: { version: &OKHTTP_VERSION '4.10.0' }
+  okhttp: { version: &OKHTTP_VERSION '3.14.9' }
   okhttp-tls: { version: *OKHTTP_VERSION }
 
 com.squareup.retrofit2:

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/AbstractSubscriber.java
@@ -176,10 +176,9 @@ abstract class AbstractSubscriber implements Subscriber<HttpObject> {
         callbackExecutor.execute(() -> {
             try {
                 callback.onResponse(armeriaCall, responseBuilder
-                        .body(ResponseBody.create(content,
-                                                  Strings.isNullOrEmpty(contentType) ?
+                        .body(ResponseBody.create(Strings.isNullOrEmpty(contentType) ?
                                                   null : MediaType.parse(contentType),
-                                                  contentLength))
+                                                  contentLength, content))
                         .build());
             } catch (IOException e) {
                 callback.onFailure(armeriaCall, e);


### PR DESCRIPTION
Motivation:

Armeria doesn't explicitly declare a `okhttp` version in it's published pom files.
In the previous release, there was a usage of `okhttp3` 4.x.x API. However, most of our dependencies have a transient version dependency on `okhttp3` 3.x.x.

Due to this issue, retrofit calls aren't completed correctly due to a `NoSuchMethodException`, causing requests to hang

Modifications:

- Use `okhttp3` 3.x.x when compiling armeria
- Revert to using `okhttp3` 3.x.x APIs only

Result:

- Users don't experience indefinitely waiting retrofit calls

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
