### PR TITLE
Protobuf docservice handles structs with empty children correctly

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/FieldInfoBuilder.java
@@ -15,14 +15,12 @@
  */
 package com.linecorp.armeria.server.docs;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
@@ -53,8 +51,6 @@ public final class FieldInfoBuilder {
     FieldInfoBuilder(String name, TypeSignature typeSignature, Iterable<FieldInfo> childFieldInfos) {
         this.name = requireNonNull(name, "name");
         this.typeSignature = typeSignature;
-        checkArgument(!Iterables.isEmpty(requireNonNull(childFieldInfos, "childFieldInfos")),
-                      "childFieldInfos can't be empty.");
         this.childFieldInfos = ImmutableList.copyOf(childFieldInfos);
     }
 

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProvider.java
@@ -129,7 +129,8 @@ public final class ProtobufNamedTypeInfoProvider implements NamedTypeInfoProvide
         final TypeSignature typeSignature = newFieldTypeInfo(fieldDescriptor);
         final Object typeDescriptor = typeSignature.namedTypeDescriptor();
         final FieldInfoBuilder builder;
-        if (typeDescriptor instanceof Descriptor && visiting.add((Descriptor) typeDescriptor)) {
+        if (typeDescriptor instanceof Descriptor && visiting.add((Descriptor) typeDescriptor) &&
+            !((Descriptor) typeDescriptor).getFields().isEmpty()) {
             builder = FieldInfo.builder(fieldDescriptor.getName(), typeSignature,
                                         newFieldInfos((Descriptor) typeDescriptor, visiting));
         } else {

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProvider.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProvider.java
@@ -129,8 +129,7 @@ public final class ProtobufNamedTypeInfoProvider implements NamedTypeInfoProvide
         final TypeSignature typeSignature = newFieldTypeInfo(fieldDescriptor);
         final Object typeDescriptor = typeSignature.namedTypeDescriptor();
         final FieldInfoBuilder builder;
-        if (typeDescriptor instanceof Descriptor && visiting.add((Descriptor) typeDescriptor) &&
-            !((Descriptor) typeDescriptor).getFields().isEmpty()) {
+        if (typeDescriptor instanceof Descriptor && visiting.add((Descriptor) typeDescriptor)) {
             builder = FieldInfo.builder(fieldDescriptor.getName(), typeSignature,
                                         newFieldInfos((Descriptor) typeDescriptor, visiting));
         } else {

--- a/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProviderTest.java
+++ b/protobuf/src/test/java/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProviderTest.java
@@ -94,7 +94,7 @@ class ProtobufNamedTypeInfoProviderTest {
     void newStructInfo() throws Exception {
         final StructInfo structInfo = ProtobufNamedTypeInfoProvider.newStructInfo(TestMessage.getDescriptor());
         assertThat(structInfo.name()).isEqualTo("armeria.protobuf.testing.TestMessage");
-        assertThat(structInfo.fields()).hasSize(18);
+        assertThat(structInfo.fields()).hasSize(19);
         assertThat(structInfo.fields().get(0).name()).isEqualTo("bool");
         assertThat(structInfo.fields().get(0).typeSignature()).isEqualTo(BOOL);
         assertThat(structInfo.fields().get(1).name()).isEqualTo("int32");
@@ -143,6 +143,9 @@ class ProtobufNamedTypeInfoProviderTest {
         assertThat(self.name()).isEqualTo("self");
         // Don't visit the field infos of a circular type
         assertThat(self.childFieldInfos()).isEmpty();
+        final FieldInfo emptyNested = structInfo.fields().get(18);
+        assertThat(emptyNested.name()).isEqualTo("empty_nested");
+        assertThat(emptyNested.childFieldInfos()).isEmpty();
 
         assertThat(self.typeSignature().signature())
                 .isEqualTo("armeria.protobuf.testing.TestMessage");

--- a/protobuf/src/test/proto/messages.proto
+++ b/protobuf/src/test/proto/messages.proto
@@ -150,6 +150,8 @@ message TestMessage {
   message Nested {
     string string = 1;
   }
+  message EmptyNested {
+  }
 
   bool bool = 1;
   int32 int32 = 2;
@@ -169,4 +171,5 @@ message TestMessage {
   repeated string strings = 16;
   map<string, int32> map = 17;
   TestMessage self = 18;
+  EmptyNested empty_nested = 19;
 }

--- a/protobuf/src/test/resources/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProviderTest_specification.json5
+++ b/protobuf/src/test/resources/com/linecorp/armeria/server/protobuf/ProtobufNamedTypeInfoProviderTest_specification.json5
@@ -199,6 +199,16 @@
             "docString" : "",
             "markup" : "NONE"
           }
+        }, {
+          "name" : "empty_nested",
+          "location" : "UNSPECIFIED",
+          "requirement" : "OPTIONAL",
+          "typeSignature" : "armeria.protobuf.testing.TestMessage.EmptyNested",
+          "childFieldInfos" : [ ],
+          "descriptionInfo" : {
+            "docString" : "",
+            "markup" : "NONE"
+          }
         } ],
         "descriptionInfo" : {
           "docString" : "",
@@ -449,7 +459,24 @@
         "docString" : "",
         "markup" : "NONE"
       }
+    }, {
+      "name" : "empty_nested",
+      "location" : "UNSPECIFIED",
+      "requirement" : "OPTIONAL",
+      "typeSignature" : "armeria.protobuf.testing.TestMessage.EmptyNested",
+      "childFieldInfos" : [ ],
+      "descriptionInfo" : {
+        "docString" : "",
+        "markup" : "NONE"
+      }
     } ],
+    "descriptionInfo" : {
+      "docString" : "",
+      "markup" : "NONE"
+    }
+  }, {
+    "name" : "armeria.protobuf.testing.TestMessage.EmptyNested",
+    "fields" : [ ],
     "descriptionInfo" : {
       "docString" : "",
       "markup" : "NONE"


### PR DESCRIPTION
Motivation:

`DocService` can throw an exception if a `protobuf` `Struct` doesn't have any fields. (which is valid)
See https://line-armeria.slack.com/archives/C1NGPBUH2/p1663556941998359 for more details

Modifications:

- Only iterate recursively through structs if children is non-empty

Result:

- `DocService` is displayed correctly.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
