### PR TITLE
Fix failure of `GrpcDocServicePlugin` when `HttpEndpointSupport` is wrapped

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePlugin.java
@@ -124,13 +124,14 @@ public final class GrpcDocServicePlugin implements DocServicePlugin {
                 addServiceDescriptor(serviceInfosBuilder, grpcService);
             }
 
-            if (grpcService instanceof HttpEndpointSupport) {
-                // grpcService is a HttpJsonTranscodingService.
+            final HttpEndpointSupport httpEndpointSupport = grpcService.as(HttpEndpointSupport.class);
+            if (httpEndpointSupport != null) {
+                // grpcService can be unwrapped into HttpJsonTranscodingService.
                 // There are two routes for a method in HttpJsonTranscodingService:
                 // - The HTTP route is added below using the spec.
                 // - The auto generated route(e.g. /package.name/MethodName) is added using EndpointInfo.
                 final HttpEndpointSpecification spec =
-                        ((HttpEndpointSupport) grpcService).httpEndpointSpecification(
+                        httpEndpointSupport.httpEndpointSpecification(
                                 serviceConfig.mappedRoute()); // Use mappedRoute to find the specification.
                 if (spec != null) {
                     if (filter.test(NAME, spec.serviceName(), spec.methodName())) {


### PR DESCRIPTION
Motivation:

`GrpcDocServicePlugin` fails when using wrapped `GrpcService` since 1.18.0.

Modifications:

- Use unwrapped `GrpcService` in `generateSpecification` of `GrpcDocServicePlugin`.

Result:

- Closes #4487.
- GrpcDocServicPlugin works with GrpcService when HTTP JSON transcoding is enabled and GrpcService is wrapped.