### PR TITLE
`Protobuf` converter providers don't attempt to illegally cast nested parameterized types

### DIFF
--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionProvider.java
@@ -57,22 +57,34 @@ public final class ProtobufRequestConverterFunctionProvider implements RequestCo
             final ParameterizedType parameterizedType = (ParameterizedType) type;
             final Class<?> rawType = (Class<?>) parameterizedType.getRawType();
             if (List.class.isAssignableFrom(rawType)) {
-                final Class<?> typeArgument = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-                if (isProtobufMessage(typeArgument)) {
+                final Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];
+                if (!(actualTypeArgument instanceof Class<?>)) {
+                    return ResultType.UNKNOWN;
+                }
+                if (isProtobufMessage((Class<?>) actualTypeArgument)) {
                     return ResultType.LIST_PROTOBUF;
                 }
             } else if (Set.class.isAssignableFrom(rawType)) {
-                final Class<?> typeArgument = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-                if (isProtobufMessage(typeArgument)) {
+                final Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];
+                if (!(actualTypeArgument instanceof Class<?>)) {
+                    return ResultType.UNKNOWN;
+                }
+                if (isProtobufMessage((Class<?>) actualTypeArgument)) {
                     return ResultType.SET_PROTOBUF;
                 }
             } else if (Map.class.isAssignableFrom(rawType)) {
                 final Type[] typeArguments = parameterizedType.getActualTypeArguments();
+                if (!(typeArguments[0] instanceof Class<?>)) {
+                    return ResultType.UNKNOWN;
+                }
                 final Class<?> keyType = (Class<?>) typeArguments[0];
                 if (!String.class.isAssignableFrom(keyType)) {
                     throw new IllegalStateException(
                             keyType + " cannot be used for the key type of Map. " +
                             "(expected: Map<String, ?>)");
+                }
+                if (!(typeArguments[1] instanceof Class<?>)) {
+                    return ResultType.UNKNOWN;
                 }
                 if (isProtobufMessage((Class<?>) typeArguments[1])) {
                     return ResultType.MAP_PROTOBUF;

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionProvider.java
@@ -79,9 +79,7 @@ public final class ProtobufRequestConverterFunctionProvider implements RequestCo
                 }
                 final Class<?> keyType = (Class<?>) typeArguments[0];
                 if (!String.class.isAssignableFrom(keyType)) {
-                    throw new IllegalStateException(
-                            keyType + " cannot be used for the key type of Map. " +
-                            "(expected: Map<String, ?>)");
+                    return ResultType.UNKNOWN;
                 }
                 if (!(typeArguments[1] instanceof Class<?>)) {
                     return ResultType.UNKNOWN;

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionProvider.java
@@ -61,13 +61,17 @@ public final class ProtobufResponseConverterFunctionProvider implements Response
 
             if (Iterable.class.isAssignableFrom(rawType) || Stream.class.isAssignableFrom(rawType) ||
                 Publisher.class.isAssignableFrom(rawType)) {
-                final Class<?> typeArgument = (Class<?>) parameterizedType.getActualTypeArguments()[0];
-                return Message.class.isAssignableFrom(typeArgument);
-            }
-
-            if (Map.class.isAssignableFrom(rawType)) {
-                final Class<?> typeArgument = (Class<?>) parameterizedType.getActualTypeArguments()[1];
-                return Message.class.isAssignableFrom(typeArgument);
+                final Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];
+                if (!(actualTypeArgument instanceof Class)) {
+                    return false;
+                }
+                return Message.class.isAssignableFrom((Class<?>) actualTypeArgument);
+            } else if (Map.class.isAssignableFrom(rawType)) {
+                final Type actualTypeArgument = parameterizedType.getActualTypeArguments()[1];
+                if (!(actualTypeArgument instanceof Class)) {
+                    return false;
+                }
+                return Message.class.isAssignableFrom((Class<?>) actualTypeArgument);
             }
         }
 

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -199,6 +199,11 @@ class ProtobufRequestConverterFunctionTest {
         @Produces(MediaTypeNames.JSON)
         public void nestedValue(Map<String, List<SimpleRequest>> param) {
         }
+
+        @Get("/nonStringKey")
+        @Produces(MediaTypeNames.JSON)
+        public void nonStringKey(Map<Integer, SimpleResponse> param) {
+        }
     }
 
     private static class ProtobufArguments implements ArgumentsProvider {

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -157,8 +157,7 @@ class ProtobufRequestConverterFunctionTest {
                                          HttpData.ofUtf8(json));
         assertThatThrownBy(() -> converter.convertRequest(ctx, req, typeToken.getRawType(),
                                                           (ParameterizedType) typeToken.getType()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("cannot be used for the key type of Map.");
+                .isInstanceOf(FallthroughException.class);
     }
 
     @Test

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -170,6 +170,9 @@ class ProtobufRequestConverterFunctionTest {
             if (!Modifier.isPublic(method.getModifiers())) {
                 continue;
             }
+            if (method.getParameters().length == 0) {
+                continue;
+            }
             final RequestConverterFunction fn = provider.createRequestConverterFunction(
                     method.getParameters()[0].getParameterizedType(), converter);
             assertThat(fn).isNull();

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -162,7 +162,7 @@ class ProtobufRequestConverterFunctionTest {
     }
 
     @Test
-    void invalidProtobufParameter() {
+    void nestedProtobufParameter() {
         final ProtobufRequestConverterFunction converter = new ProtobufRequestConverterFunction();
         final ProtobufRequestConverterFunctionProvider provider = new ProtobufRequestConverterFunctionProvider();
         for (Method method : NestedProtobufService.class.getDeclaredMethods()) {

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -164,7 +164,8 @@ class ProtobufRequestConverterFunctionTest {
     @Test
     void nestedProtobufParameter() {
         final ProtobufRequestConverterFunction converter = new ProtobufRequestConverterFunction();
-        final ProtobufRequestConverterFunctionProvider provider = new ProtobufRequestConverterFunctionProvider();
+        final ProtobufRequestConverterFunctionProvider provider =
+                new ProtobufRequestConverterFunctionProvider();
         for (Method method : NestedProtobufService.class.getDeclaredMethods()) {
             if (!Modifier.isPublic(method.getModifiers())) {
                 continue;

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufRequestConverterFunctionTest.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.server.protobuf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
@@ -46,10 +48,15 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.MediaTypeNames;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.protobuf.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.protobuf.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.FallthroughException;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Produces;
+import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.protobuf.ProtobufRequestConverterFunction.ResultType;
 
 class ProtobufRequestConverterFunctionTest {
@@ -152,6 +159,42 @@ class ProtobufRequestConverterFunctionTest {
                                                           (ParameterizedType) typeToken.getType()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("cannot be used for the key type of Map.");
+    }
+
+    @Test
+    void invalidProtobufParameter() {
+        final ProtobufRequestConverterFunction converter = new ProtobufRequestConverterFunction();
+        final ProtobufRequestConverterFunctionProvider provider = new ProtobufRequestConverterFunctionProvider();
+        for (Method method : NestedProtobufService.class.getDeclaredMethods()) {
+            if (!Modifier.isPublic(method.getModifiers())) {
+                continue;
+            }
+            final RequestConverterFunction fn = provider.createRequestConverterFunction(
+                    method.getParameters()[0].getParameterizedType(), converter);
+            assertThat(fn).isNull();
+        }
+    }
+
+    private static class NestedProtobufService {
+        @Get("/nestedList")
+        @Produces(MediaTypeNames.JSON)
+        public void nestedList(List<List<SimpleResponse>> param) {
+        }
+
+        @Get("/nestedSet")
+        @Produces(MediaTypeNames.JSON)
+        public void nestedSet(Set<Set<SimpleResponse>> param) {
+        }
+
+        @Get("/nestedKey")
+        @Produces(MediaTypeNames.JSON)
+        public void nestedKey(Map<List<SimpleResponse>, SimpleResponse> param) {
+        }
+
+        @Get("/nestedValue")
+        @Produces(MediaTypeNames.JSON)
+        public void nestedValue(Map<String, List<SimpleRequest>> param) {
+        }
     }
 
     private static class ProtobufArguments implements ArgumentsProvider {

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunctionTest.java
@@ -122,7 +122,8 @@ class ProtobufResponseConverterFunctionTest {
 
     @Test
     void nestedProtobuf() {
-        final ProtobufResponseConverterFunctionProvider provider = new ProtobufResponseConverterFunctionProvider();
+        final ProtobufResponseConverterFunctionProvider provider =
+                new ProtobufResponseConverterFunctionProvider();
         for (Method method : NestedProtobufService.class.getDeclaredMethods()) {
             if (!Modifier.isPublic(method.getModifiers())) {
                 continue;

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
@@ -69,10 +69,8 @@ private[scalapb] object ScalaPbConverterUtil {
           typeArguments(1).isInstanceOf[Class[_]] &&
           isProtobufMessage(typeArguments(1).asInstanceOf[Class[_]])) {
           if (!classOf[String].isAssignableFrom(firstType))
-            throw new IllegalStateException(
-              s"$firstType cannot be used for the key type of Map. (expected: Map[String, _])")
-
-          if (classOf[Map[_, _]].isAssignableFrom(rawType))
+            ResultType.UNKNOWN
+          else if (classOf[Map[_, _]].isAssignableFrom(rawType))
             ResultType.SCALA_MAP_PROTOBUF
           else if (classOf[java.util.Map[_, _]].isAssignableFrom(rawType))
             ResultType.MAP_PROTOBUF

--- a/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
+++ b/scalapb/scalapb_2.13/src/main/scala/com/linecorp/armeria/server/scalapb/ScalaPbConverterUtil.scala
@@ -46,6 +46,9 @@ private[scalapb] object ScalaPbConverterUtil {
       case parameterizedType: ParameterizedType =>
         val rawType = parameterizedType.getRawType.asInstanceOf[Class[_]]
         val typeArguments = parameterizedType.getActualTypeArguments
+        if (!typeArguments(0).isInstanceOf[Class[_]]) {
+          return ResultType.UNKNOWN
+        }
         val firstType = typeArguments(0).asInstanceOf[Class[_]]
 
         val typeArgumentsLength = typeArguments.length
@@ -63,6 +66,7 @@ private[scalapb] object ScalaPbConverterUtil {
           else
             ResultType.UNKNOWN
         else if (typeArgumentsLength == 2 &&
+          typeArguments(1).isInstanceOf[Class[_]] &&
           isProtobufMessage(typeArguments(1).asInstanceOf[Class[_]])) {
           if (!classOf[String].isAssignableFrom(firstType))
             throw new IllegalStateException(
@@ -85,6 +89,9 @@ private[scalapb] object ScalaPbConverterUtil {
       case parameterizedType: ParameterizedType =>
         val rawType = parameterizedType.getRawType.asInstanceOf[Class[_]]
         val typeArguments = parameterizedType.getActualTypeArguments
+        if (!typeArguments(0).isInstanceOf[Class[_]]) {
+          return false
+        }
         val firstType = typeArguments(0).asInstanceOf[Class[_]]
 
         typeArguments.length == 1 &&

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
@@ -23,12 +23,14 @@ import com.linecorp.armeria.scalapb.testing.messages.SimpleRequest
 import com.linecorp.armeria.server.ServiceRequestContext
 import com.linecorp.armeria.server.annotation.FallthroughException
 import com.linecorp.armeria.server.scalapb.ScalaPbRequestConverterFunctionTest._
+
 import java.lang.reflect.ParameterizedType
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.`extension`.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, ArgumentsProvider, ArgumentsSource}
+
 import scala.collection.mutable.ArrayBuffer
 import scalapb.GeneratedMessage
 import scalapb.json4s.Printer
@@ -107,6 +109,16 @@ class ScalaPbRequestConverterFunctionTest {
     assertThatThrownBy { () =>
       converter.convertRequest(ctx, req, rawType, parameterizedType)
     }.isInstanceOf(classOf[FallthroughException])
+  }
+
+  @Test
+  def nestedServiceNotThrow(): Unit = {
+    val provider = new ScalaPbRequestConverterFunctionProvider
+    val converter = null
+    for (method <- classOf[NestedProtobufService].getDeclaredMethods) {
+      val fn = provider.createRequestConverterFunction(method.getParameters()(0).getParameterizedType, converter)
+      assert(fn == null)
+    }
   }
 }
 
@@ -194,5 +206,11 @@ private[scalapb] object ScalaPbRequestConverterFunctionTest {
       buffer += s""""${key}": ${printer.print(req)}"""
     }
     buffer.mkString("{", ",", "}")
+  }
+
+  final private class NestedProtobufService {
+    def nestedList(param: List[List[SimpleRequest]]) = ???
+
+    def nestedMap(param: Map[String, List[SimpleRequest]]) = ???
   }
 }

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
@@ -214,5 +214,7 @@ private[scalapb] object ScalaPbRequestConverterFunctionTest {
     def nestedList(param: List[List[SimpleRequest]]) = ???
 
     def nestedMap(param: Map[String, List[SimpleRequest]]) = ???
+
+    def intKeyMap(param: Map[Int, SimpleRequest]) = ???
   }
 }

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbRequestConverterFunctionTest.scala
@@ -116,8 +116,10 @@ class ScalaPbRequestConverterFunctionTest {
     val provider = new ScalaPbRequestConverterFunctionProvider
     val converter = null
     for (method <- classOf[NestedProtobufService].getDeclaredMethods) {
-      val fn = provider.createRequestConverterFunction(method.getParameters()(0).getParameterizedType, converter)
-      assert(fn == null)
+      if (!method.getParameters.isEmpty) {
+        val fn = provider.createRequestConverterFunction(method.getParameters()(0).getParameterizedType, converter)
+        assert(fn == null)
+      }
     }
   }
 }

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunctionTest.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ScalaPbResponseConverterFunctionTest.scala
@@ -19,10 +19,11 @@ package com.linecorp.armeria.server.scalapb
 import com.linecorp.armeria.common.{MediaType, MediaTypeNames}
 import com.linecorp.armeria.scalapb.testing.messages.SimpleResponse
 import com.linecorp.armeria.server.annotation.Produces
-import java.lang
+
 import java.lang.reflect.Type
 import munit.FunSuite
 import org.reactivestreams.Publisher
+
 import scala.concurrent.Future
 
 class ScalaPbResponseConverterFunctionTest extends FunSuite {
@@ -50,6 +51,20 @@ class ScalaPbResponseConverterFunctionTest extends FunSuite {
       )
     }
   }
+
+  test("shouldn't throw on nested parameterized types") {
+    val provider = new ScalaPbResponseConverterFunctionProvider
+    val converter = new ScalaPbResponseConverterFunction
+    for (method <- classOf[NestedService].getDeclaredMethods) {
+      val fn = provider.createResponseConverterFunction(method.getGenericReturnType, converter)
+      assert(fn == null)
+    }
+  }
+}
+
+final private class NestedService {
+  def nestedList: List[List[SimpleResponse]] = ???
+  def nestedMap: Map[String, List[SimpleResponse]] = ???
 }
 
 final private class ProtobufService {


### PR DESCRIPTION
Motivation:

`RequestConverterFunctionProvider#createResponseConverterFunction`, `ResponseConverterFunctionProvider#createResponseConverterFunction` is called to check if a request/response can be handled for all available request/response types in annotated services.

The previous `Protobuf[Request|Response]ConverterFunctionProvider` assumes that only 1-depth parameterized requests will be received. However, it is fairly common for json request/response objects to be defined with multiple levels of parameterized types.

This pull request fixes the current implementation so that at least a `ClassCastException` will not be thrown.
As a result of this PR, `Protobuf[Request|Response]ConverterFunctionProvider` will not handle nested protobuf types.
When used by default configuration, this causes a 500 while attempting to serialize/deserialize protobuf objects using jackson (json). e.g. the following return type will return a 500
```
List<List<Message>>
```
This is a separate point that will be addressed in the future.

Modifications:

- Check `ClassCastException` for `Protobuf[Request|Response]ConverterFunctionProvider` and it's scala counterparts.

Result:

- Users can now use `Protobuf[Request|Response]ConverterFunctionProvider` without encountering a potential `ClassCastException`.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
