### PR TITLE
Automatically publish the Armeria site using GitHub Actions

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -27,33 +27,15 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Restore the cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/wrapper
-            ~/.gradle/caches
-          key: build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('gradle.properties', 'gradle/wrapper/gradle-wrapper.properties', '**/build.gradle', 'dependencies.yml', '*/package-lock.json') }}
-          restore-keys: |
-            build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-
-            build-${{ matrix.java }}-${{ runner.os }}-
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Build the site
         run: |
           ./gradlew --no-daemon --stacktrace  --max-workers=2 --parallel site
-        shell: bash
 
       - name: Deploy the site
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: site/public
-
-      - name: Clean up the cache
-        run: |
-          rm -fr ~/.gradle/caches/[0-9]* || true
-          rm -fr ~/.gradle/caches/journal-* || true
-          rm -fr ~/.gradle/caches/transforms-* || true
-          rm -f ~/.gradle/caches/*/*.lock || true
-          rm -f ~/.gradle/caches/*/gc.properties || true
-        shell: bash

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -6,7 +6,7 @@ on:
       - armeria-*
 
 env:
-  LC_ALL: "en_US.UTF-8"
+  LC_ALL: 'en_US.UTF-8'
 
 jobs:
   publish-site:

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -1,0 +1,59 @@
+name: Publish Armeria site
+
+on:
+  push:
+    tags:
+      - armeria-*
+
+env:
+  LC_ALL: "en_US.UTF-8"
+
+jobs:
+  publish-site:
+    if: github.repository == 'line/armeria'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install svgbob_cli
+        run: |
+          sudo apt-get -y install cargo && cargo install svgbob_cli
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - id: setup-jdk-17
+        name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Restore the cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper
+            ~/.gradle/caches
+          key: build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('gradle.properties', 'gradle/wrapper/gradle-wrapper.properties', '**/build.gradle', 'dependencies.yml', '*/package-lock.json') }}
+          restore-keys: |
+            build-${{ matrix.java }}-${{ runner.os }}-${{ secrets.CACHE_VERSION }}-
+            build-${{ matrix.java }}-${{ runner.os }}-
+
+      - name: Build the site
+        run: |
+          ./gradlew --no-daemon --stacktrace  --max-workers=2 --parallel site
+        shell: bash
+
+      - name: Deploy the site
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/public
+
+      - name: Clean up the cache
+        run: |
+          rm -fr ~/.gradle/caches/[0-9]* || true
+          rm -fr ~/.gradle/caches/journal-* || true
+          rm -fr ~/.gradle/caches/transforms-* || true
+          rm -f ~/.gradle/caches/*/*.lock || true
+          rm -f ~/.gradle/caches/*/gc.properties || true
+        shell: bash

--- a/.post-release-msg
+++ b/.post-release-msg
@@ -3,31 +3,17 @@
    - Publish job: https://github.com/line/armeria/actions/workflows/publish-release.yml
    - Sonatype repository: https://oss.sonatype.org/
    - Maven Central: https://repo.maven.apache.org/maven2/com/linecorp/armeria/armeria-bom/${releaseVersion}/
+   - Site job: https://github.com/line/armeria/actions/workflows/publish-site.yml
 
-2. Build the web site:
-
-   git checkout ${tag} && \
-   ./gradlew --no-daemon clean site
-
-3. Close the milestone and set its due date with the date of the release at:
+2. Close the milestone and set its due date with the date of the release at:
 
    https://github.com/line/armeria/milestones
 
-4. Copy the generated web site to the 'gh-pages' branch, e.g.
-
-   cd ../site-armeria && \
-   git checkout gh-pages && \
-   rm -fr .buildinfo .doctrees .gradle * && \
-   rsync -aiP ../upstream-armeria/site/public/ . && \
-   git add -A . && \
-   git commit --amend -m 'Deploy the web site' && \
-   git push --force
-
-5. Update the release note at:
+3. Update the release note at:
 
    https://github.com/line/armeria/releases/tag/${tag}
 
-6. Copy the examples to armeria-examples using the script:
+4. Copy the examples to armeria-examples using the script:
 
    cd ../armeria-examples && \
    ./update-examples.sh ${releaseVersion} ../upstream-armeria && \
@@ -35,7 +21,7 @@
    git commit -m 'Update Armeria to ${releaseVersion}' && \
    git push
 
-7. Announce the release via Twitter.
+5. Announce the release via Twitter.
 
-8. Send an update pull request to https://github.com/TechEmpower/FrameworkBenchmarks
+6. Send an update pull request to https://github.com/TechEmpower/FrameworkBenchmarks
    if we made performance improvements.


### PR DESCRIPTION
Motivation:

As a part of the automation of the release process, I want to automatically
update https://armeria.dev when a new version is released.

Modifications:

- Add a new GitHub Actions job that deploys the Armeria site
  using https://github.com/peaceiris/actions-gh-pages

Result:

One more step towards release automation.
