### PR TITLE
Add support for alternative protobuf content types

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -662,6 +662,8 @@ public final class MediaType {
      * <a href="https://developers.google.com/protocol-buffers">Protocol buffers</a>.
      */
     public static final MediaType PROTOBUF = createConstant(APPLICATION_TYPE, "protobuf");
+    public static final MediaType X_PROTOBUF = createConstant(APPLICATION_TYPE, "x-protobuf");
+    public static final MediaType X_GOOGLE_PROTOBUF = createConstant(APPLICATION_TYPE, "x-google-protobuf");
 
     /**
      * <a href="https://en.wikipedia.org/wiki/RDF/XML">RDF/XML</a> documents, which are XML
@@ -1050,6 +1052,20 @@ public final class MediaType {
      */
     public boolean isJson() {
         return is(JSON) || subtype().endsWith("+json");
+    }
+
+    /**
+     * Returns {@code true} when the subtype is in [{@link MediaType#PROTOBUF}, {@link MediaType#X_PROTOBUF}, {@link MediaType#X_GOOGLE_PROTOBUF}].
+     * Otherwise {@code false}.
+     *
+     * <pre>{@code
+     * PROTOBUF.isProtobuf() // true
+     * X_PROTOBUF.isProtobuf() // true
+     * X_GOOGLE_PROTOBUF.isProtobuf() // true
+     * }</pre>
+     */
+    public boolean isProtobuf() {
+        return is(PROTOBUF) || is(X_PROTOBUF)|| is(X_GOOGLE_PROTOBUF);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -1055,8 +1055,8 @@ public final class MediaType {
     }
 
     /**
-     * Returns {@code true} when the subtype is one of {@link MediaType#PROTOBUF}, {@link MediaType#X_PROTOBUF} and {@link MediaType#X_GOOGLE_PROTOBUF}.
-     * Otherwise {@code false}.
+     * Returns {@code true} when the subtype is one of {@link MediaType#PROTOBUF}, {@link MediaType#X_PROTOBUF}
+     * and {@link MediaType#X_GOOGLE_PROTOBUF}. Otherwise {@code false}.
      *
      * <pre>{@code
      * PROTOBUF.isProtobuf() // true

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -1055,7 +1055,7 @@ public final class MediaType {
     }
 
     /**
-     * Returns {@code true} when the subtype is in [{@link MediaType#PROTOBUF}, {@link MediaType#X_PROTOBUF}, {@link MediaType#X_GOOGLE_PROTOBUF}].
+     * Returns {@code true} when the subtype is one of {@link MediaType#PROTOBUF}, {@link MediaType#X_PROTOBUF} and {@link MediaType#X_GOOGLE_PROTOBUF}.
      * Otherwise {@code false}.
      *
      * <pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -506,6 +506,14 @@ public final class MediaTypeNames {
      */
     public static final String PROTOBUF = "application/protobuf";
     /**
+     * {@value #X_PROTOBUF}.
+     */
+    public static final String X_PROTOBUF = "application/x-protobuf";
+    /**
+     * {@value #X_GOOGLE_PROTOBUF}.
+     */
+    public static final String X_GOOGLE_PROTOBUF = "application/x-google-protobuf";
+    /**
      * {@value #RDF_XML_UTF_8}.
      */
     public static final String RDF_XML_UTF_8 = "application/rdf+xml; charset=utf-8";

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
@@ -212,7 +212,12 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
         }
 
         final MediaType grpcMediaType = grpcResponse.contentType();
-        requireNonNull(grpcMediaType);
+        if (grpcMediaType == null) {
+            PooledObjects.close(grpcResponse.content());
+            res.completeExceptionally(new NullPointerException("MediaType is undefined"));
+            return;
+        }
+
         final ResponseHeadersBuilder unframedHeaders = grpcResponse.headers().toBuilder();
         unframedHeaders.set(GrpcHeaderNames.GRPC_STATUS, grpcStatusCode); // grpcStatusCode is 0 which is OK.
         if (responseContentType != null) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
@@ -139,7 +139,7 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
             HttpData content,
             CompletableFuture<HttpResponse> res,
             @Nullable Function<HttpData, HttpData> responseBodyConverter,
-            @Nullable MediaType responseContentType) {
+            MediaType responseContentType) {
         final HttpRequest grpcRequest;
         try (ArmeriaMessageFramer framer = new ArmeriaMessageFramer(
                 ctx.alloc(), ArmeriaMessageFramer.NO_MAX_OUTBOUND_MESSAGE_SIZE, false)) {
@@ -184,7 +184,7 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
                                   CompletableFuture<HttpResponse> res,
                                   UnframedGrpcErrorHandler unframedGrpcErrorHandler,
                                   @Nullable Function<HttpData, HttpData> responseBodyConverter,
-                                  @Nullable MediaType responseContentType) {
+                                  MediaType responseContentType) {
         final HttpHeaders trailers = !grpcResponse.trailers().isEmpty() ?
                                      grpcResponse.trailers() : grpcResponse.headers();
         final String grpcStatusCode = trailers.get(GrpcHeaderNames.GRPC_STATUS);
@@ -220,13 +220,7 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
 
         final ResponseHeadersBuilder unframedHeaders = grpcResponse.headers().toBuilder();
         unframedHeaders.set(GrpcHeaderNames.GRPC_STATUS, grpcStatusCode); // grpcStatusCode is 0 which is OK.
-        if (responseContentType != null) {
-            unframedHeaders.contentType(responseContentType);
-        } else if (grpcMediaType.is(GrpcSerializationFormats.PROTO.mediaType())) {
-            unframedHeaders.contentType(MediaType.PROTOBUF);
-        } else if (grpcMediaType.is(GrpcSerializationFormats.JSON.mediaType())) {
-            unframedHeaders.contentType(MediaType.JSON_UTF_8);
-        }
+        unframedHeaders.contentType(responseContentType);
 
         final ArmeriaMessageDeframer deframer = new ArmeriaMessageDeframer(
                 // Max outbound message size is handled by the GrpcService, so we don't need to set it here.

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -557,9 +557,9 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                                    "gRPC encoding is not supported for non-framed requests.");
         }
 
-        final MediaType contentType = GrpcSerializationFormats.JSON.mediaType();
+        final MediaType jsonContentType = GrpcSerializationFormats.JSON.mediaType();
         grpcHeaders.method(HttpMethod.POST)
-                   .contentType(contentType);
+                   .contentType(jsonContentType);
         // All clients support no encoding, and we don't support gRPC encoding for non-framed requests, so just
         // clear the header if it's present.
         grpcHeaders.remove(GrpcHeaderNames.GRPC_ACCEPT_ENCODING);
@@ -577,7 +577,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         ctx.setAttr(FramedGrpcService.RESOLVED_GRPC_METHOD, spec.method);
                         frameAndServe(unwrap(), ctx, grpcHeaders.build(),
                                       convertToJson(ctx, clientRequest, spec),
-                                      responseFuture, generateResponseBodyConverter(spec), contentType);
+                                      responseFuture, generateResponseBodyConverter(spec), jsonContentType);
                     } catch (IllegalArgumentException iae) {
                         responseFuture.completeExceptionally(
                                 HttpStatusException.of(HttpStatus.BAD_REQUEST, iae));

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -557,8 +557,9 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                                    "gRPC encoding is not supported for non-framed requests.");
         }
 
