### PR TITLE
Provide a way to automatically deserialize non-OK JSON response using WebClient and RestClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
@@ -122,14 +122,15 @@ final class AggregatedResponseAs {
             AggregatedHttpResponse response, HttpStatusPredicate predicate) {
         return new InvalidHttpResponseException(
                 response, "status: " + response.status() +
-                          " (expect: the success class (2xx). response: " + response, null);
+                          " (expect: the " + predicate.status().reasonPhrase() + " class (" +
+                          predicate.status().codeAsText() + "). response: " + response, null);
     }
 
     private static InvalidHttpResponseException newInvalidHttpStatusClassResponseException(
             AggregatedHttpResponse response, HttpStatusClassPredicate predicate) {
         return new InvalidHttpResponseException(
                 response, "status: " + response.status() +
-                          " (expect: the success class (2xx). response: " + response, null);
+                          " (expect: the " + predicate.statusClass() + " class response: " + response, null);
     }
 
     @FunctionalInterface

--- a/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
@@ -72,13 +72,7 @@ final class AggregatedResponseAs {
         if (!response.status().isSuccess()) {
             throw newInvalidHttpResponseException(response);
         }
-
-        try {
-            return ResponseEntity.of(response.headers(), decoder.decode(response.content().array()),
-                                     response.trailers());
-        } catch (IOException e) {
-            return Exceptions.throwUnsafely(new InvalidHttpResponseException(response, e));
-        }
+        return createJsonResponseEntity(response, decoder);
     }
 
     private static <T> ResponseEntity<T> newJsonResponseEntity(AggregatedHttpResponse response,
@@ -87,13 +81,7 @@ final class AggregatedResponseAs {
         if (!predicate.test(response.status())) {
             throw newInvalidHttpStatusResponseException(response, predicate);
         }
-
-        try {
-            return ResponseEntity.of(response.headers(), decoder.decode(response.content().array()),
-                                     response.trailers());
-        } catch (IOException e) {
-            return Exceptions.throwUnsafely(new InvalidHttpResponseException(response, e));
-        }
+        return createJsonResponseEntity(response, decoder);
     }
 
     private static <T> ResponseEntity<T> newJsonResponseEntity(AggregatedHttpResponse response,
@@ -102,7 +90,11 @@ final class AggregatedResponseAs {
         if (!predicate.test(response.status().codeClass())) {
             throw newInvalidHttpStatusClassResponseException(response, predicate);
         }
+        return createJsonResponseEntity(response, decoder);
+    }
 
+    private static <T> ResponseEntity<T> createJsonResponseEntity(AggregatedHttpResponse response,
+                                                                  JsonDecoder<T> decoder) {
         try {
             return ResponseEntity.of(response.headers(), decoder.decode(response.content().array()),
                                      response.trailers());

--- a/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
@@ -58,13 +58,53 @@ final class AggregatedResponseAs {
         return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, clazz));
     }
 
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(Class<? extends T> clazz,
+                                                                          ObjectMapper mapper,
+                                                                          HttpStatusPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, clazz),
+                                                 predicate);
+    }
+
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(Class<? extends T> clazz,
+                                                                          ObjectMapper mapper,
+                                                                          HttpStatusClassPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, clazz),
+                                                 predicate);
+    }
+
     static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef) {
         return response -> newJsonResponseEntity(response, bytes -> JacksonUtil.readValue(bytes, typeRef));
     }
 
     static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                                          HttpStatusPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> JacksonUtil.readValue(bytes, typeRef),
+                                                 predicate);
+    }
+
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                                          HttpStatusClassPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> JacksonUtil.readValue(bytes, typeRef),
+                                                 predicate);
+    }
+
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
                                                                           ObjectMapper mapper) {
         return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, typeRef));
