### PR TITLE
Create correct `FieldInfo` for renamed object fields in `DocService`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DefaultNamedTypeInfoProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DefaultNamedTypeInfoProviderTest.java
@@ -112,8 +112,7 @@ class DefaultNamedTypeInfoProviderTest {
                 newRequiredField("stringField", STRING),
                 newRequiredField("sameName", TypeSignature.ofNamed(Inner.class),
                                  newRequiredField("innerValue", BOOLEAN)),
-                // Can't get a full field information from a renamed JSON property.
-                newUnspecifiedField("rename", TypeSignature.ofNamed(Inner.class),
+                newRequiredField("rename", TypeSignature.ofNamed(Inner.class),
                                     newRequiredField("innerValue", BOOLEAN)),
                 newRequiredField("collection", TypeSignature.ofList(Inner.class)),
                 newOptionalField("nullableField", STRING),
@@ -133,8 +132,7 @@ class DefaultNamedTypeInfoProviderTest {
                 newOptionalField("getterNullableField", STRING),
                 newRequiredField("sameName", TypeSignature.ofNamed(Inner.class),
                                  newRequiredField("innerValue", BOOLEAN)),
-                // Can't get a full field information from a renamed JSON property.
-                newUnspecifiedField("rename", TypeSignature.ofNamed(Inner.class),
+                newRequiredField("rename", TypeSignature.ofNamed(Inner.class),
                                     newRequiredField("innerValue", BOOLEAN)),
                 newRequiredField("collection", TypeSignature.ofList(Inner.class)),
                 newOptionalField("nullableField", STRING),

--- a/core/src/test/resources/com/linecorp/armeria/internal/server/annotation/JsonNamedTypeInfoProviderTest_specification.json5
+++ b/core/src/test/resources/com/linecorp/armeria/internal/server/annotation/JsonNamedTypeInfoProviderTest_specification.json5
@@ -58,7 +58,7 @@
                 }, {
                   "name": "rename",
                   "location": "UNSPECIFIED",
-                  "requirement": "UNSPECIFIED", // requirement is unspecified if no field information is given.
+                  "requirement": "REQUIRED",
                   "typeSignature": "com.linecorp.armeria.internal.server.annotation.DefaultNamedTypeInfoProviderTest$Inner",
                   "childFieldInfos": [
                     {
@@ -223,7 +223,7 @@
         }, {
           "name": "rename",
           "location": "UNSPECIFIED",
-          "requirement": "UNSPECIFIED",
+          "requirement": "REQUIRED",
           "typeSignature": "com.linecorp.armeria.internal.server.annotation.DefaultNamedTypeInfoProviderTest$Inner",
           "childFieldInfos": [
             {

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
@@ -57,9 +57,9 @@ class DataClassDefaultNameTypeInfoProviderTest {
                 .requirement(FieldRequirement.REQUIRED)
                 .descriptionInfo(DescriptionInfo.of("default value 2 description"))
                 .build(),
-            FieldInfo.builder("overridden_json_field_name", STRING)
+            FieldInfo.builder("renamed", STRING)
                 .requirement(FieldRequirement.OPTIONAL)
-                .descriptionInfo(DescriptionInfo.of("overridden json field name"))
+                .descriptionInfo(DescriptionInfo.of("renamed description"))
                 .build()
         )
     }
@@ -88,9 +88,9 @@ class DataClassDefaultNameTypeInfoProviderTest {
         val defaultValue: String = "Hello",
         @Description(value = "default value 2 description")
         val defaultValue2: String = "Hello2",
-        @JsonProperty("overridden_json_field_name")
-        @Description("overridden json field name")
-        val overriddenJsonFieldName: String?
+        @JsonProperty("renamed")
+        @Description("renamed description")
+        val name: String?
     )
 
     @Description("Enum description")

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
@@ -57,9 +57,13 @@ class DataClassDefaultNameTypeInfoProviderTest {
                 .requirement(FieldRequirement.REQUIRED)
                 .descriptionInfo(DescriptionInfo.of("default value 2 description"))
                 .build(),
-            FieldInfo.builder("renamed", STRING)
+            FieldInfo.builder("renamedNonnull", STRING)
+                .requirement(FieldRequirement.REQUIRED)
+                .descriptionInfo(DescriptionInfo.of("renamed nonnull description"))
+                .build(),
+            FieldInfo.builder("renamedNullable", STRING)
                 .requirement(FieldRequirement.OPTIONAL)
-                .descriptionInfo(DescriptionInfo.of("renamed description"))
+                .descriptionInfo(DescriptionInfo.of("renamed nullable description"))
                 .build()
         )
     }
@@ -88,9 +92,12 @@ class DataClassDefaultNameTypeInfoProviderTest {
         val defaultValue: String = "Hello",
         @Description(value = "default value 2 description")
         val defaultValue2: String = "Hello2",
-        @JsonProperty("renamed")
-        @Description("renamed description")
-        val name: String?
+        @JsonProperty("renamedNonnull")
+        @Description("renamed nonnull description")
+        val nonnullName: String,
+        @JsonProperty("renamedNullable")
+        @Description("renamed nullable description")
+        val nullableName: String?
     )
 
     @Description("Enum description")

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.internal.server.annotation
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING
 import com.linecorp.armeria.server.annotation.Description
 import com.linecorp.armeria.server.docs.DescriptionInfo
@@ -55,6 +56,10 @@ class DataClassDefaultNameTypeInfoProviderTest {
             FieldInfo.builder("defaultValue2", STRING)
                 .requirement(FieldRequirement.REQUIRED)
                 .descriptionInfo(DescriptionInfo.of("default value 2 description"))
+                .build(),
+            FieldInfo.builder("overridden_json_field_name", STRING)
+                .requirement(FieldRequirement.OPTIONAL)
+                .descriptionInfo(DescriptionInfo.of("overridden json field name"))
                 .build()
         )
     }
@@ -82,7 +87,10 @@ class DataClassDefaultNameTypeInfoProviderTest {
         @Description(value = "default value description")
         val defaultValue: String = "Hello",
         @Description(value = "default value 2 description")
-        val defaultValue2: String = "Hello2"
+        val defaultValue2: String = "Hello2",
+        @JsonProperty("overridden_json_field_name")
+        @Description("overridden json field name")
+        val overriddenJsonFieldName: String?
     )
 
     @Description("Enum description")


### PR DESCRIPTION
Motivation:

- #4506

Modifications:

* Use `BeanPropertyDefinition#getInternalName` to find the right constructor parameter or getter.
  - Unlike `BeanPropertyDefinition#getName` `#getInternalName` is derived from accessor and is not based on annotations or naming strategy.

* Use `@JsonProperty` annotation-based matching strategy to find the right field or constructor parameter for the fields without accessor(getter).
  - `#getInternalName` is generated based on annotations or naming strategy if there's no available accessor for a field.
 
Limitation:
* `@JsonProperty` annotation-based field matching strategy may not cover POJOs without `@JsonProperty` and de/serialized with  non-default naming strategy .

Result:

- Closes #4506

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
