### PR TITLE
Fix a deadlock when a late response are written first in HTTP/1 pipelining

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseCompleteException;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
@@ -302,8 +303,9 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
     }
 
     final void failAndReset(Throwable cause) {
-        if (cause instanceof ProxyConnectException) {
-            // ProxyConnectException is handled by HttpSessionHandler.exceptionCaught().
+        if (cause instanceof ProxyConnectException || cause instanceof ResponseCompleteException) {
+            // - ProxyConnectException is handled by HttpSessionHandler.exceptionCaught().
+            // - ResponseCompleteException means the response is successfully received.
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -39,6 +39,8 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.util.ReferenceCountUtil;
@@ -314,6 +316,8 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
     private ChannelFuture write(HttpObject obj, ChannelPromise promise) {
         // Use FQCN for Netty HttpResponse to avoid confusion with Armeria HttpResponse
+        // We check if obj is an HttpResponse here because server-side writes both headers
+        // and errors as an HttpResponse.
         //noinspection UnnecessaryFullyQualifiedName
         if (obj instanceof io.netty.handler.codec.http.HttpResponse) {
             if (lastResponseHeadersId >= currentId) {
@@ -321,7 +325,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
                 // response while HttpResponseSubscriber writes a response headers and then waits for bodies.
                 ReferenceCountUtil.release(obj);
                 return writeReset(currentId, 1, Http2Error.PROTOCOL_ERROR);
-            } else {
+            } else if (((HttpResponse) obj).status().codeClass() != HttpStatusClass.INFORMATIONAL) {
                 lastResponseHeadersId = currentId;
             }
         }
@@ -443,6 +447,10 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
     protected final int currentId() {
         return currentId;
+    }
+
+    protected final int lastResponseHeadersId() {
+        return lastResponseHeadersId;
     }
 
     private static final class PendingWrites extends ArrayDeque<Entry<HttpObject, ChannelPromise>> {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -445,10 +445,6 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
         return closed || !channel().isActive();
     }
 
-    protected final int currentId() {
-        return currentId;
-    }
-
     protected final int lastResponseHeadersId() {
         return lastResponseHeadersId;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -81,8 +81,6 @@ import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
 
 final class HttpServerHandler extends ChannelInboundHandlerAdapter implements HttpServer {
 
@@ -173,12 +171,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private final ProxiedAddresses proxiedAddresses;
 
     private final IdentityHashMap<DecodedHttpRequest, HttpResponse> unfinishedRequests;
-
-    // Holds next request ID and pending responses to preserve response ordering for HTTP/1 pipelining.
-    private int http1NextRequestId = 1;
-    @Nullable
-    private IntObjectMap<Runnable> pendingHttp1Responses;
-
     private boolean isReading;
     private boolean isCleaning;
     private boolean handledLastRequest;
@@ -263,9 +255,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         if (msg instanceof Http2Settings) {
             handleHttp2Settings(ctx, (Http2Settings) msg);
         } else {
-            if (!protocol.isMultiplex()) {
-                pendingHttp1Responses = new IntObjectHashMap<>();
-            }
             handleRequest(ctx, (DecodedHttpRequest) msg);
         }
     }
@@ -450,7 +439,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     }
 
                     if (unfinishedRequests.isEmpty() && handledLastRequest) {
-                        assert pendingHttp1Responses == null || pendingHttp1Responses.isEmpty();
                         ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);
                     }
                 } catch (Throwable t) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -52,8 +52,6 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
     private boolean shouldSendConnectionCloseHeader;
     private boolean sentConnectionCloseHeader;
 
-    private int lastResponseHeadersId;
-
     ServerHttp1ObjectEncoder(Channel ch, SessionProtocol protocol, KeepAliveHandler keepAliveHandler,
                              boolean enableDateHeader, boolean enableServerHeader,
                              Http1HeaderNaming http1HeaderNaming) {
@@ -86,7 +84,6 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
         if (headers.status().isInformational()) {
             return write(id, converted, false);
         }
-        lastResponseHeadersId = id;
 
         if (shouldSendConnectionCloseHeader || keepAliveHandler.needToCloseConnection()) {
             converted.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
@@ -188,7 +185,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
 
     @Override
     public boolean isResponseHeadersSent(int id, int streamId) {
-        return id <= lastResponseHeadersId;
+        return id < currentId();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java
@@ -185,7 +185,7 @@ final class ServerHttp1ObjectEncoder extends Http1ObjectEncoder implements Serve
 
     @Override
     public boolean isResponseHeadersSent(int id, int streamId) {
-        return id < currentId();
+        return id <= lastResponseHeadersId();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -77,13 +76,6 @@ class Http1PipelineTest {
               });
         }
     };
-
-    private static CompletableFuture<Void> whenResponseReceived;
-
-    @BeforeEach
-    void setUp() {
-        whenResponseReceived = new CompletableFuture<>();
-    }
 
     @Test
     void httpPipelining() throws InterruptedException {

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -130,7 +130,6 @@ class Http1PipelineTest {
                 splitHttpResponse.body().collect().join();
             }).isInstanceOf(CompletionException.class)
               .hasCauseInstanceOf(ClosedSessionException.class);
-            final ServiceRequestContext sctx = server.requestContextCaptor().take();
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.base.Strings;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.ResponseAs;
+import com.linecorp.armeria.client.RestClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.SplitHttpResponse;
+import com.linecorp.armeria.common.stream.DefaultStreamMessage;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class Http1PipelineTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/slow", (ctx, req) -> {
+                return HttpResponse.delayed(HttpResponse.of("slow"), Duration.ofSeconds(3));
+            });
+
+            sb.service("/fast", (ctx, req) -> {
+                return HttpResponse.of("fast");
+            });
+
+            sb.route()
+              .path("/length-limit")
+              .requestTimeoutMillis(0)
+              .maxRequestLength(100)
+              .build((ctx, req) -> {
+                  final HttpResponseWriter writer = HttpResponse.streaming();
+                  writer.write(ResponseHeaders.of(200));
+                  req.aggregate().thenRun(() -> {
+                      writer.write(HttpData.ofUtf8("Hello!"));
+                      writer.close();
+                  });
+                  return writer;
+              });
+        }
+    };
+
+    private static CompletableFuture<Void> whenResponseReceived;
+
+    @BeforeEach
+    void setUp() {
+        whenResponseReceived = new CompletableFuture<>();
+    }
+
+    @Test
+    void httpPipelining() throws InterruptedException {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp1Pipelining(true)
+                                                  .build()) {
+            final RestClient client = RestClient.builder(server.uri(SessionProtocol.H1C))
+                                                .factory(factory)
+                                                .build();
+
+            final CompletableFuture<ResponseEntity<String>> response1;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                response1 = client.get("/slow").execute(ResponseAs.string());
+                captor.get().log().whenRequestComplete().join();
+            }
+
+            // Start the next request after the first request has completed to reuse the connection pool.
+            final CompletableFuture<ResponseEntity<String>> response2 =
+                    client.get("/fast").execute(ResponseAs.string());
+
+            assertThat(response1.join().content()).isEqualTo("slow");
+            assertThat(response2.join().content()).isEqualTo("fast");
+        }
+    }
+
+    @Test
+    void shouldResetIfTwoHeadersAreWritten() throws InterruptedException {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp1Pipelining(true)
+                                                  .build()) {
+            final WebClient client = WebClient.builder(server.uri(SessionProtocol.H1C))
+                                              .factory(factory)
+                                              .build();
+
+            final DefaultStreamMessage<HttpData> stream = new DefaultStreamMessage<>();
+            final HttpResponse response =
+                    client.prepare()
+                          .post("/length-limit")
+                          .content(MediaType.PLAIN_TEXT, stream)
+                          .execute();
+            final SplitHttpResponse splitHttpResponse = response.split();
+            final ResponseHeaders headers = splitHttpResponse.headers().join();
+            assertThat(headers.status()).isEqualTo(HttpStatus.OK);
+
+            // Trigger ContentTooLargeException to return "413 Request Entity Too Large" status.
+            stream.write(HttpData.ofUtf8(Strings.repeat("a", 101)));
+            stream.close();
+
+            // The connection should be reset as the seconds headers including "413 Request Entity Too Large"
+            // is about to be written.
+            assertThatThrownBy(() -> {
+                splitHttpResponse.body().collect().join();
+            }).isInstanceOf(CompletionException.class)
+              .hasCauseInstanceOf(ClosedSessionException.class);
+            final ServiceRequestContext sctx = server.requestContextCaptor().take();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Let's say a late request is completed first while the first request is being processed. The response to the late request is added to `pendingWritesMap` to preserve the order of responses in HTTP/1. Before the response is added to a queue, `lastResponseHeadersId` is updated to the ID of the late request.
https://github.com/line/armeria/blob/b127cd27252f6a454130f66d1175a06faed01f09/core/src/main/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoder.java#L79-L95

It is a bug because the actual headers are queued and not written. Although a normal response for the first request is completed, the response is canceled because `HttpResponseSubscriber` assumes the order of response is reversed.
https://github.com/line/armeria/blob/0930b184bf00f98692a2e0b3eb044410e78a8173/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L141-L147

Modifications:

- Fixed `Http1ObjectEncoder` to use `currentId` which is updated only when a response starts to write for `isResponseHeadersSent()`.
- Reset a connection when two headers are about to be written to a response in HTTP/1. It is possible when a request is failed by `Http1RequestDecoder` with a protocol violation.

Result:

- HTTP/1.1 responses are now correctly ordered even when HTTP pipelining is enabled.
- Fixes #4470
