### PR TITLE
Fix a bug where request duration is incorrectly recoded.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -40,6 +40,8 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     private final RequestHeaders headers;
     private final RoutingContext routingCtx;
     private final ExchangeType exchangeType;
+    private final long requestStartTimeNanos;
+    private final long requestStartTimeMicros;
 
     @Nullable
     private ServiceRequestContext ctx;
@@ -53,7 +55,8 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
 
     AggregatingDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
                                   boolean keepAlive, long maxRequestLength,
-                                  RoutingContext routingCtx, ExchangeType exchangeType) {
+                                  RoutingContext routingCtx, ExchangeType exchangeType,
+                                  long requestStartTimeNanos, long requestStartTimeMicros) {
         super(4);
         this.headers = headers;
         this.eventLoop = eventLoop;
@@ -64,6 +67,8 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
         assert routingCtx.hasResult();
         this.routingCtx = routingCtx;
         this.exchangeType = exchangeType;
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMicros = requestStartTimeMicros;
     }
 
     @Override
@@ -178,6 +183,16 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     @Override
     public ExchangeType exchangeType() {
         return exchangeType;
+    }
+
+    @Override
+    public long requestStartTimeNanos() {
+        return requestStartTimeNanos;
+    }
+
+    @Override
+    public long requestStartTimeMicros() {
+        return requestStartTimeMicros;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -21,6 +21,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -32,25 +33,30 @@ interface DecodedHttpRequest extends HttpRequest {
                                  RequestHeaders headers, boolean keepAlive,
                                  InboundTrafficController inboundTrafficController,
                                  RoutingContext routingCtx) {
+        final long requestStartTimeNanos = System.nanoTime();
+        final long requestStartTimeMicros = SystemInfo.currentTimeMicros();
         if (!routingCtx.hasResult()) {
-            return new EmptyContentDecodedHttpRequest(eventLoop, id, streamId, headers, keepAlive,
-                                                      routingCtx, ExchangeType.RESPONSE_STREAMING);
+            return new EmptyContentDecodedHttpRequest(
+                    eventLoop, id, streamId, headers, keepAlive, routingCtx, ExchangeType.RESPONSE_STREAMING,
+                    requestStartTimeNanos, requestStartTimeMicros);
         } else {
             final ServiceConfig config = routingCtx.result().value();
             final HttpService service = config.service();
             final ExchangeType exchangeType = service.exchangeType(routingCtx);
             if (endOfStream) {
-                return new EmptyContentDecodedHttpRequest(eventLoop, id, streamId, headers, keepAlive,
-                                                          routingCtx,  exchangeType);
+                return new EmptyContentDecodedHttpRequest(
+                        eventLoop, id, streamId, headers, keepAlive, routingCtx, exchangeType,
+                        requestStartTimeNanos, requestStartTimeMicros);
             } else {
                 if (exchangeType.isRequestStreaming()) {
-                    return new StreamingDecodedHttpRequest(eventLoop, id, streamId, headers, keepAlive,
-                                                           inboundTrafficController, config.maxRequestLength(),
-                                                           routingCtx, exchangeType);
+                    return new StreamingDecodedHttpRequest(
+                            eventLoop, id, streamId, headers, keepAlive, inboundTrafficController,
+                            config.maxRequestLength(), routingCtx, exchangeType,
+                            requestStartTimeNanos, requestStartTimeMicros);
                 } else {
-                    return new AggregatingDecodedHttpRequest(eventLoop, id, streamId, headers, keepAlive,
-                                                             config.maxRequestLength(), routingCtx,
-                                                             exchangeType);
+                    return new AggregatingDecodedHttpRequest(
+                            eventLoop, id, streamId, headers, keepAlive, config.maxRequestLength(), routingCtx,
+                            exchangeType, requestStartTimeNanos, requestStartTimeMicros);
                 }
             }
         }
@@ -104,4 +110,15 @@ interface DecodedHttpRequest extends HttpRequest {
      * {@link HttpResponse}.
      */
     ExchangeType exchangeType();
+
+    /**
+     * Returns the {@link System#nanoTime()} value when the request started.
+     */
+    long requestStartTimeNanos();
+
+    /**
+     * Returns the number of microseconds since the epoch, e.g. {@code System.currentTimeMillis() * 1000},
+     * when the request started.
+     */
+    long requestStartTimeMicros();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -41,6 +41,8 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     private final boolean keepAlive;
     private final RoutingContext routingContext;
     private final ExchangeType exchangeType;
+    private final long requestStartTimeNanos;
+    private final long requestStartTimeMicros;
     @Nullable
     private ServiceRequestContext ctx;
 
@@ -50,7 +52,8 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
 
     EmptyContentDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
                                    boolean keepAlive, RoutingContext routingContext,
-                                   ExchangeType exchangeType) {
+                                   ExchangeType exchangeType, long requestStartTimeNanos,
+                                   long requestStartTimeMicros) {
         delegate = HttpRequest.of(headers);
         this.eventLoop = eventLoop;
         this.id = id;
@@ -58,6 +61,8 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
         this.keepAlive = keepAlive;
         this.routingContext = routingContext;
         this.exchangeType = exchangeType;
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMicros = requestStartTimeMicros;
     }
 
     @Override
@@ -190,5 +195,15 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     @Override
     public ExchangeType exchangeType() {
         return exchangeType;
+    }
+
+    @Override
+    public long requestStartTimeNanos() {
+        return requestStartTimeNanos;
+    }
+
+    @Override
+    public long requestStartTimeMicros() {
+        return requestStartTimeMicros;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -345,7 +345,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 serviceCfg, channel, config.meterRegistry(), protocol,
                 nextRequestId(), routingCtx, routingResult, req.exchangeType(),
                 req, sslSession, proxiedAddresses, clientAddress,
-                System.nanoTime(), SystemInfo.currentTimeMicros());
+                req.requestStartTimeNanos(), req.requestStartTimeMicros());
 
         try (SafeCloseable ignored = reqCtx.push()) {
             final RequestLogBuilder logBuilder = reqCtx.logBuilder();

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -40,6 +40,8 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     private final long maxRequestLength;
     private final RoutingContext routingCtx;
     private final ExchangeType exchangeType;
+    private final long requestStartTimeNanos;
+    private final long requestStartTimeMicros;
 
     @Nullable
     private ServiceRequestContext ctx;
@@ -51,7 +53,8 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
 
     StreamingDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
                                 boolean keepAlive, InboundTrafficController inboundTrafficController,
-                                long maxRequestLength, RoutingContext routingCtx, ExchangeType exchangeType) {
+                                long maxRequestLength, RoutingContext routingCtx, ExchangeType exchangeType,
+                                long requestStartTimeNanos, long requestStartTimeMicros) {
         super(headers);
 
         this.eventLoop = eventLoop;
@@ -63,6 +66,8 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
         assert routingCtx.hasResult();
         this.routingCtx = routingCtx;
         this.exchangeType = exchangeType;
+        this.requestStartTimeNanos = requestStartTimeNanos;
+        this.requestStartTimeMicros = requestStartTimeMicros;
     }
 
     @Override
@@ -191,5 +196,15 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     @Override
     public ExchangeType exchangeType() {
         return exchangeType;
+    }
+
+    @Override
+    public long requestStartTimeNanos() {
+        return requestStartTimeNanos;
+    }
+
+    @Override
+    public long requestStartTimeMicros() {
+        return requestStartTimeMicros;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequestTest.java
@@ -38,7 +38,7 @@ class EmptyContentDecodedHttpRequestTest {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
         final EmptyContentDecodedHttpRequest req =
                 new EmptyContentDecodedHttpRequest(eventLoop.get(), 1, 3, headers, true, null,
-                                                   ExchangeType.BIDI_STREAMING);
+                                                   ExchangeType.BIDI_STREAMING, 0, 0);
 
         StepVerifier.create(req)
                     .expectComplete()

--- a/core/src/test/java/com/linecorp/armeria/server/ServerRequestDurationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerRequestDurationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ServerRequestDurationTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.requestTimeoutMillis(100_000);
+            sb.service("/slow-request", new HttpService() {
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    if (routingContext.params().contains("streaming")) {
+                        return ExchangeType.REQUEST_STREAMING;
+                    } else {
+                        return ExchangeType.UNARY;
+                    }
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                        return HttpResponse.of(agg.contentUtf8());
+                    }));
+                }
+            });
+            sb.service("/slow-response", new HttpService() {
+
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    if (routingContext.params().contains("streaming")) {
+                        return ExchangeType.RESPONSE_STREAMING;
+                    } else {
+                        return ExchangeType.UNARY;
+                    }
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                        final HttpResponseWriter writer = HttpResponse.streaming();
+                        writer.write(ResponseHeaders.of(HttpStatus.OK));
+                        writer.write(HttpData.ofUtf8("12"));
+                        ctx.eventLoop().schedule(() -> {
+                            writer.write(HttpData.ofUtf8("34"));
+                            writer.close();
+                        }, 5000, TimeUnit.MILLISECONDS);
+                        return writer;
+                    }));
+                }
+            });
+        }
+    };
+
+    @CsvSource({"/slow-request", "/slow-request?streaming=true"})
+    @ParameterizedTest
+    void requestDuration(String path) throws InterruptedException {
+        final WebClient client = server.webClient(cb -> cb.responseTimeoutMillis(100_000));
+        final DefaultStreamMessage<HttpData> stream = new DefaultStreamMessage<>();
+        final CompletableFuture<ResponseEntity<String>> future =
+                client.prepare()
+                      .post(path)
+                      .content(MediaType.PLAIN_TEXT, stream)
+                      .asString()
+                      .execute();
+
+        stream.write(HttpData.ofUtf8("12"));
+        Thread.sleep(5000);
+        stream.write(HttpData.ofUtf8("34"));
+        stream.close();
+
+        final ResponseEntity<String> response = future.join();
+        assertThat(response.content()).isEqualTo("1234");
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        final RequestLog log = ctx.log().whenComplete().join();
+        assertThat(TimeUnit.NANOSECONDS.toMillis(log.requestDurationNanos()))
+                .isGreaterThanOrEqualTo(4000);
+    }
+
+    @CsvSource({"/slow-response", "/slow-response?streaming=true"})
+    @ParameterizedTest
+    void responseDuration(String path) throws InterruptedException {
+        final WebClient client = server.webClient(cb -> cb.responseTimeoutMillis(100_000));
+        final CompletableFuture<ResponseEntity<String>> future =
+                client.prepare()
+                      .get(path)
+                      .asString()
+                      .execute();
+
+        final ResponseEntity<String> response = future.join();
+        assertThat(response.content()).isEqualTo("1234");
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        final RequestLog log = ctx.log().whenComplete().join();
+        if (path.contains("streaming")) {
+            assertThat(TimeUnit.NANOSECONDS.toMillis(log.responseDurationNanos()))
+                    .isGreaterThanOrEqualTo(4000);
+        } else {
+            // The headers and body are written together after the stream is closed.
+            assertThat(TimeUnit.NANOSECONDS.toMillis(log.responseDurationNanos()))
+                    .isLessThanOrEqualTo(1000);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
@@ -116,7 +116,7 @@ public class StreamingDecodedHttpRequestTest {
                 request = new StreamingDecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
                                                           InboundTrafficController.disabled(),
                                                           sctx.maxRequestLength(), sctx.routingContext(),
-                                                          ExchangeType.BIDI_STREAMING);
+                                                          ExchangeType.BIDI_STREAMING, 0, 0);
         request.init(sctx);
         return request;
     }


### PR DESCRIPTION
Motivation:

The start time of a request indicates when a server receives the first
headers of a request and it is recorded when `HttpServiceHandler`
receives the decoded request from `Http{1,2}RequestDecodeder`.
Previously, `Http{1,2}RequestDecoder` passes a request right after the
first `RequestHeaders` is received. So it was correctly recorded as expected.
However, after `ExchangeType` has been introduced, a fully aggregated
request is passed to `HttpServerHandler` if `ExchangeType.UNARY` or
`ExchangeType.RESPONSE_STREAMING` is set.

Modifications:

- Recode `requestStartTimeNanos` and `requestStartTimeMicros` when
  request headers is received in `Http{1,2}RequestDecoder`

Result:

- `requestStartTimeNanos` and `requestStartTimeMicros` are now correctly
  recoded when `RequestHeaders` is received.
- Fixes #4365

