### PR TITLE
Integrate `ofRichJson` to `ofJson`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandler.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandler.java
@@ -49,14 +49,18 @@ public interface UnframedGrpcErrorHandler {
     }
 
     /**
-     * Returns a JSON response.
+     * Returns a JSON response based on Google APIs.
+     * See <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
+     * for more information.
      */
     static UnframedGrpcErrorHandler ofJson() {
         return UnframedGrpcErrorHandlers.ofJson(UnframedGrpcStatusMappingFunction.of());
     }
 
     /**
-     * Returns a json response.
+     * Returns a JSON response based on Google APIs.
+     * See <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
+     * for more information.
      *
      * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
      *                              to an {@link HttpStatus} code.
@@ -80,27 +84,6 @@ public interface UnframedGrpcErrorHandler {
      */
     static UnframedGrpcErrorHandler ofPlainText(UnframedGrpcStatusMappingFunction statusMappingFunction) {
         return UnframedGrpcErrorHandlers.ofPlaintext(statusMappingFunction);
-    }
-
-    /**
-     * Returns a rich error JSON response based on Google APIs.
-     * See <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
-     * for more information.
-     */
-    static UnframedGrpcErrorHandler ofRichJson() {
-        return ofRichJson(UnframedGrpcStatusMappingFunction.of());
-    }
-
-    /**
-     * Returns a rich error JSON response based on Google APIs.
-     * See <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
-     * for more information.
-     *
-     * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
-     *                              to an {@link HttpStatus} code.
-     */
-    static UnframedGrpcErrorHandler ofRichJson(UnframedGrpcStatusMappingFunction statusMappingFunction) {
-        return UnframedGrpcErrorHandlers.ofRichJson(statusMappingFunction);
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlers.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlers.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.BadRequest;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlers.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlers.java
@@ -106,79 +106,13 @@ final class UnframedGrpcErrorHandlers {
     }
 
     /**
-     * Returns a JSON response.
-     *
+     * Returns a JSON response based on Google APIs.
+     * Please refer to <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
      * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
      *                              to an {@link HttpStatus} code.
      */
     static UnframedGrpcErrorHandler ofJson(UnframedGrpcStatusMappingFunction statusMappingFunction) {
         final UnframedGrpcStatusMappingFunction mappingFunction = withDefault(statusMappingFunction);
-        return (ctx, status, response) -> {
-            final Code grpcCode = status.getCode();
-            final String grpcMessage = status.getDescription();
-            final Throwable cause = responseCause(ctx);
-            final HttpStatus httpStatus = mappingFunction.apply(ctx, status, cause);
-            final ResponseHeaders responseHeaders = ResponseHeaders.builder(httpStatus)
-                                                                   .contentType(MediaType.JSON_UTF_8)
-                                                                   .addInt(GrpcHeaderNames.GRPC_STATUS,
-                                                                           status.getCode().value())
-                                                                   .build();
-            final ImmutableMap.Builder<String, String> messageBuilder = ImmutableMap.builder();
-            messageBuilder.put("grpc-code", grpcCode.name());
-            if (grpcMessage != null) {
-                messageBuilder.put("message", grpcMessage);
-            }
-            if (cause != null && ctx.config().verboseResponses()) {
-                messageBuilder.put("stack-trace", Exceptions.traceText(cause));
-            }
-            return HttpResponse.ofJson(responseHeaders, messageBuilder.build());
-        };
-    }
-
-    /**
-     * Returns a plaintext response.
-     *
-     * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
-     *                              to an {@link HttpStatus} code.
-     */
-    static UnframedGrpcErrorHandler ofPlaintext(UnframedGrpcStatusMappingFunction statusMappingFunction) {
-        final UnframedGrpcStatusMappingFunction mappingFunction = withDefault(statusMappingFunction);
-        return (ctx, status, response) -> {
-            final Code grpcCode = status.getCode();
-            final String grpcMessage = status.getDescription();
-            final Throwable cause = responseCause(ctx);
-            final HttpStatus httpStatus = mappingFunction.apply(ctx, status, cause);
-            final ResponseHeaders responseHeaders = ResponseHeaders.builder(httpStatus)
-                                                                   .contentType(MediaType.PLAIN_TEXT_UTF_8)
-                                                                   .addInt(GrpcHeaderNames.GRPC_STATUS,
-                                                                           grpcCode.value())
-                                                                   .build();
-            final HttpData content;
-            try (TemporaryThreadLocals ttl = TemporaryThreadLocals.acquire()) {
-                final StringBuilder msg = ttl.stringBuilder();
-                msg.append("grpc-code: ").append(grpcCode.name());
-                if (grpcMessage != null) {
-                    msg.append(", ").append(grpcMessage);
-                }
-                if (cause != null && ctx.config().verboseResponses()) {
-                    msg.append("\nstack-trace:\n").append(Exceptions.traceText(cause));
-                }
-                content = HttpData.ofUtf8(msg);
-            }
-            return HttpResponse.of(responseHeaders, content);
-        };
-    }
-
-    /**
-     * Returns a rich error JSON response based on Google APIs.
-     * Please refer to <a href="https://cloud.google.com/apis/design/errors#error_model">Google error model</a>
-     * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
-     *                              to an {@link HttpStatus} code.
-     */
-    static UnframedGrpcErrorHandler ofRichJson(UnframedGrpcStatusMappingFunction statusMappingFunction) {
-        final UnframedGrpcStatusMappingFunction mappingFunction =
-                requireNonNull(statusMappingFunction, "statusMappingFunction")
-                        .orElse(UnframedGrpcStatusMappingFunction.of());
         return (ctx, status, response) -> {
             final ByteBuf buffer = ctx.alloc().buffer();
             final Code grpcCode = status.getCode();
@@ -198,6 +132,7 @@ final class UnframedGrpcErrorHandlers {
                  JsonGenerator jsonGenerator = mapper.createGenerator(outputStream)) {
                 jsonGenerator.writeStartObject();
                 jsonGenerator.writeNumberField("code", grpcCode.value());
+                jsonGenerator.writeStringField("grpc-code", grpcCode.name());
                 if (grpcMessage != null) {
                     jsonGenerator.writeStringField("message", grpcMessage);
                 }
@@ -232,6 +167,40 @@ final class UnframedGrpcErrorHandlers {
             } else {
                 return HttpResponse.of(responseHeaders);
             }
+        };
+    }
+
+    /**
+     * Returns a plaintext response.
+     *
+     * @param statusMappingFunction The function which maps the {@link Throwable} or gRPC {@link Status} code
+     *                              to an {@link HttpStatus} code.
+     */
+    static UnframedGrpcErrorHandler ofPlaintext(UnframedGrpcStatusMappingFunction statusMappingFunction) {
+        final UnframedGrpcStatusMappingFunction mappingFunction = withDefault(statusMappingFunction);
+        return (ctx, status, response) -> {
+            final Code grpcCode = status.getCode();
+            final String grpcMessage = status.getDescription();
+            final Throwable cause = responseCause(ctx);
+            final HttpStatus httpStatus = mappingFunction.apply(ctx, status, cause);
+            final ResponseHeaders responseHeaders = ResponseHeaders.builder(httpStatus)
+                                                                   .contentType(MediaType.PLAIN_TEXT_UTF_8)
+                                                                   .addInt(GrpcHeaderNames.GRPC_STATUS,
+                                                                           grpcCode.value())
+                                                                   .build();
+            final HttpData content;
+            try (TemporaryThreadLocals ttl = TemporaryThreadLocals.acquire()) {
+                final StringBuilder msg = ttl.stringBuilder();
+                msg.append("grpc-code: ").append(grpcCode.name());
+                if (grpcMessage != null) {
+                    msg.append(", ").append(grpcMessage);
+                }
+                if (cause != null && ctx.config().verboseResponses()) {
+                    msg.append("\nstack-trace:\n").append(Exceptions.traceText(cause));
+                }
+                content = HttpData.ofUtf8(msg);
+            }
+            return HttpResponse.of(responseHeaders, content);
         };
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
@@ -161,7 +161,8 @@ public class UnframedGrpcErrorHandlerTest {
                       .execute();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
-        assertThat(content).startsWith("{\"code\":2,\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\"," +
+        assertThat(content).startsWith("{\"code\":2,\"grpc-code\":\"UNKNOWN\"," +
+                                       "\"message\":\"grpc error message\"," +
                                        "\"stack-trace\":\"io.grpc.StatusException");
         assertThat(response.trailers()).isEmpty();
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcErrorHandlerTest.java
@@ -72,7 +72,7 @@ public class UnframedGrpcErrorHandlerTest {
     static ServerExtension testServerGrpcStatus = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            configureServer(sb, false, UnframedGrpcErrorHandler.ofRichJson(), testServiceGrpcStatus);
+            configureServer(sb, false, UnframedGrpcErrorHandler.ofJson(), testServiceGrpcStatus);
         }
     };
 
@@ -161,7 +161,7 @@ public class UnframedGrpcErrorHandlerTest {
                       .execute();
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         final String content = response.contentUtf8();
-        assertThat(content).startsWith("{\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\"," +
+        assertThat(content).startsWith("{\"code\":2,\"grpc-code\":\"UNKNOWN\",\"message\":\"grpc error message\"," +
                                        "\"stack-trace\":\"io.grpc.StatusException");
         assertThat(response.trailers()).isEmpty();
     }
@@ -179,6 +179,7 @@ public class UnframedGrpcErrorHandlerTest {
                 .isEqualTo(
                         '{' +
                         "  \"code\": 2," +
+                        "  \"grpc-code\": \"UNKNOWN\"," +
                         "  \"message\": \"Unknown Exceptions Test\"," +
                         "  \"details\": [" +
                         "    {" +


### PR DESCRIPTION
Motivation:

`UnframedErrorHandler#ofJson` and `UnframedErrorHandler#ofRichJson` perform similar tasks, but have a slightly different format. It is probably better that we unify the two APIs so that 1) users are less confused by similar APIs 2) and we have an API format that is widely used across different open sources.

Modifications:

- Copy contents of `UnframedErrorHandler#ofRichJson` to `UnframedErrorHandler#ofJson`, and add `grpc-code` for backwards compatibilty.

Result:

- Less confusing APIs

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
