### PR TITLE
Fix the wrong Guava `failureaccess` version

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -365,7 +365,7 @@ relocations = { from = "com.google.common", to = "com.linecorp.armeria.internal.
 # A transitive dependency of Guava which needs relocation as well.
 [libraries.guava-failureaccess]
 module = "com.google.guava:failureaccess"
-version.ref = "guava"
+version = "1.0.1"
 exclusions = ["com.google.errorprone:error_prone_annotations", "com.google.j2objc:j2objc-annotations"]
 relocations = { from = "com.google.common", to = "com.linecorp.armeria.internal.shaded.guava" }
 


### PR DESCRIPTION
Motivation:

The dependency version of `com.google.guava:failureaccess` should be
`1.0.1` but Guava's version (`31.1-jre`) is set.
Actually, it does not cause any problems because only the metadata such
`exclusions` and `relocations` are used to shade Guava.
Anyway, it would be better to use the correct value for being future-proof.

Modifications:

- Set `com.google.guava:failureaccess` to 1.0.1

Result:

Fix a migration mistake.
