### PR TITLE
Remove warning in task :kotlin:compileKotlin

### DIFF
--- a/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.future.await
  *
  * @see JacksonObjectMapperProvider
  */
-suspend inline fun <reified T> RestClientPreparation.execute(): ResponseEntity<T> {
+suspend inline fun <reified T : Any> RestClientPreparation.execute(): ResponseEntity<T> {
     return execute(object : TypeReference<T>() {}).await()!!
 }
 
@@ -37,6 +37,6 @@ suspend inline fun <reified T> RestClientPreparation.execute(): ResponseEntity<T
  * Sends the HTTP request and converts the JSON response body as the `T` object using the specified
  * [ObjectMapper].
  */
-suspend inline fun <reified T> RestClientPreparation.execute(mapper: ObjectMapper): ResponseEntity<T> {
+suspend inline fun <reified T : Any> RestClientPreparation.execute(mapper: ObjectMapper): ResponseEntity<T> {
     return execute(object : TypeReference<T>() {}, mapper).await()!!
 }


### PR DESCRIPTION
Motivation:

Noticed some warnings while building the project:

`> Task :kotlin:compileKotlin
w: Argument -Xopt-in is deprecated. Please use -opt-in instead
w: /Users/wjdalstn/Documents/GitHub/armeria/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt: (33, 12): Type parameter 'T' has nullable upper bounds while non-nullable version is expected. This warning will become an error soon. See https://youtrack.jetbrains.com/issue/KT-36770 for details
w: /Users/wjdalstn/Documents/GitHub/armeria/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt: (33, 20): Type parameter 'T' has nullable upper bounds while non-nullable version is expected. This warning will become an error soon. See https://youtrack.jetbrains.com/issue/KT-36770 for details
w: /Users/wjdalstn/Documents/GitHub/armeria/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt: (41, 12): Type parameter 'T' has nullable upper bounds while non-nullable version is expected. This warning will become an error soon. See https://youtrack.jetbrains.com/issue/KT-36770 for details
w: /Users/wjdalstn/Documents/GitHub/armeria/kotlin/src/main/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClient.kt: (41, 20): Type parameter 'T' has nullable upper bounds while non-nullable version is expected. This warning will become an error soon. See https://youtrack.jetbrains.com/issue/KT-36770 for details`

Perhaps something related to the definitly non nullable types feature since kotlin 1.6.20

Modifications:

- Providing upper bound Any removes the warning

Result:

no warnings!