### PR TITLE
Introduce a `BuiltInProperty` representing the request/response failure cause 

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.util.StringUtil;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -292,6 +293,21 @@ public enum BuiltInProperty {
         }
         if (log.isAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW)) {
             return log.responseContentPreview();
+        }
+        return null;
+    }),
+
+    /**
+     * {@code "res.cause"} - the cause of the response failure represented
+     * by {@link Throwable#printStackTrace()}.
+     * Unavailable if the response has been completed successfully.
+     */
+    RES_CAUSE("res.cause", log -> {
+        if (log.isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
+            final Throwable responseCause = log.responseCause();
+            if (responseCause != null) {
+                return Exceptions.traceText(responseCause);
+            }
         }
         return null;
     }),

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -243,6 +243,21 @@ public enum BuiltInProperty {
     }),
 
     /**
+     * {@code "req.cause"} - the cause of the request failure represented
+     * by {@link Throwable#printStackTrace()}.
+     * Unavailable if the request has been completed successfully.
+     */
+    REQ_CAUSE("req.cause", log -> {
+        if (log.isAvailable(RequestLogProperty.REQUEST_CAUSE)) {
+            final Throwable requestCause = log.requestCause();
+            if (requestCause != null) {
+                return Exceptions.traceText(requestCause);
+            }
+        }
+        return null;
+    }),
+
+    /**
      * {@code "res.status_code"} - the protocol-specific integer representation of the response status code.
      * Unavailable if the current response is not fully sent yet.
      */


### PR DESCRIPTION
Motivation:

MDC properties are useful for logging data in a structured manner.
Currently, when a request/response is successful `req.content`, `res.content` is being filled.
However, there is no structured log which expresses why a request/response failed.

It would also be useful if users can accumulate failure reason via `req.cause`, `res.cause`

Modifications:

- Introduce `req.cause`, `res.cause` which represents the throwable by `Throwable#printStackTrace`

Result:

- Better user experience