### PR TITLE
Add `AbstractRuleBuilder.onGrpcTrailers()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
@@ -175,8 +175,7 @@ public abstract class AbstractRuleBuilder {
     }
 
     private static <T> BiPredicate<ClientRequestContext, T> combinePredicates(
-            @Nullable
-            BiPredicate<ClientRequestContext, T> firstPredicate,
+            @Nullable BiPredicate<ClientRequestContext, T> firstPredicate,
             BiPredicate<? super ClientRequestContext, ? super T> secondPredicate,
             String paramName) {
 

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractRuleBuilder.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
 import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -54,6 +53,8 @@ public abstract class AbstractRuleBuilder {
     private BiPredicate<ClientRequestContext, HttpHeaders> responseTrailersFilter;
     @Nullable
     private BiPredicate<ClientRequestContext, Throwable> exceptionFilter;
+    @Nullable
+    private BiPredicate<ClientRequestContext, HttpHeaders> grpcTrailersFilter;
 
     /**
      * Creates a new instance with the specified {@code requestHeadersFilter}.
@@ -69,15 +70,8 @@ public abstract class AbstractRuleBuilder {
      */
     public AbstractRuleBuilder onResponseHeaders(
             BiPredicate<? super ClientRequestContext, ? super ResponseHeaders> responseHeadersFilter) {
-        requireNonNull(responseHeadersFilter, "responseHeadersFilter");
-        if (this.responseHeadersFilter != null) {
-            this.responseHeadersFilter = this.responseHeadersFilter.or(responseHeadersFilter);
-        } else {
-            @SuppressWarnings("unchecked")
-            final BiPredicate<ClientRequestContext, ResponseHeaders> cast =
-                    (BiPredicate<ClientRequestContext, ResponseHeaders>) responseHeadersFilter;
-            this.responseHeadersFilter = cast;
-        }
+        this.responseHeadersFilter = combinePredicates(this.responseHeadersFilter, responseHeadersFilter,
+                                                       "responseHeadersFilter");
         return this;
     }
 
@@ -86,15 +80,18 @@ public abstract class AbstractRuleBuilder {
      */
     public AbstractRuleBuilder onResponseTrailers(
             BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
-        requireNonNull(responseTrailersFilter, "responseTrailersFilter");
-        if (this.responseTrailersFilter != null) {
-            this.responseTrailersFilter = this.responseTrailersFilter.or(responseTrailersFilter);
-        } else {
-            @SuppressWarnings("unchecked")
-            final BiPredicate<ClientRequestContext, HttpHeaders> cast =
-                    (BiPredicate<ClientRequestContext, HttpHeaders>) responseTrailersFilter;
-            this.responseTrailersFilter = cast;
-        }
+        this.responseTrailersFilter = combinePredicates(this.responseTrailersFilter, responseTrailersFilter,
+                                                        "responseTrailersFilter");
+        return this;
+    }
+
+    /**
+     * Adds the specified {@code grpcTrailersFilter}.
+     */
+    public AbstractRuleBuilder onGrpcTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> grpcTrailersFilter) {
+        this.grpcTrailersFilter = combinePredicates(this.grpcTrailersFilter, grpcTrailersFilter,
+                                                    "grpcTrailersFilter");
         return this;
     }
 
@@ -166,15 +163,7 @@ public abstract class AbstractRuleBuilder {
      */
     public AbstractRuleBuilder onException(
             BiPredicate<? super ClientRequestContext, ? super Throwable> exceptionFilter) {
-        requireNonNull(exceptionFilter, "exceptionFilter");
-        if (this.exceptionFilter != null) {
-            this.exceptionFilter = this.exceptionFilter.or(exceptionFilter);
-        } else {
-            @SuppressWarnings("unchecked")
-            final BiPredicate<ClientRequestContext, Throwable> cast =
-                    (BiPredicate<ClientRequestContext, Throwable>) exceptionFilter;
-            this.exceptionFilter = cast;
-        }
+        this.exceptionFilter = combinePredicates(this.exceptionFilter, exceptionFilter, "exceptionFilter");
         return this;
     }
 
@@ -185,6 +174,23 @@ public abstract class AbstractRuleBuilder {
         return onException((unused1, unused2) -> true);
     }
 
+    private static <T> BiPredicate<ClientRequestContext, T> combinePredicates(
+            @Nullable
+            BiPredicate<ClientRequestContext, T> firstPredicate,
+            BiPredicate<? super ClientRequestContext, ? super T> secondPredicate,
+            String paramName) {
+
+        requireNonNull(secondPredicate, paramName);
+        if (firstPredicate != null) {
+            return firstPredicate.or(secondPredicate);
+        }
+
+        @SuppressWarnings("unchecked")
+        final BiPredicate<ClientRequestContext, T> cast =
+                (BiPredicate<ClientRequestContext, T>) secondPredicate;
+        return cast;
+    }
+
     /**
      * Adds an {@link UnprocessedRequestException}.
      */
@@ -193,14 +199,14 @@ public abstract class AbstractRuleBuilder {
     }
 
     /**
-     * Returns the {@link Predicate} of a {@link RequestHeaders}.
+     * Returns the {@link BiPredicate} of a {@link RequestHeaders}.
      */
     protected final BiPredicate<ClientRequestContext, RequestHeaders> requestHeadersFilter() {
         return requestHeadersFilter;
     }
 
     /**
-     * Returns the {@link Predicate} of a {@link ResponseHeaders}.
+     * Returns the {@link BiPredicate} of a {@link ResponseHeaders}.
      */
     @Nullable
     protected final BiPredicate<ClientRequestContext, ResponseHeaders> responseHeadersFilter() {
@@ -208,7 +214,7 @@ public abstract class AbstractRuleBuilder {
     }
 
     /**
-     * Returns the {@link Predicate} of a response trailers.
+     * Returns the {@link BiPredicate} of a response trailers.
      */
     @Nullable
     protected final BiPredicate<ClientRequestContext, HttpHeaders> responseTrailersFilter() {
@@ -216,10 +222,26 @@ public abstract class AbstractRuleBuilder {
     }
 
     /**
-     * Returns the {@link Predicate} of an {@link Exception}.
+     * Returns the {@link BiPredicate} of an {@link Exception}.
      */
     @Nullable
     protected final BiPredicate<ClientRequestContext, Throwable> exceptionFilter() {
         return exceptionFilter;
+    }
+
+    /**
+     * Returns the {@link BiPredicate} of gRPC trailers.
+     */
+    @Nullable
+    protected final BiPredicate<ClientRequestContext, HttpHeaders> grpcTrailersFilter() {
+        return grpcTrailersFilter;
+    }
+
+    /**
+     * Returns whether this rule being built requires HTTP response trailers.
+     */
+    protected final boolean requiresResponseTrailers() {
+        return responseTrailersFilter != null ||
+               grpcTrailersFilter != null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleBuilder.java
@@ -74,8 +74,9 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
     private CircuitBreakerRule build(CircuitBreakerDecision decision) {
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =
                 AbstractRuleBuilderUtil.buildFilter(requestHeadersFilter(), responseHeadersFilter(),
-                                                    responseTrailersFilter(), exceptionFilter(), false);
-        return build(ruleFilter, decision, responseTrailersFilter() != null);
+                                                    responseTrailersFilter(), grpcTrailersFilter(),
+                                                    exceptionFilter(), false);
+        return build(ruleFilter, decision, requiresResponseTrailers());
     }
 
     static CircuitBreakerRule build(
@@ -129,6 +130,18 @@ public final class CircuitBreakerRuleBuilder extends AbstractRuleBuilder {
     public CircuitBreakerRuleBuilder onResponseTrailers(
             BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
         return (CircuitBreakerRuleBuilder) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code grpcTrailersFilter} for a {@link CircuitBreakerRule}.
+     * If the specified {@code grpcTrailersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     */
+    @Override
+    public CircuitBreakerRuleBuilder onGrpcTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> grpcTrailersFilter) {
+        return (CircuitBreakerRuleBuilder) super.onGrpcTrailers(grpcTrailersFilter);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
@@ -75,11 +75,11 @@ public final class CircuitBreakerRuleWithContentBuilder<T extends Response>
         final boolean hasResponseFilter = responseFilter != null;
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =
                 AbstractRuleBuilderUtil.buildFilter(requestHeadersFilter(), responseHeadersFilter(),
-                                                    responseTrailersFilter(), exceptionFilter(),
-                                                    hasResponseFilter);
+                                                    responseTrailersFilter(), grpcTrailersFilter(),
+                                                    exceptionFilter(), hasResponseFilter);
 
-        final CircuitBreakerRule first = CircuitBreakerRuleBuilder.build(ruleFilter, decision,
-                                                                         responseTrailersFilter() != null);
+        final CircuitBreakerRule first = CircuitBreakerRuleBuilder.build(
+                ruleFilter, decision, requiresResponseTrailers());
         if (!hasResponseFilter) {
             return CircuitBreakerRuleUtil.fromCircuitBreakerRule(first);
         }
@@ -138,6 +138,19 @@ public final class CircuitBreakerRuleWithContentBuilder<T extends Response>
     public CircuitBreakerRuleWithContentBuilder<T> onResponseTrailers(
             BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
         return (CircuitBreakerRuleWithContentBuilder<T>) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code grpcTrailersFilter} for a {@link CircuitBreakerRuleWithContent}.
+     * If the specified {@code grpcTrailersFilter} returns {@code true},
+     * depending on the build methods({@link #thenSuccess()}, {@link #thenFailure()} and {@link #thenIgnore()}),
+     * a {@link Response} is reported as a success or failure to a {@link CircuitBreaker} or ignored.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public CircuitBreakerRuleWithContentBuilder<T> onGrpcTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> grpcTrailersFilter) {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onGrpcTrailers(grpcTrailersFilter);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
@@ -70,7 +70,8 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
 
     private RetryRule build(RetryDecision decision) {
         if (decision != RetryDecision.noRetry() &&
-            exceptionFilter() == null && responseHeadersFilter() == null && responseTrailersFilter() == null) {
+            exceptionFilter() == null && responseHeadersFilter() == null &&
+            responseTrailersFilter() == null && grpcTrailersFilter() == null) {
             throw new IllegalStateException("Should set at least one retry rule if a backoff was set.");
         }
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleBuilder.java
@@ -75,8 +75,9 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
         }
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =
                 AbstractRuleBuilderUtil.buildFilter(requestHeadersFilter(), responseHeadersFilter(),
-                                                    responseTrailersFilter(), exceptionFilter(), false);
-        return build(ruleFilter, decision, responseTrailersFilter() != null);
+                                                    responseTrailersFilter(), grpcTrailersFilter(),
+                                                    exceptionFilter(), false);
+        return build(ruleFilter, decision, requiresResponseTrailers());
     }
 
     static RetryRule build(BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter,
@@ -123,6 +124,17 @@ public final class RetryRuleBuilder extends AbstractRuleBuilder {
     public RetryRuleBuilder onResponseTrailers(
             BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
         return (RetryRuleBuilder) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code grpcTrailersFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the {@code grpcTrailersFilter} returns {@code true}. Note that using this method makes the entire
+     * response buffered, which may lead to excessive memory usage.
+     */
+    @Override
+    public RetryRuleBuilder onGrpcTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> grpcTrailersFilter) {
+        return (RetryRuleBuilder) super.onGrpcTrailers(grpcTrailersFilter);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -84,7 +84,7 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
         final boolean hasResponseFilter = responseFilter != null;
         if (decision != RetryDecision.noRetry() && exceptionFilter() == null &&
             responseHeadersFilter() == null && responseTrailersFilter() == null &&
-            !hasResponseFilter) {
+            grpcTrailersFilter() == null && !hasResponseFilter) {
             throw new IllegalStateException("Should set at least one retry rule if a backoff was set.");
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -90,10 +90,12 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
 
         final BiFunction<? super ClientRequestContext, ? super Throwable, Boolean> ruleFilter =
                 AbstractRuleBuilderUtil.buildFilter(requestHeadersFilter(), responseHeadersFilter(),
-                                                    responseTrailersFilter(), exceptionFilter(),
-                                                    hasResponseFilter);
+                                                    responseTrailersFilter(), grpcTrailersFilter(),
+                                                    exceptionFilter(), hasResponseFilter);
 
-        final RetryRule first = RetryRuleBuilder.build(ruleFilter, decision, responseTrailersFilter() != null);
+        final RetryRule first = RetryRuleBuilder.build(
+                ruleFilter, decision, requiresResponseTrailers());
+
         if (!hasResponseFilter) {
             return RetryRuleUtil.fromRetryRule(first);
         }
@@ -136,6 +138,18 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
     public RetryRuleWithContentBuilder<T> onResponseTrailers(
             BiPredicate<? super ClientRequestContext, ? super HttpHeaders> responseTrailersFilter) {
         return (RetryRuleWithContentBuilder<T>) super.onResponseTrailers(responseTrailersFilter);
+    }
+
+    /**
+     * Adds the specified {@code grpcTrailersFilter} for a {@link RetryRuleWithContent} which will retry
+     * if the {@code grpcTrailersFilter} returns {@code true}. Note that using this method makes the entire
+     * response buffered, which may lead to excessive memory usage.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public RetryRuleWithContentBuilder<T> onGrpcTrailers(
+            BiPredicate<? super ClientRequestContext, ? super HttpHeaders> grpcTrailersFilter) {
+        return (RetryRuleWithContentBuilder<T>) super.onGrpcTrailers(grpcTrailersFilter);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
@@ -96,7 +96,7 @@ public final class AbstractRuleBuilderUtil {
             return applySlow(ctx, cause, log);
         }
 
-        private boolean applySlow(ClientRequestContext ctx, Throwable cause, RequestLog log) {
+        private boolean applySlow(ClientRequestContext ctx, @Nullable Throwable cause, RequestLog log) {
             if (cause != null && exceptionFilter != null &&
                 exceptionFilter.test(ctx, Exceptions.peel(cause))) {
                 return true;

--- a/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
@@ -74,8 +74,6 @@ public final class AbstractRuleBuilderUtil {
             this.hasResponseFilter = hasResponseFilter;
         }
 
-        // TODO(trustin): Figure out why apply() is called more than once for each client call
-        //                and reduce the number of calls if possible.
         @Override
         public Boolean apply(ClientRequestContext ctx, Throwable cause) {
             final RequestLog log = ctx.log().partial();

--- a/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderUtil.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.common.InternalGrpcWebTrailers;
 
 public final class AbstractRuleBuilderUtil {
 
@@ -41,9 +42,42 @@ public final class AbstractRuleBuilderUtil {
     buildFilter(BiPredicate<ClientRequestContext, RequestHeaders> requestHeadersFilter,
                 @Nullable BiPredicate<ClientRequestContext, ResponseHeaders> responseHeadersFilter,
                 @Nullable BiPredicate<ClientRequestContext, HttpHeaders> responseTrailersFilter,
+                @Nullable BiPredicate<ClientRequestContext, HttpHeaders> grpcTrailersFilter,
                 @Nullable BiPredicate<ClientRequestContext, Throwable> exceptionFilter,
                 boolean hasResponseFilter) {
-        return (ctx, cause) -> {
+
+        return new Filter(requestHeadersFilter, exceptionFilter, responseHeadersFilter,
+                          responseTrailersFilter, grpcTrailersFilter, hasResponseFilter);
+    }
+
+    private AbstractRuleBuilderUtil() {}
+
+    private static class Filter implements BiFunction<ClientRequestContext, Throwable, Boolean> {
+        private final BiPredicate<ClientRequestContext, RequestHeaders> requestHeadersFilter;
+        private final @Nullable BiPredicate<ClientRequestContext, Throwable> exceptionFilter;
+        private final @Nullable BiPredicate<ClientRequestContext, ResponseHeaders> responseHeadersFilter;
+        private final @Nullable BiPredicate<ClientRequestContext, HttpHeaders> responseTrailersFilter;
+        private final @Nullable BiPredicate<ClientRequestContext, HttpHeaders> grpcTrailersFilter;
+        private final boolean hasResponseFilter;
+
+        Filter(BiPredicate<ClientRequestContext, RequestHeaders> requestHeadersFilter,
+               @Nullable BiPredicate<ClientRequestContext, Throwable> exceptionFilter,
+               @Nullable BiPredicate<ClientRequestContext, ResponseHeaders> responseHeadersFilter,
+               @Nullable BiPredicate<ClientRequestContext, HttpHeaders> responseTrailersFilter,
+               @Nullable BiPredicate<ClientRequestContext, HttpHeaders> grpcTrailersFilter,
+               boolean hasResponseFilter) {
+            this.requestHeadersFilter = requestHeadersFilter;
+            this.exceptionFilter = exceptionFilter;
+            this.responseHeadersFilter = responseHeadersFilter;
+            this.responseTrailersFilter = responseTrailersFilter;
+            this.grpcTrailersFilter = grpcTrailersFilter;
+            this.hasResponseFilter = hasResponseFilter;
+        }
+
+        // TODO(trustin): Figure out why apply() is called more than once for each client call
+        //                and reduce the number of calls if possible.
+        @Override
+        public Boolean apply(ClientRequestContext ctx, Throwable cause) {
             final RequestLog log = ctx.log().partial();
             if (log.isAvailable(RequestLogProperty.REQUEST_HEADERS)) {
                 final RequestHeaders requestHeaders = log.requestHeaders();
@@ -54,11 +88,17 @@ public final class AbstractRuleBuilderUtil {
 
             // Safe to return true since no filters are set
             if (exceptionFilter == null && responseHeadersFilter == null &&
-                responseTrailersFilter == null && !hasResponseFilter) {
+                responseTrailersFilter == null && grpcTrailersFilter == null &&
+                !hasResponseFilter) {
                 return true;
             }
 
-            if (cause != null && exceptionFilter != null && exceptionFilter.test(ctx, Exceptions.peel(cause))) {
+            return applySlow(ctx, cause, log);
+        }
+
+        private boolean applySlow(ClientRequestContext ctx, Throwable cause, RequestLog log) {
+            if (cause != null && exceptionFilter != null &&
+                exceptionFilter.test(ctx, Exceptions.peel(cause))) {
                 return true;
             }
 
@@ -76,9 +116,28 @@ public final class AbstractRuleBuilderUtil {
                 }
             }
 
-            return false;
-        };
-    }
+            if (grpcTrailersFilter != null && log.isAvailable(RequestLogProperty.RESPONSE_TRAILERS)) {
+                // Check HTTP trailers first, because most gRPC responses have non-empty payload + trailers.
+                HttpHeaders maybeGrpcTrailers = log.responseTrailers();
+                if (!maybeGrpcTrailers.contains("grpc-status")) {
+                    // Check HTTP headers secondly.
+                    maybeGrpcTrailers = log.responseHeaders();
+                    if (!maybeGrpcTrailers.contains("grpc-status")) {
+                        // Check gRPC Web trailers lastly, because gRPC Web is the least used protocol
+                        // in reality.
+                        maybeGrpcTrailers = InternalGrpcWebTrailers.get(ctx);
+                    }
+                }
 
-    private AbstractRuleBuilderUtil() {}
+                // Suppressing the inspection rule because we don't want to return false too early.
+                //noinspection RedundantIfStatement
+                if (maybeGrpcTrailers != null && grpcTrailersFilter.test(ctx, maybeGrpcTrailers)) {
+                    // Found the matching gRPC trailers.
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/InternalGrpcWebTrailers.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/InternalGrpcWebTrailers.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * Retrieves <a href="https://grpc.io/docs/languages/web/basics/">gRPC-Web</a> trailers.
+ */
+public final class InternalGrpcWebTrailers {
+
+    private static final AttributeKey<HttpHeaders> GRPC_WEB_TRAILERS = AttributeKey.valueOf(
+            InternalGrpcWebTrailers.class, "GRPC_WEB_TRAILERS");
+
+    /**
+     * Returns the gRPC-Web trailers which was set to the specified {@link RequestContext} using
+     * {@link #set(RequestContext, HttpHeaders)}.
+     */
+    @Nullable
+    public static HttpHeaders get(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        return ctx.attr(GRPC_WEB_TRAILERS);
+    }
+
+    /**
+     * Sets the specified gRPC-Web trailers to the {@link RequestContext}.
+     */
+    public static void set(RequestContext ctx, HttpHeaders trailers) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(trailers, "trailers");
+        ctx.setAttr(GRPC_WEB_TRAILERS, trailers);
+    }
+
+    private InternalGrpcWebTrailers() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientRuleTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientRuleTest.java
@@ -30,12 +30,14 @@ import com.google.common.collect.Maps;
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.internal.common.InternalGrpcWebTrailers;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
@@ -50,7 +52,20 @@ class CircuitBreakerClientRuleTest {
             sb.service("/slow", (ctx, req) -> HttpResponse.streaming());
             sb.service("/trailers", (ctx, req) -> HttpResponse.of(ResponseHeaders.of(200),
                                                                   HttpData.ofUtf8("oops"),
-                                                                  HttpHeaders.of("grpc-status", 3)));
+                                                                  HttpHeaders.of("x-checksum", 42)));
+            sb.service("/grpc", (ctx, req) -> HttpResponse.of(ResponseHeaders.of(200),
+                                                              HttpData.ofUtf8("oops"),
+                                                              HttpHeaders.of("grpc-status", 3)));
+            sb.service("/grpc-trailers-only", (ctx, req) -> {
+                return HttpResponse.of(ResponseHeaders.builder(200)
+                                                      .addInt("grpc-status", 7)
+                                                      .build());
+            });
+            sb.service("/grpc-web", (ctx, req) -> {
+                // We call InternalGrpcWebTrailers.set(...) to emulate a gRPC Web response,
+                // so we don't really need to do anything on the server side.
+                return HttpResponse.of(200);
+            });
         }
     };
 
@@ -98,7 +113,7 @@ class CircuitBreakerClientRuleTest {
     void openCircuitWithTrailer() {
         final CircuitBreakerRule rule =
                 CircuitBreakerRule.builder()
-                                  .onResponseTrailers((ctx, trailers) -> trailers.containsInt("grpc-status", 3))
+                                  .onResponseTrailers((ctx, trailers) -> trailers.containsInt("x-checksum", 42))
                                   .thenFailure();
 
         final WebClient client =
@@ -107,11 +122,84 @@ class CircuitBreakerClientRuleTest {
                          .build();
 
         assertThat(client.get("/trailers").aggregate().join().trailers()).containsExactly(
-                Maps.immutableEntry(HttpHeaderNames.of("grpc-status"), "3"));
+                Maps.immutableEntry(HttpHeaderNames.of("x-checksum"), "42"));
         await().untilAsserted(() -> {
             assertThatThrownBy(() -> client.get("/trailers").aggregate().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCauseInstanceOf(FailFastException.class);
+        });
+    }
+
+    @Test
+    void openCircuitWithGrpc() {
+        final CircuitBreakerRule rule =
+                CircuitBreakerRule.builder()
+                                  .onGrpcTrailers((ctx, trailers) -> trailers.containsInt("grpc-status", 3))
+                                  .thenFailure();
+
+        final BlockingWebClient client =
+                WebClient.builder(server.httpUri())
+                         .decorator(CircuitBreakerClient.newDecorator(CircuitBreaker.ofDefaultName(), rule))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse res = client.get("/grpc");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.trailers()).containsExactly(
+                Maps.immutableEntry(HttpHeaderNames.of("grpc-status"), "3"));
+        await().untilAsserted(() -> {
+            assertThatThrownBy(() -> client.get("/grpc"))
+                    .isInstanceOf(FailFastException.class);
+        });
+    }
+
+    @Test
+    void openCircuitWithGrpcTrailersOnly() {
+        final CircuitBreakerRule rule =
+                CircuitBreakerRule.builder()
+                                  .onGrpcTrailers((ctx, trailers) -> trailers.containsInt("grpc-status", 7))
+                                  .thenFailure();
+
+        final BlockingWebClient client =
+                WebClient.builder(server.httpUri())
+                         .decorator(CircuitBreakerClient.newDecorator(CircuitBreaker.ofDefaultName(), rule))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse res = client.get("/grpc-trailers-only");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers()).contains(Maps.immutableEntry(HttpHeaderNames.of("grpc-status"), "7"));
+        await().untilAsserted(() -> {
+            assertThatThrownBy(() -> client.get("/grpc-trailers-only"))
+                    .isInstanceOf(FailFastException.class);
+        });
+    }
+
+    @Test
+    void openCircuitWithGrpcWeb() {
+        final CircuitBreakerRule rule =
+                CircuitBreakerRule.builder()
+                                  .onGrpcTrailers((ctx, trailers) -> trailers.containsInt("grpc-status", 11))
+                                  .thenFailure();
+
+        final BlockingWebClient client =
+                WebClient.builder(server.httpUri())
+                         .decorator(CircuitBreakerClient.newDecorator(CircuitBreaker.ofDefaultName(), rule))
+                         .decorator((delegate, ctx, req) -> {
+                             InternalGrpcWebTrailers.set(ctx, HttpHeaders.of("grpc-status", 11));
+                             return delegate.execute(ctx, req);
+                         })
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse res = client.get("/grpc-web");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().contains("grpc-status")).isFalse();
+        assertThat(res.trailers().contains("grpc-status")).isFalse();
+
+        await().untilAsserted(() -> {
+            assertThatThrownBy(() -> client.get("/grpc-web"))
+                    .isInstanceOf(FailFastException.class);
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleBuilderTest.java
@@ -121,7 +121,6 @@ class RetryRuleBuilderTest {
         assertBackoff(rule.shouldRetry(ctx2, null)).isNull();
     }
 
-
     @Test
     void onGrpcTrailers() {
         final Backoff backoff = Backoff.fixed(1000);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryRuleBuilderTest.java
@@ -121,6 +121,25 @@ class RetryRuleBuilderTest {
         assertBackoff(rule.shouldRetry(ctx2, null)).isNull();
     }
 
+
+    @Test
+    void onGrpcTrailers() {
+        final Backoff backoff = Backoff.fixed(1000);
+        final RetryRule rule =
+                RetryRule.builder()
+                         .onGrpcTrailers((unused, trailers) -> trailers.containsInt("grpc-status", 3))
+                         .thenBackoff(backoff);
+
+        final ClientRequestContext ctx1 = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx1.logBuilder().responseHeaders(ResponseHeaders.of(HttpStatus.OK, "grpc-status", 3));
+        ctx1.logBuilder().responseTrailers(HttpHeaders.of());
+        assertBackoff(rule.shouldRetry(ctx1, null)).isSameAs(backoff);
+
+        final ClientRequestContext ctx2 = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        ctx2.logBuilder().responseTrailers(HttpHeaders.of("grpc-status", 0));
+        assertBackoff(rule.shouldRetry(ctx2, null)).isNull();
+    }
+
     @Test
     void onException() {
         final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));

--- a/core/src/test/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/AbstractRuleBuilderTest.java
@@ -54,6 +54,7 @@ class AbstractRuleBuilderTest {
                                                           method.getName().startsWith("on") &&
                                                           !"onResponseHeaders".equals(method.getName()) &&
                                                           !"onResponseTrailers".equals(method.getName()) &&
+                                                          !"onGrpcTrailers".equals(method.getName()) &&
                                                           !"onUnprocessed".equals(method.getName()) &&
                                                           !method.isVarArgs());
 

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/GrpcWebTrailers.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/common/grpc/protocol/GrpcWebTrailers.java
@@ -16,25 +16,19 @@
 
 package com.linecorp.armeria.common.grpc.protocol;
 
-import static java.util.Objects.requireNonNull;
-
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-
-import io.netty.util.AttributeKey;
+import com.linecorp.armeria.internal.common.InternalGrpcWebTrailers;
 
 /**
  * Retrieves <a href="https://grpc.io/docs/languages/web/basics/">gRPC-Web</a> trailers.
  */
 @UnstableApi
 public final class GrpcWebTrailers {
-
-    private static final AttributeKey<HttpHeaders> GRPC_WEB_TRAILERS = AttributeKey.valueOf(
-            GrpcWebTrailers.class, "GRPC_WEB_TRAILERS");
 
     /**
      * Returns the gRPC-Web trailers which was set to the specified {@link RequestContext} using
@@ -68,17 +62,14 @@ public final class GrpcWebTrailers {
      */
     @Nullable
     public static HttpHeaders get(RequestContext ctx) {
-        requireNonNull(ctx, "ctx");
-        return ctx.attr(GRPC_WEB_TRAILERS);
+        return InternalGrpcWebTrailers.get(ctx);
     }
 
     /**
      * Sets the specified gRPC-Web trailers to the {@link RequestContext}.
      */
     public static void set(RequestContext ctx, HttpHeaders trailers) {
-        requireNonNull(ctx, "ctx");
-        requireNonNull(trailers, "trailers");
-        ctx.setAttr(GRPC_WEB_TRAILERS, trailers);
+        InternalGrpcWebTrailers.set(ctx, trailers);
     }
 
     private GrpcWebTrailers() {}

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcWebTrailers.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcWebTrailers.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
+import com.linecorp.armeria.internal.common.InternalGrpcWebTrailers;
 
 /**
  * Retrieves <a href="https://grpc.io/docs/languages/web/basics/">gRPC-Web</a> trailers.
@@ -65,14 +66,14 @@ public final class GrpcWebTrailers {
      */
     @Nullable
     public static HttpHeaders get(RequestContext ctx) {
-        return com.linecorp.armeria.common.grpc.protocol.GrpcWebTrailers.get(ctx);
+        return InternalGrpcWebTrailers.get(ctx);
     }
 
     /**
      * Sets the specified gRPC-Web trailers to the {@link RequestContext}.
      */
     public static void set(RequestContext ctx, HttpHeaders trailers) {
-        com.linecorp.armeria.common.grpc.protocol.GrpcWebTrailers.set(ctx, trailers);
+        InternalGrpcWebTrailers.set(ctx, trailers);
     }
 
     private GrpcWebTrailers() {}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingClient;
-import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLogAccess;


### PR DESCRIPTION
Related issue: #4496

Motivation:

A user might want to write a circuit breaker or retry rule that makes a decision based on gRPC trailers. Accessing gRPC trailers can be tricky because they can be present in either HTTP headers, trailers or even content (if gRPC Web). It would save a lot of duplicate effort to write a filter that checks difference places if we provide a built-in filter for gRPC trailers.

Modifications:

- Add `AbstractRuleBuilder.onGrpcTrailers()`
- Modify `AbstractRuleBuilderUtil` so it handles a gRPC trailers filter.
- Move the core logic of `GrpcWebTrailers` to `InternalGrpcWebTrailers` in the `core` module, because otherwise `AbstractRuleBuilderUtil` cannot access gRPC Web trailers.
- Add `AbstractRuleBuilder.requiresResponseTrailers()` to reduce duplication
- Add `AbstractRuleBuilder.combinePredicates()` to reduce duplication.
- Fix some Javadoc errors.

Result:

- A user can write a circuit breaker or retry rule that makes a decision based on gRPC trailers, regardless of whether it's a gRPC response with/without body or even gRPC Web response.
- Partially implemented #4496 although a little bit different from the initially suggested idea