+    }
+
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                                          ObjectMapper mapper,
+                                                                          HttpStatusPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, typeRef),
+                                                 predicate);
+    }
+
+    static <T> ResponseAs<AggregatedHttpResponse, ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                                          ObjectMapper mapper,
+                                                                          HttpStatusClassPredicate predicate) {
+        return response -> newJsonResponseEntity(response, bytes -> mapper.readValue(bytes, typeRef),
+                                                 predicate);
     }
 
     private static <T> ResponseEntity<T> newJsonResponseEntity(AggregatedHttpResponse response,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
@@ -18,12 +18,10 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Predicate;
-
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.annotation.Nullable;
 
-public class HttpStatusClassPredicate implements Predicate<HttpStatusClass> {
+final class HttpStatusClassPredicate {
 
     @Nullable
     private final HttpStatusClass statusClass;
@@ -32,8 +30,7 @@ public class HttpStatusClassPredicate implements Predicate<HttpStatusClass> {
         this.statusClass = requireNonNull(statusClass, "statusClass");
     }
 
-    @Override
-    public boolean test(HttpStatusClass statusClass) {
+    boolean test(HttpStatusClass statusClass) {
         return this.statusClass == statusClass;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
@@ -36,4 +36,9 @@ public class HttpStatusClassPredicate implements Predicate<HttpStatusClass> {
     public boolean test(HttpStatusClass statusClass) {
         return this.statusClass == statusClass;
     }
+
+    @Nullable
+    HttpStatusClass statusClass() {
+        return statusClass;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusClassPredicate.java
@@ -20,20 +20,20 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Predicate;
 
-import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.annotation.Nullable;
 
-final class HttpStatusPredicate implements Predicate<HttpStatus> {
+public class HttpStatusClassPredicate implements Predicate<HttpStatusClass> {
 
     @Nullable
-    private final HttpStatus status;
+    private final HttpStatusClass statusClass;
 
-    HttpStatusPredicate(HttpStatus status) {
-        this.status = requireNonNull(status, "status");
+    HttpStatusClassPredicate(HttpStatusClass statusClass) {
+        this.statusClass = requireNonNull(statusClass, "statusClass");
     }
 
     @Override
-    public boolean test(HttpStatus status) {
-        return this.status == status;
+    public boolean test(HttpStatusClass statusClass) {
+        return this.statusClass == statusClass;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
@@ -36,4 +36,9 @@ final class HttpStatusPredicate implements Predicate<HttpStatus> {
     public boolean test(HttpStatus status) {
         return this.status == status;
     }
+
+    @Nullable
+    HttpStatus status() {
+        return status;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
@@ -47,14 +47,4 @@ final class HttpStatusPredicate implements Predicate<HttpStatus> {
         assert statusClass != null;
         return status.codeClass() == statusClass;
     }
-
-    @Nullable
-    HttpStatus status() {
-        return status;
-    }
-
-    @Nullable
-    HttpStatusClass statusClass() {
-        return statusClass;
-    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
@@ -1,0 +1,44 @@
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+final class HttpStatusPredicate implements Predicate<HttpStatus> {
+
+    @Nullable
+    private HttpStatus status;
+    @Nullable
+    private HttpStatusClass statusClass;
+
+    HttpStatusPredicate(HttpStatus status) {
+        this.status = requireNonNull(status, "status");
+    }
+
+    HttpStatusPredicate(HttpStatusClass statusClass) {
+        this.statusClass = requireNonNull(statusClass, "statusClass");
+    }
+
+    @Override
+    public boolean test(HttpStatus status) {
+        if (this.status != null) {
+            return this.status.equals(status);
+        }
+        assert statusClass != null;
+        return status.codeClass() == statusClass;
+    }
+
+    @Nullable
+    HttpStatus status() {
+        return status;
+    }
+
+    @Nullable
+    HttpStatusClass statusClass() {
+        return statusClass;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpStatusPredicate.java
@@ -18,12 +18,10 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Predicate;
-
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 
-final class HttpStatusPredicate implements Predicate<HttpStatus> {
+final class HttpStatusPredicate {
 
     @Nullable
     private final HttpStatus status;
@@ -32,8 +30,7 @@ final class HttpStatusPredicate implements Predicate<HttpStatus> {
         this.status = requireNonNull(status, "status");
     }
 
-    @Override
-    public boolean test(HttpStatus status) {
+    boolean test(HttpStatus status) {
         return this.status == status;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseAs.java
@@ -105,6 +105,22 @@ public interface ResponseAs<T, R> {
         return aggregateAndConvert(AggregatedResponseAs.json(clazz));
     }
 
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(Class<? extends T> clazz,
+                                                        HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(clazz, predicate));
+    }
+
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(Class<? extends T> clazz,
+                                                        HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(clazz, predicate));
+    }
+
     /**
      * Aggregates an {@link HttpResponse} and deserializes the JSON {@link AggregatedHttpResponse#content()}
      * into the specified non-container type using the specified {@link ObjectMapper}.

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseAs.java
@@ -135,6 +135,24 @@ public interface ResponseAs<T, R> {
         return aggregateAndConvert(AggregatedResponseAs.json(clazz, mapper));
     }
 
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(Class<? extends T> clazz, ObjectMapper mapper,
+                                                        HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(clazz, mapper, predicate));
+    }
+
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(Class<? extends T> clazz, ObjectMapper mapper,
+                                                        HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(clazz, mapper, predicate));
+    }
+
     /**
      * Aggregates an {@link HttpResponse} and deserializes the JSON {@link AggregatedHttpResponse#content()}
      * into the specified Java type using the default {@link ObjectMapper}.
@@ -147,6 +165,22 @@ public interface ResponseAs<T, R> {
         return aggregateAndConvert(AggregatedResponseAs.json(typeRef));
     }
 
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                        HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(typeRef, predicate));
+    }
+
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                        HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(typeRef, predicate));
+    }
+
     /**
      * Aggregates an {@link HttpResponse} and deserializes the JSON {@link AggregatedHttpResponse#content()}
      * into the specified Java type using the specified {@link ObjectMapper}.
@@ -157,6 +191,24 @@ public interface ResponseAs<T, R> {
         requireNonNull(typeRef, "typeRef");
         requireNonNull(mapper, "mapper");
         return aggregateAndConvert(AggregatedResponseAs.json(typeRef, mapper));
+    }
+
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                        ObjectMapper mapper, HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(typeRef, mapper, predicate));
+    }
+
+    @UnstableApi
+    static <T> FutureResponseAs<ResponseEntity<T>> json(TypeReference<? extends T> typeRef,
+                                                        ObjectMapper mapper, HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return aggregateAndConvert(AggregatedResponseAs.json(typeRef, mapper, predicate));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -72,6 +72,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.<br>
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
                                                             HttpStatus httpStatus) {
         requireNonNull(clazz, "clazz");
@@ -81,6 +88,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
                                                             HttpStatusClass httpStatusClass) {
         requireNonNull(clazz, "clazz");
@@ -90,6 +104,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
                                                             HttpStatusPredicate predicate) {
         requireNonNull(clazz, "clazz");
@@ -98,6 +119,14 @@ public final class RestClientPreparation implements RequestPreparationSetters {
                 delegate.asJson(clazz, predicate).execute();
         return cast(response);
     }
+
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
                                                             HttpStatusClassPredicate predicate) {
         requireNonNull(clazz, "clazz");
@@ -120,6 +149,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed. 
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
                                                             HttpStatus httpStatus) {
         requireNonNull(clazz, "clazz");
@@ -130,6 +164,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed. 
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
                                                             HttpStatusClass httpStatusClass) {
         requireNonNull(clazz, "clazz");
@@ -140,6 +179,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed. 
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
                                                             HttpStatusPredicate predicate) {
         requireNonNull(clazz, "clazz");
@@ -150,6 +194,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed. 
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
                                                             HttpStatusClassPredicate predicate) {
         requireNonNull(clazz, "clazz");
@@ -173,6 +222,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed. 
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             HttpStatus httpStatus) {
         requireNonNull(typeRef, "typeRef");
@@ -182,6 +238,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed. 
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             HttpStatusClass httpStatusClass) {
         requireNonNull(typeRef, "typeRef");
@@ -191,6 +254,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed. 
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             HttpStatusPredicate predicate) {
         requireNonNull(typeRef, "typeRef");
@@ -200,6 +270,13 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed. 
+     *
+     * @see JacksonObjectMapperProvider
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             HttpStatusClassPredicate predicate) {
         requireNonNull(typeRef, "typeRef");
@@ -208,8 +285,7 @@ public final class RestClientPreparation implements RequestPreparationSetters {
                 delegate.asJson(typeRef, predicate).execute();
         return cast(response);
     }
-
-
+    
     /**
      * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
      * {@link ObjectMapper}.
@@ -223,6 +299,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             ObjectMapper mapper,
                                                             HttpStatus httpStatus) {
@@ -234,6 +315,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             ObjectMapper mapper,
                                                             HttpStatusClass httpStatusClass) {
@@ -245,6 +331,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             ObjectMapper mapper,
                                                             HttpStatusPredicate predicate) {
@@ -256,6 +347,11 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    /**
+     * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     */
     public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
                                                             ObjectMapper mapper,
                                                             HttpStatusClassPredicate predicate) {

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -35,6 +35,8 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.JacksonObjectMapperProvider;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseEntity;
@@ -70,6 +72,42 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
+                                                            HttpStatus httpStatus) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(httpStatus, "httpStatus");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, httpStatus).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
+                                                            HttpStatusClass httpStatusClass) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, httpStatusClass).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
+                                                            HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, predicate).execute();
+        return cast(response);
+    }
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz,
+                                                            HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, predicate).execute();
+        return cast(response);
+    }
+
+
     /**
      * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
      * {@link ObjectMapper}.
@@ -79,6 +117,46 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         requireNonNull(mapper, "mapper");
         final CompletableFuture<? extends ResponseEntity<? extends T>> response =
                 delegate.asJson(clazz, mapper).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
+                                                            HttpStatus httpStatus) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(httpStatus, "httpStatus");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, mapper, httpStatus).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
+                                                            HttpStatusClass httpStatusClass) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, mapper, httpStatusClass).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
+                                                            HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, mapper, predicate).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(Class<? extends T> clazz, ObjectMapper mapper,
+                                                            HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(clazz, mapper, predicate).execute();
         return cast(response);
     }
 
@@ -95,6 +173,43 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         return cast(response);
     }
 
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            HttpStatus httpStatus) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(httpStatus, "httpStatus");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, httpStatus).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            HttpStatusClass httpStatusClass) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, httpStatusClass).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, predicate).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, predicate).execute();
+        return cast(response);
+    }
+
+
     /**
      * Sends the HTTP request and converts the JSON response body as the {@code T} object using the specified
      * {@link ObjectMapper}.
@@ -105,6 +220,50 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         requireNonNull(mapper, "mapper");
         final CompletableFuture<? extends ResponseEntity<? extends T>> response =
                 delegate.asJson(typeRef, mapper).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            ObjectMapper mapper,
+                                                            HttpStatus httpStatus) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(httpStatus, "httpStatus");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, mapper, httpStatus).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            ObjectMapper mapper,
+                                                            HttpStatusClass httpStatusClass) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, mapper, httpStatusClass).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            ObjectMapper mapper,
+                                                            HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, mapper, predicate).execute();
+        return cast(response);
+    }
+
+    public <T> CompletableFuture<ResponseEntity<T>> execute(TypeReference<? extends T> typeRef,
+                                                            ObjectMapper mapper,
+                                                            HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        final CompletableFuture<? extends ResponseEntity<? extends T>> response =
+                delegate.asJson(typeRef, mapper, predicate).execute();
         return cast(response);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -271,7 +271,43 @@ public final class WebClientRequestPreparation
                                                                               ObjectMapper mapper) {
         requireNonNull(clazz, "clazz");
         requireNonNull(mapper, "mapper");
-        return asEntity(ResponseAs.json(clazz));
+        return asEntity(ResponseAs.json(clazz, mapper));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              ObjectMapper mapper,
+                                                                              HttpStatus httpStatus) {
+        requireNonNull(httpStatus, "httpStatus");
+        return asJson(clazz, mapper, new HttpStatusPredicate(httpStatus));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              ObjectMapper mapper,
+                                                                              HttpStatusClass httpStatusClass) {
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        return asJson(clazz, mapper, new HttpStatusClassPredicate(httpStatusClass));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              ObjectMapper mapper,
+                                                                              HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(clazz, mapper, predicate));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              ObjectMapper mapper,
+                                                                              HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(clazz, mapper, predicate));
     }
 
     /**
@@ -300,6 +336,36 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(typeRef));
     }
 
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, HttpStatus httpStatus) {
+        requireNonNull(httpStatus, "httpStatus");
+        return asJson(typeRef, new HttpStatusPredicate(httpStatus));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, HttpStatusClass httpStatusClass) {
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        return asJson(typeRef, new HttpStatusClassPredicate(httpStatusClass));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(typeRef, predicate));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(typeRef, predicate));
+    }
+
     /**
      * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the
      * specified {@link ObjectMapper}. This method is useful when you want to deserialize the content into a
@@ -325,6 +391,38 @@ public final class WebClientRequestPreparation
         requireNonNull(typeRef, "typeRef");
         requireNonNull(mapper, "mapper");
         return asEntity(ResponseAs.json(typeRef, mapper));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatus httpStatus) {
+        requireNonNull(httpStatus, "httpStatus");
+        return asJson(typeRef, mapper, new HttpStatusPredicate(httpStatus));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusClass httpStatusClass) {
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        return asJson(typeRef, mapper, new HttpStatusClassPredicate(httpStatusClass));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(typeRef, mapper, predicate));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
+            TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusClassPredicate predicate) {
+        requireNonNull(typeRef, "typeRef");
+        requireNonNull(mapper, "mapper");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(typeRef, mapper, predicate));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.JacksonObjectMapperProvider;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseEntity;
@@ -211,6 +212,36 @@ public final class WebClientRequestPreparation
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz) {
         requireNonNull(clazz, "clazz");
         return asEntity(ResponseAs.json(clazz));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              HttpStatus httpStatus) {
+        requireNonNull(httpStatus, "httpStatus");
+        return asJson(clazz, new HttpStatusPredicate(httpStatus));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              HttpStatusClass httpStatusClass) {
+        requireNonNull(httpStatusClass, "httpStatusClass");
+        return asJson(clazz, new HttpStatusClassPredicate(httpStatusClass));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              HttpStatusPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(clazz, predicate));
+    }
+
+    @UnstableApi
+    public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
+                                                                              HttpStatusClassPredicate predicate) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(predicate, "predicate");
+        return asEntity(ResponseAs.json(clazz, predicate));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -214,6 +214,28 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(clazz));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the default {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, HttpStatus.INTERNAL_SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, HttpStatus)} for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               HttpStatus httpStatus) {
@@ -221,6 +243,28 @@ public final class WebClientRequestPreparation
         return asJson(clazz, new HttpStatusPredicate(httpStatus));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the default {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, HttpStatusClass.SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, HttpStatusClass)} for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               HttpStatusClass httpStatusClass) {
@@ -228,6 +272,31 @@ public final class WebClientRequestPreparation
         return asJson(clazz, new HttpStatusClassPredicate(httpStatusClass));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the default {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class,
+     *                   new HttpStatusPredicate(HttpStatus.INTERNAL_SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, HttpStatusPredicate)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} given as a parameter of
+     *                                      {@link HttpStatusPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               HttpStatusPredicate predicate) {
@@ -236,6 +305,31 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(clazz, predicate));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the default {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class,
+     *                   new HttpStatusClassPredicate(HttpStatusClass.SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, HttpStatusClassPredicate)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} given as a parameter of
+     *                                      {@link HttpStatusClassPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               HttpStatusClassPredicate predicate) {
@@ -274,6 +368,29 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(clazz, mapper));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the specified {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, mapper, HttpStatus.INTERNAL_SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, ObjectMapper, HttpStatus)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               ObjectMapper mapper,
@@ -282,6 +399,29 @@ public final class WebClientRequestPreparation
         return asJson(clazz, mapper, new HttpStatusPredicate(httpStatus));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the specified {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, mapper, HttpStatusClass.SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, ObjectMapper, HttpStatusClass)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               ObjectMapper mapper,
@@ -290,6 +430,31 @@ public final class WebClientRequestPreparation
         return asJson(clazz, mapper, new HttpStatusClassPredicate(httpStatusClass));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the specified {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, mapper,
+     *                   new HttpStatusPredicate(HttpStatus.INTERNAL_SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, ObjectMapper, HttpStatusPredicate)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} given as a parameter of
+     *                                      {@link HttpStatusPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               ObjectMapper mapper,
@@ -300,6 +465,31 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(clazz, mapper, predicate));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified non-container type using
+     * the specified {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<MyObject>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(MyObject.class, mapper,
+     *                   new HttpStatusClassPredicate(HttpStatusClass.SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * <p>Note that this method should NOT be used if the result type is a container such as
+     * {@link Collection} or {@link Map}. Use {@link #asJson(TypeReference, ObjectMapper, HttpStatusClassPredicate)}
+     * for the container type.
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} given as a parameter of
+     *                                      {@link HttpStatusClassPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(Class<? extends T> clazz,
                                                                               ObjectMapper mapper,
@@ -336,6 +526,27 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(typeRef));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a container
+     * type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, HttpStatus.INTERNAL_SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, HttpStatus httpStatus) {
@@ -343,6 +554,27 @@ public final class WebClientRequestPreparation
         return asJson(typeRef, new HttpStatusPredicate(httpStatus));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a container
+     * type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, HttpStatusClass.SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, HttpStatusClass httpStatusClass) {
@@ -350,6 +582,29 @@ public final class WebClientRequestPreparation
         return asJson(typeRef, new HttpStatusClassPredicate(httpStatusClass));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a container
+     * type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {},
+     *                   new HttpStatusPredicate(HttpStatus.INTERNAL_SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} given as a parameter of
+     *                                      {@link HttpStatusPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, HttpStatusPredicate predicate) {
@@ -358,6 +613,29 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(typeRef, predicate));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the default
+     * {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a container
+     * type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {},
+     *                   new HttpStatusClassPredicate(HttpStatusClass.SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} given as a parameter of
+     *                                      {@link HttpStatusClassPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     * @see JacksonObjectMapperProvider
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, HttpStatusClassPredicate predicate) {
@@ -393,6 +671,27 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(typeRef, mapper));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the
+     * specified {@link ObjectMapper}.
+     * {@link HttpStatus} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a
+     * container type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, mapper, HttpStatus.INTERNAL_SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatus httpStatus) {
@@ -400,6 +699,27 @@ public final class WebClientRequestPreparation
         return asJson(typeRef, mapper, new HttpStatusPredicate(httpStatus));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the
+     * specified {@link ObjectMapper}.
+     * {@link HttpStatusClass} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a
+     * container type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, mapper, HttpStatusClass.SERVER_ERROR)
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusClass httpStatusClass) {
@@ -407,6 +727,29 @@ public final class WebClientRequestPreparation
         return asJson(typeRef, mapper, new HttpStatusClassPredicate(httpStatusClass));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the
+     * specified {@link ObjectMapper}.
+     * {@link HttpStatusPredicate} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a
+     * container type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, mapper,
+     *                   new HttpStatusPredicate(HttpStatus.INTERNAL_SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatus} of the response is not
+     *                                      same to {@link HttpStatus} given as a parameter of
+     *                                      {@link HttpStatusPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusPredicate predicate) {
@@ -416,6 +759,29 @@ public final class WebClientRequestPreparation
         return asEntity(ResponseAs.json(typeRef, mapper, predicate));
     }
 
+    /**
+     * Deserializes the JSON content of the {@link HttpResponse} into the specified Java type using the
+     * specified {@link ObjectMapper}.
+     * {@link HttpStatusClassPredicate} type argument specify what type of response is allowed.
+     * This method is useful when you want to deserialize the content into a
+     * container type such as {@link List} and {@link Map}.
+     * For example:
+     * <pre>{@code
+     * ObjectMapper mapper = ...;
+     * WebClient client = WebClient.of("https://api.example.com");
+     * CompletableFuture<ResponseEntity<List<MyObject>>> response =
+     *     client.prepare()
+     *           .get("/v1/items/1")
+     *           .asJson(new TypeReference<List<MyObject>> {}, mapper,
+     *                   new HttpStatusClassPredicate(HttpStatusClass.SERVER_ERROR))
+     *           .execute();
+     * }</pre>
+     *
+     * @throws InvalidHttpResponseException if the {@link HttpStatusClass} of the response is not
+     *                                      same to {@link HttpStatusClass} given as a parameter of
+     *                                      {@link HttpStatusClassPredicate} type argument or fails to decode
+     *                                      the response body into the result type.
+     */
     @UnstableApi
     public <T> FutureTransformingRequestPreparation<ResponseEntity<T>> asJson(
             TypeReference<? extends T> typeRef, ObjectMapper mapper, HttpStatusClassPredicate predicate) {

--- a/core/src/test/java/com/linecorp/armeria/client/AggregatedResponseAsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/AggregatedResponseAsTest.java
@@ -192,6 +192,68 @@ class AggregatedResponseAsTest {
     }
 
     @Test
+    void jsonObject_customMapper_withHttpStatusPredicate_status200() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers, HttpData.ofUtf8("{ 'id': 10 }"));
+
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class, mapper, new HttpStatusPredicate(HttpStatus.valueOf(200))).as(response);
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_customMapper_withHttpStatusPredicate_status500() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers_statusCode500, HttpData.ofUtf8("{ 'id': 10 }"));
+
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class, mapper, new HttpStatusPredicate(HttpStatus.valueOf(500))).as(response);
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_customMapper_withHttpStatusClassPredicate_status200() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers, HttpData.ofUtf8("{ 'id': 10 }"));
+
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class, mapper,
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))).as(response);
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_customMapper_withHttpStatusClassPredicate_status500() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers_statusCode500, HttpData.ofUtf8("{ 'id': 10 }"));
+
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class, mapper,
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))).as(response);
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
     void jsonGeneric() throws JsonProcessingException {
         final MyObject myObject = new MyObject();
         myObject.setId(10);
@@ -205,6 +267,64 @@ class AggregatedResponseAsTest {
     }
 
     @Test
+    void jsonGeneric_withHttpStatusPredicate_status200() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(ImmutableList.of(myObject));
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers, HttpData.wrap(content));
+
+        final ResponseEntity<List<MyObject>> entity = AggregatedResponseAs.json(
+                new TypeReference<List<MyObject>>() {},
+                new HttpStatusPredicate(HttpStatus.valueOf(200))).as(response);
+        final List<MyObject> objects = entity.content();
+        assertThat(objects).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_withHttpStatusPredicate_status500() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(ImmutableList.of(myObject));
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers_statusCode500,
+                                                                          HttpData.wrap(content));
+
+        final ResponseEntity<List<MyObject>> entity = AggregatedResponseAs.json(
+                new TypeReference<List<MyObject>>() {},
+                new HttpStatusPredicate(HttpStatus.valueOf(500))).as(response);
+        final List<MyObject> objects = entity.content();
+        assertThat(objects).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_withHttpStatusClassPredicate_status200() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(ImmutableList.of(myObject));
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers, HttpData.wrap(content));
+
+        final ResponseEntity<List<MyObject>> entity = AggregatedResponseAs.json(
+                new TypeReference<List<MyObject>>() {},
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))).as(response);
+        final List<MyObject> objects = entity.content();
+        assertThat(objects).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_withHttpStatusClassPredicate_status500() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(ImmutableList.of(myObject));
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers_statusCode500,
+                                                                          HttpData.wrap(content));
+
+        final ResponseEntity<List<MyObject>> entity = AggregatedResponseAs.json(
+                new TypeReference<List<MyObject>>() {},
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))).as(response);
+        final List<MyObject> objects = entity.content();
+        assertThat(objects).containsExactly(myObject);
+    }
+
+    @Test
     void jsonGeneric_customMapper() {
         final AggregatedHttpResponse response =
                 AggregatedHttpResponse.of(headers, HttpData.ofUtf8("[{ 'id': 10 }]"));
@@ -213,6 +333,72 @@ class AggregatedResponseAsTest {
                                             .build();
         final ResponseEntity<List<MyObject>> entity =
                 AggregatedResponseAs.json(new TypeReference<List<MyObject>>() {}, mapper).as(response);
+        final List<MyObject> content = entity.content();
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(content).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_customMapper_withHttpStatusPredicate_status200() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers, HttpData.ofUtf8("[{ 'id': 10 }]"));
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<List<MyObject>> entity =
+                AggregatedResponseAs.json(new TypeReference<List<MyObject>>() {}, mapper,
+                                          new HttpStatusPredicate(HttpStatus.valueOf(200))).as(response);
+        final List<MyObject> content = entity.content();
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(content).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_customMapper_withHttpStatusPredicate_status500() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers_statusCode500, HttpData.ofUtf8("[{ 'id': 10 }]"));
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<List<MyObject>> entity =
+                AggregatedResponseAs.json(new TypeReference<List<MyObject>>() {}, mapper,
+                                          new HttpStatusPredicate(HttpStatus.valueOf(500))).as(response);
+        final List<MyObject> content = entity.content();
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(content).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_customMapper_withHttpStatusClassPredicate_status200() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers, HttpData.ofUtf8("[{ 'id': 10 }]"));
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<List<MyObject>> entity =
+                AggregatedResponseAs.json(
+                        new TypeReference<List<MyObject>>() {}, mapper,
+                        new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))).as(response);
+        final List<MyObject> content = entity.content();
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        assertThat(content).containsExactly(myObject);
+    }
+
+    @Test
+    void jsonGeneric_customMapper_withHttpStatusClassPredicate_status500() {
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(headers_statusCode500, HttpData.ofUtf8("[{ 'id': 10 }]"));
+        final JsonMapper mapper = JsonMapper.builder()
+                                            .enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+                                            .build();
+        final ResponseEntity<List<MyObject>> entity =
+                AggregatedResponseAs.json(
+                        new TypeReference<List<MyObject>>() {}, mapper,
+                        new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))).as(response);
         final List<MyObject> content = entity.content();
         final MyObject myObject = new MyObject();
         myObject.setId(10);

