### PR TITLE
Provide a way to configure the default `MeterRegistry` from `Flags`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.internal.client.dns.DnsUtil;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.resolver.HostsFileEntriesResolver;
@@ -462,7 +461,7 @@ public abstract class AbstractDnsResolverBuilder {
                     "Cannot set dnsCache() with cacheSpec(), ttl(), or negativeTtl().");
         }
 
-        final MeterRegistry meterRegistry = firstNonNull(this.meterRegistry, Metrics.globalRegistry);
+        final MeterRegistry meterRegistry = firstNonNull(this.meterRegistry, Flags.meterRegistry());
         if (needsToCreateDnsCache) {
             return DnsCache.builder()
                            .cacheSpec(cacheSpec)
@@ -488,7 +487,7 @@ public abstract class AbstractDnsResolverBuilder {
                        queryTimeoutMillis, queryTimeoutMillisForEachAttempt);
         }
 
-        final MeterRegistry meterRegistry = firstNonNull(this.meterRegistry, Metrics.globalRegistry);
+        final MeterRegistry meterRegistry = firstNonNull(this.meterRegistry, Flags.meterRegistry());
 
         final boolean traceEnabled = this.traceEnabled;
         final long queryTimeoutMillis = this.queryTimeoutMillis;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.util.AbstractOptions;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
@@ -221,7 +220,7 @@ public final class ClientFactoryOptions
      * The {@link MeterRegistry} which collects various stats.
      */
     public static final ClientFactoryOption<MeterRegistry> METER_REGISTRY =
