### PR TITLE
Provide two ways to customize `:authority` pseudo-header

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.client.ClientOptions.REDIRECT_CONFIG;
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -33,6 +34,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -41,6 +43,7 @@ import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 
 /**
  * A skeletal builder implementation for {@link ClientOptions}.
@@ -321,6 +324,27 @@ public class AbstractClientOptionsBuilder {
         requireNonNull(headers, "headers");
         this.headers.setObject(headers);
         return this;
+    }
+
+    /**
+     * (Advanced user only) Sets the authoritative name of the remote server. This value is passed as the
+     * value of the {@code :authority} pseudo-header in HTTP/2 or the {@code "Host"} header in HTTP/1.1.
+     * If {@code null}, the authoritative name is automatically populated from one of the following values.
+     * <ul>
+     *   <li>A base {@link URI} specified when creating a {@link Client}.</li>
+     *   <li>An absolute path specified when sending a {@link Request}.</li>
+     *   <li>An {@link HttpHeaderNames#AUTHORITY} header specified in {@link RequestHeaders}.</li>
+     * </ul>
+     *
+     * <p>Note that the authority does not change the remote peer which a {@link Request} is sent to.
+     * It only overrides the value of {@code :authority} or {@code "Host"} header. This is generally unsafe.
+     * There is no security verification of the overridden value, such as making sure the authority matches
+     * the server's TLS certificate.
+     */
+    public AbstractClientOptionsBuilder authority(String authority) {
+        requireNonNull(authority, "authority");
+        ArmeriaHttpUtil.validateAuthority(authority);
+        return setHeader(HttpHeaderNames.AUTHORITY, authority);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -339,7 +339,8 @@ public class AbstractClientOptionsBuilder {
      * <p>Note that the authority does not change the remote peer which a {@link Request} is sent to.
      * It only overrides the value of {@code :authority} or {@code "Host"} header. This is generally unsafe.
      * There is no security verification of the overridden value, such as making sure the authority matches
-     * the server's TLS certificate.
+     * the server's TLS certificate. The hostname of the endpoint of the {@link Request} is used to verify
+     * the certificate.
      */
     public AbstractClientOptionsBuilder authority(String authority) {
         requireNonNull(authority, "authority");

--- a/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
@@ -449,6 +449,12 @@ public final class BlockingWebClientRequestPreparation
     }
 
     @Override
+    public BlockingWebClientRequestPreparation authority(String authority) {
+        delegate.authority(authority);
+        return this;
+    }
+
+    @Override
     public <V> BlockingWebClientRequestPreparation attr(AttributeKey<V> key, @Nullable V value) {
         delegate.attr(key, value);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -246,6 +246,11 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     @Override
+    public ClientBuilder authority(String authority) {
+        return (ClientBuilder) super.authority(authority);
+    }
+
+    @Override
     public ClientBuilder auth(BasicToken token) {
         return (ClientBuilder) super.auth(token);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -168,6 +168,11 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder {
     }
 
     @Override
+    public ClientOptionsBuilder authority(String authority) {
+        return (ClientOptionsBuilder) super.authority(authority);
+    }
+
+    @Override
     public ClientOptionsBuilder successFunction(SuccessFunction successFunction) {
         return (ClientOptionsBuilder) super.successFunction(successFunction);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
@@ -29,7 +29,8 @@ import io.netty.util.AttributeKey;
 
 final class DefaultRequestOptions implements RequestOptions {
 
-    static final DefaultRequestOptions EMPTY = new DefaultRequestOptions(-1, -1, -1, ImmutableMap.of(), null);
+    static final DefaultRequestOptions EMPTY =
+            new DefaultRequestOptions(-1, -1, -1, ImmutableMap.of(), null, null);
 
     private final long responseTimeoutMillis;
     private final long writeTimeoutMillis;
@@ -37,15 +38,18 @@ final class DefaultRequestOptions implements RequestOptions {
     private final Map<AttributeKey<?>, Object> attributeMap;
     @Nullable
     private final ExchangeType exchangeType;
+    @Nullable
+    private final String authority;
 
     DefaultRequestOptions(long responseTimeoutMillis, long writeTimeoutMillis,
                           long maxResponseLength, Map<AttributeKey<?>, Object> attributeMap,
-                          @Nullable ExchangeType exchangeType) {
+                          @Nullable ExchangeType exchangeType, @Nullable String authority) {
         this.responseTimeoutMillis = responseTimeoutMillis;
         this.writeTimeoutMillis = writeTimeoutMillis;
         this.maxResponseLength = maxResponseLength;
         this.attributeMap = attributeMap;
         this.exchangeType = exchangeType;
+        this.authority = authority;
     }
 
     @Override
@@ -74,28 +78,34 @@ final class DefaultRequestOptions implements RequestOptions {
     }
 
     @Override
+    public String authority() {
+        return authority;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
 
-        if (!(o instanceof DefaultRequestOptions)) {
+        if (!(o instanceof RequestOptions)) {
             return false;
         }
 
-        final DefaultRequestOptions that = (DefaultRequestOptions) o;
+        final RequestOptions that = (RequestOptions) o;
 
-        return responseTimeoutMillis == that.responseTimeoutMillis &&
-               writeTimeoutMillis == that.writeTimeoutMillis &&
-               maxResponseLength == that.maxResponseLength &&
-               attributeMap.equals(that.attributeMap) &&
-               exchangeType == that.exchangeType;
+        return responseTimeoutMillis == that.responseTimeoutMillis() &&
+               writeTimeoutMillis == that.writeTimeoutMillis() &&
+               maxResponseLength == that.maxResponseLength() &&
+               attributeMap.equals(that.attrs()) &&
+               exchangeType == that.exchangeType() &&
+               Objects.equals(authority, that.authority());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(responseTimeoutMillis, writeTimeoutMillis, maxResponseLength,
-                            attributeMap, exchangeType);
+                            attributeMap, exchangeType, authority);
     }
 
     @Override
@@ -106,6 +116,7 @@ final class DefaultRequestOptions implements RequestOptions {
                           .add("maxResponseLength", maxResponseLength)
                           .add("attributeMap", attributeMap)
                           .add("exchangeType", exchangeType)
+                          .add("authority", authority)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -397,4 +397,10 @@ public final class FutureTransformingRequestPreparation<T>
         delegate.exchangeType(exchangeType);
         return this;
     }
+
+    @Override
+    public FutureTransformingRequestPreparation<T> authority(String authority) {
+        delegate.authority(authority);
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptions.java
@@ -19,12 +19,15 @@ package com.linecorp.armeria.client;
 import static com.linecorp.armeria.client.DefaultRequestOptions.EMPTY;
 import static java.util.Objects.requireNonNull;
 
+import java.net.URI;
 import java.util.Map;
 
 import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -104,4 +107,22 @@ public interface RequestOptions {
      */
     @Nullable
     ExchangeType exchangeType();
+
+    /**
+     * (Advanced user only) Returns the authoritative name of the remote server. This value is passed as the
+     * value of the {@code :authority} pseudo-header in HTTP/2 or the {@code "Host"} header in HTTP/1.1.
+     * If {@code null}, the authoritative name is automatically populated from one of the following values.
+     * <ul>
+     *   <li>A base {@link URI} specified when building a {@link Client}.</li>
+     *   <li>An absolute path specified when sending a {@link Request}.</li>
+     *   <li>An {@link HttpHeaderNames#AUTHORITY} header specified in {@link RequestHeaders}.</li>
+     * </ul>
+     *
+     * <p>Note that the authority does not change the remote peer which a {@link Request} is sent to.
+     * It only overrides the value of {@code :authority} or {@code "Host"} header. This is generally unsafe.
+     * There is no security verification of the overridden value, such as making sure the authority matches
+     * the server's TLS certificate.
+     */
+    @Nullable
+    String authority();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptionsBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 
 import io.netty.util.AttributeKey;
 
@@ -44,6 +45,8 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
     private Map<AttributeKey<?>, Object> attributes;
     @Nullable
     private ExchangeType exchangeType;
+    @Nullable
+    private String authority;
 
     RequestOptionsBuilder(@Nullable RequestOptions options) {
         if (options != null) {
@@ -55,6 +58,7 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
                 attributes = new HashMap<>(attrs);
             }
             exchangeType = options.exchangeType();
+            authority = options.authority();
         }
     }
 
@@ -121,12 +125,20 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
         return this;
     }
 
+    @Override
+    public RequestOptionsBuilder authority(String authority) {
+        requireNonNull(authority, "authority");
+        ArmeriaHttpUtil.validateAuthority(authority);
+        this.authority = authority;
+        return this;
+    }
+
     /**
      * Returns a newly created {@link RequestOptions} with the properties specified so far.
      */
     public RequestOptions build() {
         if (responseTimeoutMillis < 0 && writeTimeoutMillis < 0 &&
-            maxResponseLength < 0 && attributes == null && exchangeType == null) {
+            maxResponseLength < 0 && attributes == null && exchangeType == null && authority == null) {
             return EMPTY;
         } else {
             final Map<AttributeKey<?>, Object> attributes;
@@ -136,7 +148,7 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
                 attributes = ImmutableMap.copyOf(this.attributes);
             }
             return new DefaultRequestOptions(responseTimeoutMillis, writeTimeoutMillis,
-                                             maxResponseLength, attributes, exchangeType);
+                                             maxResponseLength, attributes, exchangeType, authority);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
@@ -16,12 +16,15 @@
 
 package com.linecorp.armeria.client;
 
+import java.net.URI;
 import java.time.Duration;
 
 import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -135,4 +138,22 @@ interface RequestOptionsSetters {
      */
     @UnstableApi
     RequestOptionsSetters exchangeType(ExchangeType exchangeType);
+
+    /**
+     * (Advanced user only) Sets the authoritative name of the remote server. This value is passed as the
+     * value of the {@code :authority} pseudo-header in HTTP/2 or the {@code "Host"} header in HTTP/1.1.
+     * If {@code null}, the authoritative name is automatically populated from one of the following values.
+     * <ul>
+     *   <li>A base {@link URI} specified when creating a {@link Client}.</li>
+     *   <li>An absolute path specified when sending a {@link Request}.</li>
+     *   <li>An {@link HttpHeaderNames#AUTHORITY} header specified in {@link RequestHeaders}.</li>
+     * </ul>
+     *
+     * <p>Note that the authority does not change the remote peer which a {@link Request} is sent to.
+     * It only overrides the value of {@code :authority} or {@code "Host"} header. This is generally unsafe.
+     * There is no security verification of the overridden value, such as making sure the authority matches
+     * the server's TLS certificate.
+     */
+    @UnstableApi
+    RequestOptionsSetters authority(String authority);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -199,6 +199,11 @@ public final class RestClientBuilder extends AbstractWebClientBuilder {
     }
 
     @Override
+    public RestClientBuilder authority(String authority) {
+        return (RestClientBuilder) super.authority(authority);
+    }
+
+    @Override
     public RestClientBuilder setHeaders(
             Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         return (RestClientBuilder) super.setHeaders(headers);

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -287,6 +287,12 @@ public final class RestClientPreparation implements RequestPreparationSetters {
     }
 
     @Override
+    public RestClientPreparation authority(String authority) {
+        delegate.authority(authority);
+        return this;
+    }
+
+    @Override
     public RestClientPreparation requestOptions(RequestOptions requestOptions) {
         delegate.requestOptions(requestOptions);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
@@ -322,4 +322,10 @@ public class TransformingRequestPreparation<T, R> implements WebRequestPreparati
         delegate.attr(key, value);
         return this;
     }
+
+    @Override
+    public TransformingRequestPreparation<T, R> authority(String authority) {
+        delegate.authority(authority);
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -194,10 +194,9 @@ public abstract class UserClient<I extends Request, O extends Response>
             rpcReq = (RpcRequest) req;
         }
 
-        final boolean hasBaseUri = !Clients.isUndefinedUri(params.uri());
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
                 meterRegistry, protocol, id, method, path, query, fragment, options(), httpReq, rpcReq,
-                requestOptions, System.nanoTime(), SystemInfo.currentTimeMicros(), hasBaseUri);
+                requestOptions, System.nanoTime(), SystemInfo.currentTimeMicros());
 
         return initContextAndExecuteWithFallback(unwrap(), ctx, endpointGroup,
                                                  futureConverter, errorResponseFactory);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -201,6 +201,11 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
     }
 
     @Override
+    public WebClientBuilder authority(String authority) {
+        return (WebClientBuilder) super.authority(authority);
+    }
+
+    @Override
     public WebClientBuilder auth(BasicToken token) {
         return (WebClientBuilder) super.auth(token);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -375,6 +375,12 @@ public final class WebClientRequestPreparation
         return this;
     }
 
+    @Override
+    public WebClientRequestPreparation authority(String authority) {
+        requestOptionsBuilder().authority(authority);
+        return this;
+    }
+
     private RequestOptionsBuilder requestOptionsBuilder() {
         if (requestOptionsBuilder == null) {
             requestOptionsBuilder = RequestOptions.builder();

--- a/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestHeadersBuilder.java
@@ -23,7 +23,10 @@ import java.util.Map.Entry;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.AbstractClientOptionsBuilder;
+import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RequestOptionsBuilder;
 
 /**
  * Builds a {@link RequestHeaders}.
@@ -81,11 +84,74 @@ public interface RequestHeadersBuilder extends HttpHeadersBuilder, RequestHeader
 
     /**
      * Sets the {@code ":authority"} header.
+     *
+     * <p>Note that if this {@link RequestHeaders} is sent via a base-URI {@link Client}, the specified the
+     * authority header is overwritten by the base-URI. If this {@link RequestHeaders} is sent via non-base
+     * {@link Client}, the authority header value is potentially used as the endpoint.
+     * <pre>{@code
+     * WebClient nonBaseClient = WebClient.of();
+     * RequestHeaders headers =
+     *     RequestHeaders.builder(HttpMethod.GET, "/")
+     *                   .scheme("http")
+     *                   .authority("my-example.com")
+     *                   .build();
+     * HttpRequest request = HttpRequest.of(headers);
+     * // Sends the request to "my-example.com"
+     * nonBaseClient.execute(request);
+     *
+     * WebClient baseClient = WebClient.of("proxy-example.com");
+     * RequestHeaders headers =
+     *     RequestHeaders.builder(HttpMethod.GET, "/")
+     *                   .scheme("http")
+     *                   .authority("my-example.com")
+     *                   .build();
+     * HttpRequest request = HttpRequest.of(headers);
+     * // The authority headers is overwritten to "proxy-example.com", and then
+     * // the request is sent to "proxy-example.com"
+     * baseClient.execute(request);
+     * }
+     * </pre>
+     *
+     * <p>To set the {@code :authority} header and the target endpoint of the {@link HttpRequest} to
+     * different values, refer to {@link AbstractClientOptionsBuilder#authority(String)} or
+     * {@link RequestOptionsBuilder#authority(String)}.
      */
     RequestHeadersBuilder authority(String authority);
 
     /**
      * Sets the {@code ":authority"} header from the specified {@link Endpoint}.
+     *
+     * <p>Note that if this {@link RequestHeaders} is sent via a base-URI {@link Client}, the specified the
+     * authority header is overwritten by the base-URI. If this {@link RequestHeaders} is sent via non-base
+     * {@link Client}, the authority header value is potentially used as the endpoint.
+     * <pre>{@code
+     * Endpoint exampleEndpoint = Endpoint.of("my-example.com");
+     * WebClient nonBaseClient = WebClient.of();
+     * RequestHeaders headers =
+     *     RequestHeaders.builder(HttpMethod.GET, "/")
+     *                   .scheme("http")
+     *                   .authority(exampleEndpoint)
+     *                   .build();
+     * HttpRequest request = HttpRequest.of(headers);
+     * // Sends the request to "my-example.com"
+     * nonBaseClient.execute(request);
+     *
+     * WebClient baseClient = WebClient.of("proxy-example.com");
+     * RequestHeaders headers =
+     *     RequestHeaders.builder(HttpMethod.GET, "/")
+     *                   .scheme("http")
+     *                   .authority(exampleEndpoint)
+     *                   .build();
+     * HttpRequest request = HttpRequest.of(headers);
+     * // The authority headers is overwritten to "proxy-example.com", and then
+     * // the request is sent to "proxy-example.com"
+     * baseClient.execute(request);
+     * }
+     * </pre>
+     *
+     * <p>To set the {@code :authority} header and the target endpoint of the {@link HttpRequest} to
+     * different values, refer to {@link AbstractClientOptionsBuilder#authority(String)} or
+     * {@link RequestOptionsBuilder#authority(String)}.
      *
      * @throws IllegalArgumentException if the specified {@link Endpoint} refers to a group
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpHeadersUtil.java
@@ -47,8 +47,7 @@ public final class HttpHeadersUtil {
         return builder.build();
     }
 
-    public static RequestHeaders mergeRequestHeaders(RequestHeaders headers,
-                                                     HttpHeaders additionalHeaders) {
+    public static RequestHeaders mergeRequestHeaders(RequestHeaders headers, HttpHeaders additionalHeaders) {
         if (additionalHeaders.isEmpty()) {
             return headers;
         }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -387,6 +387,11 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder
     }
 
     @Override
+    public EurekaEndpointGroupBuilder authority(String authority) {
+        return (EurekaEndpointGroupBuilder) super.authority(authority);
+    }
+
+    @Override
     public EurekaEndpointGroupBuilder auth(BasicToken token) {
         return (EurekaEndpointGroupBuilder) super.auth(token);
     }

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -485,6 +485,11 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     }
 
     @Override
+    public EurekaUpdatingListenerBuilder authority(String authority) {
+        return (EurekaUpdatingListenerBuilder) super.authority(authority);
+    }
+
+    @Override
     public EurekaUpdatingListenerBuilder setHeaders(
             Iterable<? extends Entry<? extends CharSequence, ?>> headers) {
         return (EurekaUpdatingListenerBuilder) super.setHeaders(headers);

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -515,6 +515,11 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     @Override
+    public GrpcClientBuilder authority(String authority) {
+        return (GrpcClientBuilder) super.authority(authority);
+    }
+
+    @Override
     public GrpcClientBuilder auth(BasicToken token) {
         return (GrpcClientBuilder) super.auth(token);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/CustomAuthorityTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/CustomAuthorityTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+
+class CustomAuthorityTest {
+
+    @RegisterExtension
+    static ServerExtension virtualHostingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(LoggingService.newDecorator());
+            sb.virtualHost("foo.com")
+              .service(GrpcService.builder()
+                                  .addService(new FooService())
+                                  .build())
+              .and()
+              .virtualHost("bar.com")
+              .service(GrpcService.builder()
+                                  .addService(new BarService())
+                                  .build());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension simpleServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new BazService())
+                                  .build());
+        }
+    };
+
+    @CsvSource({ "foo.com, FooService", "bar.com, BarService" })
+    @ParameterizedTest
+    void overrideAuthorityUsingClientBuilder(String authority, String expectation) throws Exception {
+        final TestServiceBlockingStub client = GrpcClients.builder(virtualHostingServer.httpUri())
+                                                          .authority(authority)
+                                                          .build(TestServiceBlockingStub.class);
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final SimpleResponse response = client.unaryCall(SimpleRequest.getDefaultInstance());
+            assertThat(response.getUsername()).isEqualTo(expectation);
+            // Make sure that the endpoint is not changed by the additional authority.
+            assertThat(captor.get().endpoint().authority())
+                    .isEqualTo(virtualHostingServer.httpUri().getAuthority());
+        }
+        final ServiceRequestContext sctx = virtualHostingServer.requestContextCaptor().take();
+        assertThat(sctx.request().headers().authority()).isEqualTo(authority);
+    }
+
+    @CsvSource({ "foo.com, FooService", "bar.com, BarService" })
+    @ParameterizedTest
+    void overrideAuthorityUsingCallOptions(String authority, String expectation) throws Exception {
+        final ClientInterceptor authorityOverridingInterceptor = new ClientInterceptor() {
+            @Override
+            public <I, O> ClientCall<I, O> interceptCall(
+                    MethodDescriptor<I, O> method,
+                    CallOptions callOptions, Channel next) {
+                return next.newCall(method, callOptions.withAuthority(authority));
+            }
+        };
+        final TestServiceBlockingStub client = GrpcClients.builder(virtualHostingServer.httpUri())
+                                                          .intercept(authorityOverridingInterceptor)
+                                                          .build(TestServiceBlockingStub.class);
+
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final SimpleResponse response = client.unaryCall(SimpleRequest.getDefaultInstance());
+            assertThat(response.getUsername()).isEqualTo(expectation);
+            // Make sure that the endpoint is not changed by the additional authority.
+            assertThat(captor.get().endpoint().authority())
+                    .isEqualTo(virtualHostingServer.httpUri().getAuthority());
+        }
+        final ServiceRequestContext sctx = virtualHostingServer.requestContextCaptor().take();
+        assertThat(sctx.request().headers().authority()).isEqualTo(authority);
+    }
+
+    @Test
+    void shouldUseBaseUriAsEndpoint() throws Exception {
+        final TestServiceBlockingStub client = GrpcClients.builder(simpleServer.httpUri())
+                                                          .authority("foo.com")
+                                                          .build(TestServiceBlockingStub.class);
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final SimpleResponse response = client.unaryCall(SimpleRequest.getDefaultInstance());
+            assertThat(response.getUsername()).isEqualTo("BazService");
+            // Make sure that the endpoint is not changed by the additional authority.
+            assertThat(captor.get().endpoint().authority())
+                    .isEqualTo(simpleServer.httpUri().getAuthority());
+        }
+        final ServiceRequestContext sctx = simpleServer.requestContextCaptor().take();
+        assertThat(sctx.request().headers().authority()).isEqualTo("foo.com");
+    }
+
+    private static final class FooService extends TestServiceGrpc.TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("FooService")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static final class BarService extends TestServiceGrpc.TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("BarService")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static final class BazService extends TestServiceGrpc.TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("BazService")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -406,6 +406,11 @@ public final class ArmeriaRetrofitBuilder extends AbstractClientOptionsBuilder {
     }
 
     @Override
+    public ArmeriaRetrofitBuilder authority(String authority) {
+        return (ArmeriaRetrofitBuilder) super.authority(authority);
+    }
+
+    @Override
     public ArmeriaRetrofitBuilder auth(BasicToken token) {
         return (ArmeriaRetrofitBuilder) super.auth(token);
     }

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
@@ -145,6 +145,11 @@ final class ScalaRestClientPreparation private[scala] (delegate: RestClientPrepa
     this
   }
 
+  override def authority(authority: String): ScalaRestClientPreparation = {
+    delegate.authority(authority)
+    this
+  }
+
   override def content(content: String): ScalaRestClientPreparation = {
     delegate.content(content)
     this

--- a/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
@@ -324,6 +324,11 @@ public final class ThriftClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     @Override
+    public ThriftClientBuilder authority(String authority) {
+        return (ThriftClientBuilder) super.authority(authority);
+    }
+
+    @Override
     public ThriftClientBuilder auth(BasicToken token) {
         return (ThriftClientBuilder) super.auth(token);
     }


### PR DESCRIPTION
Motivation:

Overriding `:authority` is generally not recommended because there is no
security verification for the overriden value. That being said,
sometimes, it would be useful when requests are dynamically routed to
servers behind a proxy server which can be used as an API gateway
pattern.

Modifications:

- Add a setter method to `AbstractClientOptionsBuilder` and override
  it in all known subclasses.
- Add `RequestOptions.authority()` which is used to set an `:authority`
  header at the request level. `RequestOptions.authority()` takes
  precedence over `AbstractClientOptionsBuilder.authority()`.
- If a custom `authority` is set to a `CallOptions` of a gRPC client, the value is set
  to `ctx.additionalRequestHeaders()`.
- Remove `:authority` header from disallowed additional headers.
  The value was added by mistake.
- Fix a bug where an additional authority overrides the target endpoint.


Result:

- You now override an HTTP/2 `:authority` pseudo-header or HTTP/1.1 `Host`
  header using `ClientBuilder.authority(String)` or
  `RequestOptionsBuilder.authority(String)`.
  ```java
  // A connection is bound to my-proxy.example.com but
  // `my-order.service.com` is used for the authority header.
  WebClient.builder("http://my-proxy.example.com/")
           .authority("my-order.service.com")
           .build();

  var client = WebClient.of();
  client.prepare()
        .get("http://my-proxy.example.com/api/v1/orders")
        .authority("my-order.service.com")
        .execute();
  ```
- You can now override an authority of a gRPC client using
  `CallOptions`.
- Fixes #4440
