### PR TITLE
Fix `AnnotatedService` behavior with `void` return types

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -463,7 +463,7 @@ public final class AnnotatedService implements HttpService {
     private ResponseHeaders buildResponseHeaders(ServiceRequestContext ctx, HttpHeaders customHeaders) {
         final ResponseHeadersBuilder builder;
 
-        // Prefer ResponseHeaders#toBuilder because builder#add is an expensive operation.
+        // Prefer ResponseHeaders#toBuilder because builder#add(Iterable) is an expensive operation.
         if (customHeaders instanceof ResponseHeaders) {
             builder = ((ResponseHeaders) customHeaders).toBuilder();
         } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -432,7 +432,6 @@ public final class AnnotatedService implements HttpService {
 
         if (result instanceof HttpResult) {
             final HttpResult<?> httpResult = (HttpResult<?>) result;
-
             headers = buildResponseHeaders(ctx, httpResult.headers());
             result = httpResult.content();
             trailers = httpResult.trailers();
@@ -474,15 +473,15 @@ public final class AnnotatedService implements HttpService {
                 builder.status(defaultStatus);
             }
         }
-        return addContentTypeIfNeeded(ctx, builder).build();
+        return maybeAddContentType(ctx, builder).build();
     }
 
     private ResponseHeaders buildResponseHeaders(ServiceRequestContext ctx) {
-        return addContentTypeIfNeeded(ctx, ResponseHeaders.builder(defaultStatus)).build();
+        return maybeAddContentType(ctx, ResponseHeaders.builder(defaultStatus)).build();
     }
 
-    private static ResponseHeadersBuilder addContentTypeIfNeeded(ServiceRequestContext ctx,
-                                                                 ResponseHeadersBuilder builder) {
+    private static ResponseHeadersBuilder maybeAddContentType(ServiceRequestContext ctx,
+                                                              ResponseHeadersBuilder builder) {
         if (builder.status().isContentAlwaysEmpty()) {
             return builder;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.internal.server.annotation;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.util.ObjectCollectingUtil.collectFrom;
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.invoke.MethodHandle;
@@ -613,7 +613,7 @@ public final class AnnotatedService implements HttpService {
 
         @Override
         public Boolean isResponseStreaming(Type returnType, @Nullable MediaType contentType) {
-            final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+            final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
             if (clazz == null) {
                 return null;
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -178,7 +179,7 @@ public final class AnnotatedServiceFactory {
             // Set a default HTTP status code for a response depending on the return type of the method.
             final Class<?> returnType = method.getReturnType();
 
-            if (Publisher.class.isAssignableFrom(returnType)) {
+            if (Publisher.class.isAssignableFrom(returnType) || CompletionStage.class.isAssignableFrom(returnType)) {
                 // This doesn't cover suspending function returning Publisher<Void>.
                 final Type type = method.getGenericReturnType();
                 if (type instanceof ParameterizedType) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -34,6 +34,8 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -49,6 +51,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -166,11 +169,25 @@ public final class AnnotatedServiceFactory {
                       .collect(toImmutableList());
     }
 
-    private static HttpStatus defaultResponseStatus(Method method) {
+    private static HttpStatus defaultResponseStatus(Method method, Class<?> clazz) {
         final StatusCode statusCodeAnnotation = AnnotationUtil.findFirst(method, StatusCode.class);
         if (statusCodeAnnotation == null) {
+            if (!producibleMediaTypes(method, clazz).isEmpty()) {
+                return HttpStatus.OK;
+            }
             // Set a default HTTP status code for a response depending on the return type of the method.
             final Class<?> returnType = method.getReturnType();
+
+            if (Publisher.class.isAssignableFrom(returnType)) {
+                // This doesn't cover suspending function returning Publisher<Void>.
+                final Type type = method.getGenericReturnType();
+                if (type instanceof ParameterizedType) {
+                    final ParameterizedType containerType = (ParameterizedType) type;
+                    final Type actualReturnType = containerType.getActualTypeArguments()[0];
+
+                    return actualReturnType == Void.class ? HttpStatus.NO_CONTENT : HttpStatus.OK;
+                }
+            }
             return returnType == Void.class ||
                    returnType == void.class ||
                    KotlinUtil.isSuspendingAndReturnTypeUnit(method) ? HttpStatus.NO_CONTENT : HttpStatus.OK;
@@ -231,6 +248,19 @@ public final class AnnotatedServiceFactory {
         }
 
         final Class<?> clazz = object.getClass();
+        final String classAlias = clazz.getName();
+        final String methodAlias = String.format("%s.%s()", classAlias, method.getName());
+
+        final HttpHeaders responseHeaders = responseHeaders(method, clazz, classAlias, methodAlias);
+        final HttpHeaders responseTrailers = responseTrailers(method, clazz, classAlias, methodAlias);
+
+        final HttpStatus defaultStatus = defaultResponseStatus(method, clazz);
+        if (defaultStatus.isContentAlwaysEmpty() && !responseTrailers.isEmpty()) {
+            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
+                        "Trailers defined at '{}' might be ignored if HTTP/1.1 is used.",
+                        defaultStatus.code(), methodAlias);
+        }
+
         final List<Route> routes = routes(method, clazz, pathPrefix);
 
         final List<RequestConverterFunction> req =
@@ -245,18 +275,6 @@ public final class AnnotatedServiceFactory {
                 getAnnotatedInstances(method, clazz, ExceptionHandler.class, ExceptionHandlerFunction.class,
                                       dependencyInjector)
                         .addAll(baseExceptionHandlers).build();
-
-        final String classAlias = clazz.getName();
-        final String methodAlias = String.format("%s.%s()", classAlias, method.getName());
-        final HttpHeaders responseHeaders = responseHeaders(method, clazz, classAlias, methodAlias);
-        final HttpHeaders responseTrailers = responseTrailers(method, clazz, classAlias, methodAlias);
-
-        final HttpStatus defaultStatus = defaultResponseStatus(method);
-        if (defaultStatus.isContentAlwaysEmpty() && !responseTrailers.isEmpty()) {
-            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
-                        "Trailers defined at '{}' might be ignored if HTTP/1.1 is used.",
-                        defaultStatus.code(), methodAlias);
-        }
 
         final boolean needToUseBlockingTaskExecutor =
                 needToUseBlockingTaskExecutor(object, method, useBlockingTaskExecutor);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -171,10 +171,7 @@ public final class AnnotatedServiceFactory {
     private static HttpStatus defaultResponseStatus(Method method, Class<?> clazz) {
         final StatusCode statusCodeAnnotation = AnnotationUtil.findFirst(method, StatusCode.class);
         if (statusCodeAnnotation != null) {
-            final int statusCode = statusCodeAnnotation.value();
-            checkArgument(statusCode >= 0,
-                          "invalid HTTP status code: %s (expected: >= 0)", statusCode);
-            return HttpStatus.valueOf(statusCode);
+            return HttpStatus.valueOf(statusCodeAnnotation.value());
         }
 
         if (!producibleMediaTypes(method, clazz).isEmpty()) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -179,7 +179,8 @@ public final class AnnotatedServiceFactory {
             // Set a default HTTP status code for a response depending on the return type of the method.
             final Class<?> returnType = method.getReturnType();
 
-            if (Publisher.class.isAssignableFrom(returnType) || CompletionStage.class.isAssignableFrom(returnType)) {
+            if (Publisher.class.isAssignableFrom(returnType) ||
+                CompletionStage.class.isAssignableFrom(returnType)) {
                 // This doesn't cover suspending function returning Publisher<Void>.
                 final Type type = method.getGenericReturnType();
                 if (type instanceof ParameterizedType) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -21,6 +21,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.concatPaths;
 import static com.linecorp.armeria.internal.server.RouteUtil.ensureAbsolutePath;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
 import static com.linecorp.armeria.internal.server.annotation.ProcessedDocumentationHelper.getFileName;
 import static java.util.Objects.requireNonNull;
 import static org.reflections.ReflectionUtils.getAllMethods;
@@ -34,8 +36,6 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -46,13 +46,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,19 +181,8 @@ public final class AnnotatedServiceFactory {
             return HttpStatus.OK;
         }
         // Set a default HTTP status code for a response depending on the return type of the method.
-        final Class<?> returnType = method.getReturnType();
+        final Class<?> returnType = typeToClass(unwrapAsyncType(method.getGenericReturnType()));
 
-        if (Publisher.class.isAssignableFrom(returnType) ||
-            CompletionStage.class.isAssignableFrom(returnType)) {
-            // This doesn't cover suspending function returning Publisher<Void>.
-            final Type type = method.getGenericReturnType();
-            if (type instanceof ParameterizedType) {
-                final ParameterizedType containerType = (ParameterizedType) type;
-                final Type actualReturnType = containerType.getActualTypeArguments()[0];
-
-                return actualReturnType == Void.class ? HttpStatus.NO_CONTENT : HttpStatus.OK;
-            }
-        }
         return returnType == Void.class ||
                returnType == void.class ||
                KotlinUtil.isSuspendingAndReturnTypeUnit(method) ? HttpStatus.NO_CONTENT : HttpStatus.OK;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -21,6 +21,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.concatPaths;
 import static com.linecorp.armeria.internal.server.RouteUtil.ensureAbsolutePath;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
 import static com.linecorp.armeria.internal.server.annotation.ProcessedDocumentationHelper.getFileName;
 import static java.util.Objects.requireNonNull;
 import static org.reflections.ReflectionUtils.getAllMethods;
@@ -34,8 +36,6 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.EnumMap;
@@ -46,13 +46,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,19 +181,7 @@ public final class AnnotatedServiceFactory {
             return HttpStatus.OK;
         }
         // Set a default HTTP status code for a response depending on the return type of the method.
-        final Class<?> returnType = method.getReturnType();
-
-        if (Publisher.class.isAssignableFrom(returnType) ||
-            CompletionStage.class.isAssignableFrom(returnType)) {
-            // This doesn't cover suspending function returning Publisher<Void>.
-            final Type type = method.getGenericReturnType();
-            if (type instanceof ParameterizedType) {
-                final ParameterizedType containerType = (ParameterizedType) type;
-                final Type actualReturnType = containerType.getActualTypeArguments()[0];
-
-                return actualReturnType == Void.class ? HttpStatus.NO_CONTENT : HttpStatus.OK;
-            }
-        }
+        final Class<?> returnType = typeToClass(unwrapAsyncType(method.getGenericReturnType()));
         return returnType == Void.class ||
                returnType == void.class ||
                KotlinUtil.isSuspendingAndReturnTypeUnit(method) ? HttpStatus.NO_CONTENT : HttpStatus.OK;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -248,19 +248,6 @@ public final class AnnotatedServiceFactory {
         }
 
         final Class<?> clazz = object.getClass();
-        final String classAlias = clazz.getName();
-        final String methodAlias = String.format("%s.%s()", classAlias, method.getName());
-
-        final HttpHeaders responseHeaders = responseHeaders(method, clazz, classAlias, methodAlias);
-        final HttpHeaders responseTrailers = responseTrailers(method, clazz, classAlias, methodAlias);
-
-        final HttpStatus defaultStatus = defaultResponseStatus(method, clazz);
-        if (defaultStatus.isContentAlwaysEmpty() && !responseTrailers.isEmpty()) {
-            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
-                        "Trailers defined at '{}' might be ignored if HTTP/1.1 is used.",
-                        defaultStatus.code(), methodAlias);
-        }
-
         final List<Route> routes = routes(method, clazz, pathPrefix);
 
         final List<RequestConverterFunction> req =
@@ -275,6 +262,18 @@ public final class AnnotatedServiceFactory {
                 getAnnotatedInstances(method, clazz, ExceptionHandler.class, ExceptionHandlerFunction.class,
                                       dependencyInjector)
                         .addAll(baseExceptionHandlers).build();
+
+        final String classAlias = clazz.getName();
+        final String methodAlias = String.format("%s.%s()", classAlias, method.getName());
+        final HttpHeaders responseHeaders = responseHeaders(method, clazz, classAlias, methodAlias);
+        final HttpHeaders responseTrailers = responseTrailers(method, clazz, classAlias, methodAlias);
+
+        final HttpStatus defaultStatus = defaultResponseStatus(method, clazz);
+        if (defaultStatus.isContentAlwaysEmpty() && !responseTrailers.isEmpty()) {
+            logger.warn("A response with HTTP status code '{}' cannot have a content. " +
+                        "Trailers defined at '{}' might be ignored if HTTP/1.1 is used.",
+                        defaultStatus.code(), methodAlias);
+        }
 
         final boolean needToUseBlockingTaskExecutor =
                 needToUseBlockingTaskExecutor(object, method, useBlockingTaskExecutor);

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunction.java
@@ -17,7 +17,7 @@ package com.linecorp.armeria.server.annotation;
 
 import static com.linecorp.armeria.internal.server.ResponseConversionUtil.streamingFrom;
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 
 import java.lang.reflect.Type;
 import java.util.stream.Stream;
@@ -47,7 +47,7 @@ public final class ByteArrayResponseConverterFunction implements ResponseConvert
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.server.annotation;
 
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 
 import java.lang.reflect.Type;
 
@@ -41,7 +41,7 @@ public final class HttpFileResponseConverterFunction implements ResponseConverte
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
@@ -17,7 +17,7 @@ package com.linecorp.armeria.server.annotation;
 
 import static com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom;
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Type;
@@ -73,7 +73,7 @@ public final class JacksonResponseConverterFunction implements ResponseConverter
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunction.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.server.annotation;
 
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static com.linecorp.armeria.server.streaming.ServerSentEvents.fromEvent;
 import static com.linecorp.armeria.server.streaming.ServerSentEvents.fromPublisher;
 import static com.linecorp.armeria.server.streaming.ServerSentEvents.fromStream;
@@ -44,7 +44,7 @@ public final class ServerSentEventResponseConverterFunction implements ResponseC
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType contentType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunction.java
@@ -17,7 +17,7 @@ package com.linecorp.armeria.server.annotation;
 
 import static com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom;
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
@@ -50,7 +50,7 @@ public final class StringResponseConverterFunction implements ResponseConverterF
         if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {
             return false;
         }
-        final Class<?> clazz = typeToClass(unwrapAsyncType(resultType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(resultType));
         if (clazz == null) {
             return null;
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Publisher;
 
 import com.google.common.collect.ImmutableList;
 
@@ -267,27 +268,27 @@ class AnnotatedServiceTest {
         @ProducesJson
         public void voidJson204() {}
 
-        @Get("/voidMono/204")
-        public Mono<Void> voidMono204() {
+        @Get("/voidPublisher/204")
+        public Publisher<Void> voidPublisher204() {
             return Mono.empty();
         }
 
-        @Get("/voidMono/200")
+        @Get("/voidPublisher/200")
         @ResponseConverter(VoidTo200ResponseConverter.class)
-        public Mono<Void> voidMono200() {
+        public Publisher<Void> voidPublisher200() {
             return Mono.empty();
         }
 
-        @Get("/voidMono/json/200")
+        @Get("/voidPublisher/json/200")
         @ProducesJson
-        public Mono<Void> voidMonoJson200() {
+        public Publisher<Void> voidPublisherJson200() {
             return Mono.empty();
         }
 
-        @Get("/voidMono/json/204")
+        @Get("/voidPublisher/json/204")
         @StatusCode(204)
         @ProducesJson
-        public Mono<Void> voidMonoJson204() {
+        public Publisher<Void> voidPublisherJson204() {
             return Mono.empty();
         }
 
@@ -1140,7 +1141,7 @@ class AnnotatedServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "void", "voidMono", "voidFuture" })
+    @ValueSource(strings = { "void", "voidPublisher", "voidFuture" })
     void testReturnVoid(String returnType) throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             testStatusCode(hc, get("/1/" + returnType + "/204"), 204);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.reactivestreams.Publisher;
 
 import com.google.common.collect.ImmutableList;
 
@@ -268,27 +267,27 @@ class AnnotatedServiceTest {
         @ProducesJson
         public void voidJson204() {}
 
-        @Get("/voidPublisher/204")
-        public Publisher<Void> voidPublisher204() {
+        @Get("/voidMono/204")
+        public Mono<Void> voidMono204() {
             return Mono.empty();
         }
 
-        @Get("/voidPublisher/200")
+        @Get("/voidMono/200")
         @ResponseConverter(VoidTo200ResponseConverter.class)
-        public Publisher<Void> voidPublisher200() {
+        public Mono<Void> voidMono200() {
             return Mono.empty();
         }
 
-        @Get("/voidPublisher/json/200")
+        @Get("/voidMono/json/200")
         @ProducesJson
-        public Publisher<Void> voidPublisherJson200() {
+        public Mono<Void> voidMonoJson200() {
             return Mono.empty();
         }
 
-        @Get("/voidPublisher/json/204")
+        @Get("/voidMono/json/204")
         @StatusCode(204)
         @ProducesJson
-        public Publisher<Void> voidPublisherJson204() {
+        public Mono<Void> voidMonoJson204() {
             return Mono.empty();
         }
 
@@ -1141,7 +1140,7 @@ class AnnotatedServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "void", "voidPublisher", "voidFuture" })
+    @ValueSource(strings = { "void", "voidMono", "voidFuture" })
     void testReturnVoid(String returnType) throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             testStatusCode(hc, get("/1/" + returnType + "/204"), 204);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -43,6 +43,7 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Publisher;
 
 import com.google.common.collect.ImmutableList;
 
@@ -83,10 +84,14 @@ import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Produces;
+import com.linecorp.armeria.server.annotation.ProducesJson;
 import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
+import com.linecorp.armeria.server.annotation.StatusCode;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import reactor.core.publisher.Mono;
 
 class AnnotatedServiceTest {
 
@@ -251,6 +256,39 @@ class AnnotatedServiceTest {
         @Get("/void/200")
         @ResponseConverter(VoidTo200ResponseConverter.class)
         public void void200() {}
+
+        @Get("/void/json/200")
+        @ProducesJson
+        public void voidJson200() {}
+
+        @Get("/void/json/204")
+        @StatusCode(204)
+        @ProducesJson
+        public void voidJson204() {}
+
+        @Get("/voidPublisher/204")
+        public Publisher<Void> voidPublisher204() {
+            return Mono.empty();
+        }
+
+        @Get("/voidPublisher/200")
+        @ResponseConverter(VoidTo200ResponseConverter.class)
+        public Publisher<Void> voidPublisher200() {
+            return Mono.empty();
+        }
+
+        @Get("/voidPublisher/json/200")
+        @ProducesJson
+        public Publisher<Void> voidPublisherJson200() {
+            return Mono.empty();
+        }
+
+        @Get("/voidPublisher/json/204")
+        @StatusCode(204)
+        @ProducesJson
+        public Publisher<Void> voidPublisherJson204() {
+            return Mono.empty();
+        }
     }
 
     static class VoidTo200ResponseConverter implements ResponseConverterFunction {
@@ -1081,6 +1119,20 @@ class AnnotatedServiceTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             testStatusCode(hc, get("/1/void/204"), 204);
             testBodyAndContentType(hc, get("/1/void/200"), "200 OK", MediaType.PLAIN_TEXT_UTF_8.toString());
+            testStatusCode(hc, get("/1/void/json/204"), 204);
+            testBodyAndContentType(hc, get("/1/void/json/200"), "null", MediaType.JSON_UTF_8.toString());
+        }
+    }
+
+    @Test
+    void testReturnMonoVoid() throws Exception {
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            testStatusCode(hc, get("/1/voidPublisher/204"), 204);
+            testBodyAndContentType(hc, get("/1/voidPublisher/200"), "200 OK",
+                                   MediaType.PLAIN_TEXT_UTF_8.toString());
+            testStatusCode(hc, get("/1/voidPublisher/json/204"), 204);
+            testBodyAndContentType(hc, get("/1/voidPublisher/json/200"), "null",
+                                   MediaType.JSON_UTF_8.toString());
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ClassUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ClassUtilTest.java
@@ -49,7 +49,7 @@ class ClassUtilTest {
     void shouldUnwrapAsyncType(String methodName) throws NoSuchMethodException {
         final Method method = ClassUtilTest.class.getDeclaredMethod(methodName);
         final Type returnType = method.getGenericReturnType();
-        final Type type = ClassUtil.unwrapAsyncType(returnType);
+        final Type type = ClassUtil.unwrapUnaryAsyncType(returnType);
         assertThat((Class<?>) type).isAssignableFrom(String.class);
     }
 

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -19,7 +19,7 @@ package com.linecorp.armeria.server.protobuf;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom;
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static com.linecorp.armeria.server.protobuf.ProtobufRequestConverterFunction.isJson;
 import static com.linecorp.armeria.server.protobuf.ProtobufRequestConverterFunction.isProtobuf;
 import static java.util.Objects.requireNonNull;
@@ -147,7 +147,7 @@ public final class ProtobufResponseConverterFunction implements ResponseConverte
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionProvider.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.server.protobuf;
 
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -52,7 +52,7 @@ public final class ProtobufResponseConverterFunctionProvider implements Response
      * {@link ProtobufResponseConverterFunction}.
      */
     private static boolean isSupportedType(Type type) {
-        type = unwrapAsyncType(type);
+        type = unwrapUnaryAsyncType(type);
         if (type instanceof Class) {
             return MessageLite.class.isAssignableFrom((Class<?>) type);
         }

--- a/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
+++ b/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.server.rxjava2;
 
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Type;
@@ -81,7 +81,7 @@ public final class ObservableResponseConverterFunction implements ResponseConver
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
+++ b/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.server.rxjava3;
 
 import static com.linecorp.armeria.internal.server.annotation.ClassUtil.typeToClass;
-import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType;
+import static com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Type;
@@ -81,7 +81,7 @@ public final class ObservableResponseConverterFunction implements ResponseConver
 
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
-        final Class<?> clazz = typeToClass(unwrapAsyncType(returnType));
+        final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));
         if (clazz == null) {
             return null;
         }

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ClassUtilTest.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ClassUtilTest.scala
@@ -26,7 +26,11 @@ class ClassUtilTest extends FunSuite {
   test("should unwrap Future type") {
     val method = classOf[ClassUtilTest].getDeclaredMethod("future")
     val returnType = method.getGenericReturnType
-    val tpe = ClassUtil.unwrapAsyncType(returnType)
+    
+    var tpe = ClassUtil.unwrapUnaryAsyncType(returnType)
+    assertThat(tpe.asInstanceOf[Class[_]]).isAssignableFrom(classOf[String])
+    
+    tpe = ClassUtil.unwrapAsyncType(returnType)
     assertThat(tpe.asInstanceOf[Class[_]]).isAssignableFrom(classOf[String])
   }
 

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
@@ -18,7 +18,7 @@ package com.linecorp.armeria.server.scalapb
 
 import com.google.protobuf.{CodedInputStream, CodedOutputStream, Descriptors}
 import com.linecorp.armeria.common.MediaType
-import com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapAsyncType
+import com.linecorp.armeria.internal.server.annotation.ClassUtil.unwrapUnaryAsyncType
 import java.lang.invoke.{MethodHandle, MethodHandles, MethodType}
 import java.lang.reflect.{ParameterizedType, Type}
 import org.reactivestreams.Publisher
@@ -41,7 +41,7 @@ private[scalapb] object ScalaPbConverterUtil {
     contentType.is(MediaType.PROTOBUF) || contentType.is(X_PROTOBUF) || contentType.is(MediaType.OCTET_STREAM)
 
   def toResultType(tpe: Type): ResultType.Value = {
-    unwrapAsyncType(tpe) match {
+    unwrapUnaryAsyncType(tpe) match {
       case clazz: Class[_] if isProtobufMessage(clazz) => ResultType.PROTOBUF
       case parameterizedType: ParameterizedType =>
         val rawType = parameterizedType.getRawType.asInstanceOf[Class[_]]

--- a/scalapb/scalapb_2.13/src/main/scala_2/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_2.13/src/main/scala_2/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -23,7 +23,7 @@ import com.google.common.collect.Iterables
 import com.linecorp.armeria.common._
 import com.linecorp.armeria.common.annotation.{Nullable, UnstableApi}
 import com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom
-import com.linecorp.armeria.internal.server.annotation.ClassUtil.{typeToClass, unwrapAsyncType}
+import com.linecorp.armeria.internal.server.annotation.ClassUtil.{typeToClass, unwrapUnaryAsyncType}
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction
 import com.linecorp.armeria.server.scalapb.ScalaPbConverterUtil.{defaultJsonPrinter, isProtobuf}
@@ -75,7 +75,7 @@ final class ScalaPbResponseConverterFunction(jsonPrinter: Printer = defaultJsonP
   // Use java.lang.Boolean as the return type.
   // Because scala.Boolean is equivalent to Java primitive boolean that does not allow null.
   override def isResponseStreaming(returnType: Type, @Nullable produceType: MediaType): java.lang.Boolean = {
-    val clazz = typeToClass(unwrapAsyncType(returnType))
+    val clazz = typeToClass(unwrapUnaryAsyncType(returnType))
     if (clazz == null) {
       return null
     }

--- a/scalapb/scalapb_3/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
+++ b/scalapb/scalapb_3/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunction.scala
@@ -23,7 +23,7 @@ import com.google.common.collect.Iterables
 import com.linecorp.armeria.common.annotation.{Nullable, UnstableApi}
 import com.linecorp.armeria.common.{HttpData, HttpHeaders, HttpResponse, MediaType, ResponseHeaders}
 import com.linecorp.armeria.internal.server.ResponseConversionUtil.aggregateFrom
-import com.linecorp.armeria.internal.server.annotation.ClassUtil.{typeToClass, unwrapAsyncType}
+import com.linecorp.armeria.internal.server.annotation.ClassUtil.{typeToClass, unwrapUnaryAsyncType}
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction
 import com.linecorp.armeria.server.scalapb.ScalaPbConverterUtil._
@@ -78,7 +78,7 @@ final class ScalaPbResponseConverterFunction(jsonPrinter: Printer = defaultJsonP
   override def isResponseStreaming(
       returnType: Type,
       @Nullable produceType: MediaType): java.lang.Boolean | Null = {
-    val clazz = typeToClass(unwrapAsyncType(returnType))
+    val clazz = typeToClass(unwrapUnaryAsyncType(returnType))
     if (clazz == null) {
       return null
     }


### PR DESCRIPTION
Motivation:

Currently, the behavior of `AnnotatedService` with void return type(including `Publisher<Void>` and `CompletableFuture<Void>`) is confusing and users often struggle to find the right way to return `204 No Content` with `AnnotatedService`.
- Adding `@StatusCode(204)` with class-level `@ProducesJson` results in 500 errors if the return type is `void`)
- Returning `Mono<Void>` or `CompletableFuture<Void>` gives 200 response by default while returning `void` gives 204.

Modifications:

- Make `AnnotatedService` not set `Content-Type` header when the `status.isContentAlwaysEmpty()` is `true`.
- Make `Publisher<Void>`, `CompletionStage<Void>` return type gives 204 status code by default.

Result:

- Closes #4390
- You no longer see 500 errors for returning `void`, `Publisher<Void>` or `CompletionStage<Void>` when `@ProducesJson` and `@StatusCode(204)` are used at the same time.
- Returning `Publisher<Void>` or `CompletionStage<Void>` correctly gives 204 response by default.