### PR TITLE
Add AggregatedHttpRequest.toHttpRequest(headers)

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -300,6 +300,6 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      */
     default HttpRequest toHttpRequest(RequestHeaders headers) {
         requireNonNull(headers, "headers");
-        return HttpRequest.of(maybeModifyContentLength(headers, content()), content(), trailers());
+        return HttpRequest.of(headers, content(), trailers());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -298,4 +298,23 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
     default HttpRequest toHttpRequest() {
         return HttpRequest.of(headers(), content(), trailers());
     }
+
+    /**
+     * Converts this request into a new complete {@link HttpRequest} replacing the {@link #headers()}
+     * with the specified {@link RequestHeaders}.
+     *
+     * @return the new {@link HttpRequest} converted from this request.
+     */
+    default HttpRequest toHttpRequest(RequestHeaders headers) {
+        requireNonNull(headers, "headers");
+        final HttpData content = content();
+        final RequestHeadersBuilder builder = headers.toBuilder();
+        if (content.isEmpty()) {
+            builder.remove(CONTENT_LENGTH);
+        } else {
+            builder.contentLength(content.length());
+        }
+        headers = builder.build();
+        return HttpRequest.of(headers, content, trailers());
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregatedHttpRequest.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
+import static com.linecorp.armeria.common.HttpRequestUtil.maybeModifyContentLength;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
@@ -195,14 +195,7 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
         requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");
 
-        final RequestHeadersBuilder builder = headers.toBuilder();
-        if (content.isEmpty()) {
-            builder.remove(CONTENT_LENGTH);
-        } else {
-            builder.contentLength(content.length());
-        }
-        headers = builder.build();
-        return new DefaultAggregatedHttpRequest(headers, content, trailers);
+        return new DefaultAggregatedHttpRequest(maybeModifyContentLength(headers, content), content, trailers);
     }
 
     /**
@@ -307,14 +300,6 @@ public interface AggregatedHttpRequest extends AggregatedHttpMessage {
      */
     default HttpRequest toHttpRequest(RequestHeaders headers) {
         requireNonNull(headers, "headers");
-        final HttpData content = content();
-        final RequestHeadersBuilder builder = headers.toBuilder();
-        if (content.isEmpty()) {
-            builder.remove(CONTENT_LENGTH);
-        } else {
-            builder.contentLength(content.length());
-        }
-        headers = builder.build();
-        return HttpRequest.of(headers, content, trailers());
+        return HttpRequest.of(maybeModifyContentLength(headers, content()), content(), trailers());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import static com.linecorp.armeria.common.HttpHeaderNames.CONTENT_LENGTH;
+
+final class HttpRequestUtil {
+
+    static RequestHeaders maybeModifyContentLength(RequestHeaders headers, HttpData content) {
+        if (content.isEmpty()) {
+            if (headers.contentLength() <= 0) {
+                return headers;
+            }
+            return headers.toBuilder().removeAndThen(CONTENT_LENGTH).build();
+        }
+        if (headers.contentLength() == content.length()) {
+            return headers;
+        }
+        return headers.toBuilder().contentLength(content.length()).build();
+    }
+
+    private HttpRequestUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequestTest.java
@@ -52,6 +52,26 @@ class DefaultAggregatedHttpRequestTest {
     }
 
     @Test
+    void toHttpRequestWithHeaders() {
+        final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(
+                HttpMethod.POST, "/foo", PLAIN_TEXT_UTF_8, "bar");
+        final RequestHeaders newHeaders = RequestHeaders.of(HttpMethod.POST, "/baz",
+                                                            CONTENT_TYPE, PLAIN_TEXT_UTF_8,
+                                                            CONTENT_LENGTH, 4);
+        final HttpRequest req = aReq.toHttpRequest(newHeaders);
+
+        final RequestHeaders appliedHeaders = RequestHeaders.of(HttpMethod.POST, "/baz",
+                                                                CONTENT_TYPE, PLAIN_TEXT_UTF_8,
+                                                                // content length is set correctly.
+                                                                CONTENT_LENGTH, 3);
+        assertThat(req.headers()).isEqualTo(appliedHeaders);
+        StepVerifier.create(req)
+                    .expectNext(HttpData.of(StandardCharsets.UTF_8, "bar"))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
     void toHttpRequestWithoutContent() {
         final AggregatedHttpRequest aReq = AggregatedHttpRequest.of(HttpMethod.GET, "/bar");
         final HttpRequest req = aReq.toHttpRequest();


### PR DESCRIPTION
Motivation:
I found out it's useful when:
- in a decorator, aggregating an `HttpRequest` to sign header with the body content
- converting the aggregated request back to the `HttpRequest` with the new header

Modification:
- Add `AggregatedHttpRequest.toHttpRequest(headers)`.

Result:
- You can now convert an `AggregatedHttpRequest` to an `HttpRequest` with a new headers.