### PR TITLE
Remove use of deprecated method RequestContextWrapper$delegate

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -47,129 +47,129 @@ public class ClientRequestContextWrapper
     @Override
     public ClientRequestContext newDerivedContext(RequestId id, @Nullable HttpRequest req,
                                                   @Nullable RpcRequest rpcReq, @Nullable Endpoint endpoint) {
-        return delegate().newDerivedContext(id, req, rpcReq, endpoint);
+        return unwrap().newDerivedContext(id, req, rpcReq, endpoint);
     }
 
     @Override
     public EndpointGroup endpointGroup() {
-        return delegate().endpointGroup();
+        return unwrap().endpointGroup();
     }
 
     @Override
     public Endpoint endpoint() {
-        return delegate().endpoint();
+        return unwrap().endpoint();
     }
 
     @Override
     public String fragment() {
-        return delegate().fragment();
+        return unwrap().fragment();
     }
 
     @Override
     public ClientOptions options() {
-        return delegate().options();
+        return unwrap().options();
     }
 
     @Override
     public long writeTimeoutMillis() {
-        return delegate().writeTimeoutMillis();
+        return unwrap().writeTimeoutMillis();
     }
 
     @Override
     public void setWriteTimeoutMillis(long writeTimeoutMillis) {
-        delegate().setWriteTimeoutMillis(writeTimeoutMillis);
+        unwrap().setWriteTimeoutMillis(writeTimeoutMillis);
     }
 
     @Override
     public void setWriteTimeout(Duration writeTimeout) {
-        delegate().setWriteTimeout(writeTimeout);
+        unwrap().setWriteTimeout(writeTimeout);
     }
 
     @Override
     public long responseTimeoutMillis() {
-        return delegate().responseTimeoutMillis();
+        return unwrap().responseTimeoutMillis();
     }
 
     @Override
     public void clearResponseTimeout() {
-        delegate().clearResponseTimeout();
+        unwrap().clearResponseTimeout();
     }
 
     @Override
     public void setResponseTimeoutMillis(TimeoutMode mode, long responseTimeoutMillis) {
-        delegate().setResponseTimeoutMillis(mode, responseTimeoutMillis);
+        unwrap().setResponseTimeoutMillis(mode, responseTimeoutMillis);
     }
 
     @Override
     public void setResponseTimeout(TimeoutMode mode, Duration responseTimeout) {
-        delegate().setResponseTimeout(mode, responseTimeout);
+        unwrap().setResponseTimeout(mode, responseTimeout);
     }
 
     @Override
     public long maxResponseLength() {
-        return delegate().maxResponseLength();
+        return unwrap().maxResponseLength();
     }
 
     @Override
     public void setMaxResponseLength(long maxResponseLength) {
-        delegate().setMaxResponseLength(maxResponseLength);
+        unwrap().setMaxResponseLength(maxResponseLength);
     }
 
     @Override
     public HttpHeaders additionalRequestHeaders() {
-        return delegate().additionalRequestHeaders();
+        return unwrap().additionalRequestHeaders();
     }
 
     @Override
     public void setAdditionalRequestHeader(CharSequence name, Object value) {
-        delegate().setAdditionalRequestHeader(name, value);
+        unwrap().setAdditionalRequestHeader(name, value);
     }
 
     @Override
     public void addAdditionalRequestHeader(CharSequence name, Object value) {
-        delegate().addAdditionalRequestHeader(name, value);
+        unwrap().addAdditionalRequestHeader(name, value);
     }
 
     @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
