### PR TITLE
Fix a bug where `WeightRampingUpStrategy` raises a NPE when a `DynamicEndpointGroup` is not initialized

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -74,6 +74,8 @@ import io.netty.util.concurrent.EventExecutor;
 final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
     private static final Ticker defaultTicker = Ticker.systemTicker();
+    private static final WeightedRandomDistributionEndpointSelector EMPTY_SELECTOR =
+            new WeightedRandomDistributionEndpointSelector(ImmutableList.of());
 
     static final WeightRampingUpStrategy INSTANCE =
             new WeightRampingUpStrategy(defaultTransition, () -> CommonPools.workerGroup().next(),
@@ -121,7 +123,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
     final class RampingUpEndpointWeightSelector extends AbstractEndpointSelector {
 
         private final EventExecutor executor;
-        private volatile WeightedRandomDistributionEndpointSelector endpointSelector;
+        private volatile WeightedRandomDistributionEndpointSelector endpointSelector = EMPTY_SELECTOR;
 
         private final List<Endpoint> endpointsFinishedRampingUp = new ArrayList<>();
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
@@ -34,10 +34,13 @@ import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy.EndpointsRampingUpEntry.EndpointAndStep;
 import com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy.RampingUpEndpointWeightSelector;
 import com.linecorp.armeria.client.endpoint.WeightedRandomDistributionEndpointSelector.Entry;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 
 import io.netty.channel.DefaultEventLoop;
 import io.netty.util.concurrent.ScheduledFuture;
@@ -372,6 +375,15 @@ final class WeightRampingUpStrategyTest {
         while ((scheduledFuture = scheduledFutures.poll()) != null) {
             verify(scheduledFuture, times(1)).cancel(true);
         }
+    }
+
+    @Test
+    void shouldReturnNullWhenEndpointGroupIsNotReady() {
+        final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
+        final EndpointSelector endpointSelector =
+                EndpointSelectionStrategy.rampingUp().newSelector(endpointGroup);
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(endpointSelector.selectNow(ctx)).isNull();
     }
 
     private static RampingUpEndpointWeightSelector setInitialEndpoints(DynamicEndpointGroup endpointGroup,


### PR DESCRIPTION
Motivation:

`RampingUpEndpointWeightSelector` creates a new endpoint selector when a listener added to the `EndpointGroup` is invoked.
https://github.com/line/armeria/blob/790a2db01a8514b591bde90932ab18f63693829e/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L139-L145 
If a `DynamicEndpointGroup` is not initialized, listeners won't be invoked when the initial values are set.
So `.selectNow()` can raise a `NullPointerException`. 
https://github.com/line/armeria/blob/790a2db01a8514b591bde90932ab18f63693829e/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L175-L177

Modifications:

- Initialize `WeightedRandomDistributionEndpointSelector` with an empty selector which is replaced with the actual selector when the `EndpointGroup` is ready.

Result:

You no longer see a `NullPointerException` when using `EndpointSelectionStrategy.rampingUp()`.

