### PR TITLE
Set okhttp version explicitly in `retrofit2` module

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -176,13 +176,6 @@ com.spotify:
       to: com.linecorp.armeria.internal.shaded.futures
   futures-extra: { version: '4.3.1' }
 
-# The OkHttp version is aligned with Retrofit's transitive version
-# to avoid unexpected conflicts. This is a temporary measure that
-# will be improved with better dependency version management in the future.
-com.squareup.okhttp3:
-  okhttp: { version: &OKHTTP_VERSION '3.14.9' }
-  okhttp-tls: { version: *OKHTTP_VERSION }
-
 com.squareup.retrofit2:
   retrofit:
     version: &RETROFIT2_VERSION '2.9.0'

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -177,7 +177,7 @@ com.spotify:
   futures-extra: { version: '4.3.1' }
 
 com.squareup.okhttp3:
-  okhttp: { version: &OKHTTP_VERSION '4.10.10' }
+  okhttp: { version: &OKHTTP_VERSION '4.10.0' }
   okhttp-tls: { version: *OKHTTP_VERSION }
 
 com.squareup.retrofit2:

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -176,6 +176,7 @@ com.spotify:
       to: com.linecorp.armeria.internal.shaded.futures
   futures-extra: { version: '4.3.1' }
 
+# OkHttp is used only for testing in it:okhttp module.
 com.squareup.okhttp3:
   okhttp: { version: &OKHTTP_VERSION '4.10.0' }
   okhttp-tls: { version: *OKHTTP_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -176,6 +176,10 @@ com.spotify:
       to: com.linecorp.armeria.internal.shaded.futures
   futures-extra: { version: '4.3.1' }
 
+com.squareup.okhttp3:
+  okhttp: { version: &OKHTTP_VERSION '4.10.10' }
+  okhttp-tls: { version: *OKHTTP_VERSION }
+
 com.squareup.retrofit2:
   retrofit:
     version: &RETROFIT2_VERSION '2.9.0'

--- a/it/okhttp/build.gradle
+++ b/it/okhttp/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    testImplementation 'com.squareup.okhttp3:okhttp'
-    testImplementation 'com.squareup.okhttp3:okhttp-tls'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.10.0'
 }

--- a/it/okhttp/build.gradle
+++ b/it/okhttp/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    testImplementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.10.0'
+    testImplementation 'com.squareup.okhttp3:okhttp'
+    testImplementation 'com.squareup.okhttp3:okhttp-tls'
 }

--- a/retrofit2/build.gradle
+++ b/retrofit2/build.gradle
@@ -2,6 +2,13 @@ dependencies {
     api 'com.squareup.retrofit2:retrofit'
 
     implementation 'com.github.ben-manes.caffeine:caffeine'
+    [ 'okhttp', 'okhttp-tls' ].each {
+        implementation("com.squareup.okhttp3:$it") {
+            version {
+                strictly '3.14.9'
+            }
+        }
+    }
 
     testImplementation 'com.squareup.retrofit2:converter-jackson'
 }

--- a/retrofit2/build.gradle
+++ b/retrofit2/build.gradle
@@ -2,11 +2,10 @@ dependencies {
     api 'com.squareup.retrofit2:retrofit'
 
     implementation 'com.github.ben-manes.caffeine:caffeine'
-    [ 'okhttp', 'okhttp-tls' ].each {
-        implementation("com.squareup.okhttp3:$it") {
-            version {
-                strictly '3.14.9'
-            }
+    implementation("com.squareup.okhttp3:okhttp") {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly '3.14.9'
         }
     }
 


### PR DESCRIPTION
Motivation:

Previously, our `dependencies.yml` has had `okhttp3` version set as `4.x.x `.
With the following [pull request](https://github.com/line/armeria/pull/4342/files), I had tried fixing the `okhttp3` version to be compatible with `retrofit` for Armeria builds.
However, it turns out the `okhttp3` downgrade is causing a test failure in the `it:okhttp` module for mac only.

Modifications:

- Globally define `okhttp3` version to `4.10.10`
- Strictly define `retrofit2` module's `okhttp3` version to `3.14.9`

Result:

- Closes #4345

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