+        final MediaType contentType = GrpcSerializationFormats.JSON.mediaType();
         grpcHeaders.method(HttpMethod.POST)
-                   .contentType(GrpcSerializationFormats.JSON.mediaType());
+                   .contentType(contentType);
         // All clients support no encoding, and we don't support gRPC encoding for non-framed requests, so just
         // clear the header if it's present.
         grpcHeaders.remove(GrpcHeaderNames.GRPC_ACCEPT_ENCODING);
@@ -576,7 +577,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         ctx.setAttr(FramedGrpcService.RESOLVED_GRPC_METHOD, spec.method);
                         frameAndServe(unwrap(), ctx, grpcHeaders.build(),
                                       convertToJson(ctx, clientRequest, spec),
-                                      responseFuture, generateResponseBodyConverter(spec));
+                                      responseFuture, generateResponseBodyConverter(spec), contentType);
                     } catch (IllegalArgumentException iae) {
                         responseFuture.completeExceptionally(
                                 HttpStatusException.of(HttpStatus.BAD_REQUEST, iae));

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -145,13 +145,6 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,
                                RequestLogProperty.RESPONSE_CONTENT);
 
-        final MediaType responseContentType;
-        if (clientHeaders.accept().isEmpty() || clientHeaders.accept().contains(contentType)) {
-            responseContentType = contentType;
-        } else {
-            responseContentType = null;
-        }
-
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
         req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((clientRequest, t) -> {
             try (SafeCloseable ignore = ctx.push()) {
@@ -159,7 +152,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                     responseFuture.completeExceptionally(t);
                 } else {
                     frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(),
-                                  responseFuture, null, responseContentType);
+                                  responseFuture, null, contentType);
                 }
             }
             return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -159,7 +159,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                     responseFuture.completeExceptionally(t);
                 } else {
                     frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(),
-                            responseFuture, null, responseContentType);
+                                  responseFuture, null, responseContentType);
                 }
             }
             return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -145,14 +145,21 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,
                                RequestLogProperty.RESPONSE_CONTENT);
 
