### PR TITLE
Fix a bug where a connection is closed before a response is written in HTTP/1.x

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -40,6 +40,10 @@ public final class CancelledSubscriptionException extends RuntimeException {
                new CancelledSubscriptionException() : INSTANCE;
     }
 
+    public CancelledSubscriptionException(String message) {
+        super(message);
+    }
+
     private CancelledSubscriptionException() {}
 
     private CancelledSubscriptionException(@SuppressWarnings("unused") boolean dummy) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -40,6 +40,9 @@ public final class CancelledSubscriptionException extends RuntimeException {
                new CancelledSubscriptionException() : INSTANCE;
     }
 
+    /**
+     * Creates a new exception with the specified {@code message}.
+     */
     public CancelledSubscriptionException(String message) {
         super(message);
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -416,7 +416,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
     @Override
     public final boolean isClosed() {
-        return closed;
+        return closed || !channel().isActive();
     }
 
     private static final class PendingWrites extends ArrayDeque<Entry<HttpObject, ChannelPromise>> {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
@@ -126,6 +126,6 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
 
     @Override
     public boolean isClosed() {
-        return closed;
+        return closed || !channel().isActive();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.CancellationScheduler.CancellationTask;
@@ -60,6 +61,8 @@ abstract class AbstractHttpResponseHandler {
      * Returns whether a response has been finished.
      */
     abstract boolean isDone();
+
+    abstract boolean tryComplete(@Nullable Throwable cause);
 
     /**
      * Fails a request and a response with the specified {@link Throwable}.

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -82,7 +82,6 @@ abstract class AbstractHttpResponseHandler {
         return true;
     }
 
-
     /**
      * Fails a request and a response with the specified {@link Throwable}.
      * This method won't send any response to the remote peer but log the failed request.

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -173,7 +173,6 @@ abstract class AbstractHttpResponseHandler {
         return response;
     }
 
-
     final void endLogRequestAndResponse(Throwable cause) {
         logBuilder().endRequest(cause);
         logBuilder().endResponse(cause);

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -45,15 +45,11 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         implements BiFunction<AggregatedHttpResponse, Throwable, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(AggregatedHttpResponseHandler.class);
-    private final CompletableFuture<Void> completionFuture;
-
-    private boolean isComplete;
 
     AggregatedHttpResponseHandler(ChannelHandlerContext ctx, ServerHttpObjectEncoder responseEncoder,
                                   DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
                                   CompletableFuture<Void> completionFuture) {
-        super(ctx, responseEncoder, reqCtx, req);
-        this.completionFuture = completionFuture;
+        super(ctx, responseEncoder, reqCtx, req, completionFuture);
         scheduleTimeout();
     }
 
@@ -135,25 +131,6 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
             }
         });
         ctx.flush();
-    }
-
-    @Override
-    boolean tryComplete(@Nullable Throwable cause) {
-        if (isComplete) {
-            return false;
-        }
-        isComplete = true;
-        if (cause == null) {
-            completionFuture.complete(null);
-        } else {
-            completionFuture.completeExceptionally(cause);
-        }
-        return true;
-    }
-
-    @Override
-    boolean isDone() {
-        return isComplete;
     }
 
     private final class WriteFutureListener implements ChannelFutureListener {

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 
 import org.slf4j.Logger;
@@ -44,12 +45,15 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         implements BiFunction<AggregatedHttpResponse, Throwable, Void> {
 
     private static final Logger logger = LoggerFactory.getLogger(AggregatedHttpResponseHandler.class);
+    private final CompletableFuture<Void> completionFuture;
 
     private boolean isComplete;
 
     AggregatedHttpResponseHandler(ChannelHandlerContext ctx, ServerHttpObjectEncoder responseEncoder,
-                                  DefaultServiceRequestContext reqCtx, DecodedHttpRequest req) {
+                                  DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
+                                  CompletableFuture<Void> completionFuture) {
         super(ctx, responseEncoder, reqCtx, req);
+        this.completionFuture = completionFuture;
         scheduleTimeout();
     }
 
@@ -80,7 +84,6 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
 
         logBuilder().startResponse();
         write(response, null);
-        return;
     }
 
     private void write(AggregatedHttpResponse response, @Nullable Throwable cause) {
@@ -119,7 +122,7 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
 
     @Override
     void fail(Throwable cause) {
-        if (tryComplete()) {
+        if (tryComplete(cause)) {
             endLogRequestAndResponse(cause);
             maybeWriteAccessLog();
         }
@@ -134,11 +137,17 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         ctx.flush();
     }
 
-    private boolean tryComplete() {
+    @Override
+    boolean tryComplete(@Nullable Throwable cause) {
         if (isComplete) {
             return false;
         }
         isComplete = true;
+        if (cause == null) {
+            completionFuture.complete(null);
+        } else {
+            completionFuture.completeExceptionally(cause);
+        }
         return true;
     }
 
@@ -185,7 +194,7 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         // - any write operation is failed with a cause.
         if (isSuccess) {
             logBuilder().responseFirstBytesTransferred();
-            if (tryComplete()) {
+            if (tryComplete(cause)) {
                 if (cause == null) {
                     cause = CapturedServiceException.get(reqCtx);
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -292,7 +292,8 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
         final State oldState = setDone(false);
         if (oldState == State.NEEDS_HEADERS) {
             logger.warn("{} Published nothing (or only informational responses): {}", ctx.channel(), service());
-            responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR);
+            responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR)
+                           .addListener(future -> tryComplete(null));
             ctx.flush();
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -140,7 +140,8 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                 } else {
                     if (responseEncoder.isResponseHeadersSent(req.id(), req.streamId())) {
                         // The response is sent by the HttpRequestDecoder so we just cancel the stream message.
-                        tryComplete(CancelledSubscriptionException.get());
+                        tryComplete(new CancelledSubscriptionException(
+                                "An HTTP response was sent already. ctx: " + reqCtx));
                         setDone(true);
                         return;
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -425,7 +425,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
                     if (!isTransientService) {
                         gracefulShutdownSupport.dec();
-                    } unfinishedRequests.remove(req); if (unfinishedRequests.isEmpty() && handledLastRequest) {
+                    }
+                    unfinishedRequests.remove(req);
+                    if (unfinishedRequests.isEmpty() && handledLastRequest) {
                         ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);
                     }
                 } catch (Throwable t) {
@@ -439,7 +441,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             // when the peer cancels the stream.
             req.setResponse(res);
 
-            assert responseEncoder != null; if (reqCtx.exchangeType().isResponseStreaming()) {
+            assert responseEncoder != null;
+            if (reqCtx.exchangeType().isResponseStreaming()) {
                 final HttpResponseSubscriber resSubscriber =
                         new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, resWriteFuture);
                 res.subscribe(resSubscriber, eventLoop, SubscriptionOption.WITH_POOLED_OBJECTS);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -422,8 +422,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     } else {
                         req.abort(cause);
                     }
-                    // NB: logBuilder.endResponse() is called by
-                    // HttpResponseSubscriber below.
+                    // NB: logBuilder.endResponse() is called by HttpResponseSubscriber below.
                     if (!isTransientService) {
                         gracefulShutdownSupport.dec();
                     } unfinishedRequests.remove(req); if (unfinishedRequests.isEmpty() && handledLastRequest) {
@@ -431,7 +430,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     }
                 } catch (Throwable t) {
                     logger.warn("Unexpected exception:", t);
-                } return null;
+                }
+                return null;
                 // Reschedule to abort the request after all post-processes such logging have been handled.
             }, eventLoop);
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.IdentityHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -201,6 +202,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (responseEncoder != null) {
+            // Immediately close responseEncoder so that a late response is completed with
+            // a ClosedSessionException.
+            responseEncoder.close();
+        }
+
         // Give the unfinished streaming responses a chance to close themselves before we abort them,
         // so that successful responses are not aborted due to a race condition like the following:
         //
@@ -226,10 +233,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private void cleanup() {
-        if (responseEncoder != null) {
-            responseEncoder.close();
-        }
-
         if (!unfinishedRequests.isEmpty()) {
             final ClosedSessionException cause = ClosedSessionException.get();
             unfinishedRequests.forEach((req, res) -> {
@@ -409,7 +412,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 return null;
             });
 
-            res.whenComplete().handleAsync((ret, cause) -> {
+            // A future which is completed when the all response objects are written to channel and
+            // the returned promises are done.
+            final CompletableFuture<Void> resWriteFuture = new CompletableFuture<>();
+            resWriteFuture.handle((ret, cause) -> {
+                assert eventLoop.inEventLoop();
                 try {
                     if (cause == null) {
                         req.abort();
@@ -428,7 +435,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     logger.warn("Unexpected exception:", t);
                 }
                 return null;
-            }, eventLoop);
+            });
 
             // Set the response to the request in order to be able to immediately abort the response
             // when the peer cancels the stream.
@@ -437,11 +444,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             assert responseEncoder != null;
             if (reqCtx.exchangeType().isResponseStreaming()) {
                 final HttpResponseSubscriber resSubscriber =
-                        new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req);
+                        new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, resWriteFuture);
                 res.subscribe(resSubscriber, eventLoop, SubscriptionOption.WITH_POOLED_OBJECTS);
             } else {
                 final AggregatedHttpResponseHandler resHandler =
-                        new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req);
+                        new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req, resWriteFuture);
                 res.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), eventLoop))
                    .handle(resHandler);
             }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -409,7 +409,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     }
                 } catch (Throwable t) {
                     logger.warn("Unexpected exception:", t);
-                } return null;
+                }
+                return null;
             });
 
             // A future which is completed when the all response objects are written to channel and

--- a/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
@@ -66,7 +66,6 @@ class Http1KeepAliveTest {
     void noKeepAlive(ExchangeType exchangeType) throws Exception {
         try (Socket socket = new Socket("127.0.0.1", server.httpPort())) {
             socket.setSoTimeout(10000);
-            socket.setReceiveBufferSize(2);
             final PrintWriter writer = new PrintWriter(socket.getOutputStream());
             writer.print("GET /?exchangeType=" + exchangeType.name() + " HTTP/1.1\r\n");
             writer.print("Connection: close\r\n\r\n");

--- a/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.time.Duration;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class Http1KeepAliveTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(LoggingService.newDecorator());
+
+            sb.service("/", new HttpService() {
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    return ExchangeType.valueOf(routingContext.params().get("exchangeType"));
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    // Wrap `delayedResponse` with an `HttpResponseException` so that
+                    // the HttpResponseException completes first and `delayedResponse` is written later.
+                    final HttpResponse delayedResponse =
+                            HttpResponse.delayed(HttpResponse.of("A late response"),
+                                                 Duration.ofSeconds(1));
+                    throw HttpResponseException.of(delayedResponse);
+                }
+            });
+        }
+    };
+
+    @EnumSource(ExchangeType.class)
+    @ParameterizedTest
+    void noKeepAlive(ExchangeType exchangeType) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", server.httpPort())) {
+            socket.setSoTimeout(10000);
+            socket.setReceiveBufferSize(2);
+            final PrintWriter writer = new PrintWriter(socket.getOutputStream());
+            writer.print("GET /?exchangeType=" + exchangeType.name() + " HTTP/1.1\r\n");
+            writer.print("Connection: close\r\n\r\n");
+            writer.flush();
+
+            final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            assertThat(in.readLine()).isEqualTo("HTTP/1.1 200 OK");
+
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (line.isEmpty() || line.contains(":")) {
+                    // Skip headers.
+                    continue;
+                }
+                assertThat(line).isEqualTo("A late response");
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingFailureTest.java
@@ -88,9 +88,9 @@ class ContentPreviewingFailureTest {
                 assertThat(log.responseCause()).isNull();
                 break;
             case "/http-status-exception-with-cause":
-                assertThat(log.requestCause())
-                        .isInstanceOf(RuntimeException.class)
-                        .hasMessage("with-status");
+                // The cause of HttpStatusException and HttpResponseException are only propagated to
+                // `log.responseCause()`.
+                assertThat(log.requestCause()).isNull();
                 assertThat(log.responseCause())
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("with-status");


### PR DESCRIPTION
Motivation:

If `connection: close` header is recevied, `HttpServerHandler` closes a connection when an `HttpResponse` is completed.
https://github.com/line/armeria/blob/f6c4debed749f77d71aec836e98bdffef6537273/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L412-L425 However, `HttpResponse` completion does not guarantee that the response is fully written to the connection. If a response write starts after the completion of `HttpResponse.whenComplete()`, a response could write to a closed connection which causes
`io.netty.channel.StacklessClosedChannelException`.

Modifications:

- Start the post-process of a response after the response is really written to the channel.
- Add `completionFuture` and make it complete when `AbstractHttpResponseHandler` finishes all write operations.
- Immediately close `responseEncoder` so that a late response is completed with a `ClosedSessionException`.

Result:

You no longer see `StacklessClosedChannelException` when handling
an HTTP1 request with 'Connection: close`.

