### PR TITLE
Remove an invalid `content-length` in a gRPC streaming response.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Splitter;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpObject;
@@ -487,6 +488,14 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                     builder.set(GrpcHeaderNames.GRPC_ENCODING, compressor.getMessageEncoding());
                 }
                 MetadataUtil.fillHeaders(metadata, builder);
+
+                // Delete the custom content-length of the streaming response which might be set by wrongly
+                // implemented stubs such as Monix-gRPC. https://github.com/monix/monix-grpc/issues/43
+                // If a wrong content-length is set, an RST_STREAM error occurs at the Netty level.
+                // The content-length of a unary call is eventually adjusted when the response is aggregated.
+                if (!method.getType().serverSendsOneMessage() && builder.contentLength() > -1) {
+                    builder.remove(HttpHeaderNames.CONTENT_LENGTH);
+                }
             });
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
@@ -492,7 +492,8 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                 // Delete the custom content-length of the streaming response which might be set by wrongly
                 // implemented stubs such as Monix-gRPC. https://github.com/monix/monix-grpc/issues/43
                 // If a wrong content-length is set, an RST_STREAM error occurs at the Netty level.
-                // The content-length of a unary call is eventually adjusted when the response is aggregated.
+                // We don't need to care about the content-length of a unary call because it is eventually
+                // adjusted when the response is aggregated.
                 if (!method.getType().serverSendsOneMessage() && builder.contentLength() > -1) {
                     builder.remove(HttpHeaderNames.CONTENT_LENGTH);
                 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseLengthTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidResponseLengthTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.grpc.testing.Messages.ResponseParameters;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallRequest;
+import com.linecorp.armeria.grpc.testing.Messages.StreamingOutputCallResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceStub;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.stub.StreamObserver;
+
+class InvalidResponseLengthTest {
+
+    private static final Metadata.Key<String> CONTENT_LENGTH =
+            Metadata.Key.of("content-length", Metadata.ASCII_STRING_MARSHALLER);
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final ServerInterceptor interceptor = new ServerInterceptor() {
+                @Override
+                public <I, O> Listener<I> interceptCall(ServerCall<I, O> call,
+                                                        Metadata requestHeaders,
+                                                        ServerCallHandler<I, O> next) {
+                    return next.startCall(new SimpleForwardingServerCall<I, O>(call) {
+                        @Override
+                        public void sendHeaders(Metadata responseHeaders) {
+                            // Set a wrong content-length
+                            responseHeaders.put(CONTENT_LENGTH, "1");
+                            super.sendHeaders(responseHeaders);
+                        }
+                    }, requestHeaders);
+                }
+            };
+
+            final GrpcService grpcService =
+                    GrpcService.builder()
+                               .addService(new TestServiceImpl(CommonPools.blockingTaskExecutor()))
+                               .intercept(interceptor)
+                               .build();
+
+            sb.service(grpcService);
+        }
+    };
+
+    @Test
+    void streamingResponse() {
+        final TestServiceStub client = GrpcClients.newClient(server.httpUri(), TestServiceStub.class);
+        final StreamingOutputCallRequest request =
+                StreamingOutputCallRequest
+                        .newBuilder()
+                        .addResponseParameters(ResponseParameters.newBuilder().setSize(10))
+                        .addResponseParameters(ResponseParameters.newBuilder().setSize(11))
+                        .addResponseParameters(ResponseParameters.newBuilder().setSize(12))
+                        .addResponseParameters(ResponseParameters.newBuilder().setSize(13))
+                        .build();
+        final AtomicInteger responseCount = new AtomicInteger();
+        final AtomicBoolean completed = new AtomicBoolean();
+
+        client.streamingOutputCall(request, new StreamObserver<StreamingOutputCallResponse>() {
+
+            @Override
+            public void onNext(StreamingOutputCallResponse value) {
+                responseCount.incrementAndGet();
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onCompleted() {
+                completed.set(true);
+            }
+        });
+
+        await().untilTrue(completed);
+        assertThat(responseCount).hasValue(4);
+    }
+
+    @Test
+    void unaryResponse() {
+        final TestServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
+        final SimpleResponse simpleResponse = client.unaryCall(SimpleRequest.newBuilder()
+                                                                            .setResponseSize(100)
+                                                                            .build());
+        assertThat(simpleResponse.getPayload().getBody().size()).isEqualTo(100);
+    }
+}


### PR DESCRIPTION
Motivation:

If a wrong content-length is set, the request/stream is reset by the Netty HTTP/2 codec. Most gRPC server call implmentations do not set a `content-length` to response headers. But some gRPC implementations such as Monix-gRPC send a `content-length` which was in the request content-length. I guess the runtime uses the incoming `Metadata` as the response `Metadata` itself.
Related: https://github.com/monix/monix-grpc/issues/43

Modifications:

- Remove the `content-length` in headers of the gRPC streaming response if set

Result:

- A custom content-length is automatically stripped when response streaming is used in `GrpcService`.