+        final MediaType responseContentType;
+        if (clientHeaders.accept().isEmpty() || clientHeaders.accept().contains(contentType)) {
+            responseContentType = contentType;
+        } else {
+            responseContentType = null;
+        }
+
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
         req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((clientRequest, t) -> {
             try (SafeCloseable ignore = ctx.push()) {
                 if (t != null) {
                     responseFuture.completeExceptionally(t);
                 } else {
-                    frameAndServe(unwrap(), ctx, grpcHeaders.build(),
-                                  clientRequest.content(), responseFuture, null, contentType);
+                    frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(),
+                            responseFuture, null, responseContentType);
                 }
             }
             return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -119,14 +119,16 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
         final RequestHeadersBuilder grpcHeaders = clientHeaders.toBuilder();
 
         final MediaType framedContentType;
-        if (contentType.is(MediaType.PROTOBUF)) {
+        if (contentType.isProtobuf()) {
             framedContentType = GrpcSerializationFormats.PROTO.mediaType();
         } else if (contentType.is(MediaType.JSON)) {
             framedContentType = GrpcSerializationFormats.JSON.mediaType();
         } else {
             return HttpResponse.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE,
                                    MediaType.PLAIN_TEXT_UTF_8,
-                                   "Unsupported media type. Only application/protobuf is supported.");
+                                   "Unsupported media type. Only application/protobuf, " +
+                                           "application/x-protobuf, application/x-google-protobuf" +
+                                           "and application/json are supported.");
         }
         grpcHeaders.contentType(framedContentType);
 
@@ -150,7 +152,7 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                     responseFuture.completeExceptionally(t);
                 } else {
                     frameAndServe(unwrap(), ctx, grpcHeaders.build(),
-                                  clientRequest.content(), responseFuture, null);
+                                  clientRequest.content(), responseFuture, null, contentType);
                 }
             }
             return null;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
@@ -87,7 +87,7 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
 
         final AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.contentType()).isEqualTo(MediaType.PROTOBUF);
