### PR TITLE
Upgrade dependencies

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -59,7 +59,7 @@ class FlagsTest {
     private Class<?> flags;
 
     @BeforeEach
-    private void reloadFlags() throws ClassNotFoundException {
+    void reloadFlags() throws ClassNotFoundException {
         final FlagsClassLoader classLoader = new FlagsClassLoader();
         flags = classLoader.loadClass(Flags.class.getCanonicalName());
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtilTest.java
@@ -30,7 +30,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.EnumSet;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
@@ -41,7 +41,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.internal.server.annotation.AnnotationUtil.FindOption;
 
-public class AnnotationUtilTest {
+class AnnotationUtilTest {
 
     @Retention(RetentionPolicy.RUNTIME)
     @interface TestMetaOfMetaAnnotation {}
@@ -138,7 +138,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void declared() throws NoSuchMethodException {
+    void declared() throws NoSuchMethodException {
         List<TestAnnotation> list;
 
         list = findDeclared(TestClass.class.getMethod("directlyPresent"), TestAnnotation.class);
@@ -159,7 +159,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void declared_repeatable() throws NoSuchMethodException {
+    void declared_repeatable() throws NoSuchMethodException {
         List<TestRepeatable> list;
 
         list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableSingle"),
@@ -181,7 +181,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void declared_repeatable_multi() throws NoSuchMethodException {
+    void declared_repeatable_multi() throws NoSuchMethodException {
         List<TestRepeatable> list;
 
         list = findDeclared(TestClass.class.getMethod("directlyPresentRepeatableMulti"),
@@ -208,7 +208,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void lookupSuperClass() {
+    void lookupSuperClass() {
         List<TestAnnotation> list;
 
         list = findInherited(TestClass.class, TestAnnotation.class);
@@ -235,7 +235,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void lookupSuperClass_repeatable() {
+    void lookupSuperClass_repeatable() {
         List<TestRepeatable> list;
 
         list = findInherited(SingleRepeatableTestClass.class, TestRepeatable.class);
@@ -262,7 +262,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void lookupSuperClass_repeatable_multi() {
+    void lookupSuperClass_repeatable_multi() {
         List<TestRepeatable> list;
 
         list = findInherited(TestClass.class, TestRepeatable.class);
@@ -298,7 +298,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void lookupMetaAnnotations_declared() {
+    void lookupMetaAnnotations_declared() {
         List<TestMetaAnnotation> list;
 
         for (final Class<?> clazz : ImmutableList.of(TestClass.class,
@@ -320,7 +320,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void findAll_includingRepeatable() {
+    void findAll_includingRepeatable() {
         List<TestMetaAnnotation> list;
 
         list = findAll(SingleRepeatableTestClass.class, TestMetaAnnotation.class);
@@ -340,7 +340,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void findAll_includingRepeatable_multi() {
+    void findAll_includingRepeatable_multi() {
         List<TestMetaAnnotation> list;
 
         list = findAll(TestClass.class, TestMetaAnnotation.class);
@@ -366,7 +366,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void findAll_interfaces() {
+    void findAll_interfaces() {
         List<TestAnnotation> list;
 
         list = findAll(TestClassWithIface.class, TestAnnotation.class);
@@ -385,7 +385,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void findAll_metaAnnotationOfMetaAnnotation() {
+    void findAll_metaAnnotationOfMetaAnnotation() {
         List<TestMetaOfMetaAnnotation> list;
 
         list = findAll(TestClass.class, TestMetaOfMetaAnnotation.class);
@@ -399,7 +399,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void findAll_cyclic() throws Exception {
+    void findAll_cyclic() throws Exception {
         List<CyclicAnnotation> list = findAll(TestClassWithCyclicAnnotation.class, CyclicAnnotation.class);
         assertThat(list).hasSize(1);
         assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);
@@ -411,7 +411,7 @@ public class AnnotationUtilTest {
 
     @Test
     @EnabledForJreRange(max = JRE.JAVA_15)
-    public void cglibProxy() {
+    void cglibProxy() {
         final Enhancer enhancer = new Enhancer();
         enhancer.setSuperclass(TestGrandChildClass.class);
         enhancer.setCallback((FixedValue) () -> null);
@@ -440,7 +440,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void getAnnotations_declared() {
+    void getAnnotations_declared() {
         final List<Annotation> list = getAnnotations(TestGrandChildClass.class);
         assertThat(list).hasSize(2);
         assertThat(list.get(0)).isInstanceOf(TestRepeatables.class);
@@ -448,7 +448,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void getAnnotations_inherited() {
+    void getAnnotations_inherited() {
         final List<Annotation> list =
                 getAnnotations(TestGrandChildClass.class, FindOption.LOOKUP_SUPER_CLASSES);
         assertThat(list).hasSize(6);
@@ -461,7 +461,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void getAnnotations_all() {
+    void getAnnotations_all() {
         final List<Annotation> list = getAllAnnotations(TestGrandChildClass.class);
         assertThat(list).hasSize(18);
         for (int i = 0; i < 3 * 6;) {
@@ -477,7 +477,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void getAnnotations_all_cyclic() throws Exception {
+    void getAnnotations_all_cyclic() throws Exception {
         List<Annotation> list = getAllAnnotations(TestClassWithCyclicAnnotation.class);
         assertThat(list).hasSize(1);
         assertThat(list.get(0)).isInstanceOf(CyclicAnnotation.class);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtilTest.java
@@ -31,6 +31,8 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.FixedValue;
@@ -408,6 +410,7 @@ public class AnnotationUtilTest {
     }
 
     @Test
+    @EnabledForJreRange(max = JRE.JAVA_15)
     public void cglibProxy() {
         final Enhancer enhancer = new Enhancer();
         enhancer.setSuperclass(TestGrandChildClass.class);

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -387,6 +387,7 @@ exclusions = [
     "org.slf4j:slf4j-log4j12"]
 
 # Validator is only used for examples and testings in Spring
+# version 7 starts using jakarta api, which isn't compatible with spring-boot2
 [libraries.hibernate-validator]
 module = "org.hibernate.validator:hibernate-validator"
 version = "6.2.3.Final"

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -704,10 +704,11 @@ version.ref = "resteasy"
 module = "org.jboss.resteasy:resteasy-jackson2-provider"
 version.ref = "resteasy"
 # "provided" dependency required by RESTEasy "resteasy-core-spi"
+# jboss 3.5.0 requires at least jdk 11
 [libraries.resteasy-jboss-logging]
 module = "org.jboss.logging:jboss-logging"
-version = "3.5.0.Final"
-javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.5.3.Final/"
+version = "3.4.3.Final"
+javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.4.3.Final/"
 [libraries.resteasy-jboss-logging-annotations]
 module = "org.jboss.logging:jboss-logging-annotations"
 version = "2.2.1.Final"

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -8,7 +8,7 @@ dropwizard1 = "1.3.29"
 dropwizard2 = "2.1.1"
 errorprone = "2.14.0"
 eureka = "1.10.17"
-graphql-kotlin = "6.0.0"
+graphql-kotlin = "6.1.0"
 grpc-kotlin = "1.3.0"
 groovy = "3.0.5"
 guava = "31.1-jre"
@@ -31,7 +31,7 @@ protobuf = "3.21.1"
 reactive-grpc = "1.2.3"
 reactive-streams = "1.0.4"
 reactor = "3.4.21"
-resteasy = "5.0.2.Final"
+resteasy = "5.0.4.Final"
 retrofit2 = "2.9.0"
 sangria = "3.0.1"
 sangria-slowlog = "2.0.4"
@@ -41,7 +41,7 @@ scalapb-json = "0.12.0"
 slf4j = "1.7.36"
 spring-boot1 = "1.5.22.RELEASE"
 spring-boot2 = "2.7.2"
-tomcat8 = "8.5.78"
+tomcat8 = "8.5.81"
 tomcat9 = "9.0.65"
 
 [boms]
@@ -280,7 +280,7 @@ version = "4.3.1"
 # gax-grpc is only used for gRPC test module.
 [libraries.gax-grpc]
 module = "com.google.api:gax-grpc"
-version = "2.18.6"
+version = "2.18.7"
 
 [libraries.graphql-java]
 module = "com.graphql-java:graphql-java"
@@ -816,7 +816,7 @@ version.ref = "sangria-slowlog"
 # you also need to change the scala version in `scala.gradle`.
 [libraries.scala_v212]
 module = "org.scala-lang:scala-library"
-version = "2.12.15"
+version = "2.12.16"
 [libraries.scala_v213]
 module = "org.scala-lang:scala-library"
 version = "2.13.8"
@@ -933,6 +933,7 @@ exclusions = "org.springframework.boot:spring-boot-starter-reactor-netty"
 module = "org.springframework.boot:spring-boot-configuration-processor"
 version.ref = "spring-boot2"
 
+# jdk 11 is required from testng version 7.6
 [libraries.testng]
 module = "org.testng:testng"
 version = "7.5"

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -707,7 +707,7 @@ version.ref = "resteasy"
 [libraries.resteasy-jboss-logging]
 module = "org.jboss.logging:jboss-logging"
 version = "3.5.0.Final"
-javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.5.0.Final/"
+javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.5.3.Final/"
 [libraries.resteasy-jboss-logging-annotations]
 module = "org.jboss.logging:jboss-logging-annotations"
 version = "2.2.1.Final"

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -2,58 +2,58 @@
 akka = "2.6.19"
 bouncycastle = "1.70"
 brotli4j = "1.7.1"
-curator = "5.2.1"
-dagger = "2.42"
+curator = "5.3.0"
+dagger = "2.43.1"
 dropwizard1 = "1.3.29"
-dropwizard2 = "2.1.0"
+dropwizard2 = "2.1.1"
 errorprone = "2.14.0"
 eureka = "1.10.17"
-graphql-kotlin = "5.3.2"
+graphql-kotlin = "6.0.0"
 grpc-kotlin = "1.3.0"
 groovy = "3.0.5"
 guava = "31.1-jre"
 hamcrest = "2.2"
 jetty93 = '9.3.30.v20211001'
-jetty94 = "9.4.46.v20220331"
+jetty94 = "9.4.48.v20220622"
 jmh = "1.35"
 json-unit = "2.35.0"
 junit5 = "5.8.2"
-kotlin = "1.7.0"
-kotlin-coroutine = "1.6.3"
-micrometer = "1.9.1"
+kotlin = "1.7.10"
+kotlin-coroutine = "1.6.4"
+micrometer = "1.9.2"
 micrometer13 = "1.3.20"
 mockito = "4.6.1"
 monix = "3.4.1"
 munit = "0.7.29"
 okhttp4 = "4.10.0"
 opensaml = "3.4.6"
-protobuf = "3.19.2"
+protobuf = "3.21.1"
 reactive-grpc = "1.2.3"
 reactive-streams = "1.0.4"
-reactor = "3.4.19"
+reactor = "3.4.21"
 resteasy = "5.0.2.Final"
 retrofit2 = "2.9.0"
-sangria = "3.0.0"
+sangria = "3.0.1"
 sangria-slowlog = "2.0.4"
 scala-java8-compat = "1.0.2"
 scalapb = "0.11.11"
 scalapb-json = "0.12.0"
 slf4j = "1.7.36"
 spring-boot1 = "1.5.22.RELEASE"
-spring-boot2 = "2.7.1"
+spring-boot2 = "2.7.2"
 tomcat8 = "8.5.78"
-tomcat9 = "9.0.62"
+tomcat9 = "9.0.65"
 
 [boms]
-brave = { module = "io.zipkin.brave:brave-bom", version = "5.13.9" }
+brave = { module = "io.zipkin.brave:brave-bom", version = "5.13.10" }
 dropwizard-metrics = { module = "io.dropwizard.metrics:metrics-bom", version = "4.2.10" }
 # Ensure that we use the same Protobuf version as what gRPC depends on.
-# See: https://github.com/grpc/grpc-java/blob/master/build.gradle
-#      (Switch to the right tag and look for "protobufVersion" and "protocVersion".)
-grpc-java = { module = "io.grpc:grpc-bom", version = "1.47.0" }
+# See: https://github.com/grpc/grpc-java/blob/master/gradle/libs.versions.toml
+#      (Switch to the right tag and look for "protobuf".)
+grpc-java = { module = "io.grpc:grpc-bom", version = "1.48.0" }
 jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.13.3" }
-junit5 = { module = "org.junit:junit-bom", version = "5.8.2" }
-netty = { module = "io.netty:netty-bom", version = "4.1.78.Final" }
+junit5 = { module = "org.junit:junit-bom", version = "5.9.0" }
+netty = { module = "io.netty:netty-bom", version = "4.1.79.Final" }
 
 # Akka is used only for testing in it:grpcweb module.
 [libraries.akka-http-cors_v213]
@@ -126,8 +126,8 @@ version.ref = "brotli4j"
 
 [libraries.bucket4j]
 module = "com.github.vladimir-bukhtoyarov:bucket4j-core"
-version = "7.5.0"
-javadocs = "https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.5.0/"
+version = "7.6.0"
+javadocs = "https://javadoc.io/doc/com.github.vladimir-bukhtoyarov/bucket4j-core/7.6.0/"
 
 # Don"t upgrade Caffeine to 3.x that requires Java 11.
 [libraries.caffeine]
@@ -147,7 +147,7 @@ version = "2.5.5"
 
 [libraries.checkstyle]
 module = "com.puppycrawl.tools:checkstyle"
-version = "10.3.1"
+version = "10.3.2"
 
 [libraries.consul]
 module = "com.pszymczyk.consul:embedded-consul"
@@ -160,13 +160,13 @@ version = "2.2.1"
 module = "org.apache.curator:curator-recipes"
 version.ref = "curator"
 javadocs = [
-    "https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.1.0/",
-    "https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.1.0/"]
+    "https://www.javadoc.io/doc/org.apache.curator/curator-framework/5.3.0/",
+    "https://www.javadoc.io/doc/org.apache.curator/curator-recipes/5.3.0/"]
 exclusions = "org.apache.zookeeper:zookeeper"
 [libraries.curator-discovery]
 module = "org.apache.curator:curator-x-discovery"
 version.ref = "curator"
-javadocs = "https://www.javadoc.io/doc/org.apache.curator/curator-x-discovery/5.1.0/"
+javadocs = "https://www.javadoc.io/doc/org.apache.curator/curator-x-discovery/5.3.0/"
 
 # This is only used for examples/context-propagation/dagger
 [libraries.dagger]
@@ -182,7 +182,7 @@ version.ref = "dagger"
 # DGS is used only for testing in it:dgs module.
 [libraries.dgs]
 module = "com.netflix.graphql.dgs:graphql-dgs-client"
-version = "5.0.4"
+version = "5.0.5"
 
 [libraries.dropwizard1-core]
 module = "io.dropwizard:dropwizard-core"
@@ -212,7 +212,7 @@ version.ref = "dropwizard1"
 [libraries.dropwizard2-core]
 module = "io.dropwizard:dropwizard-core"
 version.ref = "dropwizard2"
-javadocs = "https://www.javadoc.io/doc/io.dropwizard/dropwizard-core/2.1.0/"
+javadocs = "https://www.javadoc.io/doc/io.dropwizard/dropwizard-core/2.1.1/"
 [libraries.dropwizard2-jackson]
 module = "io.dropwizard:dropwizard-jackson"
 version.ref = "dropwizard2"
@@ -263,7 +263,7 @@ relocations = { from = "it.unimi.dsi.fastutil", to = "com.linecorp.armeria.inter
 # Finagle is used only for testing in zookeeper module.
 [libraries.finagle-serversets_v213]
 module = "com.twitter:finagle-serversets_2.13"
-version = "22.4.0"
+version = "22.7.0"
 
 [libraries.findbugs]
 module = "com.google.code.findbugs:jsr305"
@@ -280,11 +280,11 @@ version = "4.3.1"
 # gax-grpc is only used for gRPC test module.
 [libraries.gax-grpc]
 module = "com.google.api:gax-grpc"
-version = "2.18.2"
+version = "2.18.6"
 
 [libraries.graphql-java]
 module = "com.graphql-java:graphql-java"
-version = "18.2"
+version = "19.0"
 
 [libraries.graphql-kotlin-client]
 module = "com.expediagroup:graphql-kotlin-client"
@@ -302,7 +302,7 @@ version.ref = "graphql-kotlin"
 # Groovy is only used for testing consul
 [libraries.groovy-xml]
 module = "org.codehaus.groovy:groovy-xml"
-version = "3.0.11"
+version = "3.0.12"
 
 [libraries.grpc-core]
 module = "io.grpc:grpc-core"
@@ -501,7 +501,7 @@ version.ref = "json-unit"
 # JSoup is only used for Gradle script and SAML testing.
 [libraries.jsoup]
 module = "org.jsoup:jsoup"
-version = "1.15.1"
+version = "1.15.2"
 
 [libraries.junit4]
 module = "junit:junit"
@@ -529,12 +529,12 @@ version = "1.7.1"
 
 [libraries.jwt]
 module = "com.auth0:java-jwt"
-version = "3.19.1"
-javadocs = "https://www.javadoc.io/doc/com.auth0/java-jwt/3.19.0/"
+version = "4.0.0"
+javadocs = "https://www.javadoc.io/doc/com.auth0/java-jwt/4.0.0/"
 
 [libraries.kafka]
 module = "org.apache.kafka:kafka-clients"
-version = "3.2.0"
+version = "3.2.1"
 javadocs = "https://kafka.apache.org/30/javadoc/"
 
 [libraries.kotlin-allopen]
@@ -650,8 +650,8 @@ javadocs = "https://prometheus.github.io/client_java/"
 
 # Ensure that we use the same Protobuf version as what gRPC depends on.
 # See: https://github.com/grpc/grpc-java/blob/master/build.gradle
-#      (Switch to the right tag and look for "protobufVersion" and "protocVersion".)
-#      e.g. https://github.com/grpc/grpc-java/blob/v1.47.0/build.gradle
+#      (Switch to the right tag and look for "protobuf".)
+#      e.g. https://github.com/grpc/grpc-java/blob/v1.48.0/gradle/libs.versions.toml
 [libraries.protobuf-java]
 module = "com.google.protobuf:protobuf-java"
 version.ref = "protobuf"
@@ -664,7 +664,7 @@ module = "com.google.protobuf:protoc"
 version.ref = "protobuf"
 [libraries.protobuf-gradle-plugin]
 module = "com.google.protobuf:protobuf-gradle-plugin"
-version = "0.8.18"
+version = "0.8.19"
 
 [libraries.protobuf-jackson]
 module = "org.curioswitch.curiostack:protobuf-jackson"
@@ -681,7 +681,7 @@ module = "io.projectreactor:reactor-test"
 version.ref = "reactor"
 [libraries.reactor-kotlin]
 module = "io.projectreactor.kotlin:reactor-kotlin-extensions"
-version = '1.1.6'
+version = '1.1.7'
 
 [libraries.reactor-grpc]
 module = "com.salesforce.servicelibs:reactor-grpc"
@@ -706,8 +706,8 @@ version.ref = "resteasy"
 # "provided" dependency required by RESTEasy "resteasy-core-spi"
 [libraries.resteasy-jboss-logging]
 module = "org.jboss.logging:jboss-logging"
-version = "3.4.3.Final"
-javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.4.3.Final/"
+version = "3.5.0.Final"
+javadocs = "https://javadoc.io/doc/org.jboss.logging/jboss-logging/3.5.0.Final/"
 [libraries.resteasy-jboss-logging-annotations]
 module = "org.jboss.logging:jboss-logging-annotations"
 version = "2.2.1.Final"
@@ -821,11 +821,11 @@ module = "org.scala-lang:scala-library"
 version = "2.13.8"
 [libraries.scala_v3]
 module = "org.scala-lang:scala3-library_3"
-version = "3.1.2"
+version = "3.1.3"
 
 [libraries.scala-collection-compat_v212]
 module = "org.scala-lang.modules:scala-collection-compat_2.12"
-version = "2.7.0"
+version = "2.8.1"
 [libraries.scala-java8-compat_v212]
 module = "org.scala-lang.modules:scala-java8-compat_2.12"
 version.ref = "scala-java8-compat"
@@ -887,7 +887,7 @@ version.ref = "slf4j"
 
 [libraries.spring-web]
 module = "org.springframework:spring-web"
-version = "5.3.21"
+version = "5.3.22"
 
 [libraries.spring-boot1-autoconfigure]
 module = "org.springframework.boot:spring-boot-autoconfigure"

--- a/gradle/scripts/lib/scala.gradle
+++ b/gradle/scripts/lib/scala.gradle
@@ -58,7 +58,7 @@ configure(scala212 + scala213 + scala3) {
 
 configure(scala212) {
     dependencies {
-        implementation('org.scala-lang:scala-library:2.12.15')
+        implementation('org.scala-lang:scala-library:2.12.16')
         if (managedVersions.containsKey('org.scalameta:munit_2.12')) {
             testImplementation "org.scalameta:munit_2.12:${managedVersions['org.scalameta:munit_2.12']}"
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlServiceTest.java
@@ -254,7 +254,8 @@ class GraphqlServiceTest {
         final AggregatedHttpResponse response = BlockingWebClient.of(server.httpUri())
                                                                  .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.contentUtf8()).contains("Validation error of type FieldUndefined");
+        assertThat(response.contentUtf8()).contains("Validation error")
+                                          .contains("FieldUndefined");
     }
 
     @Test

--- a/it/spring/boot2-tomcat8/build.gradle
+++ b/it/spring/boot2-tomcat8/build.gradle
@@ -1,6 +1,6 @@
 final def SPRING_BOOT_VERSION = '2.1.18.RELEASE'
 final def SPRING_VERSION = '5.1.20.RELEASE'
-final def TOMCAT_VERSION = '8.5.78'
+final def TOMCAT_VERSION = '8.5.81'
 
 dependencies {
     implementation(project(':spring:boot2-starter')) {

--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -48,30 +48,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-css-loader
-MIT
-Copyright JS Foundation and other contributors
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-'Software'), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
 graphql
 MIT
 MIT License

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
@@ -79,7 +79,7 @@ class ScalaPbResponseAnnotatedServiceTest {
   }
 
   @AfterEach
-  private def tearDown(): Unit = {
+  def tearDown(): Unit = {
     server.stop
     ScalaPbResponseAnnotatedServiceTest.cause = None
   }

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseAnnotatedServiceTest.scala
@@ -70,7 +70,7 @@ class ScalaPbResponseAnnotatedServiceTest {
   private val parser: Parser = new Parser()
 
   @BeforeEach
-  private def setUp(): Unit = {
+  def setUp(): Unit = {
     server.start()
     client = WebClient
       .builder(ScalaPbResponseAnnotatedServiceTest.server.httpUri)

--- a/spring/boot1-autoconfigure/build.gradle
+++ b/spring/boot1-autoconfigure/build.gradle
@@ -54,3 +54,10 @@ tasks.compileTestJava.dependsOn(project(':spring:boot2-autoconfigure').tasks.com
 tasks.withType(Checkstyle) {
     onlyIf { false }
 }
+
+// allows illegal access by cglib
+if (rootProject.ext.testJavaVersion >= 16) {
+    tasks.withType(Test) {
+        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    }
+}

--- a/spring/boot2-autoconfigure/build.gradle
+++ b/spring/boot2-autoconfigure/build.gradle
@@ -20,3 +20,10 @@ dependencies {
     // Enables cglib for testing
     testImplementation libs.hibernate.validator
 }
+
+// allows illegal access by cglib
+test {
+    if (rootProject.ext.testJavaVersion >= 9) {
+        jvmArgs '--add-exports=java.base/java.lang=ALL-UNNAMED'
+    }
+}

--- a/spring/boot2-autoconfigure/build.gradle
+++ b/spring/boot2-autoconfigure/build.gradle
@@ -22,8 +22,8 @@ dependencies {
 }
 
 // allows illegal access by cglib
-test {
-    if (rootProject.ext.testJavaVersion >= 9) {
-        jvmArgs '--add-exports=java.base/java.lang=ALL-UNNAMED'
+if (rootProject.ext.testJavaVersion >= 16) {
+    tasks.withType(Test) {
+        jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     }
 }

--- a/tomcat8/build.gradle
+++ b/tomcat8/build.gradle
@@ -1,5 +1,3 @@
-final def TOMCAT_VERSION = '8.5.78'
-
 dependencies {
     // Tomcat
     api libs.tomcat8.core


### PR DESCRIPTION
- Brave 5.13.9 -> 5.13.10
- Bucket4j 7.5.0 -> 7.6.0
- Curator 5.2.1 -> 5.3.0
- Dropwizard metrics 2.1.0 -> 2.1.1
- GraphQL-Java 18.2 -> 19.0
- GraphQL-Kotlin 5.3.2 -> 6.1.0
- gRPC-Java 1.47.0 -> 1.48.0
- java-jwt 3.19.1 -> 4.0.0
- Jetty 9.4.46.v20220331 -> 9.4.48.v20220622
- kafka-clients 3.2.0 -> 3.2.1
- Kotlin 1.7.0 -> 1.7.10
- Kotlin Coroutine 1.6.3 -> 1.6.4
- Micrometer 1.9.1 -> 1.9.2
- Netty 4.1.78.Final -> 4.1.79.Final
- Protobuf 3.19.2 -> 3.21.1
- Reactor 3.4.19 -> 3.4.21
- RESTEasy 5.0.2.Final -> 5.0.4.Final
- Sangria 3.0.0 -> 3.0.1
- Scala 2.12.15 -> 2.12.16, 3.1.2 -> 3.1.3
- scala-collection-compat 2.7.0 -> 2.8.1
- Spring Boot 2.7.1 -> 2.7.2
- Spring Web 5.3.21 -> 5.3.22
- Tomcat8 8.5.78 -> 8.5.81
- Tomcat9 9.0.62 -> 9.0.65
- Build
    - Checkstyle 10.3.1 -> 10.3.2
    - Dagger 2.42 -> 2.43.1 
    - Finagle Serversets 22.4.0 -> 22.7.0
    - gax-grpc 2.18.2 -> 2.18.7
    - Gradle 7.4.2 -> 7.5.0  
    - GraphQL DGS 5.0.4 -> 5.0.5
    - Groovy 3.0.11 -> 3.0.12
    - JSoup 1.15.1 -> 1.15.2
    - JUnit Jupiter 5.8.2 -> 5.9.0
    - Protobuf Gradle 0.8.18 -> 0.8.19
    - Reactor Kotlin 1.1.6 -> 1.1.7

