### PR TITLE
make params and return collapsible

### DIFF
--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles({
   hidden: {
     display: 'none',
   },
+  expand: {
+    textAlign: 'end',
+  },
 });
 
 interface Variable {
@@ -128,7 +131,9 @@ const FieldInfo: React.FunctionComponent<FieldInfoProps> = ({
           )}
         </TableCell>
         {hasChildren && (
-          <TableCell>{expanded ? <ExpandLess /> : <ExpandMore />}</TableCell>
+          <TableCell className={styles.expand}>
+            {expanded ? <ExpandLess /> : <ExpandMore />}
+          </TableCell>
         )}
       </TableRow>
       {hasChildren && (

--- a/docs-client/src/containers/MethodPage/ReturnType.tsx
+++ b/docs-client/src/containers/MethodPage/ReturnType.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import TableContainer from '@material-ui/core/TableContainer';
+import * as React from 'react';
+
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import { useReducer } from 'react';
+import { makeStyles } from '@material-ui/core';
+import VariableList from '../../components/VariableList';
+import Section from '../../components/Section';
+import { Method, Specification } from '../../lib/specification';
+
+const useStyles = makeStyles({
+  expand: {
+    textAlign: 'end',
+  },
+});
+
+interface Props {
+  method: Method;
+  specification: Specification;
+}
+
+const ReturnType: React.FunctionComponent<Props> = ({
+  method,
+  specification,
+}) => {
+  const returnTypeVariables =
+    specification.getStructByName(method.returnTypeSignature)?.fields || [];
+
+  const [returnTypeExpanded, toggleReturnTypeExpanded] = useReducer(
+    (value) => !value,
+    false,
+  );
+
+  const styles = useStyles();
+  return (
+    <Section>
+      <Typography variant="h6">Return Type</Typography>
+      <TableContainer>
+        <Table>
+          <TableBody>
+            <TableRow onClick={toggleReturnTypeExpanded}>
+              <TableCell>
+                <code>
+                  {specification.getTypeSignatureHtml(
+                    method.returnTypeSignature,
+                  )}
+                </code>
+              </TableCell>
+              {returnTypeVariables.length > 0 && (
+                <TableCell className={styles.expand}>
+                  {returnTypeExpanded ? <ExpandLess /> : <ExpandMore />}
+                </TableCell>
+              )}
+            </TableRow>
+            {returnTypeExpanded && returnTypeVariables.length > 0 && (
+              <TableRow>
+                <VariableList
+                  key={method.returnTypeSignature}
+                  title=""
+                  variables={returnTypeVariables}
+                  specification={specification}
+                />
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Section>
+  );
+};
+
+export default React.memo(ReturnType);

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -158,7 +158,7 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
       param.typeSignature,
     )?.fields;
     if (childFieldInfos) {
-       return { ...param, childFieldInfos };
+      return { ...param, childFieldInfos };
     }
     return param;
   });

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -157,7 +157,9 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
     const childFieldInfos = props.specification.getStructByName(
       param.typeSignature,
     )?.fields;
-    if (childFieldInfos) return { ...param, childFieldInfos };
+    if (childFieldInfos) {
+       return { ...param, childFieldInfos };
+    }
     return param;
   });
 

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -14,12 +14,7 @@
  * under the License.
  */
 
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
-import TableContainer from '@material-ui/core/TableContainer';
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 
@@ -40,6 +35,7 @@ import DebugPage from './DebugPage';
 import Endpoints from './Endpoints';
 import Exceptions from './Exceptions';
 import Description from '../../components/Description';
+import ReturnType from './ReturnType';
 
 interface OwnProps {
   specification: Specification;
@@ -157,6 +153,14 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
     debugTransport !== undefined &&
     debugTransport.supportsMimeType(GRAPHQL_HTTP_MIME_TYPE);
 
+  const parameterVariables = method.parameters.map((param) => {
+    const childFieldInfos = props.specification.getStructByName(
+      param.typeSignature,
+    )?.fields;
+    if (childFieldInfos) return { ...param, childFieldInfos };
+    return param;
+  });
+
   return (
     <>
       <Typography variant="h5" paragraph>
@@ -171,28 +175,11 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
         <VariableList
           key={method.name}
           title="Parameters"
-          variables={method.parameters}
+          variables={parameterVariables}
           specification={props.specification}
         />
       </Section>
-      <Section>
-        <Typography variant="h6">Return Type</Typography>
-        <TableContainer>
-          <Table>
-            <TableBody>
-              <TableRow>
-                <TableCell>
-                  <code>
-                    {props.specification.getTypeSignatureHtml(
-                      method.returnTypeSignature,
-                    )}
-                  </code>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Section>
+      <ReturnType method={method} specification={props.specification} />
       {!isAnnotatedService && (
         <Exceptions method={method} specification={props.specification} />
       )}


### PR DESCRIPTION
Motivation:

Especially for gRPC methods, not seeing the fields of parameters and return type is very frustrating. You should click and visit another page to see the parameters and the return type. It also makes using the `debug form` harder.

Modifications:

- Update `MethodPage` to have collapsible request and response types.

Result:

- Closes #4481 


https://user-images.githubusercontent.com/7023385/196294177-758e5b6a-9cb5-426a-afb8-85b54b5a6447.mov



<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
