### PR TITLE
Fix a bug where `HealthEndpointGroup` raises `NoSuchElementException` while closing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -192,12 +192,12 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     @VisibleForTesting
     List<Endpoint> allHealthyEndpoints() {
         synchronized (contextGroupChain) {
-            if (contextGroupChain.isEmpty()) {
+            final HealthCheckContextGroup newGroup = contextGroupChain.pollLast();
+            if (newGroup == null) {
                 return ImmutableList.of();
             }
 
             final List<Endpoint> allHealthyEndpoints = new ArrayList<>();
-            final HealthCheckContextGroup newGroup = contextGroupChain.getLast();
             for (Endpoint candidate : newGroup.candidates()) {
                 if (healthyEndpoints.contains(candidate)) {
                     allHealthyEndpoints.add(candidate);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -189,9 +189,14 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         return contextGroupChain;
     }
 
-    private List<Endpoint> allHealthyEndpoints() {
-        final List<Endpoint> allHealthyEndpoints = new ArrayList<>();
+    @VisibleForTesting
+    List<Endpoint> allHealthyEndpoints() {
         synchronized (contextGroupChain) {
+            if (contextGroupChain.isEmpty()) {
+                return ImmutableList.of();
+            }
+
+            final List<Endpoint> allHealthyEndpoints = new ArrayList<>();
             final HealthCheckContextGroup newGroup = contextGroupChain.getLast();
             for (Endpoint candidate : newGroup.candidates()) {
                 if (healthyEndpoints.contains(candidate)) {
@@ -211,8 +216,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                     }
                 }
             }
+            return allHealthyEndpoints;
         }
-        return allHealthyEndpoints;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -297,7 +297,7 @@ final class HttpHealthChecker implements AsyncCloseable {
                 pingCheckFuture.cancel(false);
             }
 
-            if (updatedHealth) {
+            if (closeable.isClosing() || updatedHealth) {
                 return;
             }
 


### PR DESCRIPTION
Motivation:

`HealthEndpointGroup.allHealthyEnpoints()` is used to get all health
endpoints from `contextGroupChain`, which is called when either
the healthiness of an `Endpoint` is updated after a health check
https://github.com/line/armeria/blob/554d5963bef33162b1cb077077336de3ef3aadfb/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java#L252-L263
or when the first `contextGroup` is resolved.
https://github.com/line/armeria/blob/554d5963bef33162b1cb077077336de3ef3aadfb/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java#L171-L181

`allHealthyEndpoints`, in turn, assumes that at least one `contextGroup` is
available when it is called. However, if an `Endpoint` is updated while
an `HealthEndpointGroup` is closing, `allHealthyEndpoints` can see an
empty `contextGroup` and the following error is warned.
```
Caused by: com.linecorp.armeria.common.util.CompositeException$ExceptionOverview: Multiple exceptions (2)
|-- java.util.NoSuchElementException: null
    at java.base/java.util.ArrayDeque.getLast(ArrayDeque.java:413)
|-- com.linecorp.armeria.common.stream.AbortedStreamException: null
    at com.linecorp.armeria.common.stream.AbortedStreamException.get(AbortedStreamException.java:39)
```

Modifications:

- Return an empty list if `contextGroupChain` is empty
- Do not update the healthiness of an `Endpoint` if `HttpHealthChecker` is
  closing

Result:

You no longer see a `NoSuchElementException` while an
`HealthEndpointGroup` is closing.