--- a/core/src/test/java/com/linecorp/armeria/client/AggregatedResponseAsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/AggregatedResponseAsTest.java
@@ -32,6 +32,8 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.ResponseAsTest.MyObject;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.internal.common.JacksonUtil;
@@ -39,6 +41,7 @@ import com.linecorp.armeria.internal.common.JacksonUtil;
 class AggregatedResponseAsTest {
 
     private final ResponseHeaders headers = ResponseHeaders.of(200);
+    private final ResponseHeaders headers_statusCode500 = ResponseHeaders.of(500);
 
     @Test
     void bytes() {
@@ -68,6 +71,60 @@ class AggregatedResponseAsTest {
     }
 
     @Test
+    void jsonObject_withHttpStatusPredicate_status200() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers, HttpData.wrap(content));
+
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusPredicate(HttpStatus.valueOf(200))).as(response);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_withHttpStatusPredicate_status500() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers_statusCode500,
+                                                                          HttpData.wrap(content));
+
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusPredicate(HttpStatus.valueOf(500))).as(response);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_withHttpStatusClassPredicate_status200() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers, HttpData.wrap(content));
+
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))).as(response);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
+    void jsonObject_withHttpStatusClassPredicate_status500() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response = AggregatedHttpResponse.of(headers_statusCode500,
+                                                                          HttpData.wrap(content));
+
+        final ResponseEntity<MyObject> entity = AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))).as(response);
+        assertThat(entity.content()).isEqualTo(myObject);
+    }
+
+    @Test
     void jsonObject_withInvalidStatus() throws JsonProcessingException {
         final MyObject myObject = new MyObject();
         myObject.setId(10);
@@ -78,6 +135,36 @@ class AggregatedResponseAsTest {
         assertThatThrownBy(() -> AggregatedResponseAs.json(MyObject.class).as(response))
                 .isInstanceOf(InvalidHttpResponseException.class)
                 .hasMessageContaining("(expect: the success class (2xx)");
+    }
+
+    @Test
+    void jsonObject_withInvalidHttpStatusPredicate() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(ResponseHeaders.of(200), HttpData.wrap(content));
+
+        assertThatThrownBy(() -> AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusPredicate(HttpStatus.valueOf(500))).as(response))
+                .isInstanceOf(InvalidHttpResponseException.class)
+                .hasMessageContaining("status: 200 OK (expect: the Internal Server Error class (500)");
+    }
+
+    @Test
+    void jsonObject_withInvalidHttpStatusClassPredicate() throws JsonProcessingException {
+        final MyObject myObject = new MyObject();
+        myObject.setId(10);
+        final byte[] content = JacksonUtil.writeValueAsBytes(myObject);
+        final AggregatedHttpResponse response =
+                AggregatedHttpResponse.of(ResponseHeaders.of(200), HttpData.wrap(content));
+
+        assertThatThrownBy(() -> AggregatedResponseAs.json(
+                MyObject.class,
+                new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))).as(response))
+                .isInstanceOf(InvalidHttpResponseException.class)
+                .hasMessageContaining("status: 200 OK (expect: the SERVER_ERROR class response");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/HttpStatusClassPredicateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpStatusClassPredicateTest.java
@@ -55,4 +55,10 @@ class HttpStatusClassPredicateTest {
         assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(100))
                            .test(HttpStatusClass.valueOf(300))).isFalse();
     }
