### PR TITLE
Use default locale(en-US) for `currentBuildDate` in Gatsby

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -17,9 +17,6 @@ module.exports = {
     {
       resolve: 'gatsby-source-build-date',
       options: {
-        // Generate ISO8601 date.
-        // See: https://stackoverflow.com/a/58633686/55808
-        locales: 'sv-SE',
         options: {
           timeZone: 'Asia/Seoul',
           year: 'numeric',


### PR DESCRIPTION
Motivation:
We use `sv-SE` locale to generate ISO8601 like date String. e.g. (2022-07-10 12:31:32 GMT+9)
https://stackoverflow.com/questions/25050034/get-iso-8601-using-intl-datetimeformat/58633686#58633686
However, the String uses a space as a delimiter for separating date and time and it's not allowed anymore in ISO 8601.
https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations
Also, the converted String is not properly parsed back to the Date object by dayjs in certain browsers(Safari)
so [this](https://github.com/line/armeria/blob/master/site/src/layouts/footer.tsx#L28) doesn't work properly.

Modifications:
- Use the default locale which dayjs easily converts to the Date object

Result:
- You no longer see NaN from the site.
