### PR TITLE
Add `enable-auto-injection` prop in `spring-configuration-metadata.json`

### DIFF
--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationUtil.java
@@ -195,7 +195,7 @@ public final class ArmeriaConfigurationUtil {
         dependencyInjectors.forEach(injector -> {
             server.dependencyInjector(injector, false); // The injector is closed by Spring.
         });
-        if (settings.enableAutoInjection()) {
+        if (settings.isEnableAutoInjection()) {
             server.dependencyInjector(SpringDependencyInjector.of(beanFactory), false);
         }
     }

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -1046,7 +1046,7 @@ public class ArmeriaSettings {
     /**
      * Returns whether to apply {@link SpringDependencyInjector} automatically.
      */
-    public boolean enableAutoInjection() {
+    public boolean isEnableAutoInjection() {
         return enableAutoInjection;
     }
 


### PR DESCRIPTION
Motivation:

`enable-auto-injection` spring configuration property was introduced but wasn't correctly added to `spring-configuration-metadata.json` by spring configuration processor.

This is because the current getter for `enable-auto-injection` property doesn't follow spring's getter naming convention, which expects the method name to start with `get` or `is`, and thus not being correctly recognized by the annotation processor.

See [PropertyDescriptorResolver.java#L104](https://github.com/spring-projects/spring-boot/blob/44b88cc88c2e848154a98ae17c03b1cd6c8f5830/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/PropertyDescriptorResolver.java#L104) and [TypeElementMembers.java#L126](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-tools/spring-boot-configuration-processor/src/main/java/org/springframework/boot/configurationprocessor/TypeElementMembers.java#L126) for the annotation processor implementation.

Modifications:

- Make `enable-auto-injection` property getter follow spring's getter naming convention.

Result:

- `enable-auto-injection` property is correctly added to the generated `spring-configuration-metadata.json` file.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
