### PR TITLE
Fix `ConcurrentModificationException` in `HttpServerHandler`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -244,6 +244,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 // Mark the request stream as closed due to disconnection.
                 req.abortResponse(cause, cancel);
             });
+            unfinishedRequests.clear();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -421,6 +421,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             final CompletableFuture<Void> resWriteFuture = new CompletableFuture<>();
             resWriteFuture.handle((ret, cause) -> {
                 try {
+                    assert eventLoop.inEventLoop();
                     if (cause == null || !req.isOpen()) {
                         req.abort(ResponseCompleteException.get());
                     } else {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -172,6 +172,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private final IdentityHashMap<DecodedHttpRequest, HttpResponse> unfinishedRequests;
     private boolean isReading;
+    private boolean isCleaning;
     private boolean handledLastRequest;
 
     HttpServerHandler(ServerConfig config,
@@ -235,6 +236,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private void cleanup() {
         if (!unfinishedRequests.isEmpty()) {
+            isCleaning = true;
             final ClosedSessionException cause = ClosedSessionException.get();
             unfinishedRequests.forEach((req, res) -> {
                 // An HTTP2 request is cancelled by Http2RequestDecoder.onRstStreamRead()
@@ -427,7 +429,13 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     if (!isTransientService) {
                         gracefulShutdownSupport.dec();
                     }
-                    unfinishedRequests.remove(req);
+
+                    // This callback could be called by `req.abortResponse(cause, cancel)` in `cleanup()`.
+                    // As `unfinishedRequests` is being iterated, `unfinishedRequests` should not be removed.
+                    if (!isCleaning) {
+                        unfinishedRequests.remove(req);
+                    }
+
                     if (unfinishedRequests.isEmpty() && handledLastRequest) {
                         ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);
                     }

--- a/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
@@ -51,7 +51,10 @@ class UnfinishedRequestTest {
         try (ClientFactory factory = ClientFactory.builder()
                                                   .idleTimeoutMillis(0)
                                                   .build()) {
-            final WebClient client = server.webClient(cb -> cb.factory(factory));
+            final WebClient client = WebClient.builder(server.httpUri())
+                                              .responseTimeoutMillis(0)
+                                              .factory(factory)
+                                              .build();
             client.get("/").aggregate();
             client.get("/").aggregate();
 

--- a/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -48,21 +47,16 @@ class UnfinishedRequestTest {
 
     @Test
     void shouldCompleteUnfinishedRequestWhenConnectionIsClosed() throws Exception {
-        try (ClientFactory factory = ClientFactory.builder()
-                                                  .idleTimeoutMillis(0)
-                                                  .build()) {
-            final WebClient client = WebClient.builder(server.httpUri())
-                                              .responseTimeoutMillis(0)
-                                              .factory(factory)
-                                              .build();
-            client.get("/").aggregate();
-            client.get("/").aggregate();
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        client.get("/").aggregate();
+        client.get("/").aggregate();
 
-            final ServiceRequestContext ctx1 = server.requestContextCaptor().take();
-            final ServiceRequestContext ctx2 = server.requestContextCaptor().take();
-            // Make sure that `HttpServerHandler.cleanup()` aborts all unfinished requests successfully.
-            ctx1.log().whenComplete().join();
-            ctx2.log().whenComplete().join();
-        }
+        final ServiceRequestContext ctx1 = server.requestContextCaptor().take();
+        final ServiceRequestContext ctx2 = server.requestContextCaptor().take();
+        // Make sure that `HttpServerHandler.cleanup()` aborts all unfinished requests successfully.
+        ctx1.log().whenComplete().join();
+        ctx2.log().whenComplete().join();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
@@ -47,9 +47,7 @@ class UnfinishedRequestTest {
 
     @Test
     void shouldCompleteUnfinishedRequestWhenConnectionIsClosed() throws Exception {
-        final WebClient client = WebClient.builder(server.httpUri())
-                                          .responseTimeoutMillis(0)
-                                          .build();
+        final WebClient client = server.webClient(cb -> cb.responseTimeoutMillis(0));
         client.get("/").aggregate();
         client.get("/").aggregate();
 

--- a/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class UnfinishedRequestTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+
+            final AtomicInteger requestCounter = new AtomicInteger();
+            sb.service("/", (ctx, req) -> {
+                if (requestCounter.incrementAndGet() == 2) {
+                    ctx.initiateConnectionShutdown(0);
+                }
+                return HttpResponse.delayed(HttpResponse.of(200), Duration.ofMinutes(1));
+            });
+        }
+    };
+
+    @Test
+    void shouldCompleteUnfinishedRequestWhenConnectionIsClosed() throws Exception {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .idleTimeoutMillis(0)
+                                                  .build()) {
+            final WebClient client = server.webClient(cb -> cb.factory(factory));
+            client.get("/").aggregate();
+            client.get("/").aggregate();
+
+            final ServiceRequestContext ctx1 = server.requestContextCaptor().take();
+            final ServiceRequestContext ctx2 = server.requestContextCaptor().take();
+            // Make sure that `HttpServerHandler.cleanup()` aborts all unfinished requests successfully.
+            ctx1.log().whenComplete().join();
+            ctx2.log().whenComplete().join();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

If a connection is closed, unfinished requests are aborted.
https://github.com/line/armeria/blob/e94bbd075b745098a76e514e870a6c1803cbeec8/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L236-L246
When the unfinished requests are aborted, their responses are aborted as well. The abortion signal completes `resWriteFuture` exceptionally and its callback tries to remove the request from `unfinishedRequests`.
https://github.com/line/armeria/blob/e94bbd075b745098a76e514e870a6c1803cbeec8/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L418-L430
This recursive removal while iterating `unfinishedRequests` causes `ConcurrentModificationException`.

Modifications:

- Do not remove a request from `unfinishedRequests` if it is called in `cleanup()`

Result:

You no longer see `ConcurrentModificationException` when a connection is closed in a server.