+
+    @Test
+    public void statusClassMethodReturnHttpStatusClass() {
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(200)).statusClass())
+                .isEqualTo(HttpStatusClass.valueOf(200));
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpStatusClassPredicateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpStatusClassPredicateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpStatusClass;
+
+class HttpStatusClassPredicateTest {
+
+    @Test
+    public void httpStatusClassIsEqualToTestArgument() {
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatusClass.valueOf(100))).isTrue();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))
+                           .test(HttpStatusClass.valueOf(200))).isTrue();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(300))
+                           .test(HttpStatusClass.valueOf(300))).isTrue();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(400))
+                           .test(HttpStatusClass.valueOf(400))).isTrue();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(500))
+                           .test(HttpStatusClass.valueOf(500))).isTrue();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatusClass.valueOf(600))).isTrue();
+    }
+
+    @Test
+    public void httpStatusClassIsNotEqualToTestArgument() {
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(200))
+                           .test(HttpStatusClass.valueOf(300))).isFalse();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(300))
+                           .test(HttpStatusClass.valueOf(200))).isFalse();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatusClass.valueOf(600))).isFalse();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatusClass.valueOf(100))).isFalse();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatusClass.valueOf(200))).isFalse();
+        assertThat(new HttpStatusClassPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatusClass.valueOf(300))).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 
 class HttpStatusPredicateTest {
 
@@ -52,38 +51,6 @@ class HttpStatusPredicateTest {
         assertThat(new HttpStatusPredicate(HttpStatus.valueOf(600))
                            .test(HttpStatus.valueOf(200))).isFalse();
         assertThat(new HttpStatusPredicate(HttpStatus.valueOf(100))
-                           .test(HttpStatus.valueOf(300))).isFalse();
-    }
-
-    @Test
-    public void httpStatusClassIsEqualToTestArgument() {
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
-                           .test(HttpStatus.valueOf(100))).isTrue();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(200))
-                           .test(HttpStatus.valueOf(200))).isTrue();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(300))
-                           .test(HttpStatus.valueOf(300))).isTrue();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(400))
-                           .test(HttpStatus.valueOf(400))).isTrue();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(500))
-                           .test(HttpStatus.valueOf(500))).isTrue();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
-                           .test(HttpStatus.valueOf(600))).isTrue();
-    }
-
-    @Test
-    public void httpStatusClassIsNotEqualToTestArgument() {
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(200))
-                           .test(HttpStatus.valueOf(300))).isFalse();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(300))
-                           .test(HttpStatus.valueOf(200))).isFalse();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
-                           .test(HttpStatus.valueOf(600))).isFalse();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
-                           .test(HttpStatus.valueOf(100))).isFalse();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
-                           .test(HttpStatus.valueOf(200))).isFalse();
-        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
                            .test(HttpStatus.valueOf(300))).isFalse();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+
