### PR TITLE
add requestLogger, responseLogger in LoggingDecoratorBuilder

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -16,8 +16,10 @@
 package com.linecorp.armeria.client.logging;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.logging.*;
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -29,9 +31,6 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -80,12 +79,14 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
                     ? extends @Nullable Object> responseTrailersSanitizer,
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer,
+            Consumer<RequestOnlyLog> requestLogger,
+            Consumer<RequestLog> responseLogger,
             Sampler<? super ClientRequestContext> successSampler,
             Sampler<? super ClientRequestContext> failureSampler) {
 
         super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
               requestHeadersSanitizer, requestContentSanitizer, requestTrailersSanitizer,
               responseHeadersSanitizer, responseContentSanitizer, responseTrailersSanitizer,
-              responseCauseSanitizer, successSampler, failureSampler);
+                responseCauseSanitizer, requestLogger, responseLogger, successSampler, failureSampler);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -57,6 +57,8 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
                                  responseContentSanitizer(),
                                  responseTrailersSanitizer(),
                                  responseCauseSanitizer(),
+                                 requestLogger(),
+                                 responseLogger(),
                                  successSampler(),
                                  failureSampler());
     }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -17,8 +17,10 @@
 package com.linecorp.armeria.client.logging;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.logging.*;
 import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -30,9 +32,6 @@ import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -81,12 +80,14 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
                     ? extends @Nullable Object> responseTrailersSanitizer,
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer,
+            Consumer<RequestOnlyLog> requestLogger,
+            Consumer<RequestLog> responseLogger,
             Sampler<? super ClientRequestContext> successSampler,
             Sampler<? super ClientRequestContext> failureSampler) {
 
         super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
               requestHeadersSanitizer, requestContentSanitizer, requestTrailersSanitizer,
               responseHeadersSanitizer, responseContentSanitizer, responseTrailersSanitizer,
-              responseCauseSanitizer, successSampler, failureSampler);
+              responseCauseSanitizer, requestLogger, responseLogger, successSampler, failureSampler);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -60,6 +60,8 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
                                     responseContentSanitizer(),
                                     responseTrailersSanitizer(),
                                     responseCauseSanitizer(),
+                                    requestLogger(),
+                                    responseLogger(),
                                     successSampler(),
                                     failureSampler());
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.logging;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -68,6 +69,12 @@ public abstract class LoggingDecoratorBuilder {
             responseCauseSanitizer = DEFAULT_CAUSE_SANITIZER;
     private BiFunction<? super RequestContext, ? super HttpHeaders, ? extends @Nullable Object>
             responseTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
+
+    @Nullable
+    private Consumer<RequestOnlyLog> requestLogger;
+
+    @Nullable
+    private Consumer<RequestLog> responseLogger;
 
     /**
      * Sets the {@link Logger} to use when logging.
@@ -410,6 +417,28 @@ public abstract class LoggingDecoratorBuilder {
                     ? extends @Nullable Object> responseCauseSanitizer) {
         this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
         return this;
+    }
+
+    public LoggingDecoratorBuilder requestLogger(
+            Consumer<RequestOnlyLog> requestLogger
+    ) {
+        this.requestLogger = requireNonNull(requestLogger, "requestLogger");
+        return this;
+    }
+
+    public Consumer<RequestOnlyLog> requestLogger() {
+        return requestLogger;
+    }
+
+    public LoggingDecoratorBuilder responseLogger(
+            Consumer<RequestLog> responseLogger
+    ) {
+        this.responseLogger = requireNonNull(responseLogger, "responseLogger");
+        return this;
+    }
+
+    public Consumer<RequestLog> responseLogger() {
+        return responseLogger;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -68,9 +68,6 @@ public final class LoggingService extends SimpleDecoratingHttpService {
         return new LoggingServiceBuilder();
     }
 
-    private final RequestLogger requestLogger = new RequestLogger();
-    private final ResponseLogger responseLogger = new ResponseLogger();
-
     private final Logger logger;
     private final RequestLogLevelMapper requestLogLevelMapper;
     private final ResponseLogLevelMapper responseLogLevelMapper;
@@ -92,6 +89,9 @@ public final class LoggingService extends SimpleDecoratingHttpService {
             ? extends @Nullable Object> responseCauseSanitizer;
 
     private final Sampler<? super RequestLog> sampler;
+
+    private final Consumer<RequestOnlyLog> requestLogger;
+    private final Consumer<RequestLog> responseLogger;
 
     /**
      * Creates a new instance that logs {@link HttpRequest}s and {@link HttpResponse}s at the specified
@@ -116,6 +116,8 @@ public final class LoggingService extends SimpleDecoratingHttpService {
                     ? extends @Nullable Object> responseTrailersSanitizer,
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer,
+            Consumer<RequestOnlyLog> requestLogger,
+            Consumer<RequestLog> responseLogger,
             Sampler<? super ServiceRequestContext> successSampler,
             Sampler<? super ServiceRequestContext> failureSampler) {
 
@@ -132,6 +134,9 @@ public final class LoggingService extends SimpleDecoratingHttpService {
         this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
         this.responseTrailersSanitizer = requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
         this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
+        this.requestLogger = firstNonNull(requestLogger, new RequestLogger());
+        this.responseLogger = firstNonNull(responseLogger, new ResponseLogger());
+
         requireNonNull(successSampler, "successSampler");
         requireNonNull(failureSampler, "failureSampler");
         sampler = requestLog -> {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -132,6 +132,8 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
                                   responseContentSanitizer(),
                                   responseTrailersSanitizer(),
                                   responseCauseSanitizer(),
+                                  requestLogger(),
+                                  responseLogger(),
                                   successSampler,
                                   failureSampler);
     }


### PR DESCRIPTION
Motivation:

I experienced discomfort when custom logging service.
I just want to modify the request logging logic and the response logging logic.
But to do that, I have to do a lot of work.
I think it will be convenient if add this function.

Modifications:

- add requestLogger parameter
- add responseLogger parameter
- add requestLogger method
- add responseLogger method

Result:

- When you want to modify the request logging logic and the response logging logic, you can call requestLogger() and responseLogger().

If requestLogging() and responseLogging() are not intended, could you tell me the reason ?