### PR TITLE
implement request timeout annotation

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/BuiltInDependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/BuiltInDependencyInjector.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.server.annotation.ServerSentEventResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.decorator.LoggingDecoratorFactoryFunction;
 import com.linecorp.armeria.server.annotation.decorator.RateLimitingDecoratorFactoryFunction;
+import com.linecorp.armeria.server.annotation.decorator.RequestTimeoutDecoratorFunction;
 
 public enum BuiltInDependencyInjector implements DependencyInjector {
 
@@ -36,7 +37,8 @@ public enum BuiltInDependencyInjector implements DependencyInjector {
     private static final Set<Class<?>> builtInClasses =
             ImmutableSet.of(LoggingDecoratorFactoryFunction.class,
                             RateLimitingDecoratorFactoryFunction.class,
-                            ServerSentEventResponseConverterFunction.class);
+                            ServerSentEventResponseConverterFunction.class,
+                            RequestTimeoutDecoratorFunction.class);
 
     private static final Map<Class<?>, Object> instances = new ConcurrentHashMap<>();
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -201,7 +201,7 @@ public final class CancellationScheduler {
                 eventLoop.execute(() -> setTimeoutNanosFromStart0(timeoutNanos));
             }
         } else {
-            addPendingTimeoutNanos(timeoutNanos);
+            setPendingTimeoutNanos(timeoutNanos);
             addPendingTask(() -> setTimeoutNanosFromStart0(timeoutNanos));
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -260,18 +260,18 @@ public final class CancellationScheduler {
             if (eventLoop.inEventLoop()) {
                 setTimeoutNanosFromNow0(timeoutNanos);
             } else {
-                final long startTimeNanos = System.nanoTime();
+                final long eventLoopStartTimeNanos = System.nanoTime();
                 eventLoop.execute(() -> {
-                    final long passedTimeNanos0 = System.nanoTime() - startTimeNanos;
+                    final long passedTimeNanos0 = System.nanoTime() - eventLoopStartTimeNanos;
                     final long timeoutNanos0 = Math.max(1, timeoutNanos - passedTimeNanos0);
                     setTimeoutNanosFromNow0(timeoutNanos0);
                 });
             }
         } else {
-            final long startTimeNanos = System.nanoTime();
+            final long pendingTaskRegisterTimeNanos = System.nanoTime();
             setPendingTimeoutNanos(timeoutNanos);
             addPendingTask(() -> {
-                final long passedTimeNanos0 = System.nanoTime() - startTimeNanos;
+                final long passedTimeNanos0 = System.nanoTime() - pendingTaskRegisterTimeNanos;
                 final long timeoutNanos0 = Math.max(1, timeoutNanos - passedTimeNanos0);
                 setTimeoutNanosFromNow0(timeoutNanos0);
             });

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -411,7 +411,8 @@ public final class CancellationScheduler {
         }
     }
 
-    private boolean isInitialized() {
+    @VisibleForTesting
+    public boolean isInitialized() {
         return pendingTask == noopPendingTask && eventLoop != null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 public final class LoggingDecoratorFactoryFunction implements DecoratorFactoryFunction<LoggingDecorator> {
 
     /**
-     * Creates a new decorator with the specified {@code parameter}.
+     * Creates a new decorator with the specified {@link LoggingDecorator}.
      */
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(LoggingDecorator parameter) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RateLimitingDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RateLimitingDecoratorFactoryFunction.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.server.throttling.ThrottlingStrategy;
 public final class RateLimitingDecoratorFactoryFunction
         implements DecoratorFactoryFunction<RateLimitingDecorator> {
     /**
-     * Creates a new decorator with the specified {@code parameter}.
+     * Creates a new decorator with the specified {@link RateLimitingDecorator}.
      */
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(RateLimitingDecorator parameter) {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation.decorator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import com.linecorp.armeria.server.annotation.DecoratorFactory;
+
+/**
+ * Annotation for request timeout
+ */
+@DecoratorFactory(RequestTimeoutDecoratorFunction.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface RequestTimeout {
+
+    /**
+     * Value of request timeout to set
+     */
+    long value();
+
+    /**
+     * Time unit of request timeout to set
+     */
+    TimeUnit unit();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
@@ -41,9 +41,4 @@ public @interface RequestTimeout {
      * Time unit of request timeout to set.
      */
     TimeUnit unit() default TimeUnit.MILLISECONDS;
-
-    /**
-     * Timeout mode of request timeout to set.
-     */
-    TimeoutMode timeoutMode() default TimeoutMode.SET_FROM_START;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
@@ -25,6 +25,8 @@ import com.linecorp.armeria.server.annotation.DecoratorFactory;
 
 /**
  * Annotation for request timeout.
+ * When applied to gRPC services, the timeout value set using {@link RequestTimeout} is only respected if
+ * {@code GrpcServiceBuilder#useClientTimeoutHeader()} is disabled.
  */
 @DecoratorFactory(RequestTimeoutDecoratorFunction.class)
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
@@ -21,7 +21,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
-import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.annotation.DecoratorFactory;
 
 /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeout.java
@@ -21,10 +21,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
+import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.server.annotation.DecoratorFactory;
 
 /**
- * Annotation for request timeout
+ * Annotation for request timeout.
  */
 @DecoratorFactory(RequestTimeoutDecoratorFunction.class)
 @Retention(RetentionPolicy.RUNTIME)
@@ -32,12 +33,17 @@ import com.linecorp.armeria.server.annotation.DecoratorFactory;
 public @interface RequestTimeout {
 
     /**
-     * Value of request timeout to set
+     * Value of request timeout to set.
      */
     long value();
 
     /**
-     * Time unit of request timeout to set
+     * Time unit of request timeout to set.
      */
-    TimeUnit unit();
+    TimeUnit unit() default TimeUnit.MILLISECONDS;
+
+    /**
+     * Timeout mode of request timeout to set.
+     */
+    TimeoutMode timeoutMode() default TimeoutMode.SET_FROM_START;
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.annotation.decorator;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
+
+/**
+ * A factory which creates a decorator that sets request timeout to current {@link ServiceRequestContext}
+ */
+public class RequestTimeoutDecoratorFunction implements DecoratorFactoryFunction<RequestTimeout> {
+
+    /**
+     * Creates a new decorator with the specified {@code parameter}.
+     */
+    @Override
+    public Function<? super HttpService, ? extends HttpService> newDecorator(RequestTimeout parameter) {
+        final Duration duration = Duration.of(parameter.value(), parameter.unit().toChronoUnit());
+
+        return delegate -> new SimpleDecoratingHttpService(delegate) {
+            @Override
+            public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                ServiceRequestContext.current().setRequestTimeout(TimeoutMode.SET_FROM_START, duration);
+                return delegate.serve(ctx, req);
+            }
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.server.annotation.decorator;
 
-import java.time.Duration;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.HttpRequest;
@@ -27,21 +26,21 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 
 /**
- * A factory which creates a decorator that sets request timeout to current {@link ServiceRequestContext}
+ * A factory which creates a decorator that sets request timeout to current {@link ServiceRequestContext}.
  */
-public class RequestTimeoutDecoratorFunction implements DecoratorFactoryFunction<RequestTimeout> {
+public final class RequestTimeoutDecoratorFunction implements DecoratorFactoryFunction<RequestTimeout> {
 
     /**
      * Creates a new decorator with the specified {@code parameter}.
      */
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(RequestTimeout parameter) {
-        final Duration duration = Duration.of(parameter.value(), parameter.unit().toChronoUnit());
-
+        final long timeoutMillis = parameter.unit().toMillis(parameter.value());
         return delegate -> new SimpleDecoratingHttpService(delegate) {
             @Override
             public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                ServiceRequestContext.current().setRequestTimeout(TimeoutMode.SET_FROM_START, duration);
+                ServiceRequestContext.current()
+                                     .setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
                 return delegate.serve(ctx, req);
             }
         };

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
@@ -39,8 +39,7 @@ public final class RequestTimeoutDecoratorFunction implements DecoratorFactoryFu
         return delegate -> new SimpleDecoratingHttpService(delegate) {
             @Override
             public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                ServiceRequestContext.current()
-                                     .setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
+                ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
                 return delegate.serve(ctx, req);
             }
         };

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
@@ -39,7 +39,11 @@ public final class RequestTimeoutDecoratorFunction implements DecoratorFactoryFu
         return delegate -> new SimpleDecoratingHttpService(delegate) {
             @Override
             public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
+                if (timeoutMillis <= 0) {
+                    ctx.clearRequestTimeout();
+                } else {
+                    ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
+                }
                 return delegate.serve(ctx, req);
             }
         };

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/RequestTimeoutDecoratorFunction.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 public final class RequestTimeoutDecoratorFunction implements DecoratorFactoryFunction<RequestTimeout> {
 
     /**
-     * Creates a new decorator with the specified {@code parameter}.
+     * Creates a new decorator with the specified {@link RequestTimeout}.
      */
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(RequestTimeout parameter) {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Get;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -64,9 +64,11 @@ public class RequestTimeoutAnnotationTest {
         }
 
         @Get("/subscriberIsInitialized")
-        public boolean subscriberIsInitialized(ServiceRequestContext ctx, HttpRequest req) {
+        public String subscriberIsInitialized(ServiceRequestContext ctx, HttpRequest req) {
             AnnotatedServiceTest.validateContextAndRequest(ctx, req);
-            return ((DefaultServiceRequestContext) ctx).requestCancellationScheduler().isInitialized();
+            boolean isInitialized = ((DefaultServiceRequestContext) ctx)
+                    .requestCancellationScheduler().isInitialized();
+            return Boolean.toString(isInitialized);
         }
     }
 
@@ -91,7 +93,7 @@ public class RequestTimeoutAnnotationTest {
         final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
 
         final AggregatedHttpResponse response = client.execute(
-                RequestHeaders.of(HttpMethod.GET, "/myService/timeoutMillis"));
+                RequestHeaders.of(HttpMethod.GET, "/myService/subscriberIsInitialized"));
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(Boolean.parseBoolean(response.contentUtf8())).isEqualTo(true);
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -1,0 +1,70 @@
+package com.linecorp.armeria.internal.server.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.decorator.RequestTimeout;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class RequestTimeoutAnnotationTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/myService", new MyAnnotationService());
+
+        }
+    };
+
+    static final long timeoutMillis = 1230;
+    static final long timeoutSeconds = 4560;
+
+    public static class MyAnnotationService {
+        @Get("/timeoutMillis")
+        @RequestTimeout(timeoutMillis)
+        public String timeoutMillis(ServiceRequestContext ctx, HttpRequest req) {
+            AnnotatedServiceTest.validateContextAndRequest(ctx, req);
+            ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
+            return Long.toString(ctx.requestTimeoutMillis());
+        }
+
+        @Get("/timeoutSeconds")
+        @RequestTimeout(value = timeoutSeconds, unit = TimeUnit.SECONDS)
+        public String timeoutSeconds(ServiceRequestContext ctx, HttpRequest req) {
+            AnnotatedServiceTest.validateContextAndRequest(ctx, req);
+            return Long.toString(ctx.requestTimeoutMillis());
+        }
+    }
+
+    @Test
+    public void testRequestTimeoutSet() {
+        final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
+
+        AggregatedHttpResponse response;
+
+        response = client.execute(RequestHeaders.of(HttpMethod.GET, "/myService/timeoutMillis"));
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(Long.parseLong(response.contentUtf8())).isEqualTo(timeoutMillis);
+
+        response = client.execute(RequestHeaders.of(HttpMethod.GET, "/myService/timeoutSeconds"));
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(Long.parseLong(response.contentUtf8()))
+                .isEqualTo(TimeUnit.SECONDS.toMillis(timeoutSeconds));
+    }
+
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.internal.server.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +29,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -28,7 +43,6 @@ public class RequestTimeoutAnnotationTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.annotatedService("/myService", new MyAnnotationService());
-
         }
     };
 
@@ -77,9 +91,9 @@ public class RequestTimeoutAnnotationTest {
     public void testCancellationSchedulerInit() {
         final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
 
-        final AggregatedHttpResponse response = client.execute(RequestHeaders.of(HttpMethod.GET, "/myService/timeoutMillis"));
+        final AggregatedHttpResponse response = client.execute(
+                RequestHeaders.of(HttpMethod.GET, "/myService/timeoutMillis"));
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(Boolean.parseBoolean(response.contentUtf8())).isEqualTo(true);
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -66,7 +66,7 @@ public class RequestTimeoutAnnotationTest {
         @Get("/subscriberIsInitialized")
         public String subscriberIsInitialized(ServiceRequestContext ctx, HttpRequest req) {
             AnnotatedServiceTest.validateContextAndRequest(ctx, req);
-            boolean isInitialized = ((DefaultServiceRequestContext) ctx)
+            final boolean isInitialized = ((DefaultServiceRequestContext) ctx)
                     .requestCancellationScheduler().isInitialized();
             return Boolean.toString(isInitialized);
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -62,19 +62,11 @@ class RequestTimeoutAnnotationTest {
             AnnotatedServiceTest.validateContextAndRequest(ctx, req);
             return Long.toString(ctx.requestTimeoutMillis());
         }
-
-        @Get("/subscriberIsInitialized")
-        public String subscriberIsInitialized(ServiceRequestContext ctx, HttpRequest req) {
-            AnnotatedServiceTest.validateContextAndRequest(ctx, req);
-            final boolean isInitialized = ((DefaultServiceRequestContext) ctx)
-                    .requestCancellationScheduler().isInitialized();
-            return Boolean.toString(isInitialized);
-        }
     }
 
     @Test
     void testRequestTimeoutSet() {
-        final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
+        final BlockingWebClient client = server.blockingWebClient();
 
         AggregatedHttpResponse response;
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.internal.server.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -35,7 +35,7 @@ import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.decorator.RequestTimeout;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-public class RequestTimeoutAnnotationTest {
+class RequestTimeoutAnnotationTest {
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -48,7 +48,7 @@ public class RequestTimeoutAnnotationTest {
     static final long timeoutMillis = 1230;
     static final long timeoutSeconds = 4560;
 
-    public static class MyAnnotationService {
+    static class MyAnnotationService {
         @Get("/timeoutMillis")
         @RequestTimeout(timeoutMillis)
         public String timeoutMillis(ServiceRequestContext ctx, HttpRequest req) {
@@ -73,7 +73,7 @@ public class RequestTimeoutAnnotationTest {
     }
 
     @Test
-    public void testRequestTimeoutSet() {
+    void testRequestTimeoutSet() {
         final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
 
         AggregatedHttpResponse response;
@@ -86,15 +86,5 @@ public class RequestTimeoutAnnotationTest {
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(Long.parseLong(response.contentUtf8()))
                 .isEqualTo(TimeUnit.SECONDS.toMillis(timeoutSeconds));
-    }
-
-    @Test
-    public void testCancellationSchedulerInit() {
-        final BlockingWebClient client = BlockingWebClient.of(server.httpUri());
-
-        final AggregatedHttpResponse response = client.execute(
-                RequestHeaders.of(HttpMethod.GET, "/myService/subscriberIsInitialized"));
-        assertThat(response.status()).isEqualTo(HttpStatus.OK);
-        assertThat(Boolean.parseBoolean(response.contentUtf8())).isEqualTo(true);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/RequestTimeoutAnnotationTest.java
@@ -39,7 +39,6 @@ public class RequestTimeoutAnnotationTest {
         @RequestTimeout(timeoutMillis)
         public String timeoutMillis(ServiceRequestContext ctx, HttpRequest req) {
             AnnotatedServiceTest.validateContextAndRequest(ctx, req);
-            ctx.setRequestTimeoutMillis(TimeoutMode.SET_FROM_START, timeoutMillis);
             return Long.toString(ctx.requestTimeoutMillis());
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -229,12 +229,11 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             final String timeoutHeader = req.headers().get(GrpcHeaderNames.GRPC_TIMEOUT);
             if (timeoutHeader != null) {
                 try {
-                    final Duration timeout = Duration.ofNanos(TimeoutHeaderUtil.fromHeaderValue(timeoutHeader));
-                    final long existingTimeoutMillis = ctx.requestTimeoutMillis();
-                    if (timeout.isZero()) {
+                    final long timeout = TimeoutHeaderUtil.fromHeaderValue(timeoutHeader);
+                    if (timeout == 0) {
                         ctx.clearRequestTimeout();
-                    } else if (existingTimeoutMillis == 0 || existingTimeoutMillis > timeout.toMillis()) {
-                        ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, timeout);
+                    } else {
+                        ctx.setRequestTimeout(TimeoutMode.SET_FROM_NOW, Duration.ofNanos(timeout));
                     }
                 } catch (IllegalArgumentException e) {
                     final Metadata metadata = new Metadata();


### PR DESCRIPTION
Motivation:

Provide a way to set a request timeout using annotation

Modifications:
- Add @interface RequestTimeout
- Add RequestTimeoutDecoratorFunction

Result:

- Closes #4463
- users can use RequestTimeout annotation to set request timeout to service methods