-        delegate().additionalRequestHeaders();
+        unwrap().additionalRequestHeaders();
     }
 
     @Override
     public ExchangeType exchangeType() {
-        return delegate().exchangeType();
+        return unwrap().exchangeType();
     }
 
     @Override
     public boolean isCancelled() {
-        return delegate().isCancelled();
+        return unwrap().isCancelled();
     }
 
     @Override
     public boolean isTimedOut() {
-        return delegate().isTimedOut();
+        return unwrap().isTimedOut();
     }
 
     @Override
     public CompletableFuture<Throwable> whenResponseCancelling() {
-        return delegate().whenResponseCancelling();
+        return unwrap().whenResponseCancelling();
     }
 
     @Override
     public CompletableFuture<Throwable> whenResponseCancelled() {
-        return delegate().whenResponseCancelled();
+        return unwrap().whenResponseCancelled();
     }
 
     @Deprecated
     @Override
     public CompletableFuture<Void> whenResponseTimingOut() {
-        return delegate().whenResponseTimingOut();
+        return unwrap().whenResponseTimingOut();
     }
 
     @Deprecated
     @Override
     public CompletableFuture<Void> whenResponseTimedOut() {
-        return delegate().whenResponseTimedOut();
+        return unwrap().whenResponseTimedOut();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -222,7 +222,7 @@ public abstract class RequestContextWrapper<T extends RequestContext>
 
     @Override
     public ExchangeType exchangeType() {
-        return delegate().exchangeType();
+        return unwrap().exchangeType();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -51,7 +51,7 @@ public class ServiceRequestContextWrapper
 
     @Override
     public ServiceRequestContext root() {
-        return delegate().root();
+        return unwrap().root();
     }
 
     @Nonnull
@@ -65,181 +65,181 @@ public class ServiceRequestContextWrapper
     @Nonnull
     @Override
     public <A extends SocketAddress> A remoteAddress() {
-        return delegate().remoteAddress();
+        return unwrap().remoteAddress();
     }
 
     @Nonnull
     @Override
     public <A extends SocketAddress> A localAddress() {
-        return delegate().localAddress();
+        return unwrap().localAddress();
     }
 
     @Override
     public InetAddress clientAddress() {
-        return delegate().clientAddress();
+        return unwrap().clientAddress();
     }
 
     @Override
     public ServiceConfig config() {
-        return delegate().config();
+        return unwrap().config();
     }
 
     @Override
     public RoutingContext routingContext() {
-        return delegate().routingContext();
+        return unwrap().routingContext();
     }
 
     @Override
     public Map<String, String> pathParams() {
-        return delegate().pathParams();
+        return unwrap().pathParams();
     }
 
     @Override
     public QueryParams queryParams() {
-        return delegate().queryParams();
+        return unwrap().queryParams();
     }
 
     @Override
     public ContextAwareScheduledExecutorService blockingTaskExecutor() {
-        return delegate().blockingTaskExecutor();
+        return unwrap().blockingTaskExecutor();
     }
 
     @Override
     public String mappedPath() {
-        return delegate().mappedPath();
+        return unwrap().mappedPath();
     }
 
     @Override
     public String decodedMappedPath() {
-        return delegate().decodedMappedPath();
+        return unwrap().decodedMappedPath();
     }
 
     @Nullable
     @Override
     public MediaType negotiatedResponseMediaType() {
-        return delegate().negotiatedResponseMediaType();
+        return unwrap().negotiatedResponseMediaType();
     }
 
     @Override
     public long requestTimeoutMillis() {
-        return delegate().requestTimeoutMillis();
+        return unwrap().requestTimeoutMillis();
     }
 
     @Override
     public void clearRequestTimeout() {
-        delegate().clearRequestTimeout();
+        unwrap().clearRequestTimeout();
     }
 
     @Override
     public void setRequestTimeoutMillis(TimeoutMode mode, long requestTimeoutMillis) {
-        delegate().setRequestTimeoutMillis(mode, requestTimeoutMillis);
+        unwrap().setRequestTimeoutMillis(mode, requestTimeoutMillis);
     }
 
     @Override
     public void setRequestTimeout(TimeoutMode mode, Duration requestTimeout) {
-        delegate().setRequestTimeout(mode, requestTimeout);
+        unwrap().setRequestTimeout(mode, requestTimeout);
     }
 
     @Override
     public CompletableFuture<Throwable> whenRequestCancelling() {
-        return delegate().whenRequestCancelling();
+        return unwrap().whenRequestCancelling();
     }
 
     @Override
     public CompletableFuture<Throwable> whenRequestCancelled() {
-        return delegate().whenRequestCancelled();
+        return unwrap().whenRequestCancelled();
     }
 
     @Deprecated
     @Override
     public CompletableFuture<Void> whenRequestTimingOut() {
-        return delegate().whenRequestTimingOut();
+        return unwrap().whenRequestTimingOut();
     }
 
     @Deprecated
     @Override
     public CompletableFuture<Void> whenRequestTimedOut() {
-        return delegate().whenRequestTimedOut();
+        return unwrap().whenRequestTimedOut();
     }
 
     @Override
     public boolean isCancelled() {
-        return delegate().isCancelled();
+        return unwrap().isCancelled();
     }
 
     @Override
     public boolean isTimedOut() {
-        return delegate().isTimedOut();
+        return unwrap().isTimedOut();
     }
 
     @Override
     public ExchangeType exchangeType() {
-        return delegate().exchangeType();
+        return unwrap().exchangeType();
     }
 
     @Override
     public long maxRequestLength() {
-        return delegate().maxRequestLength();
+        return unwrap().maxRequestLength();
     }
 
     @Override
     public void setMaxRequestLength(long maxRequestLength) {
-        delegate().setMaxRequestLength(maxRequestLength);
+        unwrap().setMaxRequestLength(maxRequestLength);
     }
 
     @Override
     public HttpHeaders additionalResponseHeaders() {
-        return delegate().additionalResponseHeaders();
+        return unwrap().additionalResponseHeaders();
     }
 
     @Override
     public void setAdditionalResponseHeader(CharSequence name, Object value) {
-        delegate().setAdditionalResponseHeader(name, value);
+        unwrap().setAdditionalResponseHeader(name, value);
     }
 
     @Override
     public void addAdditionalResponseHeader(CharSequence name, Object value) {
-        delegate().addAdditionalResponseHeader(name, value);
+        unwrap().addAdditionalResponseHeader(name, value);
     }
 
     @Override
     public void mutateAdditionalResponseHeaders(Consumer<HttpHeadersBuilder> mutator) {
-        delegate().mutateAdditionalResponseHeaders(mutator);
+        unwrap().mutateAdditionalResponseHeaders(mutator);
     }
 
     @Override
     public HttpHeaders additionalResponseTrailers() {
-        return delegate().additionalResponseTrailers();
+        return unwrap().additionalResponseTrailers();
     }
 
     @Override
     public void setAdditionalResponseTrailer(CharSequence name, Object value) {
-        delegate().setAdditionalResponseTrailer(name, value);
+        unwrap().setAdditionalResponseTrailer(name, value);
     }
 
     @Override
     public void addAdditionalResponseTrailer(CharSequence name, Object value) {
-        delegate().addAdditionalResponseTrailer(name, value);
+        unwrap().addAdditionalResponseTrailer(name, value);
     }
 
     @Override
     public void mutateAdditionalResponseTrailers(Consumer<HttpHeadersBuilder> mutator) {
-        delegate().mutateAdditionalResponseTrailers(mutator);
+        unwrap().mutateAdditionalResponseTrailers(mutator);
     }
 
     @Override
     public ProxiedAddresses proxiedAddresses() {
-        return delegate().proxiedAddresses();
+        return unwrap().proxiedAddresses();
     }
 
     @Override
     public CompletableFuture<Void> initiateConnectionShutdown(long drainDurationMicros) {
-        return delegate().initiateConnectionShutdown(drainDurationMicros);
+        return unwrap().initiateConnectionShutdown(drainDurationMicros);
     }
 
     @Override
     public CompletableFuture<Void> initiateConnectionShutdown() {
-        return delegate().initiateConnectionShutdown();
+        return unwrap().initiateConnectionShutdown();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RequestContextWrapperTest.java
@@ -49,7 +49,7 @@ class RequestContextWrapperTest {
         @Override
         @MustBeClosed
         public SafeCloseable push() {
-            return delegate().push();
+            return unwrap().push();
         }
     }
 


### PR DESCRIPTION
Motivation:

RequestContextWrapper$delegate is deprecated since #4308 

Modifications:

- replaced all occurrences of delegate() with unwrap()
