### PR TITLE
Fix that reactive health endpoint is not handled correctly

### DIFF
--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     optionalApi libs.dropwizard.metrics.json
 
     implementation libs.spring.boot2.autoconfigure
+    optionalImplementation libs.reactor.core
 
     testImplementation libs.spring.boot2.starter.actuator
     testImplementation libs.spring.boot2.starter.test

--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ReactiveHealthEndpointWebExtensionUtil.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/ReactiveHealthEndpointWebExtensionUtil.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.spring.actuate;
+
+import static com.linecorp.armeria.spring.actuate.WebOperationService.handleResult;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.reactivestreams.Publisher;
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+final class ReactiveHealthEndpointWebExtensionUtil {
+
+    static HttpResponse handleMaybeReactorResult(SimpleHttpCodeStatusMapper statusMapper,
+                                                 ServiceRequestContext ctx, Object result,
+                                                 HttpMethod method) throws Throwable {
+        if (result instanceof Flux) {
+            return handlePublisher(statusMapper, ctx, ((Flux<?>) result).collectList(), method);
+        }
+
+        if (result instanceof Publisher) {
+            return handlePublisher(statusMapper, ctx, (Publisher<?>) result, method);
+        }
+
+        return handleResult(statusMapper, ctx, result, method);
+    }
+
+    private static HttpResponse handlePublisher(SimpleHttpCodeStatusMapper statusMapper,
+                                                ServiceRequestContext ctx, Publisher<?> result,
+                                                HttpMethod method) {
+        final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+        Mono.from(result).subscribe(result0 -> {
+            try {
+                future.complete(handleResult(statusMapper, ctx, result0, method));
+            } catch (Throwable e) {
+                future.completeExceptionally(e);
+            }
+        }, throwable -> {
+            if (throwable instanceof InvalidEndpointRequestException) {
+                future.complete(HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                                ((InvalidEndpointRequestException) throwable).getReason()));
+                return;
+            }
+            future.completeExceptionally(throwable);
+        });
+        return HttpResponse.from(future);
+    }
+
+    private ReactiveHealthEndpointWebExtensionUtil() {}
+}

--- a/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationServiceUtil.java
+++ b/spring/boot2-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationServiceUtil.java
@@ -87,10 +87,10 @@ final class WebOperationServiceUtil {
     }
 
     static void addAdditionalPath(ServerBuilder sb, List<Integer> exposedPorts,
-                                          SimpleHttpCodeStatusMapper statusMapper, WebOperation operation,
-                                          WebOperationRequestPredicate predicate,
-                                          Set<HealthEndpointGroup> additionalGroups,
-                                          @Nullable CorsServiceBuilder cors) {
+                                  SimpleHttpCodeStatusMapper statusMapper, WebOperation operation,
+                                  WebOperationRequestPredicate predicate,
+                                  Set<HealthEndpointGroup> additionalGroups,
+                                  @Nullable CorsServiceBuilder cors) {
         for (HealthEndpointGroup group : additionalGroups) {
             final AdditionalHealthEndpointPath additionalPath = group.getAdditionalPath();
             if (additionalPath != null) {

--- a/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaSpringActuatorReactiveIndicatorTest.java
+++ b/spring/boot2-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ArmeriaSpringActuatorReactiveIndicatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring.web.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.endpoint.ApiVersion;
+import org.springframework.boot.actuate.health.AbstractReactiveHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.spring.web.reactive.ArmeriaSpringActuatorReactiveIndicatorTest.TestConfiguration;
+
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = TestConfiguration.class)
+@ActiveProfiles("test_actuator")
+class ArmeriaSpringActuatorReactiveIndicatorTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> JSON_MAP =
+            new TypeReference<Map<String, Object>>() {};
+
+    private static final AtomicBoolean healthy = new AtomicBoolean(true);
+
+    @SpringBootApplication
+    @Configuration
+    static class TestConfiguration {
+
+        @Component
+        static class TestReactiveHealthIndicator extends AbstractReactiveHealthIndicator {
+
+            @Override
+            protected Mono<Health> doHealthCheck(Health.Builder builder) {
+                return Mono.fromSupplier(() -> {
+                    if (healthy.get()) {
+                        return builder.up().build();
+                    }
+                    return builder.down().build();
+                });
+            }
+        }
+    }
+
+    @LocalServerPort
+    int port;
+
+    private WebClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = WebClient.of("http://127.0.0.1:" + port);
+    }
+
+    @Test
+    void testHealth() throws Exception {
+        AggregatedHttpResponse res = client.get("/internal/actuator/health").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentType().toString()).isEqualTo(ApiVersion.V3.getProducedMimeType().toString());
+        Map<String, Object> values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
+        assertThat(values).containsEntry("status", "UP");
+
+        healthy.set(false);
+
+        res = client.get("/internal/actuator/health").aggregate().get();
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.contentType().toString()).isEqualTo(ApiVersion.V3.getProducedMimeType().toString());
+        values = OBJECT_MAPPER.readValue(res.content().array(), JSON_MAP);
+        assertThat(values).containsEntry("status", "DOWN");
+    }
+}

--- a/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_actuator.yml
+++ b/spring/boot2-webflux-autoconfigure/src/test/resources/config/application-test_actuator.yml
@@ -1,0 +1,11 @@
+armeria:
+  ports:
+    - port: 0
+      protocol: HTTP
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+      base-path: /internal/actuator


### PR DESCRIPTION
Motivation:
If an autoconfigure module is in the classpath, [HealthEndpointWebExtension](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/HealthEndpointWebExtension.java) is used for handling an actuator request.
Whereas, if a WebFlux module is also in the classpath, [ReactiveHealthEndpointWebExtension](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/health/ReactiveHealthEndpointWebExtension.java) is used which returns `Mono`.
We should handle the `Mono` response.

Modifications:
- Handle `Mono` response in `WebOperationService`.

Result:
- Close #4396 
- You can now use Armeria Spring actuator with WebFlux correctly.

Co-authored-by: @DasAmpharos