### PR TITLE
Ensure the post-process of a response is executed without a local request context

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -294,7 +294,11 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
         if (oldState == State.NEEDS_HEADERS) {
             logger.warn("{} Published nothing (or only informational responses): {}", ctx.channel(), service());
             responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR)
-                           .addListener(future -> tryComplete(null));
+                           .addListener(future -> {
+                               try (SafeCloseable ignored = RequestContextUtil.pop()) {
+                                   tryComplete(null);
+                               }
+                           });
             ctx.flush();
             return;
         }


### PR DESCRIPTION
Motivation:

A listener of a `ChannelFuture` can have a different request context in the thread local. Because Netty handles some pending requests in a batch task with an event loop having the different request context.

Modifications:

- Remove a request context from thread local before invoking `tryComplete()`

Result:

Fixed a potential context leak when an incomplete `HttpResponse` is returned.
