### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,11 +148,7 @@ configure(projectsWithFlags('java')) {
         // Logging
         implementation libs.slf4j.api
         testImplementation libs.slf4j.jul.to.slf4j
-
-        // Dropwizard has its own logback dependency, so don't need to add it.
-        if (!project.name.contains('dropwizard')) {
-            testImplementation libs.logback
-        }
+        testImplementation libs.logback
         testRuntimeOnly libs.slf4j.jcl.over.slf4j
         testRuntimeOnly libs.slf4j.log4j.over.slf4j
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ configure(projectsWithFlags('java')) {
         implementation libs.slf4j.api
         testImplementation libs.slf4j.jul.to.slf4j
 
-        // TODO(ikhoon): Remove this condition when Dropwizard supports Logback 1.3.0 or above.
+        // Dropwizard has its own logback dependency, so don't need to add it.
         if (!project.name.contains('dropwizard')) {
             testImplementation libs.logback
         }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 buildscript {
     dependencies {
-        classpath 'org.jsoup:jsoup:1.14.3'
+        classpath libs.jsoup
     }
 }
 
@@ -148,7 +148,11 @@ configure(projectsWithFlags('java')) {
         // Logging
         implementation libs.slf4j.api
         testImplementation libs.slf4j.jul.to.slf4j
-        testImplementation libs.logback
+
+        // TODO(ikhoon): Remove this condition when Dropwizard supports Logback 1.3.0 or above.
+        if (!project.name.contains('dropwizard')) {
+            testImplementation libs.logback
+        }
         testRuntimeOnly libs.slf4j.jcl.over.slf4j
         testRuntimeOnly libs.slf4j.log4j.over.slf4j
 

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -1,14 +1,14 @@
 [versions]
 akka = "2.6.19"
 bouncycastle = "1.70"
-brotli4j = "1.7.1"
+brotli4j = "1.8.0"
 curator = "5.3.0"
-dagger = "2.43.1"
+dagger = "2.43.2"
 dropwizard1 = "1.3.29"
 dropwizard2 = "2.1.1"
-errorprone = "2.14.0"
+errorprone = "2.15.0"
 eureka = "1.10.17"
-graphql-kotlin = "6.1.0"
+graphql-kotlin = "6.2.2"
 grpc-kotlin = "1.3.0"
 groovy = "3.0.5"
 guava = "31.1-jre"
@@ -17,12 +17,12 @@ jetty93 = '9.3.30.v20211001'
 jetty94 = "9.4.48.v20220622"
 jmh = "1.35"
 json-unit = "2.35.0"
-junit5 = "5.8.2"
+junit5 = "5.9.0"
 kotlin = "1.7.10"
 kotlin-coroutine = "1.6.4"
-micrometer = "1.9.2"
+micrometer = "1.9.3"
 micrometer13 = "1.3.20"
-mockito = "4.6.1"
+mockito = "4.7.0"
 monix = "3.4.1"
 munit = "0.7.29"
 okhttp4 = "4.10.0"
@@ -30,30 +30,30 @@ opensaml = "3.4.6"
 protobuf = "3.21.1"
 reactive-grpc = "1.2.3"
 reactive-streams = "1.0.4"
-reactor = "3.4.21"
+reactor = "3.4.22"
 resteasy = "5.0.4.Final"
 retrofit2 = "2.9.0"
-sangria = "3.0.1"
+sangria = "3.2.0"
 sangria-slowlog = "2.0.4"
 scala-java8-compat = "1.0.2"
 scalapb = "0.11.11"
 scalapb-json = "0.12.0"
 slf4j = "1.7.36"
 spring-boot1 = "1.5.22.RELEASE"
-spring-boot2 = "2.7.2"
+spring-boot2 = "2.7.3"
 tomcat8 = "8.5.81"
 tomcat9 = "9.0.65"
 
 [boms]
-brave = { module = "io.zipkin.brave:brave-bom", version = "5.13.10" }
-dropwizard-metrics = { module = "io.dropwizard.metrics:metrics-bom", version = "4.2.10" }
+brave = { module = "io.zipkin.brave:brave-bom", version = "5.13.11" }
+dropwizard-metrics = { module = "io.dropwizard.metrics:metrics-bom", version = "4.2.12" }
 # Ensure that we use the same Protobuf version as what gRPC depends on.
 # See: https://github.com/grpc/grpc-java/blob/master/gradle/libs.versions.toml
 #      (Switch to the right tag and look for "protobuf".)
-grpc-java = { module = "io.grpc:grpc-bom", version = "1.48.0" }
-jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.13.3" }
+grpc-java = { module = "io.grpc:grpc-bom", version = "1.49.0" }
+jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.13.4" }
 junit5 = { module = "org.junit:junit-bom", version = "5.9.0" }
-netty = { module = "io.netty:netty-bom", version = "4.1.79.Final" }
+netty = { module = "io.netty:netty-bom", version = "4.1.80.Final" }
 
 # Akka is used only for testing in it:grpcweb module.
 [libraries.akka-http-cors_v213]
@@ -280,7 +280,7 @@ version = "4.3.1"
 # gax-grpc is only used for gRPC test module.
 [libraries.gax-grpc]
 module = "com.google.api:gax-grpc"
-version = "2.18.7"
+version = "2.19.0"
 
 [libraries.graphql-java]
 module = "com.graphql-java:graphql-java"
@@ -562,10 +562,11 @@ version.ref = "kotlin-coroutine"
 module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2"
 version.ref = "kotlin-coroutine"
 
+# Don't upgrade Logback to 1.4.0 which requires Java 11
 [libraries.logback]
 module = "ch.qos.logback:logback-classic"
-version = "1.2.11"
-javadocs = "https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.11/"
+version = "1.3.0"
+javadocs = "https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.3.0/"
 
 [libraries.micrometer-core]
 module = "io.micrometer:micrometer-core"
@@ -823,7 +824,7 @@ module = "org.scala-lang:scala-library"
 version = "2.13.8"
 [libraries.scala_v3]
 module = "org.scala-lang:scala3-library_3"
-version = "3.1.3"
+version = "3.2.0"
 
 [libraries.scala-collection-compat_v212]
 module = "org.scala-lang.modules:scala-collection-compat_2.12"
@@ -990,6 +991,9 @@ javadocs = "https://tomcat.apache.org/tomcat-9.0-doc/api/"
 [libraries.tomcat8-jasper]
 module = "org.apache.tomcat.embed:tomcat-embed-jasper"
 version.ref = "tomcat8"
+[libraries.tomcat8-el]
+module = "org.apache.tomcat.embed:tomcat-embed-el"
+version.ref = "tomcat8"
 [libraries.tomcat9-core]
 module = "org.apache.tomcat.embed:tomcat-embed-core"
 version.ref = "tomcat9"
@@ -1022,7 +1026,7 @@ module = "org.dmonix.junit:zookeeper-junit"
 version = "1.2"
 
 [plugins]
-jmh = { id = "me.champeau.jmh", version = "0.6.6" }
+jmh = { id = "me.champeau.jmh", version = "0.6.7" }
 osdetector = { id = "com.google.osdetector", version = "1.6.2" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -53,7 +53,7 @@ dropwizard-metrics = { module = "io.dropwizard.metrics:metrics-bom", version = "
 grpc-java = { module = "io.grpc:grpc-bom", version = "1.49.0" }
 jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.13.4" }
 junit5 = { module = "org.junit:junit-bom", version = "5.9.0" }
-netty = { module = "io.netty:netty-bom", version = "4.1.80.Final" }
+netty = { module = "io.netty:netty-bom", version = "4.1.79.Final" }
 
 # Akka is used only for testing in it:grpcweb module.
 [libraries.akka-http-cors_v213]

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -562,11 +562,12 @@ version.ref = "kotlin-coroutine"
 module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2"
 version.ref = "kotlin-coroutine"
 
-# Don't upgrade Logback to 1.4.0 which requires Java 11
+# Don't upgrade Logback 1.4.0 which requires Java 11
+# TODO(ikhoon): Upgrade Logback to 1.3.0 when Spring Boot 2 supports it.
 [libraries.logback]
 module = "ch.qos.logback:logback-classic"
-version = "1.3.0"
-javadocs = "https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.3.0/"
+version = "1.2.11"
+javadocs = "https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.11/"
 
 [libraries.micrometer-core]
 module = "io.micrometer:micrometer-core"

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -1,3 +1,5 @@
+import com.github.benmanes.gradle.versions.reporter.*
+import com.github.benmanes.gradle.versions.reporter.result.*
 import org.yaml.snakeyaml.Yaml
 
 buildscript {
@@ -8,7 +10,7 @@ buildscript {
 
     dependencies {
         // These should be the only dependencies that need hard-coded versions.
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0'
         classpath 'org.yaml:snakeyaml:1.29'
     }
 }
@@ -30,7 +32,6 @@ def dependencyManagementProject = dependencyManagementProjects[0]
 
 configure(dependencyManagementProject) {
     apply plugin: 'java-platform'
-    apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
 
     repositories {
         google()
@@ -51,6 +52,10 @@ configure(dependencyManagementProject) {
             }
         }
     }
+}
+
+configure(rootProject) {
+    apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin
 
     tasks {
         dependencyUpdates {
@@ -59,7 +64,8 @@ configure(dependencyManagementProject) {
             resolutionStrategy {
                 componentSelection { rules ->
                     rules.all { ComponentSelection selection ->
-                        boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'preview'].any { qualifier ->
+                        boolean rejected = ['alpha', 'beta', 'ea', 'rc',
+                                            'cr', 'm', 'preview'].any { qualifier ->
                             selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-]*/
                         }
                         if (rejected) {
@@ -70,19 +76,16 @@ configure(dependencyManagementProject) {
             }
 
             checkConstraints = true
-
-            // We have downgraded versions for legacy artifacts which versions plugin has no way of handling.
-            // But we can provide a reminder to manually check for updates.
-            doLast {
-                logger.quiet "Don't forget to check the following for updates to legacy version downgrades"
-                managedDependencyOverrides.each { override ->
-                    def (group, artifact, version) = override.split(':')
-                    def parts = version.split('\\.')
-                    if (parts.length >= 2) {
-                        logger.quiet "${artifact} is currently version ${version}"
-                        logger.quiet "https://search.maven.org/search?q=g:${group}%20a:${artifact}%20v:${parts[0]}.${parts[1]}.*\n"
-                    }
+            outputFormatter = result -> {
+                File filename = new File(outputDir, 'report.txt')
+                project.file(outputDir).mkdirs()
+                File outputFile = project.file(filename)
+                def reporter = new GentlePlainTextReporter(project, "release", "release-candidate")
+                reporter.write(System.out, result)
+                outputFile.withPrintWriter { PrintWriter pw ->
+                    reporter.write(pw, result)
                 }
+                logger.lifecycle '\nGenerated report file ' + filename
             }
         }
     }
@@ -289,4 +292,48 @@ static def getManagedVersions(Project rootProject) {
         }
     }
     return managedVersions
+}
+
+final class GentlePlainTextReporter implements Reporter {
+
+    private final Reporter delegate
+
+    GentlePlainTextReporter(Project project, String revision, String gradleReleaseChannel) {
+        delegate = new PlainTextReporter(project, revision, gradleReleaseChannel)
+    }
+
+    def write(Object printStream, Result result) {
+        delegate.write(printStream, updateProjectUrl(result))
+    }
+
+    private static Result updateProjectUrl(Result result) {
+        DependenciesGroup<DependencyOutdated> outdated = result.outdated
+        def updated = outdated.dependencies.collect { old ->
+            List versionParts = []
+            if (old.version != null) {
+                versionParts = old.version.split('\\.').toList()
+            }
+            if (versionParts.size() < 2) {
+                return old
+            }
+
+            String quickSearchLink = "https://search.maven.org/search?q=g:${old.group}%20a:${old.name}%20v:" +
+                                     "${versionParts[0]}.${versionParts[1]}.*\n"
+            String projectUrl
+            if (old.projectUrl == null) {
+                projectUrl = quickSearchLink
+            } else {
+                projectUrl = "${old.projectUrl}\n     $quickSearchLink"
+            }
+            return new DependencyOutdated(old.group, old.name, old.version, projectUrl, old.userReason, old.available)
+        } as SortedSet
+
+        DependenciesGroup<DependencyOutdated> outdatedWithNote = new DependenciesGroup<>(outdated.count, updated)
+        return new Result(result.count, result.current, outdatedWithNote, result.exceeded, result.undeclared,
+                          result.unresolved, result.gradle)
+    }
+
+    String getFileExtension() {
+        return delegate.getFileExtension()
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/spring/boot2-tomcat8/build.gradle
+++ b/it/spring/boot2-tomcat8/build.gradle
@@ -1,6 +1,5 @@
 final def SPRING_BOOT_VERSION = '2.1.18.RELEASE'
 final def SPRING_VERSION = '5.1.20.RELEASE'
-final def TOMCAT_VERSION = '8.5.81'
 
 dependencies {
     implementation(project(':spring:boot2-starter')) {
@@ -28,14 +27,9 @@ dependencies {
         }
     }
 
-    [ 'tomcat-embed-core', 'tomcat-embed-jasper', 'tomcat-embed-el' ].each {
-        implementation("org.apache.tomcat.embed:$it") {
-            version {
-                // Will fail the build if the override doesn't work
-                strictly TOMCAT_VERSION
-            }
-        }
-    }
+    implementation libs.tomcat8.core
+    implementation libs.tomcat8.jasper
+    implementation libs.tomcat8.el
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         version {

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -20,11 +20,13 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.slf4j.MDC;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -327,6 +329,21 @@ public final class RequestContextExportingAppender
         }
 
         @Override
+        public int getNanoseconds() {
+            return event.getNanoseconds();
+        }
+
+        @Override
+        public long getSequenceNumber() {
+            return event.getSequenceNumber();
+        }
+
+        @Override
+        public List<KeyValuePair> getKeyValuePairs() {
+            return event.getKeyValuePairs();
+        }
+
+        @Override
         public StackTraceElement[] getCallerData() {
             return event.getCallerData();
         }
@@ -339,6 +356,11 @@ public final class RequestContextExportingAppender
         @Override
         public Marker getMarker() {
             return event.getMarker();
+        }
+
+        @Override
+        public List<Marker> getMarkerList() {
+            return event.getMarkerList();
         }
 
         @Override

--- a/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/RequestContextExportingAppender.java
@@ -20,13 +20,11 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.slf4j.MDC;
 import org.slf4j.Marker;
-import org.slf4j.event.KeyValuePair;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -329,21 +327,6 @@ public final class RequestContextExportingAppender
         }
 
         @Override
-        public int getNanoseconds() {
-            return event.getNanoseconds();
-        }
-
-        @Override
-        public long getSequenceNumber() {
-            return event.getSequenceNumber();
-        }
-
-        @Override
-        public List<KeyValuePair> getKeyValuePairs() {
-            return event.getKeyValuePairs();
-        }
-
-        @Override
         public StackTraceElement[] getCallerData() {
             return event.getCallerData();
         }
@@ -356,11 +339,6 @@ public final class RequestContextExportingAppender
         @Override
         public Marker getMarker() {
             return event.getMarker();
-        }
-
-        @Override
-        public List<Marker> getMarkerList() {
-            return event.getMarkerList();
         }
 
         @Override

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.jsoup:jsoup:1.14.3'
+        classpath libs.jsoup
     }
 }
 


### PR DESCRIPTION
- Brave 5.13.10 -> 5.13.11
- Brotli4J 1.7.1 -> 1.8.0
- Dropwizard Metrics 4.2.10 -> 4.2.12
- gRPC-Java 1.48.0 -> 1.49.0
- Jackson 2.13.3 -> 2.13.4
- Logback 1.2.11 -> 1.3.0
- Micrometer 1.9.2 -> 1.9.3
- Reactor 3.4.21 -> 3.4.22
- Sangria 3.0.1 -> 3.2.0
- Scala 3.1.3 -> 3.2.0
- Spring Boot 2.7.2 -> 2.7.3
- Build
  - Dagger 2.43.1 -> 2.43.2
  - Error Prone 2.14.0 -> 2.15.0
  - gax-grpc 2.18.7 -> 2.19.0
  - graphql-kotlin 6.1.0 -> 6.2.2
  - JUnit5 5.8.2 -> 5.9.2
  - JMH plugin 0.6.6 -> 0.6.7
  - Mockito 4.6.1 -> 4.7.0

