### PR TITLE
Fix Multipart not to raise an exception when closing boundary only

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
@@ -173,7 +173,7 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
 
     @Override
     public boolean isEmpty() {
-        return parts.isEmpty();
+        return false;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/DefaultMultipart.java
@@ -173,6 +173,9 @@ final class DefaultMultipart implements Multipart, StreamMessage<HttpData> {
 
     @Override
     public boolean isEmpty() {
+        // This is always false even parts.isEmpty() == true.
+        // It's because isEmpty() is called after this multipart is converted into a StreamMessage and the
+        // StreamMessage produces at least a closing boundary.
         return false;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -424,13 +424,6 @@ final class MimeParser {
 
         final int length = in.readableBytes();
 
-        // Consider all the whitespace. e.g. boundary+whitespace+"\r\n"
-        int linearWhiteSpace = 0;
-        for (int i = boundaryStartOffset + boundaryLength;
-             i < length && (in.getByte(i) == ' ' || in.getByte(i) == '\t'); i++) {
-            ++linearWhiteSpace;
-        }
-
         // Three valid cases:
         // boundary+"--" + "whatever after --" // closing boundary
         // boundary+whitespace+"\n"
@@ -455,6 +448,13 @@ final class MimeParser {
                 return;
             }
             throwInvalidBoundaryException(followingCharOffset + 2);
+        }
+
+        // Consider all the whitespace. e.g. boundary+whitespace+"\r\n"
+        int linearWhiteSpace = 0;
+        for (int i = boundaryStartOffset + boundaryLength;
+             i < length && (in.getByte(i) == ' ' || in.getByte(i) == '\t'); i++) {
+            ++linearWhiteSpace;
         }
 
         // Check the rest.

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -227,7 +227,7 @@ final class MimeParser {
                             // Skip ':' from value
                             final String value = headerLine.substring(index + 1).trim();
                             bodyPartHeadersBuilder.add(key, value);
-                            return;
+                            break;
                         }
                         state = State.BODY;
                         startOfLine = true;
@@ -482,8 +482,7 @@ final class MimeParser {
     private void throwInvalidBoundaryException(int length) {
         final ByteBuf byteBuf = in.readBytes(length);
         try {
-            throw new MimeParsingException(
-                    "Invalid boundary: " + new String(ByteBufUtil.getBytes(byteBuf)));
+            throw new MimeParsingException("Invalid boundary: " + new String(ByteBufUtil.getBytes(byteBuf)));
         } finally {
             byteBuf.release();
         }

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -431,13 +431,13 @@ final class MimeParser {
 
         // Check the closing boundary first.
         int followingCharOffset = boundaryStartOffset + boundaryLength;
-        if (followingCharOffset >= length) {
+        if (followingCharOffset == length) {
             // Need more data.
             return;
         }
 
         if (in.getByte(followingCharOffset) == '-') {
-            if (followingCharOffset + 1 >= length) {
+            if (followingCharOffset + 1 == length) {
                 // Need more data.
                 return;
             }
@@ -459,7 +459,7 @@ final class MimeParser {
 
         // Check the rest.
         followingCharOffset = boundaryStartOffset + boundaryLength + linearWhiteSpace;
-        if (followingCharOffset >= length) {
+        if (followingCharOffset == length) {
             // Need more data.
             return;
         }
@@ -472,7 +472,7 @@ final class MimeParser {
         }
 
         if (followingChar == '\r') {
-            if (followingCharOffset + 1 >= length) {
+            if (followingCharOffset + 1 == length) {
                 // Need one more character.
                 return;
             }

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/Multipart.java
@@ -330,6 +330,9 @@ public interface Multipart {
      *              }
      *          });
      * }</pre>
+     *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while aggregating
+     * so handle it properly.
      */
     CompletableFuture<AggregatedMultipart> aggregate();
 
@@ -350,6 +353,9 @@ public interface Multipart {
      *              }
      *          });
      * }</pre>
+     *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while aggregating
+     * so handle it properly.
      */
     CompletableFuture<AggregatedMultipart> aggregate(EventExecutor executor);
 
@@ -358,6 +364,9 @@ public interface Multipart {
      * be notified when the {@link BodyPart}s of the {@link Multipart} is received fully.
      * {@link AggregatedBodyPart#content()} will return a pooled object, and the caller must ensure
      * to release it. If you don't know what this means, use {@link #aggregate()}.
+     *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while aggregating
+     * so handle it properly.
      */
     CompletableFuture<AggregatedMultipart> aggregateWithPooledObjects(ByteBufAllocator alloc);
 
@@ -366,6 +375,9 @@ public interface Multipart {
      * be notified when the {@link BodyPart}s of the {@link Multipart} is received fully.
      * {@link AggregatedBodyPart#content()} will return a pooled object, and the caller must ensure
      * to release it. If you don't know what this means, use {@link #aggregate()}.
+     *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while aggregating
+     * so handle it properly.
      */
     CompletableFuture<AggregatedMultipart> aggregateWithPooledObjects(EventExecutor executor,
                                                                       ByteBufAllocator alloc);
@@ -391,6 +403,9 @@ public interface Multipart {
      *                  });
      * }</pre>
      *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while collecting
+     * so handle it properly.
+     *
      * @param function A {@link Function} that processes the {@link BodyPart} and returns a future that will
      *                 complete with the process result. The {@link Function} must consume the {@link BodyPart}.
      *                 And If not, collect method will stop processing next {@link BodyPart}.
@@ -407,6 +422,9 @@ public interface Multipart {
      *
      * <p>Note that if this {@link Multipart} was subscribed by other {@link Subscriber} already,
      * the returned {@link CompletableFuture} will be completed with an {@link IllegalStateException}.
+     *
+     * <p>Note that a {@link MimeParsingException} or another exception can be raised while collecting
+     * so handle it properly.
      */
     @UnstableApi
     default <T> CompletableFuture<List<T>> collect(

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
@@ -75,23 +75,6 @@ class MimeParserTest {
     }
 
     @Test
-    void testNoPreambule() {
-        final String boundary = "boundary";
-        final byte[] chunk1 = ("--" + boundary +
-                               "Content-Id: part1\n" +
-                               '\n' +
-                               "1\n" +
-                               "--" + boundary + "--").getBytes();
-
-        final List<AggregatedBodyPart> parts = parse("boundary", chunk1);
-        assertThat(parts).hasSize(1);
-
-        final AggregatedBodyPart part1 = parts.get(0);
-        assertThat(part1.headers().get('-' + boundary + "Content-Id")).isEqualTo("part1");
-        assertThat(part1.contentUtf8()).isEqualTo("1");
-    }
-
-    @Test
     void testEndMessageEvent() {
         final String boundary = "boundary";
         final byte[] chunk1 = ("--" + boundary + '\n' +
@@ -133,6 +116,38 @@ class MimeParserTest {
         final AggregatedBodyPart part2 = parts.get(1);
         assertThat(part2.headers().get("Content-Id")).isEqualTo("part2");
         assertThat(part2.contentUtf8()).isEqualTo("2");
+    }
+
+    @Test
+    void ignoreAfterEndingBoundary() {
+        final String boundary = "boundary";
+        final byte[] chunk1 = ("--" + boundary + "--foobarbaz").getBytes();
+
+        final List<AggregatedBodyPart> parts = parse("boundary", chunk1);
+        assertThat(parts).isEmpty();
+    }
+
+
+    @Test
+    void invalidBoundary() {
+        final String boundary = "boundary";
+        final byte[] data1 = ("--" + boundary + "foo").getBytes();
+
+        assertThatThrownBy(() -> parse("boundary", data1))
+                .isInstanceOf(MimeParsingException.class)
+                .hasMessage("Invalid boundary: --boundaryf");
+
+        final byte[] data2 = ("--" + boundary + "\rfoo\n").getBytes();
+
+        assertThatThrownBy(() -> parse("boundary", data2))
+                .isInstanceOf(MimeParsingException.class)
+                .hasMessage("Invalid boundary: --boundary\rf");
+
+        final byte[] data3 = ("--" + boundary + "-foo-").getBytes();
+
+        assertThatThrownBy(() -> parse("boundary", data3))
+                .isInstanceOf(MimeParsingException.class)
+                .hasMessage("Invalid boundary: --boundary-f");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
@@ -149,6 +149,11 @@ class MimeParserTest {
         assertThatThrownBy(() -> parse("boundary", data3))
                 .isInstanceOf(MimeParsingException.class)
                 .hasMessage("Invalid boundary: --boundary-f");
+
+        final byte[] data4 = ("--" + boundary + " --").getBytes();
+        assertThatThrownBy(() -> parse("boundary", data4))
+                .isInstanceOf(MimeParsingException.class)
+                .hasMessage("Invalid boundary: --boundary -");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MimeParserTest.java
@@ -119,32 +119,33 @@ class MimeParserTest {
     }
 
     @Test
-    void ignoreAfterEndingBoundary() {
+    void ignoreAfterClosingBoundary() {
         final String boundary = "boundary";
         final byte[] chunk1 = ("--" + boundary + "--foobarbaz").getBytes();
 
-        final List<AggregatedBodyPart> parts = parse("boundary", chunk1);
+        List<AggregatedBodyPart> parts = parse("boundary", chunk1);
+        assertThat(parts).isEmpty();
+
+        final byte[] chunk2 = ("--" + boundary + '-').getBytes();
+        final byte[] chunk3 = ("--" + boundary + "-foobarbaz").getBytes();
+        parts = parse("boundary", ImmutableList.of(chunk2, chunk3));
         assertThat(parts).isEmpty();
     }
-
 
     @Test
     void invalidBoundary() {
         final String boundary = "boundary";
         final byte[] data1 = ("--" + boundary + "foo").getBytes();
-
         assertThatThrownBy(() -> parse("boundary", data1))
                 .isInstanceOf(MimeParsingException.class)
                 .hasMessage("Invalid boundary: --boundaryf");
 
         final byte[] data2 = ("--" + boundary + "\rfoo\n").getBytes();
-
         assertThatThrownBy(() -> parse("boundary", data2))
                 .isInstanceOf(MimeParsingException.class)
                 .hasMessage("Invalid boundary: --boundary\rf");
 
         final byte[] data3 = ("--" + boundary + "-foo-").getBytes();
-
         assertThatThrownBy(() -> parse("boundary", data3))
                 .isInstanceOf(MimeParsingException.class)
                 .hasMessage("Invalid boundary: --boundary-f");

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.armeria.common.AggregatedHttpObject;
 import com.linecorp.armeria.common.ContentDisposition;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 public class MultipartTest {
@@ -158,4 +159,13 @@ public class MultipartTest {
         assertThat(path).isEqualTo(tempDir.resolve("name2"));
         assertThat(path).content().isEqualTo("");
     }
+
+    @Test
+    void emptyMultipart() {
+        final Multipart multipart = Multipart.of();
+        final HttpRequest request = multipart.toHttpRequest("/foo");
+        assertThat(request.isEmpty()).isFalse();
+        assertThat(request.aggregate().join().contentUtf8()).isNotEmpty();
+    }
 }
+

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
@@ -97,6 +97,24 @@ class AnnotatedServiceMultipartTest {
     }
 
     @Test
+    void emptyBodyPart2() {
+        final String boundary = "ArmeriaBoundary";
+        final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter("boundary", boundary);
+        final RequestHeaders headers = RequestHeaders.builder(HttpMethod.POST, "/uploadWithMultipartObject")
+                                                     .contentType(contentType)
+                                                     .build();
+        final HttpRequest request =
+                HttpRequest.of(headers, HttpData.ofUtf8(
+                        "--" + boundary + "--\n" +
+                        "content-disposition:form-data; name=\"file1\"; filename=\"foo.txt\"\n" +
+                        "content-type:application/octet-stream\n" +
+                        '\n' +
+                        "foo\n"));
+        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+    }
+
+    @Test
     void missingEndingBoundary() {
         final String boundary = "ArmeriaBoundary";
         final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter("boundary", boundary);

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
@@ -18,12 +18,14 @@ package com.linecorp.armeria.internal.server.annotation;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -33,8 +35,14 @@ import com.google.common.io.Files;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ContentDisposition;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.MediaTypeNames;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.multipart.AggregatedBodyPart;
 import com.linecorp.armeria.common.multipart.BodyPart;
 import com.linecorp.armeria.common.multipart.Multipart;
@@ -45,6 +53,7 @@ import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class AnnotatedServiceMultipartTest {
@@ -54,6 +63,7 @@ class AnnotatedServiceMultipartTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.annotatedService("/", new MyAnnotatedService());
+            sb.decorator(LoggingService.newDecorator());
         }
     };
 
@@ -76,6 +86,33 @@ class AnnotatedServiceMultipartTest {
                            "\"multipartFile1\":\"qux.txt_qux\"," +
                            "\"multipartFile2\":\"quz.txt_quz\"," +
                            "\"param1\":\"armeria\"}");
+    }
+
+    @Test
+    void emptyBodyPart() {
+        final Multipart multipart = Multipart.of();
+        final HttpRequest request = multipart.toHttpRequest("/uploadWithMultipartObject");
+        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+    }
+
+    @Test
+    void missingEndingBoundary() {
+        final String boundary = "ArmeriaBoundary";
+        final MediaType contentType = MediaType.MULTIPART_FORM_DATA.withParameter("boundary", boundary);
+        final RequestHeaders headers = RequestHeaders.builder(HttpMethod.POST, "/uploadWithMultipartObject")
+                                                     .contentType(contentType)
+                                                     .build();
+        final HttpRequest request =
+                HttpRequest.of(headers, HttpData.ofUtf8(
+                        "--ArmeriaBoundary\n" +
+                        "content-disposition:form-data; name=\"file1\"; filename=\"foo.txt\"\n" +
+                        "content-type:application/octet-stream\n" +
+                        '\n' +
+                        "foo\n"));
+        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
+        assertThat(response.headers().status()).isSameAs(HttpStatus.BAD_REQUEST);
+        assertThat(response.contentUtf8()).contains("No closing MIME boundary");
     }
 
     @Consumes(MediaTypeNames.MULTIPART_FORM_DATA)
@@ -110,7 +147,12 @@ class AnnotatedServiceMultipartTest {
         @Post
         @Path("/uploadWithMultipartObject")
         public HttpResponse uploadWithMultipartObject(Multipart multipart) {
-            return HttpResponse.from(multipart.aggregate().thenApply(aggregated -> {
+            return HttpResponse.from(multipart.aggregate().handle((aggregated, cause) -> {
+                if (cause != null) {
+                    return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                           cause.getMessage());
+                }
+
                 final ImmutableMap<String, String> body =
                         aggregated.names().stream().collect(toImmutableMap(Function.identity(), e -> {
                             final AggregatedBodyPart bodyPart =

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
@@ -105,7 +105,7 @@ class AnnotatedServiceMultipartTest {
                                                      .build();
         final HttpRequest request =
                 HttpRequest.of(headers, HttpData.ofUtf8(
-                        "--ArmeriaBoundary\n" +
+                        "--" + boundary + '\n' +
                         "content-disposition:form-data; name=\"file1\"; filename=\"foo.txt\"\n" +
                         "content-type:application/octet-stream\n" +
                         '\n' +


### PR DESCRIPTION
Motivation:
A `Multipart` can be terminated with the ending boundary without a body part. For example, the following request is totally valid:
```
POST /test.html HTTP/1.1
Host: example.org
Content-Type: multipart/form-data;boundary="boundary"

--boundary--
```
We must not raise an exception in that case.

Modifications:
- Do not raise an exception when `Multipart` has the ending boundary only.
- Propagate an exception in `MultipartDecoder` to the subscriber correctly.
- Change to return `false` from `StreamMessage.isEmpty()` when the `StreamMessage` is created from a empty `Multipart`
  - Because it produces the ending boundary.

Result:
- You no longer see a 500 response when an empty multipart request is sent.