### PR TITLE
Don't limit a max selection timeout to a response timeout in `EndpointSelector`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -88,23 +88,17 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
             // A static EndpointGroup.
             return UnmodifiableFuture.completedFuture(null);
         }
-        long responseTimeoutMillis = ctx.responseTimeoutMillis();
-        if (responseTimeoutMillis == 0) {
-            responseTimeoutMillis = Long.MAX_VALUE;
-        }
-
-        final long timeoutMillis = Math.min(selectionTimeoutMillis, responseTimeoutMillis);
 
         // Schedule the timeout task.
-        if (timeoutMillis < Long.MAX_VALUE) {
+        if (selectionTimeoutMillis < Long.MAX_VALUE) {
             final ScheduledFuture<?> timeoutFuture = executor.schedule(() -> {
                 final EndpointSelectionTimeoutException ex =
-                        EndpointSelectionTimeoutException.get(endpointGroup, timeoutMillis);
+                        EndpointSelectionTimeoutException.get(endpointGroup, selectionTimeoutMillis);
                 ClientPendingThrowableUtil.setPendingThrowable(ctx, ex);
                 // Don't complete exceptionally so that the throwable
                 // can be handled after executing the attached decorators
                 listeningFuture.complete(null);
-            }, timeoutMillis, TimeUnit.MILLISECONDS);
+            }, selectionTimeoutMillis, TimeUnit.MILLISECONDS);
             listeningFuture.timeoutFuture = timeoutFuture;
 
             // Cancel the timeout task if listeningFuture is done already.

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
@@ -18,23 +18,23 @@ package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.endpoint.AbstractEndpointSelector.ListeningFuture;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsServiceEndpointGroup;
@@ -44,12 +44,9 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.client.ClientPendingThrowableUtil;
-
-import io.netty.channel.EventLoop;
-import io.netty.channel.EventLoopGroup;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 class SelectionTimeoutTest {
 
@@ -341,30 +338,23 @@ class SelectionTimeoutTest {
 
     @Test
     void selectorSelectionTimeout() {
-        final EventLoopGroup eventLoopGroup = EventLoopGroups.newEventLoopGroup(1);
-        final EventLoop eventLoop = eventLoopGroup.next();
-        final AtomicBoolean completed = new AtomicBoolean();
-        eventLoop.execute(() -> {
-            try (DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup(true, 4000)) {
-                assertSelectionTimeout(endpointGroup).isEqualTo(4000);
-                final ClientRequestContext ctx =
-                        ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
-                                            .eventLoop(eventLoop)
-                                            .build();
-                ctx.setResponseTimeoutMillis(1000);
-                final Stopwatch timer = Stopwatch.createStarted();
-                endpointGroup.select(ctx, CommonPools.blockingTaskExecutor()).join();
-                final long elapsed = timer.stop().elapsed(TimeUnit.MILLISECONDS);
-                // Should complete after the selection timeout.
-                assertThat(elapsed).isGreaterThanOrEqualTo(2000);
-                assertThat(ClientPendingThrowableUtil.pendingThrowable(ctx))
-                        .isInstanceOf(EndpointSelectionTimeoutException.class)
-                        .hasMessageContaining("Failed to select within 4000 ms an endpoint from");
-                completed.set(true);
-            }
-        });
-        await().untilTrue(completed);
-        eventLoopGroup.shutdownGracefully();
+        try (DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup(true, 4000)) {
+            assertSelectionTimeout(endpointGroup).isEqualTo(4000);
+            final ClientRequestContext ctx =
+                    ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                        .requestOptions(RequestOptions.builder()
+                                                                      .responseTimeoutMillis(1000)
+                                                                      .build())
+                                        .build();
+            final Stopwatch timer = Stopwatch.createStarted();
+            endpointGroup.select(ctx, CommonPools.blockingTaskExecutor()).join();
+            final long elapsed = timer.stop().elapsed(TimeUnit.MILLISECONDS);
+            // Should complete after the selection timeout.
+            assertThat(elapsed).isGreaterThanOrEqualTo(2000);
+            assertThat(ClientPendingThrowableUtil.pendingThrowable(ctx))
+                    .isInstanceOf(EndpointSelectionTimeoutException.class)
+                    .hasMessageContaining("Failed to select within 4000 ms an endpoint from");
+        }
     }
 
     private static AbstractLongAssert<?> assertSelectionTimeout(EndpointGroup endpointGroup) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
@@ -45,7 +45,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.client.ClientPendingThrowableUtil;
-import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 class SelectionTimeoutTest {
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.AbstractLongAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
@@ -44,10 +44,12 @@ import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.client.ClientPendingThrowableUtil;
 
 import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 
 class SelectionTimeoutTest {
 
@@ -339,7 +341,8 @@ class SelectionTimeoutTest {
 
     @Test
     void selectorSelectionTimeout() {
-        final EventLoop eventLoop = CommonPools.workerGroup().next();
+        final EventLoopGroup eventLoopGroup = EventLoopGroups.newEventLoopGroup(1);
+        final EventLoop eventLoop = eventLoopGroup.next();
         final AtomicBoolean completed = new AtomicBoolean();
         eventLoop.execute(() -> {
             try (DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup(true, 4000)) {
@@ -361,6 +364,7 @@ class SelectionTimeoutTest {
             }
         });
         await().untilTrue(completed);
+        eventLoopGroup.shutdownGracefully();
     }
 
     private static AbstractLongAssert<?> assertSelectionTimeout(EndpointGroup endpointGroup) {


### PR DESCRIPTION
Motivation:

If a selection timeout is larger than a response timeout, it is clamped
to a response timeout.
https://github.com/line/armeria/blob/554d5963bef33162b1cb077077336de3ef3aadfb/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java#L96
It ignores the need for users to set large selection timeouts in a warmup
situation.

Modifications:

- Use `selectionTimeoutMillis` as is to schedule a selection timeout.

Result:

`EndpointSelector` now correctly waits for the selection timeout of an
`EndpointGroup`.