### PR TITLE
Clean up dead code in `Server`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -728,38 +728,6 @@ public final class Server implements ListenableAsyncCloseable {
         private void logStopFailure(Throwable cause) {
             logger.warn("Failed to stop a server: {}", cause.getMessage(), cause);
         }
-
-        private void shutdownExecutor(Iterable<ScheduledExecutorService> executors) {
-            for (ScheduledExecutorService executor : executors) {
-                if (executor instanceof UnstoppableScheduledExecutorService) {
-                    executor = ((UnstoppableScheduledExecutorService) executor).getExecutorService();
-                }
-
-                executor.shutdown();
-            }
-
-            boolean interrupted = false;
-            for (ScheduledExecutorService executor : executors) {
-                if (executor instanceof UnstoppableScheduledExecutorService) {
-                    executor = ((UnstoppableScheduledExecutorService) executor).getExecutorService();
-                }
-
-                try {
-                    while (!executor.isTerminated()) {
-                        try {
-                            executor.awaitTermination(1, TimeUnit.DAYS);
-                        } catch (InterruptedException ignore) {
-                            interrupted = true;
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.warn("Failed to shutdown the blockingTaskExecutor: {}", executor, e);
-                }
-            }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

Clean up dead code that was introduced by https://github.com/line/armeria/commit/aa647fae9278fa54c4f303c29e1db8f058fbaf78 and removed by https://github.com/line/armeria/commit/84dd0cfea367f2c41720d13cb87a5bf477174d00

Modifications:

- Remove dead code `Server#shutdownExecutor`

Result:

- No impact
