### PR TITLE
Update missing release notes in 1.20.3

### DIFF
--- a/site/src/pages/release-notes/1.20.3.mdx
+++ b/site/src/pages/release-notes/1.20.3.mdx
@@ -5,16 +5,16 @@ date: 2022-11-10
 ## 📈 Improvements
 
 - You can now see HTTP/2 stream error logs at the debug level. #4515
-- You can now see <type://FieldInfo> of parameters and a return type in the debug form without 
+- You can now see <type://FieldInfo> of parameter types and return types in the debug form without 
   visiting the detail page. #4481 #4484
 
 ## 🛠️ Bug fixes
 
 - You no longer see `ConcurrentModificationException` when a connection is closed in a server. #4524
 - Fixed a potential <type://RequestContext> leak when an incomplete <type://HttpResponse> is returned. #4527
-- Create correct <type://FieldInfo> for renamed object fields in <type://DocService>. #4506 #4507 
+- <type://FieldInfo> is created correctly for renamed object fields in <type://DocService>. #4506 #4507 
 - You can throw an exception from `ServerInterceptor` and utilize <type://GrpcStatusFunction> without 
-  the warn log. #4492
+  encountering a warn log. #4492
 
 ## 🙇 Thank you
 

--- a/site/src/pages/release-notes/1.20.3.mdx
+++ b/site/src/pages/release-notes/1.20.3.mdx
@@ -5,7 +5,7 @@ date: 2022-11-10
 ## 📈 Improvements
 
 - You can now see HTTP/2 stream error logs at the debug level. #4515
-- You can now see <type://FieldInfo> of a parameters and a return type in the debug form without 
+- You can now see <type://FieldInfo> of parameters and a return type in the debug form without 
   visiting the detail page. #4481 #4484
 
 ## 🛠️ Bug fixes

--- a/site/src/pages/release-notes/1.20.3.mdx
+++ b/site/src/pages/release-notes/1.20.3.mdx
@@ -2,14 +2,27 @@
 date: 2022-11-10
 ---
 
+## 📈 Improvements
+
+- You can now see HTTP/2 stream error logs at the debug level. #4515
+- You can now see <type://FieldInfo> of a parameters and a return type in the debug form without 
+  visiting the detail page. #4481 #4484
+
 ## 🛠️ Bug fixes
 
 - You no longer see `ConcurrentModificationException` when a connection is closed in a server. #4524
 - Fixed a potential <type://RequestContext> leak when an incomplete <type://HttpResponse> is returned. #4527
+- Create correct <type://FieldInfo> for renamed object fields in <type://DocService>. #4506 #4507 
+- You can throw an exception from `ServerInterceptor` and utilize <type://GrpcStatusFunction> without 
+  the warn log. #4492
+
 ## 🙇 Thank you
 
 <ThankYou usernames={[
+  'Dogacel',
   'ikhoon',
   'jrhee17',
-  'minwoox'
+  'ks-yim',
+  'minwoox',
+  'nao0811ta'
 ]} />


### PR DESCRIPTION
Motivation:

When the target release version changed from 1.21.0 to 1.20.3, some PRs were already merged into the master branch. So their milestone should be changed and the release notes also need to be updated.

Modifications:

- Add #4515, #4507, #4484 and #4492 to the release notes.

Result:

Update the missing issues and PRs.
