### PR TITLE
Return cached aggregated message for following withPooledObjects call

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -205,9 +205,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             final AggregatedHttpRequestHandler reqHandler = new AggregatedHttpRequestHandler(
                     channel, requestEncoder, responseDecoder, req, res, ctx, writeTimeoutMillis);
             try (SafeCloseable ignored = ctx.push()) {
-                req.aggregate(AggregationOptions.builder()
-                                                .usePooledObjects(ctx.alloc())
-                                                .executor(channel.eventLoop()).build())
+                req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), channel.eventLoop()))
                    .handle(reqHandler);
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
 import com.linecorp.armeria.client.proxy.ProxyType;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -204,7 +205,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             final AggregatedHttpRequestHandler reqHandler = new AggregatedHttpRequestHandler(
                     channel, requestEncoder, responseDecoder, req, res, ctx, writeTimeoutMillis);
             try (SafeCloseable ignored = ctx.push()) {
-                req.aggregateWithPooledObjects(channel.eventLoop(), ctx.alloc()).handle(reqHandler);
+                req.aggregate(AggregationOptions.builder()
+                                                .usePooledObjects(ctx.alloc())
+                                                .executor(channel.eventLoop()).build())
+                   .handle(reqHandler);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -139,10 +139,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);
             execute0(ctx, redirectCtx, reqDuplicator, true);
         } else {
-            req.aggregate(AggregationOptions.builder()
-                                            .usePooledObjects(ctx.alloc())
-                                            .executor(ctx.eventLoop())
-                                            .build())
+            req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
                .handle((agg, cause) -> {
                    if (cause != null) {
                        handleException(ctx, null, responseFuture, cause, true);

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.client.redirect.TooManyRedirectsException;
 import com.linecorp.armeria.client.redirect.UnexpectedDomainRedirectException;
 import com.linecorp.armeria.client.redirect.UnexpectedProtocolRedirectException;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -138,15 +139,19 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);
             execute0(ctx, redirectCtx, reqDuplicator, true);
         } else {
-            req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((agg, cause) -> {
-                if (cause != null) {
-                    handleException(ctx, null, responseFuture, cause, true);
-                } else {
-                    final HttpRequestDuplicator reqDuplicator = new AggregatedHttpRequestDuplicator(agg);
-                    execute0(ctx, redirectCtx, reqDuplicator, true);
-                }
-                return null;
-            });
+            req.aggregate(AggregationOptions.builder()
+                                            .usePooledObjects(ctx.alloc())
+                                            .executor(ctx.eventLoop())
+                                            .build())
+               .handle((agg, cause) -> {
+                   if (cause != null) {
+                       handleException(ctx, null, responseFuture, cause, true);
+                   } else {
+                       final HttpRequestDuplicator reqDuplicator = new AggregatedHttpRequestDuplicator(agg);
+                       execute0(ctx, redirectCtx, reqDuplicator, true);
+                   }
+                   return null;
+               });
         }
         return res;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestDuplicator;
@@ -244,15 +245,19 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);
             doExecute0(ctx, reqDuplicator, req, res, responseFuture);
         } else {
-            req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((agg, cause) -> {
-                if (cause != null) {
-                    handleException(ctx, null, responseFuture, cause, true);
-                } else {
-                    final HttpRequestDuplicator reqDuplicator = new AggregatedHttpRequestDuplicator(agg);
-                    doExecute0(ctx, reqDuplicator, req, res, responseFuture);
-                }
-                return null;
-            });
+            req.aggregate(AggregationOptions.builder()
+                                            .usePooledObjects(ctx.alloc())
+                                            .executor(ctx.eventLoop())
+                                            .build())
+               .handle((agg, cause) -> {
+                   if (cause != null) {
+                       handleException(ctx, null, responseFuture, cause, true);
+                   } else {
+                       final HttpRequestDuplicator reqDuplicator = new AggregatedHttpRequestDuplicator(agg);
+                       doExecute0(ctx, reqDuplicator, req, res, responseFuture);
+                   }
+                   return null;
+               });
         }
         return res;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -245,10 +245,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);
             doExecute0(ctx, reqDuplicator, req, res, responseFuture);
         } else {
-            req.aggregate(AggregationOptions.builder()
-                                            .usePooledObjects(ctx.alloc())
-                                            .executor(ctx.eventLoop())
-                                            .build())
+            req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
                .handle((agg, cause) -> {
                    if (cause != null) {
                        handleException(ctx, null, responseFuture, cause, true);

--- a/core/src/main/java/com/linecorp/armeria/common/AggregationOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregationOptions.java
@@ -37,6 +37,14 @@ public interface AggregationOptions {
     }
 
     /**
+     * Returns a new {@link AggregationOptions} that creates {@link PooledObjects} without making a copy using
+     * the {@link ByteBufAllocator}.
+     */
+    static AggregationOptions usePooledObjects(ByteBufAllocator alloc) {
+        return builder().usePooledObjects(alloc).build();
+    }
+
+    /**
      * Returns the {@link EventExecutor} that executes the aggregation.
      */
     @Nullable
@@ -46,6 +54,11 @@ public interface AggregationOptions {
      * Returns whether to cache the aggregation result.
      */
     boolean cacheResult();
+
+    /**
+     * Returns whether to return the cached {@link AggregatedHttpMessage} if there's one.
+     */
+    boolean preferCached();
 
     /**
      * (Advanced users only) Returns the {@link ByteBufAllocator} that can be used to create a

--- a/core/src/main/java/com/linecorp/armeria/common/AggregationOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregationOptions.java
@@ -45,6 +45,15 @@ public interface AggregationOptions {
     }
 
     /**
+     * Returns a new {@link AggregationOptions} that creates {@link PooledObjects} without making a copy using
+     * the {@link ByteBufAllocator}. The specified {@link EventExecutor} is used to
+     * run the aggregation function.
+     */
+    static AggregationOptions usePooledObjects(ByteBufAllocator alloc, EventExecutor executor) {
+        return builder().usePooledObjects(alloc).executor(executor).build();
+    }
+
+    /**
      * Returns the {@link EventExecutor} that executes the aggregation.
      */
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/AggregationOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AggregationOptionsBuilder.java
@@ -41,7 +41,7 @@ public final class AggregationOptionsBuilder {
     AggregationOptionsBuilder() {}
 
     /**
-     * Sets the {@link EventExecutor} to run the aggregation function on.
+     * Sets the {@link EventExecutor} to run the aggregation function.
      */
     public AggregationOptionsBuilder executor(EventExecutor executor) {
         requireNonNull(executor, "executor");
@@ -69,7 +69,7 @@ public final class AggregationOptionsBuilder {
      * is created.
      *
      * <p>{@link PooledObjects} cannot be cached since they have their own life cycle.
-     * Therefore, that this method and {@link #cacheResult(boolean)} are mutually exclusive.
+     * Therefore, this method and {@link #cacheResult(boolean)} are mutually exclusive.
      * If {@link #cacheResult(boolean)} is enabled and this option is set, an {@link IllegalStateException} will
      * be raised.
      *
@@ -91,7 +91,7 @@ public final class AggregationOptionsBuilder {
      * this option is ineffective and the cached {@link AggregatedHttpMessage} is returned.
      *
      * <p>{@link PooledObjects} cannot be cached since they have their own life cycle.
-     * Therefore, that this method and {@link #cacheResult(boolean)} are mutually exclusive.
+     * Therefore, this method and {@link #cacheResult(boolean)} are mutually exclusive.
      * If {@link #cacheResult(boolean)} is enabled and this option is set, an {@link IllegalStateException} will
      * be raised.
      */
@@ -105,7 +105,7 @@ public final class AggregationOptionsBuilder {
      * this option is ineffective and the cached {@link AggregatedHttpMessage} is returned.
      *
      * <p>{@link PooledObjects} cannot be cached since they have their own life cycle.
-     * Therefore, that this method and {@link #cacheResult(boolean)} are mutually exclusive.
+     * Therefore, this method and {@link #cacheResult(boolean)} are mutually exclusive.
      * If {@link #cacheResult(boolean)} is enabled and this option is set, an {@link IllegalStateException} will
      * be raised.
      */
@@ -120,7 +120,7 @@ public final class AggregationOptionsBuilder {
      * if {@code preferCached} is {@code false}, an {@link IllegalStateException} will be raised.
      *
      * <p>{@link PooledObjects} cannot be cached since they have their own life cycle.
-     * Therefore, that this method and {@link #cacheResult(boolean)} are mutually exclusive.
+     * Therefore, this method and {@link #cacheResult(boolean)} are mutually exclusive.
      * If {@link #cacheResult(boolean)} is enabled and this option is set, an {@link IllegalStateException} will
      * be raised.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultAggregationOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultAggregationOptions.java
@@ -31,12 +31,14 @@ final class DefaultAggregationOptions implements AggregationOptions {
     private final EventExecutor executor;
     @Nullable
     private final ByteBufAllocator alloc;
+    private final boolean preferCached;
     private final boolean cacheResult;
 
     DefaultAggregationOptions(@Nullable EventExecutor executor, @Nullable ByteBufAllocator alloc,
-                              boolean cacheResult) {
+                              boolean preferCached, boolean cacheResult) {
         this.executor = executor;
         this.alloc = alloc;
+        this.preferCached = preferCached;
         this.cacheResult = cacheResult;
     }
 
@@ -48,6 +50,11 @@ final class DefaultAggregationOptions implements AggregationOptions {
     @Override
     public boolean cacheResult() {
         return cacheResult;
+    }
+
+    @Override
+    public boolean preferCached() {
+        return preferCached;
     }
 
     @Override
@@ -65,13 +72,14 @@ final class DefaultAggregationOptions implements AggregationOptions {
         }
         final AggregationOptions that = (AggregationOptions) o;
         return cacheResult == that.cacheResult() &&
+               preferCached == that.preferCached() &&
                Objects.equals(executor, that.executor()) &&
                Objects.equals(alloc, that.alloc());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(executor, alloc, cacheResult);
+        return Objects.hash(executor, alloc, cacheResult, preferCached);
     }
 
     @Override
@@ -80,6 +88,7 @@ final class DefaultAggregationOptions implements AggregationOptions {
                           .add("executor", executor)
                           .add("alloc", alloc)
                           .add("cacheResult", cacheResult)
+                          .add("preferCached", preferCached)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpData.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpData.java
@@ -477,8 +477,10 @@ public interface HttpData extends HttpObject, SafeCloseable {
      * <ul>
      *   <li>{@link StreamMessage#subscribe(Subscriber, SubscriptionOption...)} with
      *       {@link SubscriptionOption#WITH_POOLED_OBJECTS}</li>
-     *   <li>{@link HttpRequest#aggregateWithPooledObjects(ByteBufAllocator)}</li>
-     *   <li>{@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}</li>
+     *   <li>{@link HttpRequest#aggregate(AggregationOptions)} with
+     *       {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}</li>
+     *   <li>{@link HttpResponse#aggregate(AggregationOptions)} with
+     *       {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}</li>
      *   <li>{@link HttpFile#aggregateWithPooledObjects(Executor, ByteBufAllocator)}</li>
      * </ul>
      * If you don't use such operations, you don't need to call this method.

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -526,7 +526,11 @@ public interface HttpRequest extends Request, HttpMessage {
      * }</pre>
      *
      * @see PooledObjects
+     *
+     * @deprecated Use {@link #aggregate(AggregationOptions)} with
+     *             {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}.
      */
+    @Deprecated
     @UnstableApi
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         return aggregateWithPooledObjects(defaultSubscriberExecutor(), alloc);
@@ -546,14 +550,18 @@ public interface HttpRequest extends Request, HttpMessage {
      * // An `IllegalStateException` will be raised.
      * request.aggregateWithPooledObjects(executor, alloc).join();
      * }</pre>
+     *
+     * @deprecated Use {@link #aggregate(AggregationOptions)} with
+     *             {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}.
      */
+    @Deprecated
     default CompletableFuture<AggregatedHttpRequest> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
         return aggregate(AggregationOptions.builder()
                                            .executor(executor)
-                                           .alloc(alloc)
+                                           .usePooledObjects(alloc)
                                            .build());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -697,7 +697,11 @@ public interface HttpResponse extends Response, HttpMessage {
      * }</pre>
      *
      * @see PooledObjects
+     *
+     * @deprecated Use {@link #aggregate(AggregationOptions)} with
+     *             {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}.
      */
+    @Deprecated
     @UnstableApi
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(ByteBufAllocator alloc) {
         return aggregateWithPooledObjects(defaultSubscriberExecutor(), alloc);
@@ -717,14 +721,18 @@ public interface HttpResponse extends Response, HttpMessage {
      * // An `IllegalStateException` will be raised.
      * response.aggregateWithPooledObjects(executor, alloc).join();
      * }</pre>
+     *
+     * @deprecated Use {@link #aggregate(AggregationOptions)} with
+     *             {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}.
      */
+    @Deprecated
     default CompletableFuture<AggregatedHttpResponse> aggregateWithPooledObjects(
             EventExecutor executor, ByteBufAllocator alloc) {
         requireNonNull(executor, "executor");
         requireNonNull(alloc, "alloc");
         return aggregate(AggregationOptions.builder()
                                            .executor(executor)
-                                           .alloc(alloc)
+                                           .usePooledObjects(alloc)
                                            .build());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AggregationSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AggregationSupport.java
@@ -94,60 +94,51 @@ public abstract class AggregationSupport {
         final SubscriptionOption[] subscriptionOptions = alloc != null ? POOLED_OBJECTS : EMPTY_OPTIONS;
 
         if (!options.cacheResult()) {
+            final CompletableFuture<?> aggregation = this.aggregation;
             if (aggregation != null) {
-                throw new IllegalStateException("the stream was aggregated already. options: " + options);
+                return handleAggregation(options, aggregation);
             }
-            if (aggregationUpdater.compareAndSet(this, null, NO_CACHE)) {
-                EventExecutor executor = options.executor();
-                if (executor == null) {
-                    executor = httpMessage.defaultSubscriberExecutor();
-                }
-                return httpMessage.collect(executor, subscriptionOptions)
-                                  .thenApply(objects -> aggregate(objects, headers, alloc));
-            } else {
-                throw new IllegalStateException("the stream was aggregated already. options: " + options);
+            if (!aggregationUpdater.compareAndSet(this, null, NO_CACHE)) {
+                final CompletableFuture<Object> aggregation0 = this.aggregation;
+                assert aggregation0 != null;
+                return handleAggregation(options, aggregation0);
             }
-        }
-
-        final CompletableFuture<?> aggregation = this.aggregation;
-        if (aggregation != null) {
-            if (aggregation == NO_CACHE) {
-                throw new IllegalStateException(
-                        "the stream was aggregated previously without cache. options: " + options);
-            }
-
-            //noinspection unchecked
-            return (CompletableFuture<U>) aggregation;
-        }
-
-        final CompletableFuture<U> aggregationFuture = new CompletableFuture<>();
-        if (aggregationUpdater.compareAndSet(this, null, aggregationFuture)) {
-            // Propagate the result to `aggregation`
             EventExecutor executor = options.executor();
             if (executor == null) {
                 executor = httpMessage.defaultSubscriberExecutor();
             }
-            httpMessage.collect(executor, subscriptionOptions)
-                       .thenApply(objects -> aggregate(objects, headers, alloc)).handle((res, cause) -> {
-                           if (cause != null) {
-                               cause = Exceptions.peel(cause);
-                               aggregationFuture.completeExceptionally(cause);
-                           } else {
-                               //noinspection unchecked
-                               aggregationFuture.complete((U) res);
-                           }
-                           return null;
-                       });
-            return aggregationFuture;
+            return httpMessage.collect(executor, subscriptionOptions)
+                              .thenApply(objects -> aggregate(objects, headers, alloc));
         }
 
-        final CompletableFuture<?> aggregation0 = this.aggregation;
-        if (aggregation0 == NO_CACHE) {
-            throw new IllegalStateException(
-                    "the stream was aggregated previously without cache. " + "options: " + options);
+        final CompletableFuture<?> aggregation = this.aggregation;
+        if (aggregation != null) {
+            return handleAggregation(options, aggregation);
         }
-        //noinspection unchecked
-        return (CompletableFuture<U>) aggregation0;
+
+        final CompletableFuture<U> aggregationFuture = new CompletableFuture<>();
+        if (!aggregationUpdater.compareAndSet(this, null, aggregationFuture)) {
+            final CompletableFuture<?> aggregation0 = this.aggregation;
+            assert aggregation0 != null;
+            return handleAggregation(options, aggregation0);
+        }
+        // Propagate the result to `aggregation`
+        EventExecutor executor = options.executor();
+        if (executor == null) {
+            executor = httpMessage.defaultSubscriberExecutor();
+        }
+        httpMessage.collect(executor, subscriptionOptions)
+                   .thenApply(objects -> aggregate(objects, headers, alloc)).handle((res, cause) -> {
+                       if (cause != null) {
+                           cause = Exceptions.peel(cause);
+                           aggregationFuture.completeExceptionally(cause);
+                       } else {
+                           //noinspection unchecked
+                           aggregationFuture.complete((U) res);
+                       }
+                       return null;
+                   });
+        return aggregationFuture;
     }
 
     @SuppressWarnings("unchecked")
@@ -159,5 +150,16 @@ public abstract class AggregationSupport {
         } else {
             return (U) HttpMessageAggregator.aggregateResponse(objects, allocator);
         }
+    }
+
+    private static <U extends AggregatedHttpMessage> CompletableFuture<U> handleAggregation(
+            AggregationOptions options, CompletableFuture<?> aggregation) {
+        if (aggregation == NO_CACHE) {
+            throw new IllegalStateException(
+                    "the stream was aggregated previously without cache. options: " + options);
+        }
+
+        //noinspection unchecked
+        return (CompletableFuture<U>) aggregation;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -34,6 +34,7 @@ import javax.net.ssl.SSLSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -441,7 +442,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             } else {
                 final AggregatedHttpResponseHandler resHandler =
                         new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req);
-                res.aggregateWithPooledObjects(eventLoop, ctx.alloc()).handle(resHandler);
+                res.aggregate(AggregationOptions.builder()
+                                                .usePooledObjects(ctx.alloc())
+                                                .executor(eventLoop)
+                                                .build())
+                   .handle(resHandler);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -442,10 +442,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             } else {
                 final AggregatedHttpResponseHandler resHandler =
                         new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req);
-                res.aggregate(AggregationOptions.builder()
-                                                .usePooledObjects(ctx.alloc())
-                                                .executor(eventLoop)
-                                                .build())
+                res.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), eventLoop))
                    .handle(resHandler);
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/unsafe/PooledObjects.java
+++ b/core/src/main/java/com/linecorp/armeria/unsafe/PooledObjects.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executor;
 
 import org.reactivestreams.Subscriber;
 
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -48,8 +49,10 @@ import io.netty.buffer.ByteBufAllocator;
  * <ul>
  *   <li>{@link StreamMessage#subscribe(Subscriber, SubscriptionOption...)} with
  *       {@link SubscriptionOption#WITH_POOLED_OBJECTS}</li>
- *   <li>{@link HttpRequest#aggregateWithPooledObjects(ByteBufAllocator)}</li>
- *   <li>{@link HttpResponse#aggregateWithPooledObjects(ByteBufAllocator)}</li>
+ *   <li>{@link HttpRequest#aggregate(AggregationOptions)} with
+ *       {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}</li>
+ *   <li>{@link HttpResponse#aggregate(AggregationOptions)} with
+ *       {@link AggregationOptions#usePooledObjects(ByteBufAllocator)}</li>
  *   <li>{@link HttpFile#aggregateWithPooledObjects(Executor, ByteBufAllocator)}</li>
  * </ul>
  *

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -30,6 +30,7 @@ import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -112,7 +113,9 @@ class ProxyClientIntegrationTest {
             sb.port(0, SessionProtocol.HTTP);
             sb.port(0, SessionProtocol.HTTPS);
             sb.tlsSelfSigned();
-            sb.service(PROXY_PATH, (ctx, req) -> HttpResponse.of(SUCCESS_RESPONSE));
+            sb.service(PROXY_PATH, (ctx, req) -> {
+                return HttpResponse.delayed(HttpResponse.of(SUCCESS_RESPONSE), Duration.ofMillis(200));
+            });
         }
     };
 
@@ -255,12 +258,13 @@ class ProxyClientIntegrationTest {
                                   .useHttp2Preface(true)
                                   .build()) {
 
-            final WebClient webClient = WebClient.builder(SessionProtocol.H1C, backendServer.httpEndpoint())
+            final WebClient webClient = WebClient.builder(SessionProtocol.H2C, backendServer.httpEndpoint())
                                                  .factory(clientFactory)
                                                  .decorator(LoggingClient.newDecorator())
                                                  .build();
             final CompletableFuture<AggregatedHttpResponse> responseFuture =
                     webClient.get(PROXY_PATH).aggregate();
+            webClient.get(PROXY_PATH).aggregate();
             final AggregatedHttpResponse response = responseFuture.join();
             assertThat(response.status()).isEqualTo(HttpStatus.OK);
             assertThat(response.contentUtf8()).isEqualTo(SUCCESS_RESPONSE);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultHttpRequestTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -40,8 +41,6 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
-
-import io.netty.buffer.PooledByteBufAllocator;
 
 class DefaultHttpRequestTest {
 
@@ -58,14 +57,18 @@ class DefaultHttpRequestTest {
         // Practically same execution, but we need to test the both case due to code duplication.
         if (executorSpecified) {
             if (withPooledObjects) {
-                future = req.aggregateWithPooledObjects(
-                        CommonPools.workerGroup().next(), PooledByteBufAllocator.DEFAULT);
+                future = req.aggregate(AggregationOptions.builder()
+                                                         .usePooledObjects()
+                                                         .executor(CommonPools.workerGroup().next())
+                                                         .build());
             } else {
                 future = req.aggregate(CommonPools.workerGroup().next());
             }
         } else {
             if (withPooledObjects) {
-                future = req.aggregateWithPooledObjects(PooledByteBufAllocator.DEFAULT);
+                future = req.aggregate(AggregationOptions.builder()
+                                                         .usePooledObjects()
+                                                         .build());
             } else {
                 future = req.aggregate();
             }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultHttpResponseTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -43,7 +44,6 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import reactor.test.StepVerifier;
 
@@ -112,14 +112,16 @@ class DefaultHttpResponseTest {
         // Practically same execution, but we need to test the both case due to code duplication.
         if (executorSpecified) {
             if (withPooledObjects) {
-                future = res.aggregateWithPooledObjects(
-                        CommonPools.workerGroup().next(), PooledByteBufAllocator.DEFAULT);
+                future = res.aggregate(AggregationOptions.builder()
+                                                         .usePooledObjects()
+                                                         .executor(CommonPools.workerGroup().next())
+                                                         .build());
             } else {
                 future = res.aggregate(CommonPools.workerGroup().next());
             }
         } else {
             if (withPooledObjects) {
-                future = res.aggregateWithPooledObjects(PooledByteBufAllocator.DEFAULT);
+                future = res.aggregate(AggregationOptions.builder().usePooledObjects().build());
             } else {
                 future = res.aggregate();
             }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpMethod;
@@ -194,36 +195,41 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
                 ctx = captor.get();
             }
             final EventLoop eventLoop = ctx.eventLoop().withoutContext();
-            response.aggregateWithPooledObjects(eventLoop, ctx.alloc()).handle((aggregatedRes, cause) -> {
-                if (closed) {
-                    return null;
-                }
-                if (cause != null) {
-                    logger.warn("Unexpected exception while fetching the registry from: {}." +
-                                " (requestHeaders: {})", webClient.uri(), requestHeaders, cause);
-                } else {
-                    try (HttpData content = aggregatedRes.content()) {
-                        final HttpStatus status = aggregatedRes.status();
-                        if (!status.isSuccess()) {
-                            logger.warn("Unexpected response from: {}. (status: {}, content: {}, " +
-                                        "requestHeaders: {})", webClient.uri(), status,
-                                        aggregatedRes.contentUtf8(), requestHeaders);
+            response.aggregate(AggregationOptions.builder()
+                                                 .usePooledObjects(ctx.alloc())
+                                                 .executor(eventLoop)
+                                                 .build())
+                    .handle((aggregatedRes, cause) -> {
+                        if (closed) {
+                            return null;
+                        }
+                        if (cause != null) {
+                            logger.warn("Unexpected exception while fetching the registry from: {}." +
+                                        " (requestHeaders: {})", webClient.uri(), requestHeaders, cause);
                         } else {
-                            try {
-                                final List<Endpoint> endpoints = responseConverter.apply(content.array());
-                                setEndpoints(endpoints);
-                            } catch (Exception e) {
-                                logger.warn("Unexpected exception while parsing a response from: {}. " +
-                                            "(content: {}, responseConverter: {}, requestHeaders: {})",
-                                            webClient.uri(), content.toStringUtf8(),
-                                            responseConverter, requestHeaders, e);
+                            try (HttpData content = aggregatedRes.content()) {
+                                final HttpStatus status = aggregatedRes.status();
+                                if (!status.isSuccess()) {
+                                    logger.warn("Unexpected response from: {}. (status: {}, content: {}, " +
+                                                "requestHeaders: {})", webClient.uri(), status,
+                                                aggregatedRes.contentUtf8(), requestHeaders);
+                                } else {
+                                    try {
+                                        final List<Endpoint> endpoints = responseConverter.apply(
+                                                content.array());
+                                        setEndpoints(endpoints);
+                                    } catch (Exception e) {
+                                        logger.warn("Unexpected exception while parsing a response from: {}. " +
+                                                    "(content: {}, responseConverter: {}, requestHeaders: {})",
+                                                    webClient.uri(), content.toStringUtf8(),
+                                                    responseConverter, requestHeaders, e);
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                scheduleNextFetch(eventLoop);
-                return null;
-            });
+                        scheduleNextFetch(eventLoop);
+                        return null;
+                    });
         } catch (Exception e) {
             logger.warn("Unexpected exception while fetching the registry from: {}." +
                         " (requestHeaders: {})", webClient.uri(), requestHeaders, e);

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -195,10 +195,7 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
                 ctx = captor.get();
             }
             final EventLoop eventLoop = ctx.eventLoop().withoutContext();
-            response.aggregate(AggregationOptions.builder()
-                                                 .usePooledObjects(ctx.alloc())
-                                                 .executor(eventLoop)
-                                                 .build())
+            response.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), eventLoop))
                     .handle((aggregatedRes, cause) -> {
                         if (closed) {
                             return null;

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -198,6 +198,9 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
             response.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), eventLoop))
                     .handle((aggregatedRes, cause) -> {
                         if (closed) {
+                            if (aggregatedRes != null) {
+                                aggregatedRes.content().close();
+                            }
                             return null;
                         }
                         if (cause != null) {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -178,10 +178,8 @@ public final class UnaryGrpcClient {
 
         @Override
         public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) {
-            final AggregationOptions aggregationOptions = AggregationOptions.builder()
-                                                                            .usePooledObjects(ctx.alloc())
-                                                                            .executor(ctx.eventLoop())
-                                                                            .build();
+            final AggregationOptions aggregationOptions =
+                    AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop());
             return HttpResponse.from(
                     req.aggregate(aggregationOptions)
                        .thenCompose(

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.SimpleDecoratingHttpClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -129,7 +130,10 @@ public final class UnaryGrpcClient {
                 RequestHeaders.builder(HttpMethod.POST, uri).contentType(serializationFormat.mediaType())
                               .add(HttpHeaderNames.TE, HttpHeaderValues.TRAILERS.toString()).build(),
                 HttpData.wrap(payload));
-        return webClient.execute(request).aggregateWithPooledObjects(PooledByteBufAllocator.DEFAULT)
+        return webClient.execute(request).aggregate(
+                                AggregationOptions.builder()
+                                                  .usePooledObjects(PooledByteBufAllocator.DEFAULT)
+                                                  .build())
                         .thenApply(msg -> {
                             try (HttpData content = msg.content()) {
                                 if (msg.status() != HttpStatus.OK) {
@@ -174,8 +178,12 @@ public final class UnaryGrpcClient {
 
         @Override
         public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) {
+            final AggregationOptions aggregationOptions = AggregationOptions.builder()
+                                                                            .usePooledObjects(ctx.alloc())
+                                                                            .executor(ctx.eventLoop())
+                                                                            .build();
             return HttpResponse.from(
-                    req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc())
+                    req.aggregate(aggregationOptions)
                        .thenCompose(
                                msg -> {
                                    try (HttpData content = msg.content()) {
@@ -188,8 +196,7 @@ public final class UnaryGrpcClient {
 
                                        try {
                                            return unwrap().execute(ctx, HttpRequest.of(req.headers(), framed))
-                                                          .aggregateWithPooledObjects(ctx.eventLoop(),
-                                                                                      ctx.alloc());
+                                                          .aggregate(aggregationOptions);
                                        } catch (Exception e) {
                                            throw new ArmeriaStatusException(StatusCodes.INTERNAL,
                                                                             "Error executing request.");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
@@ -33,6 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -164,18 +165,22 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
             return;
         }
 
-        grpcResponse.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle(
-                (framedResponse, t) -> {
-                    try (SafeCloseable ignore = ctx.push()) {
-                        if (t != null) {
-                            res.completeExceptionally(t);
-                        } else {
-                            deframeAndRespond(ctx, framedResponse, res, unframedGrpcErrorHandler,
-                                              responseBodyConverter, responseContentType);
-                        }
-                    }
-                    return null;
-                });
+        grpcResponse.aggregate(AggregationOptions.builder()
+                                                 .usePooledObjects(ctx.alloc())
+                                                 .executor(ctx.eventLoop())
+                                                 .build())
+                    .handle(
+                            (framedResponse, t) -> {
+                                try (SafeCloseable ignore = ctx.push()) {
+                                    if (t != null) {
+                                        res.completeExceptionally(t);
+                                    } else {
+                                        deframeAndRespond(ctx, framedResponse, res, unframedGrpcErrorHandler,
+                                                          responseBodyConverter, responseContentType);
+                                    }
+                                }
+                                return null;
+                            });
     }
 
     @VisibleForTesting

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractUnframedGrpcService.java
@@ -165,10 +165,7 @@ abstract class AbstractUnframedGrpcService extends SimpleDecoratingHttpService i
             return;
         }
 
-        grpcResponse.aggregate(AggregationOptions.builder()
-                                                 .usePooledObjects(ctx.alloc())
-                                                 .executor(ctx.eventLoop())
-                                                 .build())
+        grpcResponse.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
                     .handle(
                             (framedResponse, t) -> {
                                 try (SafeCloseable ignore = ctx.push()) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -23,9 +23,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -54,8 +51,6 @@ import io.grpc.Status;
  * via {@link Listener}, and writing messages passed back to the response.
  */
 final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
-
-    private static final Logger logger = LoggerFactory.getLogger(UnaryServerCall.class);
 
     private final HttpRequest req;
     private final CompletableFuture<HttpResponse> resFuture;
@@ -98,10 +93,7 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
 
     @Override
     void startDeframing() {
-        req.aggregate(AggregationOptions.builder()
-                                        .usePooledObjects(ctx.alloc())
-                                        .executor(ctx.eventLoop())
-                                        .build())
+        req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
            .handle((aggregatedHttpRequest, cause) -> {
                if (cause != null) {
                    onError(cause);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -147,20 +147,18 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                                RequestLogProperty.RESPONSE_CONTENT);
 
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        req.aggregate(AggregationOptions.builder()
-                                        .usePooledObjects(ctx.alloc())
-                                        .executor(ctx.eventLoop())
-                                        .build()).handle((clientRequest, t) -> {
-            try (SafeCloseable ignore = ctx.push()) {
-                if (t != null) {
-                    responseFuture.completeExceptionally(t);
-                } else {
-                    frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(),
-                                  responseFuture, null, contentType);
-                }
-            }
-            return null;
-        });
+        req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
+           .handle((clientRequest, t) -> {
+               try (SafeCloseable ignore = ctx.push()) {
+                   if (t != null) {
+                       responseFuture.completeExceptionally(t);
+                   } else {
+                       frameAndServe(unwrap(), ctx, grpcHeaders.build(), clientRequest.content(),
+                                     responseFuture, null, contentType);
+                   }
+               }
+               return null;
+           });
         return HttpResponse.from(responseFuture);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -146,7 +147,10 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                                RequestLogProperty.RESPONSE_CONTENT);
 
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((clientRequest, t) -> {
+        req.aggregate(AggregationOptions.builder()
+                                        .usePooledObjects(ctx.alloc())
+                                        .executor(ctx.eventLoop())
+                                        .build()).handle((clientRequest, t) -> {
             try (SafeCloseable ignore = ctx.push()) {
                 if (t != null) {
                     responseFuture.completeExceptionally(t);

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceItTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceItTest.java
@@ -51,6 +51,11 @@ class GrpcDecoratingServiceItTest {
         protected void configure(ServerBuilder sb) {
             sb.requestTimeoutMillis(5000);
             sb.decorator(LoggingService.newDecorator());
+            sb.decorator((delegate, ctx, req) -> {
+                // We can aggregate request if it's not a streaming request.
+                req.aggregate();
+                return delegate.serve(ctx, req);
+            });
             sb.service(GrpcService.builder()
                                   .addService(new FirstTestServiceImpl())
                                   .build());

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceSupportHttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/GrpcDecoratingServiceSupportHttpJsonTranscodingTest.java
@@ -51,6 +51,11 @@ class GrpcDecoratingServiceSupportHttpJsonTranscodingTest {
             final GrpcService grpcService = GrpcService.builder().addService(
                     new HttpJsonTranscodingTestService()).enableHttpJsonTranscoding(true).build();
             sb.requestTimeoutMillis(5000);
+            sb.decorator((delegate, ctx, req) -> {
+                // We can aggregate request if it's not a streaming request.
+                req.aggregate();
+                return delegate.serve(ctx, req);
+            });
             sb.decorator(LoggingService.newDecorator());
             sb.service(grpcService);
         }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDecoratingServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcDecoratingServiceTest.java
@@ -64,6 +64,11 @@ class GrpcDecoratingServiceTest {
         protected void configure(ServerBuilder sb) {
             sb.requestTimeoutMillis(5000);
             sb.decorator(LoggingService.newDecorator());
+            sb.decorator((delegate, ctx, req) -> {
+                // We can aggregate request if it's not a streaming request.
+                req.aggregate();
+                return delegate.serve(ctx, req);
+            });
             sb.service(GrpcService.builder()
                                   .addService(new TestServiceImpl())
                                   .addService(new MetricsServiceImpl())

--- a/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/THttpClientDelegate.java
@@ -169,10 +169,7 @@ final class THttpClientDelegate extends DecoratingClient<HttpRequest, HttpRespon
                 throw t;
             }
 
-            httpResponse.aggregate(AggregationOptions.builder()
-                                                     .usePooledObjects(ctx.alloc())
-                                                     .executor(ctx.eventLoop())
-                                                     .build())
+            httpResponse.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
                         .handle((res, cause) -> {
                             if (cause != null) {
                                 handlePreDecodeException(ctx, reply, func, Exceptions.peel(cause));

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -372,10 +372,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         final HttpResponse res = HttpResponse.from(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT);
-        req.aggregate(AggregationOptions.builder()
-                                        .usePooledObjects(ctx.alloc())
-                                        .executor(ctx.eventLoop())
-                                        .build())
+        req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
            .handle((aReq, cause) -> {
                if (cause != null) {
                    final HttpResponse errorRes;

--- a/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -371,22 +372,26 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         final HttpResponse res = HttpResponse.from(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT);
-        req.aggregateWithPooledObjects(ctx.eventLoop(), ctx.alloc()).handle((aReq, cause) -> {
-            if (cause != null) {
-                final HttpResponse errorRes;
-                if (ctx.config().verboseResponses()) {
-                    errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
-                                               MediaType.PLAIN_TEXT_UTF_8,
-                                               Exceptions.traceText(cause));
-                } else {
-                    errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-                }
-                responseFuture.complete(errorRes);
-                return null;
-            }
-            decodeAndInvoke(ctx, aReq, serializationFormat, responseFuture);
-            return null;
-        }).exceptionally(CompletionActions::log);
+        req.aggregate(AggregationOptions.builder()
+                                        .usePooledObjects(ctx.alloc())
+                                        .executor(ctx.eventLoop())
+                                        .build())
+           .handle((aReq, cause) -> {
+               if (cause != null) {
+                   final HttpResponse errorRes;
+                   if (ctx.config().verboseResponses()) {
+                       errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
+                                                  MediaType.PLAIN_TEXT_UTF_8,
+                                                  Exceptions.traceText(cause));
+                   } else {
+                       errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+                   }
+                   responseFuture.complete(errorRes);
+                   return null;
+               }
+               decodeAndInvoke(ctx, aReq, serializationFormat, responseFuture);
+               return null;
+           }).exceptionally(CompletionActions::log);
         return res;
     }
 


### PR DESCRIPTION
Motivation:
We provide a way to cache `HttpRequest.aggregate()` in #4366. It can be mainly used in a decorator to get the body of an `HttpRequest`. When `HttpRequest.aggregate()` is called in a decorator, if the destination service is an annotated service, there's no problem. However, if a gRPC service or a Thrift service calls `HttpRequest.aggregateWithPooledObjects()`, the service raises an exception.

Modifications:
- Add `AggregationOptionsBuilder.usePooledObjects(alloc, preferCached)`
  - If the `preferCached` is true, it returns the cached aggregated message.

Result:
- `GrpcService` and `ThriftService` no longer throw double subscription exceptions when the request is aggregated in a decorator.
- (Deprecated) `HttpRequest.aggregateWithPooledObjects()` and `HttpResponse.aggregateWithPooledObjects()` are deprecated.
  - Use `HttpRequest.aggregate(aggregateOptions)` with `AggregationOptions#usePooledObjects(ByteBufAllocator)`.