### PR TITLE
Add EndpointGroup info to TimeoutException for DynamicEndpointGroup.whenReady() future

### DIFF
--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -139,4 +139,13 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
         }
         future.complete(null);
     }
+
+    @Override
+    public String toString() {
+        return toStringHelper()
+                .add("serviceName", serviceName)
+                .add("datacenter", datacenter)
+                .add("filter", filter)
+                .toString();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -24,12 +24,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -64,7 +68,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
     private volatile List<Endpoint> endpoints = UNINITIALIZED_ENDPOINTS;
     private final Lock endpointsLock = new ReentrantLock();
 
-    private final CompletableFuture<List<Endpoint>> initialEndpointsFuture = new EventLoopCheckingFuture<>();
+    private final CompletableFuture<List<Endpoint>> initialEndpointsFuture = new InitialEndpointsFuture();
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
     private final boolean allowEmptyEndpoints;
     private final long selectionTimeoutMillis;
@@ -336,12 +340,31 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
 
     @Override
     public String toString() {
+        return toStringHelper().toString();
+    }
+
+    protected ToStringHelper toStringHelper() {
         return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
                           .add("selectionStrategy", selectionStrategy.getClass())
                           .add("allowsEmptyEndpoints", allowEmptyEndpoints)
                           .add("endpoints", truncate(endpoints, 10))
                           .add("numEndpoints", endpoints.size())
-                          .add("initialized", initialEndpointsFuture.isDone())
-                          .toString();
+                          .add("initialized", initialEndpointsFuture.isDone());
+    }
+
+    private class InitialEndpointsFuture extends EventLoopCheckingFuture<List<Endpoint>> {
+
+        @Override
+        public List<Endpoint> get(long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            try {
+                return super.get(timeout, unit);
+            } catch (TimeoutException e) {
+                throw new TimeoutException(
+                        InitialEndpointsFuture.class.getSimpleName() + " is timed out after " +
+                        unit.toMillis(timeout) + " milliseconds. endpoint group: " + DynamicEndpointGroup.this);
+            }
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -361,9 +361,11 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
             try {
                 return super.get(timeout, unit);
             } catch (TimeoutException e) {
-                throw new TimeoutException(
+                final TimeoutException timeoutException = new TimeoutException(
                         InitialEndpointsFuture.class.getSimpleName() + " is timed out after " +
                         unit.toMillis(timeout) + " milliseconds. endpoint group: " + DynamicEndpointGroup.this);
+                timeoutException.initCause(e);
+                throw timeoutException;
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
@@ -230,4 +230,11 @@ public final class PropertiesEndpointGroup extends DynamicEndpointGroup {
         }
         future.complete(null);
     }
+
+    @Override
+    public String toString() {
+        return toStringHelper()
+                .add("watchRegisterKey", watchRegisterKey)
+                .toString();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -208,4 +208,12 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup implements DnsCache
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return toStringHelper()
+                .add("questions", questions)
+                .add("logPrefix", logPrefix)
+                .toString();
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -214,6 +214,7 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup implements DnsCache
         return toStringHelper()
                 .add("questions", questions)
                 .add("logPrefix", logPrefix)
+                .add("attemptsSoFar", attemptsSoFar)
                 .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -90,7 +90,7 @@ final class DefaultHealthCheckerContext
         this.handle = handle;
     }
 
-    boolean isInitialized() {
+    boolean initializationStarted() {
         return handle != null;
     }
 
@@ -298,6 +298,10 @@ final class DefaultHealthCheckerContext
         return MoreObjects.toStringHelper(this)
                           .add("originalEndpoint", originalEndpoint)
                           .add("endpoint", endpoint)
+                          .add("initializationStarted", initializationStarted())
+                          .add("initialized", initialCheckFuture.isDone())
+                          .add("destroyed", destroyed)
+                          .add("refCnt", refCnt)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientOptions;
@@ -290,5 +291,13 @@ final class DefaultHealthCheckerContext
             return destroy();
         }
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("originalEndpoint", originalEndpoint)
+                          .add("endpoint", endpoint)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroup.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseable;
@@ -99,5 +101,13 @@ final class HealthCheckContextGroup {
     CompletableFuture<?> whenInitialized() {
         assert initFutures != null : "Should call initialize() before invoking this method.";
         return initFutures;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("contexts", contexts)
+                          .add("candidates", candidates)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckContextGroup.java
@@ -60,7 +60,7 @@ final class HealthCheckContextGroup {
         final List<CompletableFuture<Void>> futures =
                 contexts.values().stream()
                         .peek(context -> {
-                            if (!context.isInitialized()) {
+                            if (!context.initializationStarted()) {
                                 // A newly created context
                                 context.init(checkerFactory.apply(context));
                             }
@@ -108,6 +108,7 @@ final class HealthCheckContextGroup {
         return MoreObjects.toStringHelper(this)
                           .add("contexts", contexts)
                           .add("candidates", candidates)
+                          .add("initialized", initFutures != null && initFutures.isDone())
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -335,6 +335,9 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                           .add("numCandidates", delegateEndpoints.size())
                           .add("selectionStrategy", selectionStrategy().getClass())
                           .add("initialized", whenReady().isDone())
+                          .add("initialSelectionTimeoutMillis", initialSelectionTimeoutMillis)
+                          .add("selectionTimeoutMillis", selectionTimeoutMillis)
+                          .add("contextGroupChain", contextGroupChain)
                           .toString();
     }
 }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -410,4 +410,11 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
         }
         return endpoint;
     }
+
+    @Override
+    public String toString() {
+        return toStringHelper()
+                .add("requestHeaders", requestHeaders)
+                .toString();
+    }
 }


### PR DESCRIPTION
Motivation:
See #4404
If we add information of `DynamicEndpointGroup` to the `TimeoutException`, it would help to debug.

Modification:
- Add `EndpointGroup` to the `TimeoutException` message.
- Override `toString` in the subclasses of `DynamicEndpointGroup`

Result:
- Close #4404
