### PR TITLE
Add `StreamMessage.fromOutputStream()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -212,7 +212,7 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
         @Override
         public void write(int b) throws IOException {
-            final HttpData data = HttpData.copyOf(new byte[] { (byte) b });
+            final HttpData data = HttpData.wrap(new byte[] { (byte) b });
             if (!streamWriter.tryWrite(data)) {
                 throw new IOException("Stream closed");
             }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -120,8 +120,7 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
                 try {
                     outputStreamConsumer.accept(new StreamWriterOutputStream(outputStreamWriter));
                 } catch (Throwable t) {
-                    onError(t);
-                    subscription.cancel();
+                    outputStreamWriter.abort(t);
                 }
             });
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -36,10 +36,11 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
     private final StreamMessageAndWriter<HttpData> outputStreamWriter = new DefaultStreamMessage<>();
     private final ByteStreamMessage delegate = ByteStreamMessage.of(outputStreamWriter);
 
-    private final Consumer<OutputStream> outputStreamConsumer;
+    private final Consumer<? super OutputStream> outputStreamConsumer;
     private final Executor blockingTaskExecutor;
 
-    ByteStreamMessageOutputStream(Consumer<OutputStream> outputStreamConsumer, Executor blockingTaskExecutor) {
+    ByteStreamMessageOutputStream(Consumer<? super OutputStream> outputStreamConsumer,
+                                  Executor blockingTaskExecutor) {
         requireNonNull(outputStreamConsumer, "outputStreamConsumer");
         requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
         this.outputStreamConsumer = outputStreamConsumer;
@@ -94,12 +95,12 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
         private final Subscriber<? super HttpData> downstream;
         private final StreamMessageAndWriter<HttpData> outputStreamWriter;
-        private final Consumer<OutputStream> outputStreamConsumer;
+        private final Consumer<? super OutputStream> outputStreamConsumer;
         private final Executor blockingTaskExecutor;
 
         OutputStreamSubscriber(Subscriber<? super HttpData> downstream,
                                StreamMessageAndWriter<HttpData> outputStreamWriter,
-                               Consumer<OutputStream> outputStreamConsumer,
+                               Consumer<? super OutputStream> outputStreamConsumer,
                                Executor blockingTaskExecutor) {
             requireNonNull(downstream, "downstream");
             requireNonNull(outputStreamWriter, "outputStreamWriter");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -32,12 +32,12 @@ import io.netty.util.concurrent.EventExecutor;
 
 final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
-    private final Consumer<OutputStream> outputStreamWriter;
-    private final Executor executor;
-
     private final StreamMessageAndWriter<HttpData> streamWriter = new DefaultStreamMessage<>();
     private final ByteStreamMessage delegate = ByteStreamMessage.of(streamWriter);
     private final OutputStream outputStream = new StreamWriterOutputStream(streamWriter);
+
+    private final Consumer<OutputStream> outputStreamWriter;
+    private final Executor executor;
 
     ByteStreamMessageOutputStream(Consumer<OutputStream> outputStreamWriter, Executor executor) {
         this.outputStreamWriter = outputStreamWriter;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -154,7 +154,6 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
             }
             completed = true;
             downstream.onError(t);
-            outputStreamWriter.close();
         }
 
         @Override
@@ -164,7 +163,6 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
             }
             completed = true;
             downstream.onComplete();
-            outputStreamWriter.close();
         }
 
         @Override
@@ -201,7 +199,6 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
             }
             completed = true;
             upstream.cancel();
-            outputStreamWriter.close();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import org.reactivestreams.Subscriber;
+
+import com.linecorp.armeria.common.HttpData;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.concurrent.EventExecutor;
+
+final class ByteStreamMessageOutputStream implements ByteStreamMessage {
+
+    private final Consumer<OutputStream> outputStreamWriter;
+    private final Executor executor;
+
+    private final StreamMessageAndWriter<HttpData> streamWriter = new DefaultStreamMessage<>();
+    private final ByteStreamMessage delegate = ByteStreamMessage.of(streamWriter);
+    private final OutputStream outputStream = new StreamWriterOutputStream(streamWriter);
+
+    ByteStreamMessageOutputStream(Consumer<OutputStream> outputStreamWriter, Executor executor) {
+        this.outputStreamWriter = outputStreamWriter;
+        this.executor = executor;
+    }
+
+    @Override
+    public ByteStreamMessage range(long offset, long length) {
+        delegate.range(offset, length);
+        return this;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    @Override
+    public long demand() {
+        return delegate.demand();
+    }
+
+    @Override
+    public CompletableFuture<Void> whenComplete() {
+        return delegate.whenComplete();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpData> subscriber, EventExecutor eventExecutor,
+                          SubscriptionOption... options) {
+        executor.execute(() -> outputStreamWriter.accept(outputStream));
+        delegate.subscribe(subscriber, eventExecutor, options);
+    }
+
+    @Override
+    public void abort() {
+        delegate.abort();
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        delegate.abort(cause);
+    }
+
+    private static final class StreamWriterOutputStream extends OutputStream {
+
+        private final StreamMessageAndWriter<HttpData> streamWriter;
+
+        StreamWriterOutputStream(StreamMessageAndWriter<HttpData> streamWriter) {
+            this.streamWriter = streamWriter;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            final ByteBuf buf = Unpooled.buffer(1, 1).writeByte(b);
+            if (!streamWriter.tryWrite(HttpData.wrap(buf))) {
+                throw new IOException("Stream closed");
+            }
+            streamWriter.whenConsumed().join(); // Blocking wait until tryWrite is consumed
+        }
+
+        @Override
+        public void close() throws IOException {
+            streamWriter.close();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -214,11 +214,20 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
         @Override
         public void write(int b) throws IOException {
-            final ByteBuf buf = Unpooled.buffer(1, 1).writeByte(b);
-            if (!streamWriter.tryWrite(HttpData.wrap(buf))) {
+            final HttpData data = HttpData.copyOf(new byte[] { (byte) b });
+            if (!streamWriter.tryWrite(data)) {
                 throw new IOException("Stream closed");
             }
-            streamWriter.whenConsumed().join(); // Blocking wait until tryWrite is consumed
+            streamWriter.whenConsumed().join();
+        }
+
+        @Override
+        public void write(byte[] bytes, int off, int len) throws IOException {
+            final HttpData data = HttpData.copyOf(bytes, off, len);
+            if (!streamWriter.tryWrite(data)) {
+                throw new IOException("Stream closed");
+            }
+            streamWriter.whenConsumed().join();
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -96,7 +96,6 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
         private final StreamMessageAndWriter<HttpData> outputStreamWriter;
         private final Consumer<OutputStream> outputStreamConsumer;
         private final Executor blockingTaskExecutor;
-        private boolean completed;
 
         OutputStreamSubscriber(Subscriber<? super HttpData> downstream,
                                StreamMessageAndWriter<HttpData> outputStreamWriter,
@@ -129,29 +128,17 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
         @Override
         public void onNext(HttpData data) {
             requireNonNull(data, "data");
-            if (completed) {
-                data.close();
-                return;
-            }
             downstream.onNext(data);
         }
 
         @Override
         public void onError(Throwable t) {
             requireNonNull(t, "t");
-            if (completed) {
-                return;
-            }
-            completed = true;
             downstream.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (completed) {
-                return;
-            }
-            completed = true;
             downstream.onComplete();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -23,12 +23,15 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -276,6 +279,14 @@ public interface StreamMessage<T> extends Publisher<T> {
             builder.executor(executor);
         }
         return builder.alloc(alloc).bufferSize(bufferSize).build();
+    }
+
+    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamWriter) {
+        return fromOutputStream(outputStreamWriter, Executors.newSingleThreadExecutor());
+    }
+
+    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamWriter, Executor executor) {
+        return new ByteStreamMessageOutputStream(outputStreamWriter, executor);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -317,8 +317,9 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * @param executor the executor to execute {@link OutputStream#write}
      */
-    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer, Executor executor) {
-        return new ByteStreamMessageOutputStream(outputStreamConsumer, executor);
+    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer,
+                                              Executor blockingTaskExecutor) {
+        return new ByteStreamMessageOutputStream(outputStreamConsumer, blockingTaskExecutor);
     }
 
     /**
@@ -887,7 +888,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     @UnstableApi
     default <E extends Throwable> StreamMessage<T> recoverAndResume(Class<E> causeClass,
-            Function<? super E, ? extends StreamMessage<T>> function) {
+                                                                    Function<? super E, ? extends StreamMessage<T>> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recoverAndResume(cause -> {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -905,7 +905,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     @UnstableApi
     default <E extends Throwable> StreamMessage<T> recoverAndResume(Class<E> causeClass,
-                                                                    Function<? super E, ? extends StreamMessage<T>> function) {
+            Function<? super E, ? extends StreamMessage<T>> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recoverAndResume(cause -> {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -300,7 +300,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * assert Arrays.equals(result, new byte[] { 0, 1, 2, 3, 4 });
      * }</pre>
      */
-    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamWriter) {
+    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer) {
         final RequestContext ctx = RequestContext.currentOrNull();
         ExecutorService blockingTaskExecutor = null;
         if (ctx instanceof ServiceRequestContext) {
@@ -309,7 +309,7 @@ public interface StreamMessage<T> extends Publisher<T> {
         if (blockingTaskExecutor == null) {
             blockingTaskExecutor = CommonPools.blockingTaskExecutor();
         }
-        return fromOutputStream(outputStreamWriter, blockingTaskExecutor);
+        return fromOutputStream(outputStreamConsumer, blockingTaskExecutor);
     }
 
     /**
@@ -317,8 +317,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * @param executor the executor to execute {@link OutputStream#write}
      */
-    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamWriter, Executor executor) {
-        return new ByteStreamMessageOutputStream(outputStreamWriter, executor);
+    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer, Executor executor) {
+        return new ByteStreamMessageOutputStream(outputStreamConsumer, executor);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -300,7 +300,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * assert Arrays.equals(result, new byte[] { 0, 1, 2, 3, 4 });
      * }</pre>
      */
-    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer) {
+    static ByteStreamMessage fromOutputStream(Consumer<? super OutputStream> outputStreamConsumer) {
         final RequestContext ctx = RequestContext.currentOrNull();
         final ExecutorService blockingTaskExecutor;
         if (ctx instanceof ServiceRequestContext) {
@@ -332,7 +332,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * @param blockingTaskExecutor the blocking task executor to execute {@link OutputStream#write}
      */
-    static ByteStreamMessage fromOutputStream(Consumer<OutputStream> outputStreamConsumer,
+    static ByteStreamMessage fromOutputStream(Consumer<? super OutputStream> outputStreamConsumer,
                                               Executor blockingTaskExecutor) {
         return new ByteStreamMessageOutputStream(outputStreamConsumer, blockingTaskExecutor);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -287,18 +287,24 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>For example:<pre>{@code
      * ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-     *     try (os) {
+     *     try {
      *         for (int i = 0; i < 5; i++) {
      *             os.write(i);
      *         }
+     *         os.close();
      *     } catch (IOException e) {
-     *         throw new RuntimeException(e);
+     *         throw new UncheckedIOException(e);
      *     }
      * });
      * byte[] result = byteStreamMessage.collectBytes().join();
      *
      * assert Arrays.equals(result, new byte[] { 0, 1, 2, 3, 4 });
      * }</pre>
+     *
+     * <p>Please note that the try-with-resources statement is not used to call {@code os.close()}
+     * automatically. It's because when an exception is raised in the {@link Consumer},
+     * the {@link OutputStream} is closed by the {@link StreamMessage} and the exception is propagated
+     * to the {@link Subscriber} automatically.
      */
     static ByteStreamMessage fromOutputStream(Consumer<? super OutputStream> outputStreamConsumer) {
         final RequestContext ctx = RequestContext.currentOrNull();
@@ -317,18 +323,24 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>For example:<pre>{@code
      * ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-     *     try (os) {
+     *     try {
      *         for (int i = 0; i < 5; i++) {
      *             os.write(i);
      *         }
+     *         os.close();
      *     } catch (IOException e) {
-     *         throw new RuntimeException(e);
+     *         throw new UncheckedIOException(e);
      *     }
      * });
      * byte[] result = byteStreamMessage.collectBytes().join();
      *
      * assert Arrays.equals(result, new byte[] { 0, 1, 2, 3, 4 });
      * }</pre>
+     *
+     * <p>Please note that the try-with-resources statement is not used to call {@code os.close()}
+     * automatically. It's because when an exception is raised in the {@link Consumer},
+     * the {@link OutputStream} is closed by the {@link StreamMessage} and the exception is propagated
+     * to the {@link Subscriber} automatically.
      *
      * @param blockingTaskExecutor the blocking task executor to execute {@link OutputStream#write(int)}
      */

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -330,7 +330,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * assert Arrays.equals(result, new byte[] { 0, 1, 2, 3, 4 });
      * }</pre>
      *
-     * @param blockingTaskExecutor the blocking task executor to execute {@link OutputStream#write}
+     * @param blockingTaskExecutor the blocking task executor to execute {@link OutputStream#write(int)}
      */
     static ByteStreamMessage fromOutputStream(Consumer<? super OutputStream> outputStreamConsumer,
                                               Executor blockingTaskExecutor) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -287,11 +287,10 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>For example:<pre>{@code
      * ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-     *     try {
+     *     try (os) {
      *         for (int i = 0; i < 5; i++) {
      *             os.write(i);
      *         }
-     *         os.close();
      *     } catch (IOException e) {
      *         throw new RuntimeException(e);
      *     }
@@ -318,11 +317,10 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * <p>For example:<pre>{@code
      * ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-     *     try {
+     *     try (os) {
      *         for (int i = 0; i < 5; i++) {
      *             os.write(i);
      *         }
-     *         os.close();
      *     } catch (IOException e) {
      *         throw new RuntimeException(e);
      *     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -38,11 +39,10 @@ class ByteStreamMessageOutputStreamTest {
     @Test
     void write() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (byte b : "abcde".getBytes()) {
                     os.write(b);
                 }
-                os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -69,10 +69,9 @@ class ByteStreamMessageOutputStreamTest {
     @Test
     void writeOffset() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 final byte[] bytes = "_foobarbaz_".getBytes();
                 os.write(bytes, 1, bytes.length - 2);
-                os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -101,12 +100,11 @@ class ByteStreamMessageOutputStreamTest {
     void blockingWrite() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (int i = 0; i < 3; i++) {
                     os.write(i);
                     count.incrementAndGet();
                 }
-                os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -128,7 +126,7 @@ class ByteStreamMessageOutputStreamTest {
     @Test
     void writeAfterClosed() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (int i = 0; i < 5; i++) {
                     os.write(i);
                 }
@@ -156,7 +154,7 @@ class ByteStreamMessageOutputStreamTest {
         final CountDownLatch wait = new CountDownLatch(1);
         final CountDownLatch end = new CountDownLatch(1);
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (int i = 0; i < 5; i++) {
                     if (i < 2) {
                         os.write(i);
@@ -204,7 +202,7 @@ class ByteStreamMessageOutputStreamTest {
     @Test
     void write_error_thrown() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (int i = 0; i < 5; i++) {
                     if (i < 3) {
                         os.write(i);
@@ -212,7 +210,6 @@ class ByteStreamMessageOutputStreamTest {
                         throw new RuntimeException();
                     }
                 }
-                os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -304,11 +301,10 @@ class ByteStreamMessageOutputStreamTest {
 
     private static ByteStreamMessage newByteStreamMessage() {
         return StreamMessage.fromOutputStream(os -> {
-            try {
+            try (Closeable ignored = os) {
                 for (int i = 0; i < 5; i++) {
                     os.write(i);
                 }
-                os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
@@ -16,25 +16,130 @@
 
 package com.linecorp.armeria.common.stream;
 
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpData;
 
-import io.netty.buffer.Unpooled;
 import reactor.test.StepVerifier;
 
 class ByteStreamMessageOutputStreamTest {
 
     @Test
-    void readAll() {
+    void write() {
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                for (byte b : "abcde".getBytes()) {
+                    os.write(b);
+                }
+                os.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.ofUtf8("a"))
+                    .expectNext(HttpData.ofUtf8("b"))
+                    .expectNext(HttpData.ofUtf8("c"))
+                    .expectNext(HttpData.ofUtf8("d"))
+                    .expectNext(HttpData.ofUtf8("e"))
+                    .verifyComplete();
+    }
+
+    @Test
+    void writeIntegers() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(httpData(0), httpData(1), httpData(2), httpData(3), httpData(4))
+                    .verifyComplete();
+    }
+
+    @Test
+    void writeOffset() {
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                final byte[] bytes = "_foobarbaz_".getBytes();
+                os.write(bytes, 1, bytes.length - 2);
+                os.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.ofUtf8("foobarbaz"))
+                    .verifyComplete();
+    }
+
+    @Test
+    void writeWithStreamMessage() {
+        final StreamMessage<HttpData> streamMessage = StreamMessage
+                .of(10, 11, 12, 13, 14)
+                .map(ByteStreamMessageOutputStreamTest::httpData);
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage();
+        final StreamMessage<HttpData> concat = StreamMessage.concat(streamMessage, byteStreamMessage);
+
+        StepVerifier.create(concat)
+                    .expectNext(httpData(10), httpData(11), httpData(12), httpData(13), httpData(14))
+                    .expectNext(httpData(0), httpData(1), httpData(2), httpData(3), httpData(4))
+                    .verifyComplete();
+    }
+
+    @Test
+    void blockingWrite() throws InterruptedException {
+        final AtomicInteger count = new AtomicInteger();
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                for (int i = 0; i < 3; i++) {
+                    os.write(i);
+                    count.incrementAndGet();
+                }
+                os.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(httpData(0))
+                    .thenAwait(Duration.ofSeconds(3))
+                    .then(() -> await().untilAtomic(count, Matchers.is(1)))
+                    .thenRequest(1)
+                    .expectNext(httpData(1))
+                    .thenAwait(Duration.ofSeconds(3))
+                    .then(() -> await().untilAtomic(count, Matchers.is(2)))
+                    .thenRequest(1)
+                    .expectNext(httpData(2))
+                    .verifyComplete();
+    }
+
+    @Test
+    void writeAfterClosed() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
             try {
                 for (int i = 0; i < 5; i++) {
                     os.write(i);
                 }
-                os.close(); // should close output stream to complete ByteStreamMessage
+                os.close();
+
+                assertThatThrownBy(() -> os.write(0))
+                        .isInstanceOf(IOException.class)
+                        .hasMessage("Stream closed");
+                assertThatThrownBy(() -> os.write(new byte[] { 0 }, 0, 1))
+                        .isInstanceOf(IOException.class)
+                        .hasMessage("Stream closed");
+                assertThatCode(os::close).doesNotThrowAnyException();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -46,17 +151,83 @@ class ByteStreamMessageOutputStreamTest {
     }
 
     @Test
-    void skip1() {
+    void writeAfterStreamClosed() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
             try {
                 for (int i = 0; i < 5; i++) {
-                    os.write(i);
+                    if (i < 3) {
+                        os.write(i);
+                    } else {
+                        assertThatThrownBy(() -> os.write(0))
+                                .isInstanceOf(IOException.class)
+                                .hasMessage("Stream closed");
+                    }
+                }
+                assertThatCode(os::close).doesNotThrowAnyException();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        StepVerifier.create(byteStreamMessage, 2)
+                    .expectNext(httpData(0), httpData(1))
+                    .then(byteStreamMessage::abort)
+                    .verifyError(AbortedStreamException.class);
+    }
+
+    @Test
+    void writeAfterAborted() {
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(10, 11, 12, 13, 14);
+        final StreamMessage<HttpData> aborted = streamMessage
+                .peek(x -> {
+                    if (x == 13) {
+                        streamMessage.abort();
+                    }
+                })
+                .map(ByteStreamMessageOutputStreamTest::httpData);
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage();
+        final StreamMessage<HttpData> concat = StreamMessage.concat(aborted, byteStreamMessage);
+
+        StepVerifier.create(concat)
+                    .expectNext(httpData(10), httpData(11), httpData(12))
+                    .verifyError(AbortedStreamException.class);
+    }
+
+    @Test
+    void write_error_thrown() {
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                for (int i = 0; i < 5; i++) {
+                    if (i < 3) {
+                        os.write(i);
+                    } else {
+                        throw new RuntimeException();
+                    }
                 }
                 os.close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        }).range(1, Long.MAX_VALUE);
+        });
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(httpData(0), httpData(1), httpData(2))
+                    .verifyError(RuntimeException.class);
+    }
+
+    @Test
+    void range_zeroLength() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage();
+
+        assertThatThrownBy(() -> byteStreamMessage.range(0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("length: 0 (expected: > 0)");
+    }
+
+    @Test
+    void skip1() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage()
+                .range(1, Long.MAX_VALUE);
 
         StepVerifier.create(byteStreamMessage, 1)
                     .expectNext(httpData(1))
@@ -67,7 +238,72 @@ class ByteStreamMessageOutputStreamTest {
                     .verifyComplete();
     }
 
+    @Test
+    void skip1_take2() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage()
+                .range(1, 2);
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(httpData(1))
+                    .thenRequest(1)
+                    .expectNext(httpData(2))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skip0_take3() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage()
+                .range(0, 3);
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(httpData(0))
+                    .thenRequest(1)
+                    .expectNext(httpData(1))
+                    .thenRequest(1)
+                    .expectNext(httpData(2))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skipAll() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage()
+                .range(5, Integer.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyComplete();
+    }
+
+    @Test
+    void skipMost() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage()
+                .range(4, Integer.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(httpData(4))
+                    .verifyComplete();
+    }
+
+    @Test
+    void collectBytes() {
+        final ByteStreamMessage byteStreamMessage = newByteStreamMessage();
+        final byte[] bytes = byteStreamMessage.collectBytes().join();
+        assertThat(bytes).isEqualTo(new byte[] { 0, 1, 2, 3, 4 });
+    }
+
     private static HttpData httpData(int b) {
-        return HttpData.wrap(Unpooled.buffer(1, 1).writeByte(b));
+        return HttpData.copyOf(new byte[] { (byte) b });
+    }
+
+    private static ByteStreamMessage newByteStreamMessage() {
+        return StreamMessage.fromOutputStream(os -> {
+            try {
+                for (int i = 0; i < 5; i++) {
+                    os.write(i);
+                }
+                os.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
@@ -202,7 +202,7 @@ class ByteStreamMessageOutputStreamTest {
     @Test
     void write_error_thrown() {
         final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
-            try (Closeable ignored = os) {
+            try {
                 for (int i = 0; i < 5; i++) {
                     if (i < 3) {
                         os.write(i);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
@@ -189,7 +189,7 @@ class ByteStreamMessageOutputStreamTest {
                 .peek(x -> {
                     if (x == 13) {
                         streamMessage.abort();
-                        await().untilAsserted(() -> assertThat(streamMessage.isOpen()).isFalse());
+                        streamMessage.whenComplete().join();
                     }
                 })
                 .map(ByteStreamMessageOutputStreamTest::httpData);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStreamTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpData;
+
+import io.netty.buffer.Unpooled;
+import reactor.test.StepVerifier;
+
+class ByteStreamMessageOutputStreamTest {
+
+    @Test
+    void readAll() {
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                for (int i = 0; i < 5; i++) {
+                    os.write(i);
+                }
+                os.close(); // should close output stream to complete ByteStreamMessage
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(httpData(0), httpData(1), httpData(2), httpData(3), httpData(4))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skip1() {
+        final ByteStreamMessage byteStreamMessage = StreamMessage.fromOutputStream(os -> {
+            try {
+                for (int i = 0; i < 5; i++) {
+                    os.write(i);
+                }
+                os.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).range(1, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(httpData(1))
+                    .thenRequest(2)
+                    .expectNext(httpData(2), httpData(3))
+                    .thenRequest(1)
+                    .expectNext(httpData(4))
+                    .verifyComplete();
+    }
+
+    private static HttpData httpData(int b) {
+        return HttpData.wrap(Unpooled.buffer(1, 1).writeByte(b));
+    }
+}


### PR DESCRIPTION
**Related Issue** #3092

### Motivation:
```java
public HttpResponse serve(...) {
    var stream = StreaMessage.fromOutputStream(this:startBlockingService);
    return HttpRsponse.builder(headers)
                      .content(stream)
                      .build()
}

private void startBlockingService(OutputStream os) {
    // perform blocking operation
    var data0 = readDataFromSomeWhere0();
    // os.write() will be blocked if the subscriber of the returned HttpResponse hasn't consumed data0 yet.
    os.write(data0);
    var data1 = readDataFromSomeWhere1();
    os.write(data1);
    os.close();
}
```
>   See comment https://github.com/line/armeria/pull/4186#issuecomment-1211699740
- We decide to introduce `StreamMessage.fromOutputStream()` on previous discussion

### Modifications:

- Add `StreamMessage.fromOutputStream()`

### Result:
- You can now use `StreamMessage.fromOutputStream()` to write on `StreamMessage` via `OutputStream`
- ✅ Close #3092 issue
