### PR TITLE
Replace synchronized under core/client with ReentrantLock

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractEventLoopState.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -34,6 +35,7 @@ abstract class AbstractEventLoopState {
         return new HeapBasedEventLoopState(eventLoops, maxNumEventLoops, scheduler);
     }
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final List<EventLoop> eventLoops;
     private final DefaultEventLoopScheduler scheduler;
 
@@ -61,6 +63,14 @@ abstract class AbstractEventLoopState {
 
     final void setLastActivityTimeNanos() {
         lastActivityTimeNanos = System.nanoTime();
+    }
+
+    protected final void lock() {
+        lock.lock();
+    }
+
+    protected final void unlock() {
+        lock.unlock();
     }
 
     abstract AbstractEventLoopEntry acquire();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
@@ -251,12 +251,12 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
         for (final Iterator<AbstractEventLoopState> i = states.values().iterator(); i.hasNext();) {
             final AbstractEventLoopState state = i.next();
             final boolean remove;
-            lock();
+            lock.lock();
             try {
                 remove = state.allActiveRequests() == 0 &&
                          currentTimeNanos - state.lastActivityTimeNanos() >= CLEANUP_INTERVAL_NANOS;
             } finally {
-                unlock();
+                lock.unlock();
             }
 
             if (remove) {
@@ -294,13 +294,5 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
             final StateKey that = (StateKey) obj;
             return ipOrHost.equals(that.ipOrHost) && port == that.port && isHttp1 == that.isHttp1;
         }
-    }
-
-    private void lock() {
-        lock.lock();
-    }
-
-    private void unlock() {
-        lock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HeapBasedEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HeapBasedEventLoopState.java
@@ -27,8 +27,6 @@ import io.netty.channel.EventLoop;
 
 final class HeapBasedEventLoopState extends AbstractEventLoopState {
 
-    private final ReentrantLock lock = new ReentrantLock();
-
     /**
      * A binary heap of Entry. Ordered by:
      * <ul>
@@ -277,13 +275,5 @@ final class HeapBasedEventLoopState extends AbstractEventLoopState {
         public String toString() {
             return "(" + index + ", " + id + ", " + activeRequests() + ')';
         }
-    }
-
-    private void lock() {
-        lock.lock();
-    }
-
-    private void unlock() {
-        lock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HeapBasedEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HeapBasedEventLoopState.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.base.Joiner;
 

--- a/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantLock;
 
 import io.netty.channel.EventLoop;
 

--- a/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
@@ -24,7 +24,7 @@ import io.netty.channel.EventLoop;
 
 final class OneEventLoopState extends AbstractEventLoopState {
 
-        private final ReentrantLock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock();
 
     private final List<AbstractEventLoopEntry> entry = new ArrayList<>();
 

--- a/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
@@ -24,7 +24,7 @@ import io.netty.channel.EventLoop;
 
 final class OneEventLoopState extends AbstractEventLoopState {
 
-    private final ReentrantLock lock = new ReentrantLock();
+        private final ReentrantLock lock = new ReentrantLock();
 
     private final List<AbstractEventLoopEntry> entry = new ArrayList<>();
 

--- a/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
+++ b/core/src/main/java/com/linecorp/armeria/client/OneEventLoopState.java
@@ -24,8 +24,6 @@ import io.netty.channel.EventLoop;
 
 final class OneEventLoopState extends AbstractEventLoopState {
 
-    private final ReentrantLock lock = new ReentrantLock();
-
     private final List<AbstractEventLoopEntry> entry = new ArrayList<>();
 
     private int allActiveRequests;
@@ -105,13 +103,5 @@ final class OneEventLoopState extends AbstractEventLoopState {
         void setIndex(int index) {
             throw new UnsupportedOperationException();
         }
-    }
-
-    private void lock() {
-        lock.lock();
-    }
-
-    private void unlock() {
-        lock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistry.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -42,6 +43,8 @@ import com.linecorp.armeria.client.endpoint.FileWatcherRunnable.FileWatchEvent;
  * A registry which wraps a {@link WatchService} and allows paths to be registered.
  */
 final class FileWatcherRegistry implements AutoCloseable {
+
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * A context responsible for watching a {@link FileSystem}. It contains references to
@@ -143,22 +146,27 @@ final class FileWatcherRegistry implements AutoCloseable {
      *
      * @return a key which is used to unregister from watching.
      */
-    synchronized FileWatchRegisterKey register(Path filePath, Runnable callback) {
-        final FileWatchRegisterKey watchRegisterKey = new FileWatchRegisterKey(filePath);
-        final FileSystemWatchContext watchServiceContext = fileSystemWatchServiceMap.computeIfAbsent(
-                filePath.getFileSystem(), fileSystem -> {
-                    try {
-                        return new FileSystemWatchContext(
-                                "armeria-file-watcher-" + fileSystem.getClass().getName(),
-                                fileSystem.newWatchService());
-                    } catch (IOException e) {
-                        throw new IllegalArgumentException(
-                                "failed to create a new watch service for the path: " +
-                                watchRegisterKey.filePath(), e);
-                    }
-                });
-        watchServiceContext.register(watchRegisterKey, callback);
-        return watchRegisterKey;
+    FileWatchRegisterKey register(Path filePath, Runnable callback) {
+        lock();
+        try {
+            final FileWatchRegisterKey watchRegisterKey = new FileWatchRegisterKey(filePath);
+            final FileSystemWatchContext watchServiceContext = fileSystemWatchServiceMap.computeIfAbsent(
+                    filePath.getFileSystem(), fileSystem -> {
+                        try {
+                            return new FileSystemWatchContext(
+                                    "armeria-file-watcher-" + fileSystem.getClass().getName(),
+                                    fileSystem.newWatchService());
+                        } catch (IOException e) {
+                            throw new IllegalArgumentException(
+                                    "failed to create a new watch service for the path: " +
+                                    watchRegisterKey.filePath(), e);
+                        }
+                    });
+            watchServiceContext.register(watchRegisterKey, callback);
+            return watchRegisterKey;
+        } finally {
+            unlock();
+        }
     }
 
     /**
@@ -167,15 +175,20 @@ final class FileWatcherRegistry implements AutoCloseable {
      * method is thread safe.
      * @param watchRegisterKey the key that was used to register for watching a file.
      */
-    synchronized void unregister(FileWatchRegisterKey watchRegisterKey) {
-        final FileSystem fileSystem = watchRegisterKey.filePath().getFileSystem();
-        final FileSystemWatchContext watchServiceContext = fileSystemWatchServiceMap.get(fileSystem);
-        if (watchServiceContext == null) {
-            return;
-        }
-        watchServiceContext.unregister(watchRegisterKey);
-        if (!watchServiceContext.isRunning()) {
-            fileSystemWatchServiceMap.remove(fileSystem);
+    void unregister(FileWatchRegisterKey watchRegisterKey) {
+        lock();
+        try {
+            final FileSystem fileSystem = watchRegisterKey.filePath().getFileSystem();
+            final FileSystemWatchContext watchServiceContext = fileSystemWatchServiceMap.get(fileSystem);
+            if (watchServiceContext == null) {
+                return;
+            }
+            watchServiceContext.unregister(watchRegisterKey);
+            if (!watchServiceContext.isRunning()) {
+                fileSystemWatchServiceMap.remove(fileSystem);
+            }
+        } finally {
+            unlock();
         }
     }
 
@@ -193,15 +206,20 @@ final class FileWatcherRegistry implements AutoCloseable {
      * @throws Exception may be thrown if an I/O error occurs
      */
     @Override
-    public synchronized void close() throws Exception {
-        fileSystemWatchServiceMap.values().forEach(context -> {
-            try {
-                context.close();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        });
-        fileSystemWatchServiceMap.clear();
+    public void close() throws Exception {
+        lock();
+        try {
+            fileSystemWatchServiceMap.values().forEach(context -> {
+                try {
+                    context.close();
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            fileSystemWatchServiceMap.clear();
+        } finally {
+            unlock();
+        }
     }
 
     /**
@@ -230,5 +248,13 @@ final class FileWatcherRegistry implements AutoCloseable {
         public String toString() {
             return MoreObjects.toStringHelper(this).add("filePath", filePath).toString();
         }
+    }
+
+    private void lock() {
+        lock.lock();
+    }
+
+    private void unlock() {
+        lock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistry.java
@@ -44,8 +44,6 @@ import com.linecorp.armeria.client.endpoint.FileWatcherRunnable.FileWatchEvent;
  */
 final class FileWatcherRegistry implements AutoCloseable {
 
-    private final ReentrantLock lock = new ReentrantLock();
-
     /**
      * A context responsible for watching a {@link FileSystem}. It contains references to
      * a {@link WatchService} and a {@link Thread} which continuously watches for changes
@@ -135,6 +133,7 @@ final class FileWatcherRegistry implements AutoCloseable {
 
     private final Map<FileSystem, FileSystemWatchContext> fileSystemWatchServiceMap =
             new HashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Registers a {@code filePath} and {@code callback} to the {@link WatchService}. When the

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -21,10 +21,9 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReentrantLock;
 
-import javax.annotation.concurrent.GuardedBy;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.annotation.Nullable;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
@@ -36,12 +38,9 @@ import com.linecorp.armeria.common.annotation.Nullable;
  */
 final class WeightedRandomDistributionEndpointSelector {
 
-    /**
-     * Lock for {@link currentEntries}.
-     */
     private final ReentrantLock lock = new ReentrantLock();
-
     private final List<Entry> allEntries;
+    @GuardedBy("lock")
     private final List<Entry> currentEntries;
     private final long total;
     private long remaining;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRandomDistributionEndpointSelector.java
@@ -73,7 +73,7 @@ final class WeightedRandomDistributionEndpointSelector {
         }
 
         final ThreadLocalRandom threadLocalRandom = ThreadLocalRandom.current();
-        lock();
+        lock.lock();
         try {
             long target = threadLocalRandom.nextLong(remaining);
             final Iterator<Entry> it = currentEntries.iterator();
@@ -99,7 +99,7 @@ final class WeightedRandomDistributionEndpointSelector {
                 }
             }
         } finally {
-            unlock();
+            lock.unlock();
         }
 
         // Since `allEntries` is not empty, should select one Endpoint from `allEntries`.
@@ -141,13 +141,5 @@ final class WeightedRandomDistributionEndpointSelector {
         boolean isFull() {
             return counter >= endpoint.weight();
         }
-    }
-
-    private void lock() {
-        lock.lock();
-    }
-
-    private void unlock() {
-        lock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -29,10 +29,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 
-import javax.annotation.concurrent.GuardedBy;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -283,6 +283,7 @@ final class DefaultHealthCheckerContext
         }
     }
 
+    // The caller who calls this method must have the lock.
     @SuppressWarnings("GuardedBy")
     private <T extends Future<U>, U> T add(T future) {
         scheduledFutures.put(future, Boolean.TRUE);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
@@ -49,20 +51,17 @@ import io.netty.util.concurrent.Future;
 final class DefaultHealthCheckerContext
         extends AbstractExecutorService implements HealthCheckerContext, ScheduledExecutorService {
 
-    /**
-     * Lock for {@link scheduledFutures}.
-     */
-    private final ReentrantLock lock = new ReentrantLock();
-
     private final Endpoint originalEndpoint;
     private final Endpoint endpoint;
     private final SessionProtocol protocol;
     private final ClientOptions clientOptions;
+    private final ReentrantLock lock = new ReentrantLock();
 
     /**
      * Keeps the {@link Future}s which were scheduled via this {@link ScheduledExecutorService}.
      * Note that this field is also used as a lock.
      */
+    @GuardedBy("lock")
     private final Map<Future<?>, Boolean> scheduledFutures = new IdentityHashMap<>();
     private final CompletableFuture<Void> initialCheckFuture = new EventLoopCheckingFuture<>();
     private final Backoff retryBackoff;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,10 +100,6 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         return new HealthCheckedEndpointGroupBuilder(delegate, path);
     }
 
-    /**
-     * Lock for {@link contextGroupChain}.
-     */
-    private final ReentrantLock lock = new ReentrantLock();
     final EndpointGroup delegate;
     private final long initialSelectionTimeoutMillis;
     private final long selectionTimeoutMillis;
@@ -113,6 +111,8 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     @VisibleForTesting
     final HealthCheckStrategy healthCheckStrategy;
 
+    private final ReentrantLock lock = new ReentrantLock();
+    @GuardedBy("lock")
     private final Deque<HealthCheckContextGroup> contextGroupChain = new ArrayDeque<>(4);
 
     // Should not use NonBlockingHashSet whose remove operation does not clear the reference of the value

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -77,11 +77,6 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     private static final Logger logger = LoggerFactory.getLogger(HealthCheckedEndpointGroup.class);
 
     /**
-     * Lock for {@link contextGroupChain}.
-     */
-    private final ReentrantLock lock = new ReentrantLock();
-
-    /**
      * Returns a newly created {@link HealthCheckedEndpointGroup} that sends HTTP {@code HEAD} health check
      * requests with default options.
      *
@@ -103,6 +98,10 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         return new HealthCheckedEndpointGroupBuilder(delegate, path);
     }
 
+    /**
+     * Lock for {@link contextGroupChain}.
+     */
+    private final ReentrantLock lock = new ReentrantLock();
     final EndpointGroup delegate;
     private final long initialSelectionTimeoutMillis;
     private final long selectionTimeoutMillis;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -58,10 +58,9 @@ final class HttpHealthChecker implements AsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpHealthChecker.class);
 
-    private final ReentrantLock lock = new ReentrantLock();
-
     private static final AsciiString ARMERIA_LPHC = HttpHeaderNames.of("armeria-lphc");
 
+    private final ReentrantLock lock = new ReentrantLock();
     private final HealthCheckerContext ctx;
     private final WebClient webClient;
     private final String authority;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -57,6 +58,8 @@ final class HttpHealthChecker implements AsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpHealthChecker.class);
 
+    private final ReentrantLock lock = new ReentrantLock();
+
     private static final AsciiString ARMERIA_LPHC = HttpHeaderNames.of("armeria-lphc");
 
     private final HealthCheckerContext ctx;
@@ -87,28 +90,35 @@ final class HttpHealthChecker implements AsyncCloseable {
         check();
     }
 
-    private synchronized void check() {
-        if (closeable.isClosing()) {
-            return;
-        }
+    private void check() {
+        lock();
+        try {
+            if (closeable.isClosing()) {
+                return;
+            }
 
-        final RequestHeaders headers;
-        final RequestHeadersBuilder builder =
-                RequestHeaders.builder(useGet ? HttpMethod.GET : HttpMethod.HEAD, path)
-                              .authority(authority);
-        if (maxLongPollingSeconds > 0) {
-            headers = builder.add(HttpHeaderNames.IF_NONE_MATCH, wasHealthy ? "\"healthy\"" : "\"unhealthy\"")
-                             .add(HttpHeaderNames.PREFER, "wait=" + maxLongPollingSeconds)
-                             .build();
-        } else {
-            headers = builder.build();
-        }
+            final RequestHeaders headers;
+            final RequestHeadersBuilder builder =
+                    RequestHeaders.builder(useGet ? HttpMethod.GET : HttpMethod.HEAD, path)
+                                  .authority(authority);
+            if (maxLongPollingSeconds > 0) {
+                headers = builder.add(HttpHeaderNames.IF_NONE_MATCH,
+                                      wasHealthy ? "\"healthy\"" : "\"unhealthy\"")
+                                 .add(HttpHeaderNames.PREFER, "wait=" + maxLongPollingSeconds)
+                                 .build();
+            } else {
+                headers = builder.build();
+            }
 
-        try (ClientRequestContextCaptor reqCtxCaptor = Clients.newContextCaptor()) {
-            lastResponse = webClient.execute(headers);
-            final ClientRequestContext reqCtx = reqCtxCaptor.get();
-            lastResponse.subscribe(new HealthCheckResponseSubscriber(reqCtx, lastResponse),
-                                   reqCtx.eventLoop().withoutContext(), SubscriptionOption.WITH_POOLED_OBJECTS);
+            try (ClientRequestContextCaptor reqCtxCaptor = Clients.newContextCaptor()) {
+                lastResponse = webClient.execute(headers);
+                final ClientRequestContext reqCtx = reqCtxCaptor.get();
+                lastResponse.subscribe(new HealthCheckResponseSubscriber(reqCtx, lastResponse),
+                                       reqCtx.eventLoop().withoutContext(),
+                                       SubscriptionOption.WITH_POOLED_OBJECTS);
+            }
+        } finally {
+            unlock();
         }
     }
 
@@ -118,12 +128,17 @@ final class HttpHealthChecker implements AsyncCloseable {
     }
 
     private synchronized void closeAsync(CompletableFuture<?> future) {
-        if (lastResponse == null) {
-            // Called even before the first request is sent.
-            future.complete(null);
-        } else {
-            lastResponse.abort();
-            lastResponse.whenComplete().handle((unused1, unused2) -> future.complete(null));
+        lock();
+        try {
+            if (lastResponse == null) {
+                // Called even before the first request is sent.
+                future.complete(null);
+            } else {
+                lastResponse.abort();
+                lastResponse.whenComplete().handle((unused1, unused2) -> future.complete(null));
+            }
+        } finally {
+            unlock();
         }
     }
 
@@ -322,5 +337,13 @@ final class HttpHealthChecker implements AsyncCloseable {
                 // the delegate EndpointGroup. See HealthCheckedEndpointGroupTest.disappearedEndpoint().
             }
         }
+    }
+
+    private void lock() {
+        lock.lock();
+    }
+
+    private void unlock() {
+        lock.unlock();
     }
 }


### PR DESCRIPTION
Motivation:

synchronized should be removed because they should be avoided when using virtual threads
resolves part of https://github.com/line/armeria/issues/4510

Modifications:

- Replaced all _synchronized_  under core/client package with ReentrantLock
