### PR TITLE
Add the gauge meter for the number of active client connections

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.internal.common.Http1KeepAliveHandler;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -37,9 +38,10 @@ final class Http1ClientKeepAliveHandler extends Http1KeepAliveHandler {
 
     Http1ClientKeepAliveHandler(Channel channel, ClientHttp1ObjectEncoder encoder, Http1ResponseDecoder decoder,
                                 Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
+                                MeterRegistry meterRegistry) {
         super(channel, "client", keepAliveTimer, idleTimeoutMillis,
-              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
+              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection, meterRegistry);
         httpSession = HttpSession.get(requireNonNull(channel, "channel"));
         this.encoder = requireNonNull(encoder, "encoder");
         this.decoder = requireNonNull(decoder, "decoder");

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -81,7 +81,8 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
                                     ImmutableList.of(Tag.of("protocol", protocol.uriText())));
         return new Http2ClientKeepAliveHandler(
                 channel, encoder.frameWriter(), keepAliveTimer,
-                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
+                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                clientFactory.options().meterRegistry());
     }
 
     Http2ResponseDecoder responseDecoder() {

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.internal.common.Http2KeepAliveHandler;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -26,10 +27,12 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
+                                MeterRegistry meterRegistry) {
 
         super(channel, frameWriter, "client", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
+              meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -337,7 +337,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                             new Http1ClientKeepAliveHandler(
                                     channel, requestEncoder, responseDecoder,
                                     keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
-                                    maxConnectionAgeMillis, maxNumRequestsPerConnection);
+                                    maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                                    clientFactory.options().meterRegistry());
                     requestEncoder.setKeepAliveHandler(keepAliveHandler);
                     responseDecoder.setKeepAliveHandler(ctx, keepAliveHandler);
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
@@ -16,15 +16,16 @@
 
 package com.linecorp.armeria.internal.common;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 
 public abstract class Http1KeepAliveHandler extends AbstractKeepAliveHandler {
     protected Http1KeepAliveHandler(Channel channel, String name, Timer keepAliveTimer, long idleTimeoutMillis,
                                     long pingIntervalMillis, long maxConnectionAgeMillis,
-                                    long maxNumRequestsPerConnection) {
+                                    long maxNumRequestsPerConnection, MeterRegistry meterRegistry) {
         super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis,
-              maxNumRequestsPerConnection);
+              maxNumRequestsPerConnection, meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -31,6 +31,7 @@ import com.google.common.base.Stopwatch;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -69,9 +70,10 @@ public abstract class Http2KeepAliveHandler extends AbstractKeepAliveHandler {
 
     protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, String name,
                                     Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                    long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
+                                    long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
+                                    MeterRegistry meterRegistry) {
         super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
-              maxConnectionAgeMillis, maxNumRequestsPerConnection);
+              maxConnectionAgeMillis, maxNumRequestsPerConnection, meterRegistry);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
     }

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.internal.common.Http1KeepAliveHandler;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -27,9 +28,10 @@ final class Http1ServerKeepAliveHandler extends Http1KeepAliveHandler {
 
     Http1ServerKeepAliveHandler(Channel channel, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long maxConnectionAgeMillis,
-                                int maxNumRequestsPerConnection) {
+                                int maxNumRequestsPerConnection,
+                                MeterRegistry meterRegistry) {
         super(channel, "server", keepAliveTimer, idleTimeoutMillis, /* pingIntervalMillis(unsupported) */ 0,
-              maxConnectionAgeMillis, maxNumRequestsPerConnection);
+              maxConnectionAgeMillis, maxNumRequestsPerConnection, meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -77,7 +77,8 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
         return new Http2ServerKeepAliveHandler(
                     channel, encoder.frameWriter(), keepAliveTimer, idleTimeoutMillis,
-                    pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
+                    pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                    cfg.meterRegistry());
     }
 
     ServerHttp2ObjectEncoder getOrCreateResponseEncoder(ChannelHandlerContext connectionHandlerCtx) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.internal.common.Http2KeepAliveHandler;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -26,9 +27,11 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
+                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
+                                MeterRegistry meterRegistry) {
         super(channel, frameWriter, "server", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
+              meterRegistry);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -208,7 +208,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             final Timer keepAliveTimer = newKeepAliveTimer(H1C);
             keepAliveHandler = new Http1ServerKeepAliveHandler(p.channel(), keepAliveTimer, idleTimeoutMillis,
                                                                maxConnectionAgeMillis,
-                                                               maxNumRequestsPerConnection);
+                                                               maxNumRequestsPerConnection,
+                                                               config.meterRegistry());
         } else {
             keepAliveHandler = NoopKeepAliveHandler.INSTANCE;
         }
