### PR TITLE
Support camelcase for HttpJsonTranscodingService Query Parameters

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOptions {
+
+    static final HttpJsonTranscodingOptions DEFAULT = HttpJsonTranscodingOptions.builder().build();
+
+    private final boolean useCamelCaseQueryParams;
+    private final boolean useProtoFieldNameQueryParams;
+
+    DefaultHttpJsonTranscodingOptions(boolean useCamelCaseQueryParams, boolean useProtoFieldNameQueryParams) {
+        this.useCamelCaseQueryParams = useCamelCaseQueryParams;
+        this.useProtoFieldNameQueryParams = useProtoFieldNameQueryParams;
+    }
+
+    @Override
+    public boolean useCamelCaseQueryParams() {
+        return useCamelCaseQueryParams;
+    }
+
+    @Override
+    public boolean useProtoFieldNameQueryParams() {
+        return useProtoFieldNameQueryParams;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HttpJsonTranscodingOptions)) {
+            return false;
+        }
+        final HttpJsonTranscodingOptions that = (HttpJsonTranscodingOptions) o;
+        return useProtoFieldNameQueryParams == that.useProtoFieldNameQueryParams() &&
+               useCamelCaseQueryParams == that.useCamelCaseQueryParams();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(useProtoFieldNameQueryParams, useCamelCaseQueryParams);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("useCamelCaseQueryParams", useCamelCaseQueryParams)
+                          .add("useProtoFieldNameQueryParams", useProtoFieldNameQueryParams)
+                          .toString();
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -26,10 +25,10 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
 
     static final HttpJsonTranscodingOptions DEFAULT = HttpJsonTranscodingOptions.builder().build();
 
-    private final EnumSet<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules;
+    private final Set<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules;
     private final UnframedGrpcErrorHandler errorHandler;
 
-    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules,
+    DefaultHttpJsonTranscodingOptions(Set<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules,
                                       UnframedGrpcErrorHandler errorHandler) {
         this.queryParamMatchRules = queryParamMatchRules;
         this.errorHandler = errorHandler;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -16,7 +16,8 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import java.util.Objects;
+import java.util.EnumSet;
+import java.util.Set;
 
 import com.google.common.base.MoreObjects;
 
@@ -24,22 +25,10 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
 
     static final HttpJsonTranscodingOptions DEFAULT = HttpJsonTranscodingOptions.builder().build();
 
-    private final boolean useCamelCaseQueryParams;
-    private final boolean useProtoFieldNameQueryParams;
+    private EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
 
-    DefaultHttpJsonTranscodingOptions(boolean useCamelCaseQueryParams, boolean useProtoFieldNameQueryParams) {
-        this.useCamelCaseQueryParams = useCamelCaseQueryParams;
-        this.useProtoFieldNameQueryParams = useProtoFieldNameQueryParams;
-    }
-
-    @Override
-    public boolean useCamelCaseQueryParams() {
-        return useCamelCaseQueryParams;
-    }
-
-    @Override
-    public boolean useProtoFieldNameQueryParams() {
-        return useProtoFieldNameQueryParams;
+    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings) {
+        this.queryParamNamings = queryParamNamings;
     }
 
     @Override
@@ -51,20 +40,23 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
             return false;
         }
         final HttpJsonTranscodingOptions that = (HttpJsonTranscodingOptions) o;
-        return useProtoFieldNameQueryParams == that.useProtoFieldNameQueryParams() &&
-               useCamelCaseQueryParams == that.useCamelCaseQueryParams();
+        return queryParamNamings.equals(that.queryParamNamings());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(useProtoFieldNameQueryParams, useCamelCaseQueryParams);
+        return queryParamNamings.hashCode();
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("useCamelCaseQueryParams", useCamelCaseQueryParams)
-                          .add("useProtoFieldNameQueryParams", useProtoFieldNameQueryParams)
+                          .add("queryParamNamings", queryParamNamings)
                           .toString();
+    }
+
+    @Override
+    public Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings() {
+        return queryParamNamings;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -54,7 +54,8 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
             return false;
         }
         final HttpJsonTranscodingOptions that = (HttpJsonTranscodingOptions) o;
-        return queryParamMatchRules.equals(that.queryParamMatchRules()) && errorHandler.equals(that.errorHandler());
+        return queryParamMatchRules.equals(that.queryParamMatchRules()) &&
+               errorHandler.equals(that.errorHandler());
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -26,18 +26,18 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
 
     static final HttpJsonTranscodingOptions DEFAULT = HttpJsonTranscodingOptions.builder().build();
 
-    private final EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
+    private final EnumSet<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules;
     private final UnframedGrpcErrorHandler errorHandler;
 
-    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings,
+    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules,
                                       UnframedGrpcErrorHandler errorHandler) {
-        this.queryParamNamings = queryParamNamings;
+        this.queryParamMatchRules = queryParamMatchRules;
         this.errorHandler = errorHandler;
     }
 
     @Override
-    public Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings() {
-        return queryParamNamings;
+    public Set<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules() {
+        return queryParamMatchRules;
     }
 
     @Override
@@ -54,18 +54,18 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
             return false;
         }
         final HttpJsonTranscodingOptions that = (HttpJsonTranscodingOptions) o;
-        return queryParamNamings.equals(that.queryParamNamings()) && errorHandler.equals(that.errorHandler());
+        return queryParamMatchRules.equals(that.queryParamMatchRules()) && errorHandler.equals(that.errorHandler());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(queryParamNamings, errorHandler);
+        return Objects.hash(queryParamMatchRules, errorHandler);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("queryParamNamings", queryParamNamings)
+                          .add("queryParamMatchRules", queryParamMatchRules)
                           .add("errorHandler", errorHandler)
                           .toString();
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DefaultHttpJsonTranscodingOptions.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.grpc;
 
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
@@ -25,10 +26,23 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
 
     static final HttpJsonTranscodingOptions DEFAULT = HttpJsonTranscodingOptions.builder().build();
 
-    private EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
+    private final EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
+    private final UnframedGrpcErrorHandler errorHandler;
 
-    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings) {
+    DefaultHttpJsonTranscodingOptions(EnumSet<HttpJsonTranscodingQueryParamNaming> queryParamNamings,
+                                      UnframedGrpcErrorHandler errorHandler) {
         this.queryParamNamings = queryParamNamings;
+        this.errorHandler = errorHandler;
+    }
+
+    @Override
+    public Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings() {
+        return queryParamNamings;
+    }
+
+    @Override
+    public UnframedGrpcErrorHandler errorHandler() {
+        return errorHandler;
     }
 
     @Override
@@ -40,23 +54,19 @@ final class DefaultHttpJsonTranscodingOptions implements HttpJsonTranscodingOpti
             return false;
         }
         final HttpJsonTranscodingOptions that = (HttpJsonTranscodingOptions) o;
