### PR TITLE
wrap HttpJsonTranscodingService with GrpcDecoratingService

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -866,15 +866,14 @@ public final class GrpcServiceBuilder {
                     unframedGrpcErrorHandler != null ? unframedGrpcErrorHandler
                                                      : UnframedGrpcErrorHandler.of());
         }
-
-        if (!handlerRegistry.decorators().isEmpty()) {
-            grpcService = new GrpcDecoratingService(grpcService, handlerRegistry);
-        }
         if (enableHttpJsonTranscoding) {
             grpcService = HttpJsonTranscodingService.of(
                     grpcService,
                     httpJsonTranscodingErrorHandler != null ? httpJsonTranscodingErrorHandler
                                                             : UnframedGrpcErrorHandler.ofJson());
+        }
+        if (!handlerRegistry.decorators().isEmpty()) {
+            grpcService = new GrpcDecoratingService(grpcService, handlerRegistry);
         }
         return grpcService;
     }


### PR DESCRIPTION
Motivation:

NPE in HttpJsonTranscodingService if GrpcDecoratingService returns Response without grpc-status header

Modifications:

- Change service wrap order in GrpcServiceBuilder: Wrap HttpJsonTranscodingService with GrpcDecoratingService

Result:

- Closes #4337 

(WIP) I'm also looking to add test cases for the fix (with HttpJsonTranscoding & an annotated Decorator). Please Recommend a Test file to put it (or a name for a new Test file)