@@ -514,7 +515,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             if (needsKeepAliveHandler) {
                 keepAliveHandler = new Http1ServerKeepAliveHandler(ch, newKeepAliveTimer(H1), idleTimeoutMillis,
                                                                    maxConnectionAgeMillis,
-                                                                   maxNumRequestsPerConnection);
+                                                                   maxNumRequestsPerConnection,
+                                                                   config.meterRegistry());
             } else {
                 keepAliveHandler = NoopKeepAliveHandler.INSTANCE;
             }

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -558,8 +558,6 @@ public final class Server implements ListenableAsyncCloseable {
 
             meterRegistry.gauge("armeria.server.pending.responses", gracefulShutdownSupport,
                                 GracefulShutdownSupport::pendingResponses);
-            meterRegistry.gauge("armeria.server.connections", connectionLimitingHandler,
-                                ConnectionLimitingHandler::numConnections);
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.armeria.internal.common.AbstractKeepAliveHandler.PingState;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -65,7 +66,8 @@ class Http2KeepAliveHandlerTest {
         keepAliveHandler = new Http2KeepAliveHandler(
                 channel, frameWriter, "test", NoopMeterRegistry.get().timer(""),
                 idleTimeoutMillis, pingIntervalMillis,
-                /* maxConnectionAgeMillis */ 0, /* maxNumRequestsPerConnection */ 0) {
+                /* maxConnectionAgeMillis */ 0, /* maxNumRequestsPerConnection */ 0,
+                new SimpleMeterRegistry()) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
                 return false;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -94,7 +94,7 @@ class KeepAliveHandlerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
-                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0) {
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0, meterRegistry) {
 
                     @Override
                     public boolean isHttp2() {
@@ -137,7 +137,7 @@ class KeepAliveHandlerTest {
         final Stopwatch stopwatch = Stopwatch.createStarted();
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
-                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0) {
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0, meterRegistry) {
 
                     @Override
                     public boolean isHttp2() {
@@ -177,7 +177,7 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 0;
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                maxConnectionAgeMillis, 0) {
+                                                                maxConnectionAgeMillis, 0, meterRegistry) {
             @Override
             public boolean isHttp2() {
                 return false;
@@ -212,7 +212,7 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 500;
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                maxConnectionAgeMillis, 0) {
+                                                                maxConnectionAgeMillis, 0, meterRegistry) {
             @Override
             public boolean isHttp2() {
                 return false;
@@ -251,7 +251,7 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler pingScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0,
-                                             pingInterval, 0, 0) {
+                                             pingInterval, 0, 0, meterRegistry) {
 
                     @Override
                     public boolean isHttp2() {
@@ -300,7 +300,7 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout,
-                                             0, 0, 0) {
+                                             0, 0, 0, meterRegistry) {
 
                     @Override
                     public boolean isHttp2() {
@@ -354,7 +354,7 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, 0) {
+                                             maxConnectionAgeMillis, 0, meterRegistry) {
                     @Override
                     public boolean isHttp2() {
                         return false;
@@ -408,7 +408,8 @@ class KeepAliveHandlerTest {
         final int maxNumRequestsPerConnection = 0;
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequestsPerConnection) {
+                                             maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                                             meterRegistry) {
                     @Override
                     public boolean isHttp2() {
                         return false;
@@ -465,7 +466,8 @@ class KeepAliveHandlerTest {
         final ChannelPromise promise = channel.newPromise();
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequestsPerConnection) {
+                                             maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                                             meterRegistry) {
                     @Override
                     public boolean isHttp2() {
                         return false;


### PR DESCRIPTION
Motivation:

We have gauge meter for active server connections but we don't
have the gauge meter for client side.

Modification:

Implement the gauge for both client and server active connections
at `AbstractKeepAliveHandler`, which is where we measure the
connection lifetime.

Results:

- Add a gauge meter for active client connections.
- Unify how we count the active connections for client and server.
- Closes https://github.com/line/armeria/issues/4277