+        assertThat(res.contentType()).isEqualTo(protobufType);
     }
 
     private static class ProtobufMediaTypeProvider implements ArgumentsProvider {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
@@ -1,0 +1,106 @@
+package com.linecorp.armeria.server.grpc;
+
+import com.linecorp.armeria.common.*;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.protobuf.EmptyProtos;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+import io.grpc.BindableService;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnframedGrpcServiceResponseMediaTypeTest {
+
+    @RegisterExtension
+    static EventLoopExtension eventLoop = new EventLoopExtension();
+
+    private static class TestService extends TestServiceGrpc.TestServiceImplBase {
+
+        @Override
+        public void emptyCall(EmptyProtos.Empty request, StreamObserver<EmptyProtos.Empty> responseObserver) {
+            responseObserver.onNext(EmptyProtos.Empty.newBuilder().build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static final TestService testService = new TestService();
+    private static final int MAX_MESSAGE_BYTES = 1024;
+
+    @Test
+    void respondWithCorrespondingJSONMediaType() throws Exception {
+        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+
+        final HttpRequest request = HttpRequest.of(HttpMethod.POST,
+                "/armeria.grpc.testing.TestService/EmptyCall",
+                MediaType.JSON_UTF_8, "{}");
+        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+
+        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isNotNull();
+        assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+    }
+
+    @Test
+    void respondWithCorrespondingProtobufMediaType() throws Exception {
+        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+
+        final HttpRequest request = HttpRequest.of(HttpMethod.POST,
+                "/armeria.grpc.testing.TestService/EmptyCall",
+                MediaType.PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
+        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+
+        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isNotNull();
+        assertThat(res.contentType()).isEqualTo(MediaType.PROTOBUF);
+    }
+
+    @Test
+    void respondWithCorrespondingXProtobufMediaType() throws Exception {
+        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+
+        final HttpRequest request = HttpRequest.of(HttpMethod.POST,
+                "/armeria.grpc.testing.TestService/EmptyCall",
+                MediaType.X_PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
+        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+
+        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isNotNull();
+        assertThat(res.contentType()).isEqualTo(MediaType.X_PROTOBUF);
+    }
+
+    @Test
+    void respondWithCorrespondingXGoogleProtobufMediaType() throws Exception {
+        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+
+        final HttpRequest request = HttpRequest.of(HttpMethod.POST,
+                "/armeria.grpc.testing.TestService/EmptyCall",
+                MediaType.X_GOOGLE_PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
+        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+
+        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType()).isNotNull();
+        assertThat(res.contentType()).isEqualTo(MediaType.X_GOOGLE_PROTOBUF);
+    }
+
+    private static UnframedGrpcService buildUnframedGrpcService(BindableService bindableService) {
+        return buildUnframedGrpcService(bindableService, UnframedGrpcErrorHandler.ofPlainText());
+    }
+
+    private static UnframedGrpcService buildUnframedGrpcService(BindableService bindableService,
+                                                                UnframedGrpcErrorHandler errorHandler) {
+        return (UnframedGrpcService) GrpcService.builder()
+                .addService(bindableService)
+                .maxRequestMessageLength(MAX_MESSAGE_BYTES)
+                .maxResponseMessageLength(MAX_MESSAGE_BYTES)
+                .enableUnframedRequests(true)
+                .unframedGrpcErrorHandler(errorHandler)
+                .build();
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
@@ -16,17 +16,23 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import com.linecorp.armeria.common.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
 import com.linecorp.armeria.protobuf.EmptyProtos;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
 import io.grpc.BindableService;
 import io.grpc.stub.StreamObserver;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class UnframedGrpcServiceResponseMediaTypeTest {
 
@@ -46,15 +52,17 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
     private static final int MAX_MESSAGE_BYTES = 1024;
 
     @Test
-    void respondWithCorrespondingJSONMediaType() throws Exception {
-        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+    void respondWithCorrespondingJsonMediaType() throws Exception {
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
 
         final HttpRequest request = HttpRequest.of(HttpMethod.POST,
                 "/armeria.grpc.testing.TestService/EmptyCall",
                 MediaType.JSON_UTF_8, "{}");
-        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(request)
+                                                               .eventLoop(eventLoop.get())
+                                                               .build();
 
-        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        final AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isNotNull();
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
@@ -62,14 +70,17 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
 
     @Test
     void respondWithCorrespondingProtobufMediaType() throws Exception {
-        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
 
         final HttpRequest request = HttpRequest.of(HttpMethod.POST,
-                "/armeria.grpc.testing.TestService/EmptyCall",
-                MediaType.PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
-        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+                                                   "/armeria.grpc.testing.TestService/EmptyCall",
+                                                   MediaType.PROTOBUF,
+                                                   EmptyProtos.Empty.getDefaultInstance().toByteArray());
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(request)
+                                                               .eventLoop(eventLoop.get())
+                                                               .build();
 
-        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        final AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isNotNull();
         assertThat(res.contentType()).isEqualTo(MediaType.PROTOBUF);
@@ -77,14 +88,16 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
 
     @Test
     void respondWithCorrespondingXProtobufMediaType() throws Exception {
-        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
 
         final HttpRequest request = HttpRequest.of(HttpMethod.POST,
                 "/armeria.grpc.testing.TestService/EmptyCall",
                 MediaType.X_PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
-        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(request)
+                                                               .eventLoop(eventLoop.get())
+                                                               .build();
 
-        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        final AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isNotNull();
         assertThat(res.contentType()).isEqualTo(MediaType.X_PROTOBUF);
@@ -92,14 +105,16 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
 
     @Test
     void respondWithCorrespondingXGoogleProtobufMediaType() throws Exception {
-        UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
+        final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
 
         final HttpRequest request = HttpRequest.of(HttpMethod.POST,
                 "/armeria.grpc.testing.TestService/EmptyCall",
                 MediaType.X_GOOGLE_PROTOBUF, EmptyProtos.Empty.getDefaultInstance().toByteArray());
-        ServiceRequestContext ctx = ServiceRequestContext.builder(request).eventLoop(eventLoop.get()).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(request)
+                                                               .eventLoop(eventLoop.get())
+                                                               .build();
 
-        AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
+        final AggregatedHttpResponse res = unframedGrpcService.serve(ctx, request).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isNotNull();
         assertThat(res.contentType()).isEqualTo(MediaType.X_GOOGLE_PROTOBUF);

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
@@ -75,12 +75,12 @@ public class UnframedGrpcServiceResponseMediaTypeTest {
 
     @ParameterizedTest
     @ArgumentsSource(ProtobufMediaTypeProvider.class)
-    void respondWithCorrespondingProtobufMediaType() throws Exception {
+    void respondWithCorrespondingProtobufMediaType(MediaType protobufType) throws Exception {
         final UnframedGrpcService unframedGrpcService = buildUnframedGrpcService(testService);
 
         final HttpRequest request = HttpRequest.of(HttpMethod.POST,
                                                    "/armeria.grpc.testing.TestService/EmptyCall",
-                                                   MediaType.PROTOBUF,
+                                                   protobufType,
                                                    EmptyProtos.Empty.getDefaultInstance().toByteArray());
         final ServiceRequestContext ctx = ServiceRequestContext.builder(request)
                                                                .build();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceResponseMediaTypeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.server.grpc;
 
 import com.linecorp.armeria.common.*;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -125,7 +125,8 @@ class UnframedGrpcServiceTest {
                                                                .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
-        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(), null);
+        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res,
+                UnframedGrpcErrorHandler.of(), null, MediaType.PROTOBUF);
         assertThat(byteBuf.refCnt()).isZero();
     }
 
@@ -136,7 +137,8 @@ class UnframedGrpcServiceTest {
         final ResponseHeaders responseHeaders = ResponseHeaders.of(HttpStatus.OK);
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                 HttpData.wrap(byteBuf));
-        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(), null);
+        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res,
+                UnframedGrpcErrorHandler.of(), null, MediaType.PROTOBUF);
         assertThat(byteBuf.refCnt()).isZero();
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -123,7 +122,7 @@ class UnframedGrpcServiceTest {
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
                                                                .add(GrpcHeaderNames.GRPC_STATUS, "1")
-                                                               .add(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
+                                                               .contentType(MediaType.PROTOBUF)
                                                                .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
@@ -151,8 +150,7 @@ class UnframedGrpcServiceTest {
         final CompletableFuture<HttpResponse> res = new CompletableFuture<>();
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
-                                                               .add(HttpHeaderNames.CONTENT_TYPE,
-                                                                    MediaType.PROTOBUF.toString())
+                                                               .contentType(MediaType.PROTOBUF)
                                                                .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
@@ -167,8 +165,7 @@ class UnframedGrpcServiceTest {
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
                                                                .add(GrpcHeaderNames.GRPC_STATUS, "0")
-                                                               .add(HttpHeaderNames.CONTENT_TYPE,
-                                                                    MediaType.PROTOBUF.toString())
+                                                               .contentType(MediaType.PROTOBUF)
                                                                .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse
                 .of(responseHeaders, HttpData.wrap(byteBuf));

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -122,9 +122,9 @@ class UnframedGrpcServiceTest {
         final CompletableFuture<HttpResponse> res = new CompletableFuture<>();
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
-                                           .add(GrpcHeaderNames.GRPC_STATUS, "1")
-                                           .add(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
-                                           .build();
+                                                               .add(GrpcHeaderNames.GRPC_STATUS, "1")
+                                                               .add(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
+                                                               .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
         UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),
@@ -137,8 +137,8 @@ class UnframedGrpcServiceTest {
         final CompletableFuture<HttpResponse> res = new CompletableFuture<>();
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
-                .add(GrpcHeaderNames.GRPC_STATUS, "0")
-                .build();
+                                                               .add(GrpcHeaderNames.GRPC_STATUS, "0")
+                                                               .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse
                 .of(responseHeaders, HttpData.wrap(byteBuf));
         AbstractUnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),
@@ -151,12 +151,13 @@ class UnframedGrpcServiceTest {
         final CompletableFuture<HttpResponse> res = new CompletableFuture<>();
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
-                .add(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
-                .build();
+                                                               .add(HttpHeaderNames.CONTENT_TYPE,
+                                                                    MediaType.PROTOBUF.toString())
+                                                               .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse.of(responseHeaders,
                                                                                 HttpData.wrap(byteBuf));
-        UnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),
-                                              null, MediaType.PROTOBUF);
+        AbstractUnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),
+                                                      null, MediaType.PROTOBUF);
         assertThat(byteBuf.refCnt()).isZero();
     }
 
@@ -165,9 +166,10 @@ class UnframedGrpcServiceTest {
         final CompletableFuture<HttpResponse> res = new CompletableFuture<>();
         final ByteBuf byteBuf = Unpooled.buffer();
         final ResponseHeaders responseHeaders = ResponseHeaders.builder(HttpStatus.OK)
-                .add(GrpcHeaderNames.GRPC_STATUS, "0")
-                .add(HttpHeaderNames.CONTENT_TYPE, MediaType.PROTOBUF.toString())
-                .build();
+                                                               .add(GrpcHeaderNames.GRPC_STATUS, "0")
+                                                               .add(HttpHeaderNames.CONTENT_TYPE,
+                                                                    MediaType.PROTOBUF.toString())
+                                                               .build();
         final AggregatedHttpResponse framedResponse = AggregatedHttpResponse
                 .of(responseHeaders, HttpData.wrap(byteBuf));
         AbstractUnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),


### PR DESCRIPTION
Motivation:
Armeria `UnframedGrpcService` doesn't support alternative protobuf content types

Modifications:
- add `application/x-protobuf` and `application/x-google-protobuf` to MediaType
- add isProtobuf() function
- identify Protobuf contentType in UnframedGrpcService using isProtobuf()
- respond with request-given protobuf content type for deframed response

Result:

- Closes #4355
- Armeria `UnframedGrpcService` now supports `application/x-protobuf` and `application/x-google-protobuf` media types.
