### PR TITLE
Use `HttpHeadersBuilder` for additional headers in `RequestContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -275,7 +275,7 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
                 requestCancellationScheduler,
                 isRequestStartTimeSet() ? requestStartTimeNanos() : System.nanoTime(),
                 isRequestStartTimeSet() ? requestStartTimeMicros() : SystemInfo.currentTimeMicros(),
-                HttpHeaders.of(), HttpHeaders.of());
+                HttpHeaders.builder(), HttpHeaders.builder());
     }
 
     private static ServiceConfig findServiceConfig(Server server, HttpService service) {

--- a/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
@@ -131,7 +131,7 @@ class DefaultClientRequestContextTest {
         assertThat(derivedCtx.maxResponseLength()).isEqualTo(originalCtx.maxResponseLength());
         assertThat(derivedCtx.responseTimeoutMillis()).isEqualTo(originalCtx.responseTimeoutMillis());
         assertThat(derivedCtx.writeTimeoutMillis()).isEqualTo(originalCtx.writeTimeoutMillis());
-        assertThat(derivedCtx.additionalRequestHeaders()).isSameAs(originalCtx.additionalRequestHeaders());
+        assertThat(derivedCtx.additionalRequestHeaders()).isEqualTo(originalCtx.additionalRequestHeaders());
         // the attribute is derived as well
         assertThat(derivedCtx.attr(foo)).isEqualTo("foo");
 


### PR DESCRIPTION
Motivation:

`RequestContext`s internally reference an `HttpHeaders` to hold additional headers which override the original headers set when creating a request or a response.

`HttpHeaders` is immutable data so it should be converted into an `HttpHeadersBuilder` to mutate the values. In addition, atomic operations are required to update the newly created `HttpHeaders` to `RequestContext`.
https://github.com/line/armeria/blob/529738c836c78bf94d032f1328ec4241d662d19c/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java#L722

If `RequestContext`s have a `HttpHeadersBuilder` reference internally, 1) we don't need to use atomic operations and 2) convert `HttpHeaders` to `HttpHeadersBuilder` and back to `HttpHeaders`.

Modifications:

- Use `HttpHeadersBuilder` for `additionalRequestHeaders` in `DefaultClientRequestContext`.
- Use `HttpHeadersBuilder` for `additionalResponseHeaders` and `additionalResponseTrailers` in `DefaultServiceRequestContext`.

Result:

Simplify updating additional headers.

Side note:

This PR does not seem to be listed in the release notes.
