### PR TITLE
Correctly handle cors preflight requests for paths with query params

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRouteUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRouteUtil.java
@@ -45,20 +45,20 @@ final class ServiceRouteUtil {
                 routingStatus = RoutingStatus.INVALID_PATH;
             }
         } else {
-            if (isCorsPreflightRequest(headers)) {
-                routingStatus = RoutingStatus.CORS_PREFLIGHT;
-            } else {
-                pathAndQuery = PathAndQuery.parse(originalPath);
-                if (pathAndQuery != null) {
-                    routingStatus = RoutingStatus.OK;
+            pathAndQuery = PathAndQuery.parse(originalPath);
+            if (pathAndQuery != null) {
+                if (isCorsPreflightRequest(headers)) {
+                    routingStatus = RoutingStatus.CORS_PREFLIGHT;
                 } else {
-                    routingStatus = RoutingStatus.INVALID_PATH;
+                    routingStatus = RoutingStatus.OK;
                 }
+            } else {
+                routingStatus = RoutingStatus.INVALID_PATH;
             }
         }
 
         final VirtualHost virtualHost = serverConfig.findVirtualHost(hostname, port);
-        if (routingStatus != RoutingStatus.OK) {
+        if (pathAndQuery == null) {
             return DefaultRoutingContext.of(virtualHost, hostname, headers.path(), /* query */ null, headers,
                                             routingStatus);
         } else {

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -461,6 +461,15 @@ public class HttpServerCorsTest {
     }
 
     @Test
+    public void testCorsPreflightWithQueryParams() throws Exception {
+        final WebClient client = client();
+        final AggregatedHttpResponse response = preflightRequest(client, "/cors?a=b", "http://example.com", "POST");
+        assertEquals(HttpStatus.OK, response.status());
+        assertEquals("http://example.com", response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("Hello CORS", response.headers().get(HttpHeaderNames.of("x-preflight-cors")));
+    }
+
+    @Test
     public void testCorsAllowed() throws Exception {
         final WebClient client = client();
         final AggregatedHttpResponse response = request(client, HttpMethod.POST, "/cors", "http://example.com",


### PR DESCRIPTION
Motivation:

Assume that a cors preflight request is made for `http://host/path`. This PR attempts to ensure that cors preflight requests for paths with query parameters (i.e. `http://host/path?a=b`) are handled correctly.

Previously, cors preflight requests were handled correctly for paths with query parameters.
https://github.com/line/armeria/blob/dd33f1c84140383f750434690fec9915898f68cc/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L352-L354

Since armeria version 1.15.0, the raw path is used to query for a cors service. This change deviates from the previous behavior.
https://github.com/line/armeria/blob/0d3fa085fe0ab22f8818a7fcde363d0ce6ac196a/core/src/main/java/com/linecorp/armeria/server/ServiceRouteUtil.java#L48-L67

Modifications:

- Even for cors preflight requests, the parsed path is used to search for the correct service config.

Result:

- Cors requests with a query param work correctly.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
