### PR TITLE
Remove duplicate information from context leak stack trace

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/LeakTracingRequestContextStorage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/LeakTracingRequestContextStorage.java
@@ -40,6 +40,7 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
 
     /**
      * Creates a new instance.
+     *
      * @param delegate the underlying {@link RequestContextStorage} that stores {@link RequestContext}
      * @param sampler the {@link Sampler} that determines whether to retain the stacktrace of the context leaks
      */
@@ -54,9 +55,19 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
     public <T extends RequestContext> T push(RequestContext toPush) {
         requireNonNull(toPush, "toPush");
         if (sampler.isSampled(toPush)) {
-            return delegate.push(wrapRequestContext(toPush.unwrapAll()));
+            return delegate.push(wrapRequestContext(unwrapTraceableRequestContext(toPush)));
         }
         return delegate.push(toPush);
+    }
+
+    private static RequestContext unwrapTraceableRequestContext(RequestContext ctx) {
+        while (true) {
+            final RequestContext unwrapped = ctx.unwrap();
+            if (!(unwrapped instanceof TraceableRequestContext)) {
+                return unwrapped;
+            }
+            ctx = unwrapped;
+        }
     }
 
     @Override
@@ -77,9 +88,11 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
     }
 
     private static RequestContextWrapper<?> wrapRequestContext(RequestContext ctx) {
-        return ctx instanceof ClientRequestContext ?
-               new TraceableClientRequestContext((ClientRequestContext) ctx)
-               : new TraceableServiceRequestContext((ServiceRequestContext) ctx);
+        if (ctx instanceof ClientRequestContext) {
+            return new TraceableClientRequestContext((ClientRequestContext) ctx);
+        }
+        assert ctx instanceof ServiceRequestContext;
+        return new TraceableServiceRequestContext((ServiceRequestContext) ctx);
     }
 
     private static String stacktraceToString(StackTraceElement[] stackTrace,
@@ -92,22 +105,26 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
         return builder.toString();
     }
 
-    private static final class TraceableClientRequestContext extends ClientRequestContextWrapper {
+    private interface TraceableRequestContext {}
 
-            private final StackTraceElement[] stackTrace;
+    private static final class TraceableClientRequestContext
+            extends ClientRequestContextWrapper implements TraceableRequestContext {
 
-            private TraceableClientRequestContext(ClientRequestContext delegate) {
-                super(delegate);
-                stackTrace = currentThread().getStackTrace();
-            }
+        private final StackTraceElement[] stackTrace;
 
-            @Override
-            public String toString() {
-                return stacktraceToString(stackTrace, unwrap());
-            }
+        private TraceableClientRequestContext(ClientRequestContext delegate) {
+            super(delegate);
+            stackTrace = currentThread().getStackTrace();
         }
 
-    private static final class TraceableServiceRequestContext extends ServiceRequestContextWrapper {
+        @Override
+        public String toString() {
+            return stacktraceToString(stackTrace, unwrap());
+        }
+    }
+
+    private static final class TraceableServiceRequestContext
+            extends ServiceRequestContextWrapper implements TraceableRequestContext {
 
         private final StackTraceElement[] stackTrace;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/LeakTracingRequestContextStorage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/LeakTracingRequestContextStorage.java
@@ -54,7 +54,7 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
     public <T extends RequestContext> T push(RequestContext toPush) {
         requireNonNull(toPush, "toPush");
         if (sampler.isSampled(toPush)) {
-            return delegate.push(wrapRequestContext(toPush));
+            return delegate.push(wrapRequestContext(toPush.unwrapAll()));
         }
         return delegate.push(toPush);
     }
@@ -85,9 +85,7 @@ final class LeakTracingRequestContextStorage implements RequestContextStorage {
     private static String stacktraceToString(StackTraceElement[] stackTrace,
                                              RequestContext unwrap) {
         final StringBuilder builder = new StringBuilder(512);
-        builder.append(unwrap).append(System.lineSeparator())
-               .append("The previous RequestContext is pushed at the following stacktrace")
-               .append(System.lineSeparator());
+        builder.append(unwrap).append(System.lineSeparator());
         for (int i = 1; i < stackTrace.length; i++) {
             builder.append("\tat ").append(stackTrace[i]).append(System.lineSeparator());
         }

--- a/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
+++ b/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
@@ -216,7 +216,7 @@ class TraceRequestContextLeakTest {
         final ServiceRequestContext sctx2 = newCtx("/2");
         try (SafeCloseable ignored = sctx1.push()) {
             assertThatThrownBy(sctx2::push).isInstanceOf(IllegalStateException.class)
-                                           .hasMessageContaining("pushed at the following stacktrace");
+                                           .hasMessageContaining("but context is currently set to");
         }
     }
 
@@ -228,7 +228,7 @@ class TraceRequestContextLeakTest {
             final ClientRequestContext cctx1 = newClientCtx("/3");
             try (SafeCloseable ignore3 = cctx1.push()) {
                 assertThatThrownBy(sctx2::push).isInstanceOf(IllegalStateException.class)
-                                               .hasMessageContaining("pushed at the following stacktrace");
+                                               .hasMessageContaining("but context is currently set to");
             }
         }
     }

--- a/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
+++ b/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
@@ -74,7 +74,7 @@ class TraceRequestContextLeakTest {
             try (SafeCloseable ignore = anotherCtx.push()) {
                 final ClientRequestContext clientCtx = newClientCtx("/3");
                 try (SafeCloseable ignore2 = clientCtx.push()) {
-                    // Ignore
+                    assertThat(ClientRequestContext.current()).isSameAs(clientCtx);
                 }
             } catch (Exception ex) {
                 isThrown.set(true);

--- a/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
+++ b/it/trace-context-leak/src/test/java/com/linecorp/armeria/internal/common/TraceRequestContextLeakTest.java
@@ -74,7 +74,7 @@ class TraceRequestContextLeakTest {
             try (SafeCloseable ignore = anotherCtx.push()) {
                 final ClientRequestContext clientCtx = newClientCtx("/3");
                 try (SafeCloseable ignore2 = clientCtx.push()) {
-                    assertThat(ClientRequestContext.current()).isSameAs(clientCtx);
+                    assertThat(ClientRequestContext.current().unwrapAll()).isSameAs(clientCtx);
                 }
             } catch (Exception ex) {
                 isThrown.set(true);


### PR DESCRIPTION
Motivation:
I found that the log contains too many duplicate information while I was investingating on #4498 The `TraceableRequestContext` has the delagate which another `TraceableRequestContext` so it shows the duplicate stack trace multiple times by the number of the context is pushed.
```
Trying to call object wrapped with context [sreqId=.../test#GET]
The previous RequestContext is pushed at the following stacktrace
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
	...

The previous RequestContext is pushed at the following stacktrace
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
	...

The previous RequestContext is pushed at the following stacktrace
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
	...

, but context is currently set to [sreqId=1af77353, chanId=f0d714ac, raddr=127.0.0.1:64139, laddr=127.0.0.1:8080][h1c://gimnamjung-ui-macbookpro.local/test#GET]
The previous RequestContext is pushed at the following stacktrace
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
    ... // same a lot of duplicate stack trace

```
This is going to be:
```
Trying to call object wrapped with context [sreqId=.../test#GET]
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
	...

, but context is currently set to [sreqId=.../test#GET]
	at com.linecorp.armeria.internal.common.LeakTracingRequestContextStorage$TraceableServiceRequestContext.<init>(LeakTracingRequestContextStorage.java:118)
    ...
```

Modification:
- Unwrap the delegate context when creating `TraceableRequestContext`

Result:
- Context leak stack trace is more readable now