### PR TITLE
add overview page

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -30,6 +30,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
+import InfoOutlined from '@material-ui/icons/InfoOutlined';
 import MenuIcon from '@material-ui/icons/Menu';
 import React, { useCallback, useEffect, useReducer, useState } from 'react';
 import { Helmet } from 'react-helmet';
@@ -40,6 +41,7 @@ import EnumPage from '../EnumPage';
 import HomePage from '../HomePage';
 import MethodPage from '../MethodPage';
 import StructPage from '../StructPage';
+import OverviewPage from '../OverviewPage';
 
 import {
   packageName,
@@ -181,11 +183,22 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
         <>
           <ListItem button onClick={toggleServicesOpen}>
             <ListItemText disableTypography>
-              <Typography variant="h5">Services</Typography>
+              <Typography variant="h5">Services </Typography>
             </ListItemText>
             {servicesSectionOpen ? <ExpandLess /> : <ExpandMore />}
           </ListItem>
           <Collapse in={servicesSectionOpen} timeout="auto">
+            <ListItem
+              button
+              onClick={() => navigateTo("/overview")}
+            >
+              <ListItemText>
+                <Typography variant="subtitle2">
+                  <code> Overview </code>
+                </Typography>
+              </ListItemText>
+              <InfoOutlined />
+            </ListItem>
             {specification.getServices().map((service) => (
               <div key={service.name}>
                 <ListItem
@@ -195,7 +208,12 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                   {specification.hasUniqueServiceNames() ? (
                     <ListItemText>
                       <Typography display="inline" variant="subtitle1">
-                        <Tooltip title={service.name} placement="top">
+                        <Tooltip title={
+                          <React.Fragment>
+                            <Typography variant="subtitle1"><b>{service.name}</b></Typography>
+                            <Typography variant="subtitle2">{service.descriptionInfo?.docString}</Typography>
+                          </React.Fragment>
+                        } placement="top">
                           <code>{simpleName(service.name)}</code>
                         </Tooltip>
                       </Typography>
@@ -508,8 +526,8 @@ const App: React.FunctionComponent<Props> = (props) => {
               Armeria documentation service
               {versions
                 ? ` ${extractSimpleArtifactVersion(
-                    versions.getArmeriaArtifactVersion(),
-                  )}`
+                  versions.getArmeriaArtifactVersion(),
+                )}`
                 : ''}
             </span>
           </Typography>
@@ -570,6 +588,10 @@ const App: React.FunctionComponent<Props> = (props) => {
           exact
           path="/"
           render={(p) => <HomePage {...p} versions={versions} />}
+        />
+        <Route
+          path="/overview"
+          render={(p) => <OverviewPage {...p} specification={specification} />}
         />
         <Route
           path="/enums/:name"

--- a/docs-client/src/containers/OverviewPage/index.tsx
+++ b/docs-client/src/containers/OverviewPage/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+import TableContainer from '@material-ui/core/TableContainer';
+import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+
+import {
+  packageName,
+  simpleName,
+  Specification,
+} from '../../lib/specification';
+
+import Section from '../../components/Section';
+import Description from '../../components/Description';
+
+interface OwnProps {
+  specification: Specification;
+}
+
+type Props = OwnProps & RouteComponentProps<{ name: string }>;
+
+const OverviewPage: React.FunctionComponent<Props> = ({ match, specification }) => {
+  const data = specification.getServices()
+  if (!data) {
+    return <>Not found.</>;
+  }
+
+  return (
+    <>
+      <Typography variant="h5">
+        <code>Overview</code>
+      </Typography>
+      <Section>
+        <Typography variant="h6">Services</Typography>
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell>Description</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.length > 0 ? (
+                data.map((service) => (
+                  <TableRow key={service.name}>
+                    <TableCell>
+                      <code>{service.name}</code>
+                    </TableCell>
+                    <TableCell>{service.descriptionInfo?.docString}</TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={2}>There are no services.</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </Section>
+    </>
+  );
+};
+
+export default React.memo(OverviewPage);


### PR DESCRIPTION
Motivation:

Currently no page shows 

Modifications:

- Update tooltip on service name to include service description.
- Add an `overview` page to the top level `services` dropdown too see all services and their descriptions in a single page.

Result:

- Closes #4480 

<img width="453" alt="Screenshot 2022-11-15 at 01 23 50" src="https://user-images.githubusercontent.com/7023385/201781360-16919731-4d8f-4cdc-89f3-256f451a2469.png">
<img width="1258" alt="Screenshot 2022-11-15 at 01 22 17" src="https://user-images.githubusercontent.com/7023385/201781368-9fed4b4e-9c3b-4f19-925f-6cd9d45f44f8.png">
<img width="611" alt="Screenshot 2022-11-15 at 01 01 21" src="https://user-images.githubusercontent.com/7023385/201781372-7a2edb48-febe-48dc-ad51-84e9f84a49f7.png">


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