+class HttpStatusPredicateTest {
+
+    @Test
+    public void httpStatusIsEqualToTestArgument() {
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(200))
+                           .test(HttpStatus.valueOf(200))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(300))
+                           .test(HttpStatus.valueOf(300))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(400))
+                           .test(HttpStatus.valueOf(400))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(500))
+                           .test(HttpStatus.valueOf(500))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(600))
+                           .test(HttpStatus.valueOf(600))).isTrue();
+    }
+
+    @Test
+    public void httpStatusIsNotEqualToTestArgument() {
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(200))
+                           .test(HttpStatus.valueOf(300))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(300))
+                           .test(HttpStatus.valueOf(200))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(100))
+                           .test(HttpStatus.valueOf(600))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(600))
+                           .test(HttpStatus.valueOf(100))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(600))
+                           .test(HttpStatus.valueOf(200))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(100))
+                           .test(HttpStatus.valueOf(300))).isFalse();
+    }
+
+    @Test
+    public void httpStatusClassIsEqualToTestArgument() {
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatus.valueOf(100))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(200))
+                           .test(HttpStatus.valueOf(200))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(300))
+                           .test(HttpStatus.valueOf(300))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(400))
+                           .test(HttpStatus.valueOf(400))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(500))
+                           .test(HttpStatus.valueOf(500))).isTrue();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatus.valueOf(600))).isTrue();
+    }
+
+    @Test
+    public void httpStatusClassIsNotEqualToTestArgument() {
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(200))
+                           .test(HttpStatus.valueOf(300))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(300))
+                           .test(HttpStatus.valueOf(200))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatus.valueOf(600))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatus.valueOf(100))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(600))
+                           .test(HttpStatus.valueOf(200))).isFalse();
+        assertThat(new HttpStatusPredicate(HttpStatusClass.valueOf(100))
+                           .test(HttpStatus.valueOf(300))).isFalse();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpStatusPredicateTest.java
@@ -53,4 +53,10 @@ class HttpStatusPredicateTest {
         assertThat(new HttpStatusPredicate(HttpStatus.valueOf(100))
                            .test(HttpStatus.valueOf(300))).isFalse();
     }
