### PR TITLE
Use ClosedSessionException and ClosedStreamException correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -26,7 +26,6 @@ import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.KeepAliveHandler;
@@ -184,7 +183,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
 
                         res.initTimeout();
                         if (!res.tryWrite(ArmeriaHttpUtil.toArmeria(nettyRes))) {
-                            fail(ctx, ClosedStreamException.get());
+                            fail(ctx, ClosedSessionException.get());
                             return;
                         }
                     } else {
@@ -222,7 +221,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                                                                   .build());
                                 return;
                             } else if (!res.tryWrite(HttpData.wrap(data.retain()))) {
-                                fail(ctx, ClosedStreamException.get());
+                                fail(ctx, ClosedSessionException.get());
                                 return;
                             }
                         }
@@ -238,7 +237,7 @@ final class Http1ResponseDecoder extends HttpResponseDecoder implements ChannelI
                             final HttpHeaders trailingHeaders = ((LastHttpContent) msg).trailingHeaders();
                             if (!trailingHeaders.isEmpty() &&
                                 !res.tryWrite(ArmeriaHttpUtil.toArmeria(trailingHeaders))) {
-                                fail(ctx, ClosedStreamException.get());
+                                fail(ctx, ClosedSessionException.get());
                                 return;
                             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ClosedStreamException.java
@@ -20,7 +20,8 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
- * A {@link RuntimeException} that is raised when a {@link StreamMessage} has been closed unexpectedly.
+ * A {@link RuntimeException} that is raised when a {@link StreamMessage} or an HTTP/2 stream
+ * has been closed unexpectedly.
  */
 public class ClosedStreamException extends RuntimeException {
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.stream.ClosedStreamException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -251,7 +250,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
             // Attempted to write something on a finished request/response; discard.
             // e.g. the request already timed out.
             ReferenceCountUtil.release(obj);
-            promise.setFailure(ClosedStreamException.get());
+            promise.setFailure(ClosedSessionException.get());
             return promise;
         }
 
@@ -351,7 +350,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
         if (minClosedId <= maxIdWithPendingWrites) {
             final ClosedSessionException cause =
-                    new ClosedSessionException("An HTTP/1 stream has been reset: " + error);
+                    new ClosedSessionException("An HTTP/1 connection has been reset: " + error);
             for (int i = minClosedId; i <= maxIdWithPendingWrites; i++) {
                 final PendingWrites pendingWrites = pendingWritesMap.remove(i);
                 for (;;) {

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -77,9 +77,9 @@ abstract class AbstractHttpResponseHandler {
             Throwable cause = CapturedServiceException.get(reqCtx);
             if (cause == null) {
                 if (reqCtx.sessionProtocol().isMultiplex()) {
-                    cause = ClosedSessionException.get();
-                } else {
                     cause = ClosedStreamException.get();
+                } else {
+                    cause = ClosedSessionException.get();
                 }
             }
             fail(cause);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -229,17 +229,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
 
         if (!unfinishedRequests.isEmpty()) {
-            final boolean cancel;
-            final Exception cause;
-            if (protocol.isMultiplex()) {
-                // An HTTP2 request is cancelled by Http2RequestDecoder.onRstStreamRead()
-                cancel = false;
-                cause = ClosedStreamException.get();
-            } else {
-                cancel = true;
-                cause = ClosedSessionException.get();
-            }
+            final ClosedSessionException cause = ClosedSessionException.get();
             unfinishedRequests.forEach((req, res) -> {
+                // An HTTP2 request is cancelled by Http2RequestDecoder.onRstStreamRead()
+                final boolean cancel = !protocol.isMultiplex();
                 // Mark the request stream as closed due to disconnection.
                 req.abortResponse(cause, cancel);
             });


### PR DESCRIPTION
Motivation:
`ClosedStreamException` is raised when a {@link StreamMessage} or an HTTP/2 stream
has been closed unexpectedly. Whereas, `ClosedSessionException` is raised
when the connection to the remote peer has been closed unexpectedly.

Modifications:
- Use `ClosedSessionException` and `ClosedStreamException` correctly according to its usage.

Result:
- `ClosedSessionException` and `ClosedStreamException` are raised correctly according to its usage.