-            ClientFactoryOption.define("METER_REGISTRY", Metrics.globalRegistry);
+            ClientFactoryOption.define("METER_REGISTRY", Flags.meterRegistry());
 
     /**
      * The {@link ProxyConfigSelector} which determines the {@link ProxyConfig} to be used.

--- a/core/src/main/java/com/linecorp/armeria/client/DnsCacheBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsCacheBuilder.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.ThreadFactories;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 
 /**
  * A builder for {@link DnsCache}.
@@ -43,7 +42,7 @@ public final class DnsCacheBuilder {
     static final DnsCache DEFAULT_CACHE = DnsCache.builder().build();
 
     private String cacheSpec = Flags.dnsCacheSpec();
-    private MeterRegistry meterRegistry = Metrics.globalRegistry;
+    private MeterRegistry meterRegistry = Flags.meterRegistry();
     private ScheduledExecutorService executor = DEFAULT_EXECUTOR;
     private int minTtl = 1;
     private int maxTtl = Integer.MAX_VALUE;
@@ -62,7 +61,7 @@ public final class DnsCacheBuilder {
 
     /**
      * Sets the {@link MeterRegistry} that collects cache stats.
-     * If unspecified, {@link Metrics#globalRegistry} is used.
+     * If unspecified, {@link Flags#meterRegistry()} is used.
      */
     public DnsCacheBuilder meterRegistry(MeterRegistry meterRegistry) {
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -30,6 +30,9 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.TransientServiceOption;
 
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
 /**
  * Implementation of {@link FlagsProvider} which provides default values to {@link Flags}.
  */
@@ -402,5 +405,10 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Sampler<? super RequestContext> requestContextLeakDetectionSampler() {
         return Sampler.never();
+    }
+
+    @Override
+    public CompositeMeterRegistry meterRegistry() {
+        return Metrics.globalRegistry;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -71,6 +71,8 @@ import com.linecorp.armeria.server.file.FileServiceBuilder;
 import com.linecorp.armeria.server.file.HttpFile;
 import com.linecorp.armeria.server.logging.LoggingService;
 
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -376,6 +378,9 @@ public final class Flags {
 
     private static final Sampler<? super RequestContext> REQUEST_CONTEXT_LEAK_DETECTION_SAMPLER =
             getValue(FlagsProvider::requestContextLeakDetectionSampler, "requestContextLeakDetectionSampler");
+
+    private static final CompositeMeterRegistry METER_REGISTRY =
+            getValue(FlagsProvider::meterRegistry, "meterRegistry");
 
     /**
      * Returns the specification of the {@link Sampler} that determines whether to retain the stack
@@ -1309,6 +1314,16 @@ public final class Flags {
     @UnstableApi
     public static Sampler<? super RequestContext> requestContextLeakDetectionSampler() {
         return REQUEST_CONTEXT_LEAK_DETECTION_SAMPLER;
+    }
+
+    /**
+     * Returns the {@link CompositeMeterRegistry} where armeria records metrics to by default.
+     *
+     * <p>The default value of this flag is {@link Metrics#globalRegistry}.
+     */
+    @UnstableApi
+    public static CompositeMeterRegistry meterRegistry() {
+        return METER_REGISTRY;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -54,6 +54,8 @@ import com.linecorp.armeria.server.file.FileService;
 import com.linecorp.armeria.server.file.FileServiceBuilder;
 import com.linecorp.armeria.server.file.HttpFile;
 
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -974,6 +976,17 @@ public interface FlagsProvider {
     @UnstableApi
     @Nullable
     default Sampler<? super RequestContext> requestContextLeakDetectionSampler() {
+        return null;
+    }
+
+    /**
+     * Returns the {@link CompositeMeterRegistry} where armeria records metrics to by default.
+     *
+     * <p>The default value of this flag is {@link Metrics#globalRegistry}.
+     */
+    @Nullable
+    @UnstableApi
+    default CompositeMeterRegistry meterRegistry() {
         return null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -90,7 +90,6 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
@@ -195,7 +194,7 @@ public final class ServerBuilder implements TlsSetters {
     private int proxyProtocolMaxTlvSize = PROXY_PROTOCOL_DEFAULT_MAX_TLV_SIZE;
     private Duration gracefulShutdownQuietPeriod = DEFAULT_GRACEFUL_SHUTDOWN_QUIET_PERIOD;
     private Duration gracefulShutdownTimeout = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT;
-    private MeterRegistry meterRegistry = Metrics.globalRegistry;
+    private MeterRegistry meterRegistry = Flags.meterRegistry();
     private ServerErrorHandler errorHandler = ServerErrorHandler.ofDefault();
     private List<ClientAddressSource> clientAddressSources = ClientAddressSource.DEFAULT_SOURCES;
     private Predicate<? super InetAddress> clientAddressTrustedProxyFilter = address -> false;

--- a/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
+++ b/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
@@ -21,6 +21,8 @@ import java.util.function.Predicate;
 
 import com.linecorp.armeria.common.util.InetAddressPredicates;
 
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
 public final class BaseFlagsProvider implements FlagsProvider {
 
     @Override
@@ -81,5 +83,10 @@ public final class BaseFlagsProvider implements FlagsProvider {
     @Override
     public Predicate<InetAddress> preferredIpV4Addresses() {
         return InetAddressPredicates.ofCidr("211.111.111.111");
+    }
+
+    @Override
+    public CompositeMeterRegistry meterRegistry() {
+        return new CompositeMeterRegistry();
     }
 }

--- a/it/flags-provider/src/test/java/com/linecorp/armeria/common/FlagsProviderTest.java
+++ b/it/flags-provider/src/test/java/com/linecorp/armeria/common/FlagsProviderTest.java
@@ -39,6 +39,8 @@ import org.junitpioneer.jupiter.SetSystemProperty;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.InetAddressPredicates;
 
+import io.micrometer.core.instrument.Metrics;
+
 @SetSystemProperty(key = "com.linecorp.armeria.requestContextStorageProvider",
         value = "com.linecorp.armeria.common.Custom2RequestContextStorageProvider")
 class FlagsProviderTest {
@@ -137,6 +139,11 @@ class FlagsProviderTest {
         assertFlags("preferredIpV4Addresses")
                 .usingRecursiveComparison()
                 .isEqualTo(InetAddressPredicates.ofCidr("211.111.111.111"));
+    }
+
+    @Test
+    void testMeterRegistry() {
+        assertThat(Flags.meterRegistry()).isNotSameAs(Metrics.globalRegistry);
     }
 
     private ObjectAssert<Object> assertFlags(String flagsMethod) throws Throwable {

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -16,4 +16,7 @@
   <!-- Enable 'NoCopyrightHeader' for examples only. -->
   <suppress id="NoCopyrightHeader" files="^((?![\\/]examples[\\/]).)*$" />
   <suppress id="CopyrightHeader" files="[\\/]examples[\\/]" />
+  <!-- Suppress meterRegistry related checks in non-public code. -->
+  <suppress id="PreferFlagsMeterRegistry" files="[\\/](examples|internal|it|jmh|test)[\\/]" />
+  <suppress id="PreferFlagsMeterRegistry" files="[\\/](DefaultFlagsProvider.java|Flags.java|FlagsProvider.java)" />
 </suppressions>

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -119,6 +119,12 @@
     <property name="format" value="CompletableFuture.completedFuture"/>
     <property name="message" value="Use UnmodifiableFuture.completedFuture() instead."/>
   </module>
+  <!--  Prefer Flags.meterRegistry -->
+  <module name="RegexpSingleline">
+    <property name="id" value="PreferFlagsMeterRegistry"/>
+    <property name="format" value="Metrics.globalRegistry"/>
+    <property name="message" value="Use Flags.meterRegistry() instead."/>
+  </module>
 
   <module name="JavadocPackage"/>
 

--- a/site/src/pages/docs/advanced-metrics.mdx
+++ b/site/src/pages/docs/advanced-metrics.mdx
@@ -151,13 +151,13 @@ Micrometer's `MeterRegistry` can be configured with [meter filters](https://micr
 If you need to control the exported meters, you can apply sophisticated filters to the `MeterRegistry`.
 
 ```java
-import io.micrometer.core.instrument.Metrics;
+import com.linecorp.armeria.common.Flags;
 
-Metrics.globalRegistry
-       .config()
-       .meterFilter(MeterFilter.deny(id ->
-               id.getTag("service").equals("MyHealthCheckService")));
-       .meterFilter(MeterFilter.denyNameStartsWith("jvm"));
+Flags.meterRegistry()
+     .config()
+     .meterFilter(MeterFilter.deny(id ->
+                  id.getTag("service").equals("MyHealthCheckService")));
+     .meterFilter(MeterFilter.denyNameStartsWith("jvm"));
 ```
 
 Please refer to <type://MeterIdPrefixFunction> to learn what kinds of tags are used for request metrics.

--- a/site/src/pages/docs/client-circuit-breaker.mdx
+++ b/site/src/pages/docs/client-circuit-breaker.mdx
@@ -235,12 +235,12 @@ If you use <type://CircuitBreakerBuilder>, you can configure the parameters whic
     <type://CircuitBreakerListener#metricCollecting()> to export metrics:
 
   ```java
-  import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener
+  import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener;
 
-  import io.micrometer.core.instrument.Metrics;
+  import com.linecorp.armeria.common.Flags;
 
   final CircuitBreakerListener listener =
-          CircuitBreakerListener.metricCollecting(Metrics.globalRegistry);
+          CircuitBreakerListener.metricCollecting(Flags.meterRegistry());
   final CircuitBreakerBuilder builder = CircuitBreaker.builder()
                                                       .listener(listener);
   ```

--- a/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot2-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.context.annotation.Bean;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
@@ -46,7 +47,6 @@ import com.linecorp.armeria.server.metric.PrometheusExpositionService;
 import com.linecorp.armeria.spring.ArmeriaSettings.Port;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 
 /**
  * Abstract class for implementing ArmeriaAutoConfiguration of boot2-autoconfigure module
@@ -93,7 +93,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
         configureServerWithArmeriaSettings(serverBuilder, armeriaSettings, internalService,
                                            armeriaServerConfigurators.orElse(ImmutableList.of()),
                                            armeriaServerBuilderConsumers.orElse(ImmutableList.of()),
-                                           meterRegistry.orElse(Metrics.globalRegistry),
+                                           meterRegistry.orElse(Flags.meterRegistry()),
                                            meterIdPrefixFunction.orElse(
                                                    MeterIdPrefixFunction.ofDefault("armeria.server")),
                                            metricCollectingServiceConfigurators.orElse(ImmutableList.of()),
@@ -133,7 +133,7 @@ public abstract class AbstractArmeriaAutoConfiguration {
             Optional<List<DocServiceConfigurator>> docServiceConfigurators,
             @Value("${management.server.port:#{null}}") @Nullable Integer managementServerPort) {
 
-        return InternalServices.of(settings, meterRegistry.orElse(Metrics.globalRegistry),
+        return InternalServices.of(settings, meterRegistry.orElse(Flags.meterRegistry()),
                                    healthCheckers.orElse(ImmutableList.of()),
                                    healthCheckServiceConfigurators.orElse(ImmutableList.of()),
                                    docServiceConfigurators.orElse(ImmutableList.of()), managementServerPort);

--- a/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot2-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -54,6 +54,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -74,7 +75,6 @@ import com.linecorp.armeria.spring.InternalServices;
 import com.linecorp.armeria.spring.MetricCollectingServiceConfigurator;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Metrics;
 import io.netty.handler.ssl.ClientAuth;
 import reactor.core.Disposable;
 
@@ -159,7 +159,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
 
         if (armeriaSettings != null) {
             final MeterRegistry meterRegistry = firstNonNull(findBean(MeterRegistry.class),
-                                                             Metrics.globalRegistry);
+                                                             Flags.meterRegistry());
             configureServerWithArmeriaSettings(sb, armeriaSettings,
                                                newInternalServices(armeriaSettings, meterRegistry),
                                                findBeans(ArmeriaServerConfigurator.class),


### PR DESCRIPTION
Motivation:

Most open source projects using `micrometer` use `Metrics.globalRegistry()` as the default `MeterRegistry`.
At the same time, the default `meterRegistry` used by `armeria` is `Metrics.globalRegistry()`.

This may be problematic since users may be interested in only `armeria` metrics, but metrics for other integration may also be included. I propose that `armeria` records metrics to `Flags#meterRegistry()` by default.

Note: I've intentionally excluded adding this flag to `SystemDefaultFlags`. If needed, I suppose we can accept a class name and instantiate it although I think such a flag wouldn't have much usage.

Modifications:

- Add a new `Flags#meterRegistry` which returns a `CompositeMeterRegistry`.
- Change all internal usages of `Metrics#globalRegistry` to `Flags#meterRegistry`.
- Add lint rules to avoid usage of `Metrics#globalRegistry` in production code.

Result:

- Users have more control over how to record metrics.