+
+    @Test
+    public void statusMethodReturnHttpStatus() {
+        assertThat(new HttpStatusPredicate(HttpStatus.valueOf(200)).status())
+                .isEqualTo(HttpStatus.valueOf(200));
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientPreparationExchangeTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientPreparationExchangeTypeTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.params.provider.CsvSource;
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -108,6 +110,28 @@ class WebClientPreparationExchangeTypeTest {
                   .post("/json")
                   .content("foo")
                   .asJson(String.class)
+                  .execute();
+        }).isEqualTo(ExchangeType.UNARY);
+    }
+
+    @Test
+    void responseJson_withHttpStatus() {
+        assertExchangeType(() -> {
+            client.prepare()
+                  .post("/json")
+                  .content("foo")
+                  .asJson(String.class, HttpStatus.valueOf(200))
+                  .execute();
+        }).isEqualTo(ExchangeType.UNARY);
+    }
+
+    @Test
+    void responseJson_withHttpStatusClass() {
+        assertExchangeType(() -> {
+            client.prepare()
+                  .post("/json")
+                  .content("foo")
+                  .asJson(String.class, HttpStatusClass.valueOf(200))
                   .execute();
         }).isEqualTo(ExchangeType.UNARY);
     }


### PR DESCRIPTION
Motivation:

Please refer to #4382 

Modifications:

- Add `HttpStatusPredicate` and `HttpStatusClassPredicate` class to deserialize non-OK JSON response
- Add some methods to specify what type of response is allowed

Result:

- Closes #4382 
- Users can deserialize non-OK JSON response like the following

```java
// WebClient
CompletableFuture<ResponseEntity<MyObject>> response =
    client.prepare()
          .get("/v1/items/1")
          .asJson(MyObject.class, HttpStatus.INTERNAL_SERVER_ERROR)
          .execute();

// RestClient
CompletableFuture<ResponseEntity<MyObject>> response = 
    client.get("/v1/items/1")
          .execute(MyObject.class, HttpStatus.INTERNAL_SERVER_ERROR)
```
