### PR TITLE
Remove warn log that is thrown when an interceptor throws an exception

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -300,9 +300,6 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             call.setListener((Listener<I>) EMPTY_LISTENER);
             final Metadata metadata = new Metadata();
             call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
-            logger.warn(
-                    "Exception thrown from streaming request stub method before processing any request data" +
-                    " - this is likely a bug in the stub implementation.", t);
             return;
         }
         if (listener == null) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -298,8 +298,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                                 .startCall(call, MetadataUtil.copyFromHeaders(req.headers()));
         } catch (Throwable t) {
             call.setListener((Listener<I>) EMPTY_LISTENER);
-            final Metadata metadata = new Metadata();
-            call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
+            call.close(t);
             return;
         }
         if (listener == null) {


### PR DESCRIPTION
Motivation:

Current codes spit warn logs when an interceptor throws an exception. 
```java
    private <I, O> void startCall(ServerMethodDefinition<I, O> methodDef, ServiceRequestContext ctx,
                                  HttpRequest req, MethodDescriptor<I, O> methodDescriptor,
                                  AbstractServerCall<I, O> call) {
        final Listener<I> listener;
        try {
            listener = methodDef.getServerCallHandler()
                                .startCall(call, MetadataUtil.copyFromHeaders(req.headers()));
        } catch (Throwable t) {
            call.setListener((Listener<I>) EMPTY_LISTENER);
            final Metadata metadata = new Metadata();
            call.close(GrpcStatus.fromThrowable(statusFunction, ctx, t, metadata), metadata);
            logger.warn(
                    "Exception thrown from streaming request stub method before processing any request data" +
                    " - this is likely a bug in the stub implementation.", t);
            return;
        }
```
On the `io.grpc` [side](https://grpc.github.io/grpc-java/javadoc/io/grpc/ServerInterceptor.html),
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/322936/196897963-1473d6d4-4c8e-40be-8d8e-15b04bbfc716.png">
they don't leave warn logs and they allow only in a case `call` is not started.

So I'd like it to be allowed.

if we allow it to throw an error from an interceptor. there bring benefits to us. that makes the call to be closed and we can apply `GrpcStatusFunction` against the exception 

Modifications:

- Delete the `log.warn` line from the `catch` block
- Support to set metadata by statusExcption that is thrown from an interceptor.

Result:

- You can throw an exception from `ServerInterceptor` and utilize `statusFunction` without the warn log

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
