### PR TITLE
Remove a false postive warning for unknown `MethodType` in `ArmeriaChannel`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -69,6 +69,9 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
     static {
         final EnumMap<MethodType, RequestOptions> requestOptionsMap = new EnumMap<>(MethodType.class);
         for (MethodType methodType : MethodType.values()) {
+            if (methodType == MethodType.UNKNOWN) {
+                continue;
+            }
             requestOptionsMap.put(methodType, newRequestOptions(toExchangeType(methodType)));
         }
         REQUEST_OPTIONS_MAP = Maps.immutableEnumMap(requestOptionsMap);


### PR DESCRIPTION
Motivation:

The following message is always warned when `ArmeriaChannel` class is
initialized for the first time.

```
... WARN  c.l.a.i.c.grpc.GrpcExchangeTypeUtil - Unknown MethodType: UNKNOWN; using BIDI_STREAMING
```

This message was meant to detect unexpected `MethodType` which a
`ServerMethodDefinition` provides.
https://github.com/line/armeria/blob/49054ad7f22a7f2d64faaeb694674b0df09ad165/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java#L163-L164
However, as `ArmeriaChannel` iterates `MethodType.vaules()` containing
`MethodType.UNKNOWN` to pre-build `RequestOptions` and reuse it.
https://github.com/line/armeria/blob/435aeedcb007382250e4ee71311a5ff2c56615ae/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java#L71-L72

Slack thread: https://line-armeria.slack.com/archives/C1NGPBUH2/p1658323770269669

Modifications:

- Exclude `MethodType.UNKNOWN` when building `RequestOptions` for
  `ArmeriaChannel`.

Result:

You no longer see a false positive warning for unknown `MethodType` when
using gRPC clients.