-        return queryParamNamings.equals(that.queryParamNamings());
+        return queryParamNamings.equals(that.queryParamNamings()) && errorHandler.equals(that.errorHandler());
     }
 
     @Override
     public int hashCode() {
-        return queryParamNamings.hashCode();
+        return Objects.hash(queryParamNamings, errorHandler);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("queryParamNamings", queryParamNamings)
+                          .add("errorHandler", errorHandler)
                           .toString();
-    }
-
-    @Override
-    public Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings() {
-        return queryParamNamings;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -660,6 +660,38 @@ public final class GrpcServiceBuilder {
         return this;
     }
 
+    /**
+     * Sets whether the service handles HTTP/JSON requests using the gRPC wire protocol.
+     * Provide {@link HttpJsonTranscodingOptions} to customize HttpJsonTranscoding.
+     *
+     * <p>Example:
+     * <pre>{@code
+     * HttpJsonTranscodingOptions options = HttpJsonTranscodingOptions.buider()
+     *                                                                .camelCaseQueryParams(true)
+     *                                                                ...
+     *                                                                .build()
+     *
+     * GrpcService.builder()
+     *            // Enable HttpJsonTranscoding and use the specified HttpJsonTranscodingOption
+     *            .enableHttpJsonTranscoding(options)
+     *            .build()}</pre>
+     *
+     * <p>Limitations:
+     * <ul>
+     *     <li>Only unary methods (single request, single response) are supported.</li>
+     *     <li>
+     *         Message compression is not supported.
+     *         {@link EncodingService} should be used instead for
+     *         transport level encoding.
+     *     </li>
+     *     <li>
+     *         Transcoding will not work if the {@link GrpcService} is configured with
+     *         {@link ServerBuilder#serviceUnder(String, HttpService)}.
+     *     </li>
+     * </ul>
+     *
+     * @see <a href="https://cloud.google.com/endpoints/docs/grpc/transcoding">Transcoding HTTP/JSON to gRPC</a>
+     */
     @UnstableApi
     public GrpcServiceBuilder enableHttpJsonTranscoding(HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
         this.enableHttpJsonTranscoding = true;
@@ -994,7 +1026,6 @@ public final class GrpcServiceBuilder {
                                                             : UnframedGrpcErrorHandler.ofJson(),
                     httpJsonTranscodingOptions != null ? httpJsonTranscodingOptions
                                                             : HttpJsonTranscodingOptions.of(false));
-
         }
         if (handlerRegistry.containsDecorators()) {
             grpcService = new GrpcDecoratingService(grpcService, handlerRegistry);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -130,6 +130,9 @@ public final class GrpcServiceBuilder {
     @Nullable
     private UnframedGrpcErrorHandler httpJsonTranscodingErrorHandler;
 
+    @Nullable
+    private HttpJsonTranscodingOptions httpJsonTranscodingOptions;
+
     private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 
     private int maxRequestMessageLength = AbstractMessageDeframer.NO_MAX_INBOUND_MESSAGE_SIZE;
@@ -657,6 +660,13 @@ public final class GrpcServiceBuilder {
         return this;
     }
 
+    @UnstableApi
+    public GrpcServiceBuilder enableHttpJsonTranscoding(HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
+        this.enableHttpJsonTranscoding = true;
+        this.httpJsonTranscodingOptions = httpJsonTranscodingOptions;
+        return this;
+    }
+
     /**
      * Sets an error handler which handles an exception raised while serving a gRPC request transcoded from
      * an HTTP/JSON request. By default, {@link UnframedGrpcErrorHandler#ofJson()} would be set.
@@ -981,7 +991,10 @@ public final class GrpcServiceBuilder {
             grpcService = HttpJsonTranscodingService.of(
                     grpcService,
                     httpJsonTranscodingErrorHandler != null ? httpJsonTranscodingErrorHandler
-                                                            : UnframedGrpcErrorHandler.ofJson());
+                                                            : UnframedGrpcErrorHandler.ofJson(),
+                    httpJsonTranscodingOptions != null ? httpJsonTranscodingOptions
+                                                            : HttpJsonTranscodingOptions.of(false));
+
         }
         if (handlerRegistry.containsDecorators()) {
             grpcService = new GrpcDecoratingService(grpcService, handlerRegistry);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -660,14 +660,14 @@ public final class GrpcServiceBuilder {
     }
 
     /**
-     * Sets whether the service handles HTTP/JSON requests using the gRPC wire protocol.
+     * Enables HTTP/JSON transcoding using the gRPC wire protocol.
      * Provide {@link HttpJsonTranscodingOptions} to customize HttpJsonTranscoding.
      *
      * <p>Example:
      * <pre>{@code
      * HttpJsonTranscodingOptions options =
      *   HttpJsonTranscodingOptions.builder()
-     *                             .useCamelCaseQueryParams(true)
+     *                             .queryParamMatchRules(ORIGINAL_FIELD)
      *                             ...
      *                             .build()
      *
@@ -696,7 +696,6 @@ public final class GrpcServiceBuilder {
     @UnstableApi
     public GrpcServiceBuilder enableHttpJsonTranscoding(HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
         requireNonNull(httpJsonTranscodingOptions, "httpJsonTranscodingOptions");
-
         enableHttpJsonTranscoding = true;
         this.httpJsonTranscodingOptions = httpJsonTranscodingOptions;
         return this;
@@ -1029,11 +1028,12 @@ public final class GrpcServiceBuilder {
             final HttpJsonTranscodingOptions httpJsonTranscodingOptions;
             if (httpJsonTranscodingErrorHandler != null) {
                 httpJsonTranscodingOptions =
-                        HttpJsonTranscodingOptions.builder()
-                                                  .queryParamMatchRules(
-                                                          this.httpJsonTranscodingOptions.queryParamMatchRules())
-                                                  .errorHandler(httpJsonTranscodingErrorHandler)
-                                                  .build();
+                        HttpJsonTranscodingOptions
+                                .builder()
+                                .queryParamMatchRules(
+                                        this.httpJsonTranscodingOptions.queryParamMatchRules())
+                                .errorHandler(httpJsonTranscodingErrorHandler)
+                                .build();
             } else {
                 httpJsonTranscodingOptions = this.httpJsonTranscodingOptions;
             }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -669,12 +669,12 @@ public final class GrpcServiceBuilder {
      *   HttpJsonTranscodingOptions.builder()
      *                             .queryParamMatchRules(ORIGINAL_FIELD)
      *                             ...
-     *                             .build()
+     *                             .build();
      *
      * GrpcService.builder()
      *            // Enable HttpJsonTranscoding and use the specified HttpJsonTranscodingOption
      *            .enableHttpJsonTranscoding(options)
-     *            .build()
+     *            .build();
      * }</pre>
      *
      * <p>Limitations:

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -1030,8 +1030,8 @@ public final class GrpcServiceBuilder {
             if (httpJsonTranscodingErrorHandler != null) {
                 httpJsonTranscodingOptions =
                         HttpJsonTranscodingOptions.builder()
-                                                  .queryParamNaming(
-                                                          this.httpJsonTranscodingOptions.queryParamNamings())
+                                                  .queryParamMatchRules(
+                                                          this.httpJsonTranscodingOptions.queryParamMatchRules())
                                                   .errorHandler(httpJsonTranscodingErrorHandler)
                                                   .build();
             } else {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -665,10 +665,11 @@ public final class GrpcServiceBuilder {
      *
      * <p>Example:
      * <pre>{@code
-     * HttpJsonTranscodingOptions options = HttpJsonTranscodingOptions.buider()
-     *                                                                .camelCaseQueryParams(true)
-     *                                                                ...
-     *                                                                .build()
+     * HttpJsonTranscodingOptions options =
+     *   HttpJsonTranscodingOptions.builder()
+     *                             .useCamelCaseQueryParams(true)
+     *                             ...
+     *                             .build()
      *
      * GrpcService.builder()
      *            // Enable HttpJsonTranscoding and use the specified HttpJsonTranscodingOption

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -130,8 +130,7 @@ public final class GrpcServiceBuilder {
     @Nullable
     private UnframedGrpcErrorHandler httpJsonTranscodingErrorHandler;
 
-    @Nullable
-    private HttpJsonTranscodingOptions httpJsonTranscodingOptions;
+    private HttpJsonTranscodingOptions httpJsonTranscodingOptions = HttpJsonTranscodingOptions.ofDefault();
 
     private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 
@@ -694,7 +693,9 @@ public final class GrpcServiceBuilder {
      */
     @UnstableApi
     public GrpcServiceBuilder enableHttpJsonTranscoding(HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
-        this.enableHttpJsonTranscoding = true;
+        requireNonNull(httpJsonTranscodingOptions, "httpJsonTranscodingOptions");
+
+        enableHttpJsonTranscoding = true;
         this.httpJsonTranscodingOptions = httpJsonTranscodingOptions;
         return this;
     }
@@ -1024,8 +1025,7 @@ public final class GrpcServiceBuilder {
                     grpcService,
                     httpJsonTranscodingErrorHandler != null ? httpJsonTranscodingErrorHandler
                                                             : UnframedGrpcErrorHandler.ofJson(),
-                    httpJsonTranscodingOptions != null ? httpJsonTranscodingOptions
-                                                            : HttpJsonTranscodingOptions.of(false));
+                    httpJsonTranscodingOptions);
         }
         if (handlerRegistry.containsDecorators()) {
             grpcService = new GrpcDecoratingService(grpcService, handlerRegistry);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -130,7 +130,7 @@ public final class GrpcServiceBuilder {
     @Nullable
     private UnframedGrpcErrorHandler httpJsonTranscodingErrorHandler;
 
-    private HttpJsonTranscodingOptions httpJsonTranscodingOptions = HttpJsonTranscodingOptions.ofDefault();
+    private HttpJsonTranscodingOptions httpJsonTranscodingOptions = HttpJsonTranscodingOptions.of();
 
     private Set<SerializationFormat> supportedSerializationFormats = DEFAULT_SUPPORTED_SERIALIZATION_FORMATS;
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.armeria.server.grpc;
 
+/**
+ * User provided options for customizing {@link HttpJsonTranscodingService}.
+ */
 public final class HttpJsonTranscodingOptions {
 
     private final boolean camelCaseQueryParams;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+public final class HttpJsonTranscodingOptions {
+
+    private final boolean camelCaseQueryParams;
+
+    static HttpJsonTranscodingOptionsBuilder builder() {
+        return new HttpJsonTranscodingOptionsBuilder();
+    }
+
+    static HttpJsonTranscodingOptions of(boolean camelCaseQueryParams) {
+        return new HttpJsonTranscodingOptions(camelCaseQueryParams);
+    }
+
+    private HttpJsonTranscodingOptions(boolean camelCaseQueryParams) {
+        this.camelCaseQueryParams = camelCaseQueryParams;
+    }
+
+    Boolean camelCaseQueryParams() {
+        return this.camelCaseQueryParams;
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -23,10 +23,16 @@ public final class HttpJsonTranscodingOptions {
 
     private final boolean camelCaseQueryParams;
 
+    /**
+     * Returns a new {@link HttpJsonTranscodingOptionsBuilder}.
+     */
     public static HttpJsonTranscodingOptionsBuilder builder() {
         return new HttpJsonTranscodingOptionsBuilder();
     }
 
+    /**
+     * Creates a new {@link HttpJsonTranscodingOptions} from given parameter(s).
+     */
     public static HttpJsonTranscodingOptions of(boolean camelCaseQueryParams) {
         return new HttpJsonTranscodingOptions(camelCaseQueryParams);
     }
@@ -35,6 +41,9 @@ public final class HttpJsonTranscodingOptions {
         this.camelCaseQueryParams = camelCaseQueryParams;
     }
 
+    /**
+     * Returns the set camelCaseQueryParams option value.
+     */
     public boolean camelCaseQueryParams() {
         return this.camelCaseQueryParams;
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -16,11 +16,16 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import java.util.Set;
+
+import com.google.protobuf.Message;
+
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * User provided options for customizing {@link HttpJsonTranscodingService}.
  */
+@SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
 @UnstableApi
 public interface HttpJsonTranscodingOptions {
 
@@ -34,17 +39,13 @@ public interface HttpJsonTranscodingOptions {
     /**
      * Returns the default {@link HttpJsonTranscodingOptions}.
      */
-    static HttpJsonTranscodingOptions ofDefault() {
+    static HttpJsonTranscodingOptions of() {
         return DefaultHttpJsonTranscodingOptions.DEFAULT;
     }
 
     /**
-     * Returns whether to use a field name converted into lowerCamelCase to match query parameters.
+     * Returns the {@link HttpJsonTranscodingQueryParamNaming}s which is used to match fields in a
+     * {@link Message} with query parameters.
      */
-    boolean useCamelCaseQueryParams();
-
-    /**
-     * Returns whether to use the original field name in .proto file to match query parameters.
-     */
-    boolean useProtoFieldNameQueryParams();
+    Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings();
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -23,11 +23,11 @@ public final class HttpJsonTranscodingOptions {
 
     private final boolean camelCaseQueryParams;
 
-    static HttpJsonTranscodingOptionsBuilder builder() {
+    public static HttpJsonTranscodingOptionsBuilder builder() {
         return new HttpJsonTranscodingOptionsBuilder();
     }
 
-    static HttpJsonTranscodingOptions of(boolean camelCaseQueryParams) {
+    public static HttpJsonTranscodingOptions of(boolean camelCaseQueryParams) {
         return new HttpJsonTranscodingOptions(camelCaseQueryParams);
     }
 
@@ -35,7 +35,7 @@ public final class HttpJsonTranscodingOptions {
         this.camelCaseQueryParams = camelCaseQueryParams;
     }
 
-    Boolean camelCaseQueryParams() {
+    public boolean camelCaseQueryParams() {
         return this.camelCaseQueryParams;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -16,35 +16,35 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * User provided options for customizing {@link HttpJsonTranscodingService}.
  */
-public final class HttpJsonTranscodingOptions {
-
-    private final boolean camelCaseQueryParams;
+@UnstableApi
+public interface HttpJsonTranscodingOptions {
 
     /**
      * Returns a new {@link HttpJsonTranscodingOptionsBuilder}.
      */
-    public static HttpJsonTranscodingOptionsBuilder builder() {
+    static HttpJsonTranscodingOptionsBuilder builder() {
         return new HttpJsonTranscodingOptionsBuilder();
     }
 
     /**
-     * Creates a new {@link HttpJsonTranscodingOptions} from given parameter(s).
+     * Returns the default {@link HttpJsonTranscodingOptions}.
      */
-    public static HttpJsonTranscodingOptions of(boolean camelCaseQueryParams) {
-        return new HttpJsonTranscodingOptions(camelCaseQueryParams);
-    }
-
-    private HttpJsonTranscodingOptions(boolean camelCaseQueryParams) {
-        this.camelCaseQueryParams = camelCaseQueryParams;
+    static HttpJsonTranscodingOptions ofDefault() {
+        return DefaultHttpJsonTranscodingOptions.DEFAULT;
     }
 
     /**
-     * Returns the set camelCaseQueryParams option value.
+     * Returns whether to use a field name converted into lowerCamelCase to match query parameters.
      */
-    public boolean camelCaseQueryParams() {
-        return this.camelCaseQueryParams;
-    }
+    boolean useCamelCaseQueryParams();
+
+    /**
+     * Returns whether to use the original field name in .proto file to match query parameters.
+     */
+    boolean useProtoFieldNameQueryParams();
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -43,10 +43,10 @@ public interface HttpJsonTranscodingOptions {
     }
 
     /**
-     * Returns the {@link HttpJsonTranscodingQueryParamNaming}s which is used to match fields in a
+     * Returns the {@link HttpJsonTranscodingQueryParamMatchRule}s which is used to match fields in a
      * {@link Message} with query parameters.
      */
-    Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings();
+    Set<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules();
 
     /**
      * Return the {@link UnframedGrpcErrorHandler} which handles an exception raised while serving a gRPC

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptions.java
@@ -25,7 +25,6 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 /**
  * User provided options for customizing {@link HttpJsonTranscodingService}.
  */
-@SuppressWarnings("InterfaceMayBeAnnotatedFunctional")
 @UnstableApi
 public interface HttpJsonTranscodingOptions {
 
@@ -48,4 +47,10 @@ public interface HttpJsonTranscodingOptions {
      * {@link Message} with query parameters.
      */
     Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings();
+
+    /**
+     * Return the {@link UnframedGrpcErrorHandler} which handles an exception raised while serving a gRPC
+     * request transcoded from an HTTP/JSON request.
+     */
+    UnframedGrpcErrorHandler errorHandler();
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -16,17 +16,27 @@
 
 package com.linecorp.armeria.server.grpc;
 
+/**
+ * builder for {@link HttpJsonTranscodingOptions}.
+ */
 public class HttpJsonTranscodingOptionsBuilder {
 
-    private boolean camelCaseQueryParams = false;
+    private boolean camelCaseQueryParams;
 
     HttpJsonTranscodingOptionsBuilder() {}
 
+    /**
+     * enables camelCase query parameters for Http Json Transcoding endpoints.
+     * provided by {@link HttpJsonTranscodingService}.
+     */
     public HttpJsonTranscodingOptionsBuilder useCamelCaseQueryParams() {
         this.camelCaseQueryParams = true;
         return this;
     }
 
+    /**
+     * builds {@link HttpJsonTranscodingOptions}.
+     */
     public HttpJsonTranscodingOptions build() {
         return HttpJsonTranscodingOptions.of(camelCaseQueryParams);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+public class HttpJsonTranscodingOptionsBuilder {
+
+    private boolean camelCaseQueryParams = false;
+
+    HttpJsonTranscodingOptionsBuilder() {}
+
+    public HttpJsonTranscodingOptionsBuilder useCamelCaseQueryParams() {
+        this.camelCaseQueryParams = true;
+        return this;
+    }
+
+    public HttpJsonTranscodingOptions build() {
+        return HttpJsonTranscodingOptions.of(camelCaseQueryParams);
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -49,7 +50,7 @@ public final class HttpJsonTranscodingOptionsBuilder {
 
     /**
      * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used
-     * to match {@link QueryParams} of a {@link HttpRequest} with fields in a {@link Message}.
+     * to match {@link QueryParams} of an {@link HttpRequest} with fields in a {@link Message}.
      * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
     public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(
@@ -61,7 +62,7 @@ public final class HttpJsonTranscodingOptionsBuilder {
 
     /**
      * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used
-     * to match {@link QueryParams} of a {@link HttpRequest} with fields in a {@link Message}.
+     * to match {@link QueryParams} of an {@link HttpRequest} with fields in a {@link Message}.
      * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
     public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(
@@ -87,14 +88,14 @@ public final class HttpJsonTranscodingOptionsBuilder {
     }
 
     /**
-     * Returns a new created {@link HttpJsonTranscodingOptions}.
+     * Returns a newly created {@link HttpJsonTranscodingOptions}.
      */
     public HttpJsonTranscodingOptions build() {
-        final EnumSet<HttpJsonTranscodingQueryParamMatchRule> matchRules;
+        final Set<HttpJsonTranscodingQueryParamMatchRule> matchRules;
         if (queryParamMatchRules == null) {
             matchRules = DEFAULT_QUERY_PARAM_MATCH_RULES;
         } else {
-            matchRules = EnumSet.copyOf(queryParamMatchRules);
+            matchRules = Sets.immutableEnumSet(queryParamMatchRules);
         }
         return new DefaultHttpJsonTranscodingOptions(matchRules, errorHandler);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -30,14 +30,18 @@ import com.google.protobuf.Message;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
- * builder for {@link HttpJsonTranscodingOptions}.
+ * A builder for {@link HttpJsonTranscodingOptions}.
  */
+@UnstableApi
 public class HttpJsonTranscodingOptionsBuilder {
 
     private static final EnumSet<HttpJsonTranscodingQueryParamNaming> DEFAULT_QUERY_PARAM_NAMING =
             EnumSet.of(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+
+    private UnframedGrpcErrorHandler errorHandler = UnframedGrpcErrorHandler.ofJson();
 
     @Nullable
     private Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
@@ -72,10 +76,19 @@ public class HttpJsonTranscodingOptionsBuilder {
         return this;
     }
 
+    /**
+     * Sets an error handler which handles an exception raised while serving a gRPC request transcoded from
+     * an HTTP/JSON request. By default, {@link UnframedGrpcErrorHandler#ofJson()} would be set.
+     */
+    @UnstableApi
+    public HttpJsonTranscodingOptionsBuilder errorHandler(UnframedGrpcErrorHandler errorHandler) {
+        requireNonNull(errorHandler, "errorHandler");
+        this.errorHandler = errorHandler;
+        return this;
+    }
 
     /**
      * Returns a new created {@link HttpJsonTranscodingOptions}.
-     *
      */
     public HttpJsonTranscodingOptions build() {
         final EnumSet<HttpJsonTranscodingQueryParamNaming> paramNamings;
@@ -84,6 +97,6 @@ public class HttpJsonTranscodingOptionsBuilder {
         } else {
             paramNamings = EnumSet.copyOf(queryParamNamings);
         }
-        return new DefaultHttpJsonTranscodingOptions(paramNamings);
+        return new DefaultHttpJsonTranscodingOptions(paramNamings, errorHandler);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -29,8 +29,8 @@ public class HttpJsonTranscodingOptionsBuilder {
      * enables camelCase query parameters for Http Json Transcoding endpoints.
      * provided by {@link HttpJsonTranscodingService}.
      */
-    public HttpJsonTranscodingOptionsBuilder useCamelCaseQueryParams() {
-        this.camelCaseQueryParams = true;
+    public HttpJsonTranscodingOptionsBuilder camelCaseQueryParams(boolean camelCaseQueryParams) {
+        this.camelCaseQueryParams = camelCaseQueryParams;
         return this;
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * builder for {@link HttpJsonTranscodingOptions}.
@@ -38,8 +38,6 @@ public class HttpJsonTranscodingOptionsBuilder {
      * original field name are considered valid inputs.
      */
     public HttpJsonTranscodingOptionsBuilder useCamelCaseQueryParams(boolean useCamelCaseQueryParams) {
-        checkArgument(useCamelCaseQueryParams || useProtoFieldNameQueryParams,
-                      "Can't disable both useCamelCaseQueryParams and useProtoFieldNameQueryParams");
         this.useCamelCaseQueryParams = useCamelCaseQueryParams;
         return this;
     }
@@ -55,16 +53,19 @@ public class HttpJsonTranscodingOptionsBuilder {
      */
     public HttpJsonTranscodingOptionsBuilder useProtoFieldNameQueryParams(
             boolean useProtoFieldNameQueryParams) {
-        checkArgument(useProtoFieldNameQueryParams || useCamelCaseQueryParams,
-                      "Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
         this.useProtoFieldNameQueryParams = useProtoFieldNameQueryParams;
         return this;
     }
 
     /**
-     * builds {@link HttpJsonTranscodingOptions}.
+     * Returns a new created {@link HttpJsonTranscodingOptions}.
+     *
+     * @throws IllegalStateException if both {@link #useProtoFieldNameQueryParams(boolean)} and
+     *                               {@link #useCamelCaseQueryParams(boolean)} are set to {@code false}.
      */
     public HttpJsonTranscodingOptions build() {
+        checkState(useProtoFieldNameQueryParams || useCamelCaseQueryParams,
+                   "Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
         return new DefaultHttpJsonTranscodingOptions(useCamelCaseQueryParams, useProtoFieldNameQueryParams);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -38,41 +38,41 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 @UnstableApi
 public class HttpJsonTranscodingOptionsBuilder {
 
-    private static final EnumSet<HttpJsonTranscodingQueryParamNaming> DEFAULT_QUERY_PARAM_NAMING =
-            EnumSet.of(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+    private static final EnumSet<HttpJsonTranscodingQueryParamMatchRule> DEFAULT_QUERY_PARAM_NAMING =
+            EnumSet.of(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
 
     private UnframedGrpcErrorHandler errorHandler = UnframedGrpcErrorHandler.ofJson();
 
     @Nullable
-    private Set<HttpJsonTranscodingQueryParamNaming> queryParamNamings;
+    private Set<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules;
 
     HttpJsonTranscodingOptionsBuilder() {}
 
     /**
-     * Adds the specified {@link HttpJsonTranscodingQueryParamNaming} which is used to match {@link QueryParams}
+     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used to match {@link QueryParams}
      * of a {@link HttpRequest} with fields in a {@link Message}.
-     * If not set, {@link HttpJsonTranscodingQueryParamNaming#ORIGINAL_FIELD} is used by default.
+     * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
-    public HttpJsonTranscodingOptionsBuilder queryParamNaming(
-            HttpJsonTranscodingQueryParamNaming... queryParamNamings) {
-        requireNonNull(queryParamNamings, "queryParamNamings");
-        queryParamNaming(ImmutableList.copyOf(queryParamNamings));
+    public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(
+            HttpJsonTranscodingQueryParamMatchRule... queryParamMatchRules) {
+        requireNonNull(queryParamMatchRules, "queryParamMatchRules");
+        queryParamMatchRules(ImmutableList.copyOf(queryParamMatchRules));
         return this;
     }
 
     /**
-     * Adds the specified {@link HttpJsonTranscodingQueryParamNaming} which is used to match {@link QueryParams}
+     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used to match {@link QueryParams}
      * of a {@link HttpRequest} with fields in a {@link Message}.
-     * If not set, {@link HttpJsonTranscodingQueryParamNaming#ORIGINAL_FIELD} is used by default.
+     * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
-    public HttpJsonTranscodingOptionsBuilder queryParamNaming(
-            Iterable<HttpJsonTranscodingQueryParamNaming> queryParamNamings) {
-        requireNonNull(queryParamNamings, "queryParamNamings");
-        checkArgument(!Iterables.isEmpty(queryParamNamings), "Can't set an empty queryParamNamings");
-        if (this.queryParamNamings == null) {
-            this.queryParamNamings = new HashSet<>();
+    public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(
+            Iterable<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules) {
+        requireNonNull(queryParamMatchRules, "queryParamMatchRules");
+        checkArgument(!Iterables.isEmpty(queryParamMatchRules), "Can't set an empty queryParamMatchRules");
+        if (this.queryParamMatchRules == null) {
+            this.queryParamMatchRules = new HashSet<>();
         }
-        this.queryParamNamings.addAll(ImmutableList.copyOf(queryParamNamings));
+        this.queryParamMatchRules.addAll(ImmutableList.copyOf(queryParamMatchRules));
         return this;
     }
 
@@ -91,11 +91,11 @@ public class HttpJsonTranscodingOptionsBuilder {
      * Returns a new created {@link HttpJsonTranscodingOptions}.
      */
     public HttpJsonTranscodingOptions build() {
-        final EnumSet<HttpJsonTranscodingQueryParamNaming> paramNamings;
-        if (queryParamNamings == null) {
+        final EnumSet<HttpJsonTranscodingQueryParamMatchRule> paramNamings;
+        if (queryParamMatchRules == null) {
             paramNamings = DEFAULT_QUERY_PARAM_NAMING;
         } else {
-            paramNamings = EnumSet.copyOf(queryParamNamings);
+            paramNamings = EnumSet.copyOf(queryParamMatchRules);
         }
         return new DefaultHttpJsonTranscodingOptions(paramNamings, errorHandler);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
@@ -36,9 +35,9 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * A builder for {@link HttpJsonTranscodingOptions}.
  */
 @UnstableApi
-public class HttpJsonTranscodingOptionsBuilder {
+public final class HttpJsonTranscodingOptionsBuilder {
 
-    private static final EnumSet<HttpJsonTranscodingQueryParamMatchRule> DEFAULT_QUERY_PARAM_NAMING =
+    private static final EnumSet<HttpJsonTranscodingQueryParamMatchRule> DEFAULT_QUERY_PARAM_MATCH_RULES =
             EnumSet.of(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
 
     private UnframedGrpcErrorHandler errorHandler = UnframedGrpcErrorHandler.ofJson();
@@ -70,7 +69,7 @@ public class HttpJsonTranscodingOptionsBuilder {
         requireNonNull(queryParamMatchRules, "queryParamMatchRules");
         checkArgument(!Iterables.isEmpty(queryParamMatchRules), "Can't set an empty queryParamMatchRules");
         if (this.queryParamMatchRules == null) {
-            this.queryParamMatchRules = new HashSet<>();
+            this.queryParamMatchRules = EnumSet.noneOf(HttpJsonTranscodingQueryParamMatchRule.class);
         }
         this.queryParamMatchRules.addAll(ImmutableList.copyOf(queryParamMatchRules));
         return this;
@@ -91,12 +90,12 @@ public class HttpJsonTranscodingOptionsBuilder {
      * Returns a new created {@link HttpJsonTranscodingOptions}.
      */
     public HttpJsonTranscodingOptions build() {
-        final EnumSet<HttpJsonTranscodingQueryParamMatchRule> paramNamings;
+        final EnumSet<HttpJsonTranscodingQueryParamMatchRule> matchRules;
         if (queryParamMatchRules == null) {
-            paramNamings = DEFAULT_QUERY_PARAM_NAMING;
+            matchRules = DEFAULT_QUERY_PARAM_MATCH_RULES;
         } else {
-            paramNamings = EnumSet.copyOf(queryParamMatchRules);
+            matchRules = EnumSet.copyOf(queryParamMatchRules);
         }
-        return new DefaultHttpJsonTranscodingOptions(paramNamings, errorHandler);
+        return new DefaultHttpJsonTranscodingOptions(matchRules, errorHandler);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -16,21 +16,48 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 /**
  * builder for {@link HttpJsonTranscodingOptions}.
  */
 public class HttpJsonTranscodingOptionsBuilder {
 
-    private boolean camelCaseQueryParams;
+    private boolean useCamelCaseQueryParams;
+    private boolean useProtoFieldNameQueryParams = true;
 
     HttpJsonTranscodingOptionsBuilder() {}
 
     /**
-     * enables camelCase query parameters for Http Json Transcoding endpoints.
-     * provided by {@link HttpJsonTranscodingService}.
+     * Sets whether to use lowerCamelCase query parameters for HTTP-JSON Transcoding endpoints.
+     * This option is disabled by default.
+     *
+     * <p>Note that this option is added as an OR condition without disabling
+     * {@link #useProtoFieldNameQueryParams(boolean)}. If {@link #useCamelCaseQueryParams(boolean)} and
+     * {@link #useProtoFieldNameQueryParams(boolean)} are set to {@code true}, both lowerCamelCase and the
+     * original field name are considered valid inputs.
      */
-    public HttpJsonTranscodingOptionsBuilder camelCaseQueryParams(boolean camelCaseQueryParams) {
-        this.camelCaseQueryParams = camelCaseQueryParams;
+    public HttpJsonTranscodingOptionsBuilder useCamelCaseQueryParams(boolean useCamelCaseQueryParams) {
+        checkArgument(useCamelCaseQueryParams || useProtoFieldNameQueryParams,
+                      "Can't disable both useCamelCaseQueryParams and useProtoFieldNameQueryParams");
+        this.useCamelCaseQueryParams = useCamelCaseQueryParams;
+        return this;
+    }
+
+    /**
+     * Sets whether to use the original field name in .proto file to match query parameters.
+     * This option is enabled by default.
+     *
+     * <p>Note that this option is added as an OR condition without disabling
+     * {@link #useCamelCaseQueryParams(boolean)}. If {@link #useProtoFieldNameQueryParams(boolean)} and
+     * {@link #useCamelCaseQueryParams(boolean)} are set to {@code true}, both lowerCamelCase and the
+     * original field name are considered valid inputs.
+     */
+    public HttpJsonTranscodingOptionsBuilder useProtoFieldNameQueryParams(
+            boolean useProtoFieldNameQueryParams) {
+        checkArgument(useProtoFieldNameQueryParams || useCamelCaseQueryParams,
+                      "Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
+        this.useProtoFieldNameQueryParams = useProtoFieldNameQueryParams;
         return this;
     }
 
@@ -38,6 +65,6 @@ public class HttpJsonTranscodingOptionsBuilder {
      * builds {@link HttpJsonTranscodingOptions}.
      */
     public HttpJsonTranscodingOptions build() {
-        return HttpJsonTranscodingOptions.of(camelCaseQueryParams);
+        return new DefaultHttpJsonTranscodingOptions(useCamelCaseQueryParams, useProtoFieldNameQueryParams);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilder.java
@@ -48,8 +48,8 @@ public final class HttpJsonTranscodingOptionsBuilder {
     HttpJsonTranscodingOptionsBuilder() {}
 
     /**
-     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used to match {@link QueryParams}
-     * of a {@link HttpRequest} with fields in a {@link Message}.
+     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used
+     * to match {@link QueryParams} of a {@link HttpRequest} with fields in a {@link Message}.
      * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
     public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(
@@ -60,8 +60,8 @@ public final class HttpJsonTranscodingOptionsBuilder {
     }
 
     /**
-     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used to match {@link QueryParams}
-     * of a {@link HttpRequest} with fields in a {@link Message}.
+     * Adds the specified {@link HttpJsonTranscodingQueryParamMatchRule} which is used
+     * to match {@link QueryParams} of a {@link HttpRequest} with fields in a {@link Message}.
      * If not set, {@link HttpJsonTranscodingQueryParamMatchRule#ORIGINAL_FIELD} is used by default.
      */
     public HttpJsonTranscodingOptionsBuilder queryParamMatchRules(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * HTTP-JSON transcoding endpoint.
  */
 @UnstableApi
-public enum HttpJsonTranscodingQueryParamNaming {
+public enum HttpJsonTranscodingQueryParamMatchRule {
     /**
      * Converts
      * <a href="https://developers.google.com/protocol-buffers/docs/style#message_and_field_names">underscore_separated_names</a>

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
@@ -29,11 +29,11 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 @UnstableApi
 public enum HttpJsonTranscodingQueryParamMatchRule {
     /**
-     * Converts
-     * <a href="https://developers.google.com/protocol-buffers/docs/style#message_and_field_names">underscore_separated_names</a>
-     * into lowerCamelCase and match them with {@link QueryParams} of an {@link HttpRequest}.
+     * Converts field names that are
+     * <a href="https://developers.google.com/protocol-buffers/docs/style#message_and_field_names">underscore_separated</a>
+     * into lowerCamelCase before matching with {@link QueryParams} of an {@link HttpRequest}.
      *
-     * <p>Note that field names in which {@code code underscore_separated_names} is not used may fail to
+     * <p>Note that field names which aren't {@code underscore_separated} may fail to
      * convert correctly to lowerCamelCase. Therefore, don't use this option if you aren't following
      * Protocol Buffer's
      * <a href="https://developers.google.com/protocol-buffers/docs/style">naming conventions</a>.

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamNaming.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamNaming.java
@@ -20,11 +20,13 @@ import com.google.protobuf.Message;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * A naming rule to map {@link QueryParams} of an {@link HttpRequest} to fields in a {@link Message} for
  * HTTP-JSON transcoding endpoint.
  */
+@UnstableApi
 public enum HttpJsonTranscodingQueryParamNaming {
     /**
      * Converts

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamNaming.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamNaming.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import com.google.protobuf.Message;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.QueryParams;
+
+/**
+ * A naming rule to map {@link QueryParams} of an {@link HttpRequest} to fields in a {@link Message} for
+ * HTTP-JSON transcoding endpoint.
+ */
+public enum HttpJsonTranscodingQueryParamNaming {
+    /**
+     * Converts
+     * <a href="https://developers.google.com/protocol-buffers/docs/style#message_and_field_names">underscore_separated_names</a>
+     * into lowerCamelCase and match them with {@link QueryParams} of an {@link HttpRequest}.
+     *
+     * <p>Note that field names in which {@code code underscore_separated_names} is not used may fail to
+     * convert correctly to lowerCamelCase. Therefore, don't use this option if you aren't following
+     * Protocol Buffer's
+     * <a href="https://developers.google.com/protocol-buffers/docs/style">naming conventions</a>.
+     */
+    LOWER_CAMEL_CASE,
+    /**
+     * Uses the original fields in .proto files to match {@link QueryParams} of an {@link HttpRequest}.
+     */
+    ORIGINAL_FIELD
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -120,6 +120,7 @@ import io.netty.util.internal.StringUtil;
  */
 final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         implements HttpEndpointSupport {
+
     private static final Logger logger = LoggerFactory.getLogger(HttpJsonTranscodingService.class);
 
     /**
@@ -127,9 +128,11 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
      * to support HTTP/JSON to gRPC transcoding, a new {@link HttpJsonTranscodingService} instance
      * would be returned. Otherwise, the {@code delegate} would be returned.
      */
-    static GrpcService of(GrpcService delegate, UnframedGrpcErrorHandler unframedGrpcErrorHandler) {
+    static GrpcService of(GrpcService delegate, UnframedGrpcErrorHandler unframedGrpcErrorHandler,
+                          HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
         requireNonNull(delegate, "delegate");
         requireNonNull(unframedGrpcErrorHandler, "unframedGrpcErrorHandler");
+        requireNonNull(httpJsonTranscodingOptions, "httpJsonTranscodingOptions");
 
         final Map<Route, TranscodingSpec> specs = new HashMap<>();
 
@@ -167,7 +170,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 final Route route = routeAndVariables.getKey();
                 final List<PathVariable> pathVariables = routeAndVariables.getValue();
                 final Map<String, Field> fields =
-                        buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of());
+                        buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(), httpJsonTranscodingOptions.camelCaseQueryParams());
 
                 if (specs.containsKey(route)) {
                     logger.warn("{} is not added because the route is duplicate: {}", httpRule, route);
@@ -287,7 +290,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
 
     private static Map<String, Field> buildFields(Descriptor desc,
                                                   List<String> parentNames,
-                                                  Set<Descriptor> visitedTypes) {
+                                                  Set<Descriptor> visitedTypes,
+                                                  boolean useCamelCaseKeys) {
         final StringJoiner namePrefixJoiner = new StringJoiner(".");
         parentNames.forEach(namePrefixJoiner::add);
         final String namePrefix = namePrefixJoiner.length() == 0 ? "" : namePrefixJoiner.toString() + '.';
@@ -295,6 +299,10 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         final ImmutableMap.Builder<String, Field> builder = ImmutableMap.builder();
         desc.getFields().forEach(field -> {
             final JavaType type = field.getJavaType();
+            String key = namePrefix + field.getName();
+            if (useCamelCaseKeys) {
+                key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
+            }
             switch (type) {
                 case INT:
                 case LONG:
@@ -352,7 +360,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                                                    ImmutableSet.<Descriptor>builder()
                                                                .addAll(visitedTypes)
                                                                .add(field.getMessageType())
-                                                               .build()));
+                                                               .build(),
+                                                   useCamelCaseKeys));
                     } catch (RecursiveTypeException e) {
                         if (e.recursiveTypeDescriptor() != field.getMessageType()) {
                             // Re-throw the exception if it is not caused by my field.

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -120,7 +120,6 @@ import io.netty.util.internal.StringUtil;
  */
 final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         implements HttpEndpointSupport {
-
     private static final Logger logger = LoggerFactory.getLogger(HttpJsonTranscodingService.class);
 
     /**
@@ -170,7 +169,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 final Route route = routeAndVariables.getKey();
                 final List<PathVariable> pathVariables = routeAndVariables.getValue();
                 final Map<String, Field> fields =
-                        buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(), httpJsonTranscodingOptions.camelCaseQueryParams());
+                        buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
+                                    httpJsonTranscodingOptions.camelCaseQueryParams());
 
                 if (specs.containsKey(route)) {
                     logger.warn("{} is not added because the route is duplicate: {}", httpRule, route);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -127,10 +127,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
      * to support HTTP/JSON to gRPC transcoding, a new {@link HttpJsonTranscodingService} instance
      * would be returned. Otherwise, the {@code delegate} would be returned.
      */
-    static GrpcService of(GrpcService delegate, UnframedGrpcErrorHandler unframedGrpcErrorHandler,
-                          HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
+    static GrpcService of(GrpcService delegate, HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
         requireNonNull(delegate, "delegate");
-        requireNonNull(unframedGrpcErrorHandler, "unframedGrpcErrorHandler");
         requireNonNull(httpJsonTranscodingOptions, "httpJsonTranscodingOptions");
 
         final Map<Route, TranscodingSpec> specs = new HashMap<>();
@@ -212,8 +210,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
             // We don't need to create a new HttpJsonTranscodingService instance in this case.
             return delegate;
         }
-        return new HttpJsonTranscodingService(delegate, ImmutableMap.copyOf(specs), unframedGrpcErrorHandler,
-                                              httpJsonTranscodingOptions);
+        return new HttpJsonTranscodingService(delegate, ImmutableMap.copyOf(specs), httpJsonTranscodingOptions);
     }
 
     @Nullable
@@ -512,9 +509,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
 
     private HttpJsonTranscodingService(GrpcService delegate,
                                        Map<Route, TranscodingSpec> routeAndSpecs,
-                                       UnframedGrpcErrorHandler unframedGrpcErrorHandler,
                                        HttpJsonTranscodingOptions httpJsonTranscodingOptions) {
-        super(delegate, unframedGrpcErrorHandler);
+        super(delegate, httpJsonTranscodingOptions.errorHandler());
         this.routeAndSpecs = routeAndSpecs;
         routes = ImmutableSet.<Route>builder()
                              .addAll(delegate.routes())

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -299,10 +299,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         final ImmutableMap.Builder<String, Field> builder = ImmutableMap.builder();
         desc.getFields().forEach(field -> {
             final JavaType type = field.getJavaType();
-            String key = namePrefix + field.getName();
-            if (useCamelCaseKeys) {
-                key = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
-            }
+            final String key = namePrefix + field.getName();
+            final String camelCaseKey = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, key);
             switch (type) {
                 case INT:
                 case LONG:
@@ -313,15 +311,19 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 case BYTE_STRING:
                 case ENUM:
                     // Use field name which is specified in proto file.
-                    builder.put(namePrefix + field.getName(),
-                                new Field(field, parentNames, field.getJavaType()));
+                    builder.put(key, new Field(field, parentNames, field.getJavaType()));
+                    if (useCamelCaseKeys && key != camelCaseKey) {
+                        builder.put(camelCaseKey, new Field(field, parentNames, field.getJavaType()));
+                    }
                     break;
                 case MESSAGE:
                     @Nullable
                     final JavaType wellKnownFieldType = getJavaTypeForWellKnownTypes(field);
                     if (wellKnownFieldType != null) {
-                        builder.put(namePrefix + field.getName(),
-                                    new Field(field, parentNames, wellKnownFieldType));
+                        builder.put(key, new Field(field, parentNames, wellKnownFieldType));
+                        if (useCamelCaseKeys && key != camelCaseKey) {
+                            builder.put(camelCaseKey, new Field(field, parentNames, wellKnownFieldType));
+                        }
                         break;
                     }
 
@@ -368,8 +370,10 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                             throw e;
                         }
 
-                        builder.put(namePrefix + field.getName(),
-                                    new Field(field, parentNames, JavaType.MESSAGE));
+                        builder.put(key, new Field(field, parentNames, JavaType.MESSAGE));
+                        if (useCamelCaseKeys && key != camelCaseKey) {
+                            builder.put(camelCaseKey, new Field(field, parentNames, JavaType.MESSAGE));
+                        }
                     }
                     break;
             }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -170,8 +171,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
                                     false);
                 final Map<String, Field> camelCaseFields;
-                if (httpJsonTranscodingOptions.queryParamMatchRules()
-                                              .contains(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE)) {
+                if (httpJsonTranscodingOptions.queryParamMatchRules().contains(LOWER_CAMEL_CASE)) {
                     camelCaseFields =
                             buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
                                         true);
@@ -518,7 +518,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                              .build();
         useCamelCaseQueryParams =
                 httpJsonTranscodingOptions.queryParamMatchRules()
-                                          .contains(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
+                                          .contains(LOWER_CAMEL_CASE);
         useProtoFieldNameQueryParams =
                 httpJsonTranscodingOptions.queryParamMatchRules()
                                           .contains(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -170,8 +170,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
                                     false);
                 final Map<String, Field> camelCaseFields;
-                if (httpJsonTranscodingOptions.queryParamNamings()
-                                              .contains(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE)) {
+                if (httpJsonTranscodingOptions.queryParamMatchRules()
+                                              .contains(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE)) {
                     camelCaseFields =
                             buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
                                         true);
@@ -517,11 +517,11 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                              .addAll(routeAndSpecs.keySet())
                              .build();
         useCamelCaseQueryParams =
-                httpJsonTranscodingOptions.queryParamNamings()
-                                          .contains(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
+                httpJsonTranscodingOptions.queryParamMatchRules()
+                                          .contains(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
         useProtoFieldNameQueryParams =
-                httpJsonTranscodingOptions.queryParamNamings()
-                                          .contains(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+                httpJsonTranscodingOptions.queryParamMatchRules()
+                                          .contains(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -724,7 +724,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 // The original field name should be used for the path variable
                 field = spec.originalFields.get(entry.getKey());
             } else {
-                // A query parameter can be matched with either a original field name or a camel case name
+                // A query parameter can be matched with either an original field name or a camel case name
                 // depending on the `HttpJsonTranscodingOptions`.
                 if (useProtoFieldNameQueryParams) {
                     field = spec.originalFields.get(entry.getKey());

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.client.BlockingWebClient;
@@ -94,6 +95,7 @@ import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamNaming;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.stub.StreamObserver;
@@ -310,10 +312,17 @@ public class HttpJsonTranscodingTest {
 
     static ServerExtension createServer(boolean preservingProtoFieldNames, boolean camelCaseQueryParams,
                                         boolean protoFieldNameQueryParams) {
+        final ImmutableList.Builder<HttpJsonTranscodingQueryParamNaming> queryParamNaming =
+                ImmutableList.builder();
+        if (camelCaseQueryParams) {
+            queryParamNaming.add(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
+        }
+        if (protoFieldNameQueryParams) {
+            queryParamNaming.add(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+        }
         final HttpJsonTranscodingOptions options =
                 HttpJsonTranscodingOptions.builder()
-                                          .useCamelCaseQueryParams(camelCaseQueryParams)
-                                          .useProtoFieldNameQueryParams(protoFieldNameQueryParams)
+                                          .queryParamNaming(queryParamNaming.build())
                                           .build();
         return new ServerExtension() {
             @Override

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -95,7 +95,7 @@ import com.linecorp.armeria.server.docs.DocService;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
 import com.linecorp.armeria.server.grpc.HttpJsonTranscodingOptions;
-import com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamNaming;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.stub.StreamObserver;
@@ -312,17 +312,17 @@ public class HttpJsonTranscodingTest {
 
     static ServerExtension createServer(boolean preservingProtoFieldNames, boolean camelCaseQueryParams,
                                         boolean protoFieldNameQueryParams) {
-        final ImmutableList.Builder<HttpJsonTranscodingQueryParamNaming> queryParamNaming =
+        final ImmutableList.Builder<HttpJsonTranscodingQueryParamMatchRule> queryParamMatchRules =
                 ImmutableList.builder();
         if (camelCaseQueryParams) {
-            queryParamNaming.add(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
+            queryParamMatchRules.add(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
         }
         if (protoFieldNameQueryParams) {
-            queryParamNaming.add(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+            queryParamMatchRules.add(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
         }
         final HttpJsonTranscodingOptions options =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamNaming(queryParamNaming.build())
+                                          .queryParamMatchRules(queryParamMatchRules.build())
                                           .build();
         return new ServerExtension() {
             @Override

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -283,13 +284,16 @@ public class HttpJsonTranscodingTest {
     }
 
     @RegisterExtension
-    static final ServerExtension server = createServer(false, false);
+    static final ServerExtension server = createServer(false, false, true);
 
     @RegisterExtension
-    static final ServerExtension serverPreservingProtoFieldNames = createServer(true, false);
+    static final ServerExtension serverPreservingProtoFieldNames = createServer(true, false, true);
 
     @RegisterExtension
-    static final ServerExtension serverCamelCaseQueryParameters = createServer(false, true);
+    static final ServerExtension serverCamelCaseQueryOnlyParameters = createServer(false, true, false);
+
+    @RegisterExtension
+    static final ServerExtension serverCamelCaseQueryAndOriginalParameters = createServer(false, true, true);
 
     private final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
 
@@ -298,13 +302,19 @@ public class HttpJsonTranscodingTest {
     private final WebClient webClientPreservingProtoFieldNames =
             WebClient.builder(serverPreservingProtoFieldNames.httpUri()).build();
 
-    private final WebClient webClientCamelCaseQueryParameters =
-            WebClient.builder(serverCamelCaseQueryParameters.httpUri()).build();
+    private final BlockingWebClient webClientCamelCaseQueryOnlyParameters =
+            serverCamelCaseQueryOnlyParameters.blockingWebClient();
 
-    static ServerExtension createServer(boolean preservingProtoFieldNames, boolean camelCaseQueryParams) {
-        final HttpJsonTranscodingOptions options = HttpJsonTranscodingOptions.builder()
-                .camelCaseQueryParams(camelCaseQueryParams)
-                .build();
+    private final BlockingWebClient webClientCamelCaseQueryAndOriginalParameters =
+            serverCamelCaseQueryAndOriginalParameters.blockingWebClient();
+
+    static ServerExtension createServer(boolean preservingProtoFieldNames, boolean camelCaseQueryParams,
+                                        boolean protoFieldNameQueryParams) {
+        final HttpJsonTranscodingOptions options =
+                HttpJsonTranscodingOptions.builder()
+                                          .useCamelCaseQueryParams(camelCaseQueryParams)
+                                          .useProtoFieldNameQueryParams(protoFieldNameQueryParams)
+                                          .build();
         return new ServerExtension() {
             @Override
             protected void configure(ServerBuilder sb) throws Exception {
@@ -765,28 +775,74 @@ public class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptCamelCaseQueryParamsOnOption() throws JsonProcessingException {
-        final QueryParamsBuilder query = QueryParams.builder();
-        query.add("queryParameter", "testQuery")
-             .add("parentField.childField", "testChildField")
-             .add("parentField.childField2","testChildField2");
+    void shouldAcceptOnlyCamelCaseQueryParams() throws JsonProcessingException {
+        final QueryParams query =
+                QueryParams.builder()
+                           .add("queryParameter", "testQuery")
+                           .add("parentField.childField", "testChildField")
+                           .add("parentField.childField2", "testChildField2")
+                           .build();
 
-        final AggregatedHttpResponse response =
-                webClientCamelCaseQueryParameters.get("/v4/messages/1?" + query.toQueryString())
-                         .aggregate().join();
-        final JsonNode root = mapper.readTree(response.contentUtf8());
-        assertThat(root.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
+        final JsonNode response =
+                webClientCamelCaseQueryOnlyParameters.prepare()
+                                                     .get("/v4/messages/1")
+                                                     .queryParams(query)
+                                                     .asJson(JsonNode.class)
+                                                     .execute()
+                                                     .content();
+        assertThat(response.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
 
-        final QueryParamsBuilder query2 = QueryParams.builder();
-        query2.add("query_parameter", "testQuery")
-             .add("parent_field.child_field", "testChildField")
-             .add("parent_field.child_field_2","testChildField2");
+        final QueryParams query2 =
+                QueryParams.builder()
+                           .add("query_parameter", "testQuery")
+                           .add("parent_field.child_field", "testChildField")
+                           .add("parent_field.child_field_2", "testChildField2")
+                           .build();
 
-        final AggregatedHttpResponse response2 =
-                webClientCamelCaseQueryParameters.get("/v4/messages/1?" + query2.toQueryString())
-                                                 .aggregate().join();
-        final JsonNode root2 = mapper.readTree(response2.contentUtf8());
-        assertThat(root2.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
+        final JsonNode response2 =
+                webClientCamelCaseQueryOnlyParameters.prepare()
+                                                     .get("/v4/messages/1")
+                                                     .queryParams(query2)
+                                                     .asJson(JsonNode.class)
+                                                     .execute()
+                                                     .content();
+        // Disallow snake_case parameters.
+        assertThat(response2.get("text").asText()).isEqualTo("1:::");
+    }
+
+    @Test
+    void shouldAcceptBothCamelCaseAndSnakeCaseQueryParams() throws JsonProcessingException {
+        final QueryParams query =
+                QueryParams.builder()
+                           .add("queryParameter", "testQuery")
+                           .add("parentField.childField", "testChildField")
+                           .add("parentField.childField2", "testChildField2")
+                           .build();
+
+        final JsonNode response =
+                webClientCamelCaseQueryAndOriginalParameters.prepare()
+                                                            .get("/v4/messages/1")
+                                                            .queryParams(query)
+                                                            .asJson(JsonNode.class)
+                                                            .execute()
+                                                            .content();
+        assertThat(response.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
+
+        final QueryParams query2 =
+                QueryParams.builder()
+                           .add("query_parameter", "testQuery")
+                           .add("parent_field.child_field", "testChildField")
+                           .add("parent_field.child_field_2", "testChildField2")
+                           .build();
+
+        final JsonNode response2 =
+                webClientCamelCaseQueryAndOriginalParameters.prepare()
+                                                            .get("/v4/messages/1")
+                                                            .queryParams(query2)
+                                                            .asJson(JsonNode.class)
+                                                            .execute()
+                                                            .content();
+        assertThat(response2.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
     }
 
     public static JsonNode findMethod(JsonNode methods, String name) {

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -45,7 +45,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.CaseFormat;
 import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.client.WebClient;
@@ -303,7 +302,7 @@ public class HttpJsonTranscodingTest {
             WebClient.builder(serverCamelCaseQueryParameters.httpUri()).build();
 
     static ServerExtension createServer(boolean preservingProtoFieldNames, boolean camelCaseQueryParams) {
-        HttpJsonTranscodingOptions options = HttpJsonTranscodingOptions.builder()
+        final HttpJsonTranscodingOptions options = HttpJsonTranscodingOptions.builder()
                 .camelCaseQueryParams(camelCaseQueryParams)
                 .build();
         return new ServerExtension() {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
@@ -28,41 +28,41 @@ class HttpJsonTranscodingOptionsBuilderTest {
     @Test
     void shouldDisallowEmptyNaming() {
         assertThatThrownBy(() -> HttpJsonTranscodingOptions.builder()
-                                                           .queryParamNaming(ImmutableList.of()))
+                                                           .queryParamMatchRules(ImmutableList.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Can't set an empty queryParamNamings");
+                .hasMessage("Can't set an empty queryParamMatchRules");
     }
 
     @Test
     void shouldReturnConfiguredSettings() {
         final HttpJsonTranscodingOptions withCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamNaming(
-                                                  HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE)
+                                          .queryParamMatchRules(
+                                                  HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE)
                                           .build();
-        assertThat(withCamelCase.queryParamNamings())
-                .containsExactly(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
+        assertThat(withCamelCase.queryParamMatchRules())
+                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
 
         final HttpJsonTranscodingOptions onlyCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamNaming(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD)
+                                          .queryParamMatchRules(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD)
                                           .build();
-        assertThat(onlyCamelCase.queryParamNamings())
-                .containsExactly(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+        assertThat(onlyCamelCase.queryParamMatchRules())
+                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
 
         final HttpJsonTranscodingOptions onlyOriginalField =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamNaming(ImmutableList.of(
-                                                  HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE,
-                                                  HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD))
+                                          .queryParamMatchRules(ImmutableList.of(
+                                                  HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE,
+                                                  HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD))
                                           .build();
-        assertThat(onlyOriginalField.queryParamNamings())
-                .containsExactlyInAnyOrder(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD,
-                                           HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
+        assertThat(onlyOriginalField.queryParamMatchRules())
+                .containsExactlyInAnyOrder(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD,
+                                           HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
 
         final HttpJsonTranscodingOptions defaultOptions =
                 HttpJsonTranscodingOptions.of();
-        assertThat(defaultOptions.queryParamNamings())
-                .containsExactly(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
+        assertThat(defaultOptions.queryParamMatchRules())
+                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import static com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE;
+import static com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,32 +39,26 @@ class HttpJsonTranscodingOptionsBuilderTest {
     void shouldReturnConfiguredSettings() {
         final HttpJsonTranscodingOptions withCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamMatchRules(
-                                                  HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE)
+                                          .queryParamMatchRules(LOWER_CAMEL_CASE)
                                           .build();
         assertThat(withCamelCase.queryParamMatchRules())
-                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
+                .containsExactly(LOWER_CAMEL_CASE);
 
         final HttpJsonTranscodingOptions onlyCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamMatchRules(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD)
+                                          .queryParamMatchRules(ORIGINAL_FIELD)
                                           .build();
-        assertThat(onlyCamelCase.queryParamMatchRules())
-                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
+        assertThat(onlyCamelCase.queryParamMatchRules()).containsExactly(ORIGINAL_FIELD);
 
         final HttpJsonTranscodingOptions onlyOriginalField =
                 HttpJsonTranscodingOptions.builder()
-                                          .queryParamMatchRules(ImmutableList.of(
-                                                  HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE,
-                                                  HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD))
+                                          .queryParamMatchRules(ImmutableList.of(LOWER_CAMEL_CASE,
+                                                                                 ORIGINAL_FIELD))
                                           .build();
         assertThat(onlyOriginalField.queryParamMatchRules())
-                .containsExactlyInAnyOrder(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD,
-                                           HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE);
+                .containsExactlyInAnyOrder(ORIGINAL_FIELD, LOWER_CAMEL_CASE);
 
-        final HttpJsonTranscodingOptions defaultOptions =
-                HttpJsonTranscodingOptions.of();
-        assertThat(defaultOptions.queryParamMatchRules())
-                .containsExactly(HttpJsonTranscodingQueryParamMatchRule.ORIGINAL_FIELD);
+        final HttpJsonTranscodingOptions defaultOptions = HttpJsonTranscodingOptions.of();
+        assertThat(defaultOptions.queryParamMatchRules()).containsExactly(ORIGINAL_FIELD);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class HttpJsonTranscodingOptionsBuilderTest {
+
+    @Test
+    void shouldNotDisableBothCamelAndProtoName() {
+        assertThatThrownBy(() -> HttpJsonTranscodingOptions.builder()
+                                                           .useCamelCaseQueryParams(false)
+                                                           .useProtoFieldNameQueryParams(false)
+                                                           .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
+    }
+
+    @Test
+    void shouldReturnConfiguredSettings() {
+        final HttpJsonTranscodingOptions withCamelCase =
+                HttpJsonTranscodingOptions.builder()
+                                          .useCamelCaseQueryParams(true)
+                                          .build();
+        assertThat(withCamelCase.useCamelCaseQueryParams()).isTrue();
+        assertThat(withCamelCase.useProtoFieldNameQueryParams()).isTrue();
+
+        final HttpJsonTranscodingOptions onlyCamelCase =
+                HttpJsonTranscodingOptions.builder()
+                                          .useCamelCaseQueryParams(true)
+                                          .useProtoFieldNameQueryParams(false)
+                                          .build();
+        assertThat(onlyCamelCase.useCamelCaseQueryParams()).isTrue();
+        assertThat(onlyCamelCase.useProtoFieldNameQueryParams()).isFalse();
+
+        final HttpJsonTranscodingOptions onlyOriginalField =
+                HttpJsonTranscodingOptions.builder()
+                                          .useCamelCaseQueryParams(false)
+                                          .useProtoFieldNameQueryParams(true)
+                                          .build();
+        assertThat(onlyOriginalField.useCamelCaseQueryParams()).isFalse();
+        assertThat(onlyOriginalField.useProtoFieldNameQueryParams()).isTrue();
+
+        final HttpJsonTranscodingOptions defaultOptions =
+                HttpJsonTranscodingOptions.ofDefault();
+        assertThat(defaultOptions.useCamelCaseQueryParams()).isFalse();
+        assertThat(defaultOptions.useProtoFieldNameQueryParams()).isTrue();
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
@@ -21,13 +21,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableList;
+
 class HttpJsonTranscodingOptionsBuilderTest {
 
     @Test
-    void shouldNotDisableBothCamelAndProtoName() {
+    void shouldDisallowEmptyNaming() {
         assertThatThrownBy(() -> HttpJsonTranscodingOptions.builder()
-                                                           .useCamelCaseQueryParams(false)
-                                                           .useProtoFieldNameQueryParams(false)
+                                                           .queryParamNaming(ImmutableList.of())
                                                            .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
@@ -37,30 +38,32 @@ class HttpJsonTranscodingOptionsBuilderTest {
     void shouldReturnConfiguredSettings() {
         final HttpJsonTranscodingOptions withCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .useCamelCaseQueryParams(true)
+                                          .queryParamNaming(
+                                                  HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE)
                                           .build();
-        assertThat(withCamelCase.useCamelCaseQueryParams()).isTrue();
-        assertThat(withCamelCase.useProtoFieldNameQueryParams()).isTrue();
+        assertThat(withCamelCase.queryParamNamings())
+                .containsExactly(HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
 
         final HttpJsonTranscodingOptions onlyCamelCase =
                 HttpJsonTranscodingOptions.builder()
-                                          .useCamelCaseQueryParams(true)
-                                          .useProtoFieldNameQueryParams(false)
+                                          .queryParamNaming(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD)
                                           .build();
-        assertThat(onlyCamelCase.useCamelCaseQueryParams()).isTrue();
-        assertThat(onlyCamelCase.useProtoFieldNameQueryParams()).isFalse();
+        assertThat(onlyCamelCase.queryParamNamings())
+                .containsExactly(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
 
         final HttpJsonTranscodingOptions onlyOriginalField =
                 HttpJsonTranscodingOptions.builder()
-                                          .useCamelCaseQueryParams(false)
-                                          .useProtoFieldNameQueryParams(true)
+                                          .queryParamNaming(ImmutableList.of(
+                                                  HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE,
+                                                  HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD))
                                           .build();
-        assertThat(onlyOriginalField.useCamelCaseQueryParams()).isFalse();
-        assertThat(onlyOriginalField.useProtoFieldNameQueryParams()).isTrue();
+        assertThat(onlyOriginalField.queryParamNamings())
+                .containsExactlyInAnyOrder(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD,
+                                           HttpJsonTranscodingQueryParamNaming.LOWER_CAMEL_CASE);
 
         final HttpJsonTranscodingOptions defaultOptions =
-                HttpJsonTranscodingOptions.ofDefault();
-        assertThat(defaultOptions.useCamelCaseQueryParams()).isFalse();
-        assertThat(defaultOptions.useProtoFieldNameQueryParams()).isTrue();
+                HttpJsonTranscodingOptions.of();
+        assertThat(defaultOptions.queryParamNamings())
+                .containsExactly(HttpJsonTranscodingQueryParamNaming.ORIGINAL_FIELD);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingOptionsBuilderTest.java
@@ -28,10 +28,9 @@ class HttpJsonTranscodingOptionsBuilderTest {
     @Test
     void shouldDisallowEmptyNaming() {
         assertThatThrownBy(() -> HttpJsonTranscodingOptions.builder()
-                                                           .queryParamNaming(ImmutableList.of())
-                                                           .build())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Can't disable both useProtoFieldNameQueryParams and useCamelCaseQueryParams");
+                                                           .queryParamNaming(ImmutableList.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Can't set an empty queryParamNamings");
     }
 
     @Test

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -43,6 +43,11 @@ service HttpJsonTranscodingTestService {
       get:"/v3/messages/{message_id}"
     };
   }
+  rpc GetMessageV4(GetMessageRequestV4) returns (Message) {
+    option (google.api.http) = {
+      get:"/v4/messages/{message_id}"
+    };
+  }
 
   rpc UpdateMessageV1(UpdateMessageRequestV1) returns (Message) {
     option (google.api.http) = {
@@ -201,6 +206,16 @@ message GetMessageRequestV2 {
 message GetMessageRequestV3 {
   string message_id = 1;          // Mapped to URL path.
   repeated int64 revision = 2;    // Mapped to URL query parameter `revision`.
+}
+
+message GetMessageRequestV4 {
+  string message_id = 1;
+  string query_parameter = 2;
+  ParentMessage parent_field = 3;
+  message ParentMessage {
+     string child_field = 1;
+     string child_field_2 = 2;
+  }
 }
 
 message UpdateMessageRequestV1 {


### PR DESCRIPTION
Motivation:

fixes #4401 

Modifications:

- Add HttpJsonTranscodingOptions and HttpJsonTranscodingOptionsBuilder
- add GrpcServiceBuilder Api that consumes HttpJsonTranscodingOptions when setting enableHttpJsonTranscoding
- check HttpJsonTranscodingOptions in HttpJsonTranscodingService, then add fields with camelCase keys in buildField function if camelCaseQueryParam option is set to true

Result:

- Closes #4401
- No breaking changes: changes are only applied when the new camelCaseQueryParam option is set to true
- HttpJsonTranscoding endpoint can handle both snake_case and camelCase form of query parameters when option is set
  ```java
  HttpJsonTranscodingOptions options =
    HttpJsonTranscodingOptions.builder()
                              .queryParamMatchRules(LOWER_CAMEL_CASE)
                              ...
                              .build();
  GrpcService.builder()
             // Enable HttpJsonTranscoding and use the specified HttpJsonTranscodingOption
             .enableHttpJsonTranscoding(options)
             .build();
  ```

Some concerns with the current implementation:
1. Would the name “HttpJsonTranscodingOptions” not be confused with the google.api.http protobuf option?
2. CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, str) could lead to unexpected behavior: For instance, if str = “uint32Val”, the out come is “uint32val” which is totally unexpected
3. Should both snake_case and camelCase form of query params both be allowed, as is the current behavior in my implementation? (What if both are set? -> currently, field will be re written)
4. If a snake case form and camel case form of a same word sequence is both used in a message as field name simultaneously, there will be error (caused in HttpJsonTranscodingService#buildFields due to duplicated entry) should this corner case be dealt with?
