### PR TITLE
Replace synchronized under common/util with reentrantLock

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -17,11 +17,11 @@ package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.errorprone.annotations.concurrent.GuardedBy;
-
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
@@ -47,12 +47,12 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
      */
     protected final void notifyListeners(T latestValue) {
         final Consumer<? super T>[] updateListeners;
-        lock();
+        reentrantLock.lock();
         try {
             //noinspection unchecked
             updateListeners = this.updateListeners.toArray((Consumer<? super T>[]) EMPTY_LISTENERS);
         } finally {
-            unlock();
+            reentrantLock.unlock();
         }
 
         for (Consumer<? super T> listener : updateListeners) {
@@ -84,7 +84,7 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
      */
     public final void addListener(Consumer<? super T> listener, boolean notifyLatestValue) {
         requireNonNull(listener, "listener");
-        lock();
+        reentrantLock.lock();
         try {
             if (notifyLatestValue) {
                 final T latest = latestValue();
@@ -94,26 +94,18 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
             }
             updateListeners.add(listener);
         } finally {
-            unlock();
+            reentrantLock.unlock();
         }
     }
 
     @Override
     public final void removeListener(Consumer<?> listener) {
         requireNonNull(listener, "listener");
-        lock();
+        reentrantLock.lock();
         try {
             updateListeners.remove(listener);
         } finally {
-            unlock();
+            reentrantLock.unlock();
         }
-    }
-
-    void lock() {
-        reentrantLock.lock();
-    }
-
-    void unlock() {
-        reentrantLock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
 
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
+import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A skeletal {@link Listenable} implementation.
@@ -34,6 +35,7 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
     @SuppressWarnings("rawtypes")
     private static final Consumer[] EMPTY_LISTENERS = new Consumer[0];
 
+    @GuardedBy("reentrantLock")
     private final Set<Consumer<? super T>> updateListeners =
             new ObjectLinkedOpenCustomHashSet<>(IdentityHashStrategy.of());
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -25,7 +26,6 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
 
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
-import javax.annotation.concurrent.GuardedBy;
 
 /**
  * A skeletal {@link Listenable} implementation.

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.util;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.concurrent.GuardedBy;
+
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
@@ -251,16 +251,15 @@ public abstract class AbstractOption<
                 final AbstractOption<?, ?, ?> oldOption = options.get(name);
                 if (oldOption != null) {
                     throw new IllegalStateException(
-                        '\'' + type.getName() + '#' + name + "' exists already.");
+                            '\'' + type.getName() + '#' + name + "' exists already.");
                 }
 
                 final T newOption = optionFactory.get(name, defaultValue, validator, mergeFunction);
                 checkArgument(type.isInstance(newOption),
-                    "OptionFactory.newOption() must return an instance of %s.", type);
+                              "OptionFactory.newOption() must return an instance of %s.", type);
                 options.put(name, newOption);
                 return newOption;
-            }
-            finally {
+            } finally {
                 unlock();
             }
         }
@@ -271,7 +270,7 @@ public abstract class AbstractOption<
                 final AbstractOption<?, ?, ?> option = options.get(name);
                 if (option == null) {
                     throw new NoSuchElementException(
-                        '\'' + type.getName() + '#' + name + "' does not exist.");
+                            '\'' + type.getName() + '#' + name + "' does not exist.");
                 }
 
                 return option;

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractOption.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -235,40 +236,65 @@ public abstract class AbstractOption<
 
         private final Class<?> type;
         private final BiMap<String, AbstractOption<?, ?, ?>> options;
+        private final ReentrantLock reentrantLock = new ReentrantLock();
 
         Pool(Class<?> type) {
             this.type = type;
             options = HashBiMap.create();
         }
 
-        synchronized <T extends AbstractOption<T, U, V>, U extends AbstractOptionValue<U, T, V>, V>
+        <T extends AbstractOption<T, U, V>, U extends AbstractOptionValue<U, T, V>, V>
         T define(Factory<T, U, V> optionFactory, String name, V defaultValue,
                  Function<V, V> validator, BiFunction<U, U, U> mergeFunction) {
-            final AbstractOption<?, ?, ?> oldOption = options.get(name);
-            if (oldOption != null) {
-                throw new IllegalStateException(
+            lock();
+            try {
+                final AbstractOption<?, ?, ?> oldOption = options.get(name);
+                if (oldOption != null) {
+                    throw new IllegalStateException(
                         '\'' + type.getName() + '#' + name + "' exists already.");
-            }
+                }
 
-            final T newOption = optionFactory.get(name, defaultValue, validator, mergeFunction);
-            checkArgument(type.isInstance(newOption),
-                          "OptionFactory.newOption() must return an instance of %s.", type);
-            options.put(name, newOption);
-            return newOption;
+                final T newOption = optionFactory.get(name, defaultValue, validator, mergeFunction);
+                checkArgument(type.isInstance(newOption),
+                    "OptionFactory.newOption() must return an instance of %s.", type);
+                options.put(name, newOption);
+                return newOption;
+            }
+            finally {
+                unlock();
+            }
         }
 
-        synchronized AbstractOption<?, ?, ?> get(String name) {
-            final AbstractOption<?, ?, ?> option = options.get(name);
-            if (option == null) {
-                throw new NoSuchElementException(
+        AbstractOption<?, ?, ?> get(String name) {
+            lock();
+            try {
+                final AbstractOption<?, ?, ?> option = options.get(name);
+                if (option == null) {
+                    throw new NoSuchElementException(
                         '\'' + type.getName() + '#' + name + "' does not exist.");
-            }
+                }
 
-            return option;
+                return option;
+            } finally {
+                unlock();
+            }
         }
 
-        synchronized Set<AbstractOption<?, ?, ?>> getAll() {
-            return ImmutableSet.copyOf(options.values());
+        Set<AbstractOption<?, ?, ?>> getAll() {
+            lock();
+            try {
+                return ImmutableSet.copyOf(options.values());
+            } finally {
+                unlock();
+            }
+        }
+
+        void lock() {
+            reentrantLock.lock();
+        }
+
+        void unlock() {
+            reentrantLock.unlock();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -46,7 +47,6 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Represents an exception that is a composite of one or more other exceptions. A {@code CompositeException}
@@ -155,7 +155,7 @@ public final class CompositeException extends RuntimeException {
 
                     final StringBuilder aggregateMessage = new StringBuilder();
                     aggregateMessage.append("Multiple exceptions (").append(exceptions.size())
-                        .append(')').append(separator);
+                                    .append(')').append(separator);
 
                     for (Throwable inner : exceptions) {
                         int depth = 0;
@@ -181,11 +181,11 @@ public final class CompositeException extends RuntimeException {
                             final StackTraceElement[] st = inner.getStackTrace();
                             if (st.length > 0) {
                                 final int maxStackTraceSize =
-                                    isVerboseException ? st.length
-                                        : Math.min(DEFAULT_MAX_NUM_STACK_TRACES, st.length);
+                                        isVerboseException ? st.length
+                                                           : Math.min(DEFAULT_MAX_NUM_STACK_TRACES, st.length);
                                 for (int i = 0; i < maxStackTraceSize; i++) {
                                     aggregateMessage.append(messagePadding).append("at ")
-                                        .append(st[i]).append(separator);
+                                                    .append(st[i]).append(separator);
                                 }
                             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -321,7 +321,8 @@ public final class CompositeException extends RuntimeException {
     static final class ExceptionOverview extends RuntimeException {
 
         private static final long serialVersionUID = 3875212506787802066L;
-        private final ReentrantLock reentrantLock = new ReentrantLock();
+
+        private static final ReentrantLock reentrantLock = new ReentrantLock();
 
         ExceptionOverview(String message) {
             super(message);
@@ -347,11 +348,11 @@ public final class CompositeException extends RuntimeException {
         return exceptions.size();
     }
 
-    private void lock() {
+    void lock() {
         reentrantLock.lock();
     }
 
-    private void unlock() {
+    void unlock() {
         reentrantLock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/CompositeException.java
@@ -322,20 +322,13 @@ public final class CompositeException extends RuntimeException {
 
         private static final long serialVersionUID = 3875212506787802066L;
 
-        private static final ReentrantLock reentrantLock = new ReentrantLock();
-
         ExceptionOverview(String message) {
             super(message);
         }
 
         @Override
         public Throwable fillInStackTrace() {
-            reentrantLock.lock();
-            try {
-                return this;
-            } finally {
-                reentrantLock.unlock();
-            }
+            return this;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
@@ -104,7 +104,7 @@ public final class ShutdownHooks {
                     reentrantLock.lock();
                     try {
                         autoCloseableOnShutdownTasks.forEach((factory, queue) -> {
-                            for (; ; ) {
+                            for (;;) {
                                 final Runnable onShutdown = queue.poll();
                                 if (onShutdown == null) {
                                     break;

--- a/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
@@ -87,6 +87,7 @@ public final class ShutdownHooks {
                 closeFuture.completeExceptionally(cause);
             }
         };
+        // todo(BueVonHun): in this case, it has some design options...
         synchronized (autoCloseableOnShutdownTasks) {
             final Queue<Runnable> onShutdownTasks =
                     autoCloseableOnShutdownTasks.computeIfAbsent(autoCloseable, key -> new ArrayDeque<>());

--- a/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
@@ -43,7 +43,7 @@ public final class ShutdownHooks {
 
     private static final Logger logger = LoggerFactory.getLogger(ShutdownHooks.class);
 
-    @GuardedBy("autoCloseableOnShutdownTasks")
+    @GuardedBy("reentrantLock")
     private static final Map<AutoCloseable, Queue<Runnable>> autoCloseableOnShutdownTasks =
             new LinkedHashMap<>();
 

--- a/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayDeque;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -43,6 +44,7 @@ public final class ShutdownHooks {
     private static final Map<AutoCloseable, Queue<Runnable>> autoCloseableOnShutdownTasks =
             new LinkedHashMap<>();
 
+    @GuardedBy("autoCloseableOnShutdownTasks")
     private static final ReentrantLock reentrantLock = new ReentrantLock();
 
     private static final ThreadFactory THREAD_FACTORY = ThreadFactories

--- a/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/ShutdownHooks.java
@@ -113,8 +113,7 @@ public final class ShutdownHooks {
                                 }
                             }
                         });
-                    }
-                    finally {
+                    } finally {
                         reentrantLock.unlock();
                     }
                 }));

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -149,9 +149,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
         return start0(arg, rollbackArg, failIfStarted);
     }
 
-    private UnmodifiableFuture<V> start0(@Nullable T arg,
-                                                      @Nullable U rollbackArg,
-                                                      boolean failIfStarted) {
+    private UnmodifiableFuture<V> start0(@Nullable T arg, @Nullable U rollbackArg, boolean failIfStarted) {
         lock();
         try {
             if (closeable.isClosing()) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -61,6 +62,8 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
      * This future is {@code V}-typed when STARTING/STARTED and {@link Void}-typed when STOPPING/STOPPED.
      */
     private UnmodifiableFuture<?> future = completedFuture(null);
+
+    private final ReentrantLock reentrantLock = new ReentrantLock();
 
     /**
      * Creates a new instance.
@@ -146,75 +149,77 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
         return start0(arg, rollbackArg, failIfStarted);
     }
 
-    private synchronized UnmodifiableFuture<V> start0(@Nullable T arg,
+    private UnmodifiableFuture<V> start0(@Nullable T arg,
                                                       @Nullable U rollbackArg,
                                                       boolean failIfStarted) {
-        if (closeable.isClosing()) {
-            return exceptionallyCompletedFuture(new IllegalStateException("closed already"));
-        }
-
-        switch (state) {
-            case STARTING:
-            case STARTED:
-                if (failIfStarted) {
-                    return exceptionallyCompletedFuture(
-                            new IllegalStateException("must be stopped to start; currently " + state));
-                } else {
-                    @SuppressWarnings("unchecked")
-                    final UnmodifiableFuture<V> castFuture = (UnmodifiableFuture<V>) future;
-                    return castFuture;
-                }
-            case STOPPING:
-                // A user called start() to restart, but not stopped completely yet.
-                // Try again once stopped.
-                return UnmodifiableFuture.wrap(
-                        future.exceptionally(unused -> null)
-                              .thenComposeAsync(unused -> start(arg, failIfStarted), executor));
-        }
-
-        assert state == State.STOPPED : "state: " + state;
-        state = State.STARTING;
-
-        // Attempt to start.
-        final CompletableFuture<V> startFuture = new CompletableFuture<>();
-        boolean submitted = false;
+        lock();
         try {
-            executor.execute(() -> {
-                try {
-                    notifyListeners(State.STARTING, arg, null, null);
-                    final CompletionStage<V> f = doStart(arg);
-                    checkState(f != null, "doStart() returned null.");
-
-                    f.handle((result, cause) -> {
-                        if (cause != null) {
-                            startFuture.completeExceptionally(cause);
-                        } else {
-                            startFuture.complete(result);
-                        }
-                        return null;
-                    });
-                } catch (Exception e) {
-                    startFuture.completeExceptionally(e);
-                }
-            });
-            submitted = true;
-        } catch (Exception e) {
-            return exceptionallyCompletedFuture(e);
-        } finally {
-            if (!submitted) {
-                state = State.STOPPED;
+            if (closeable.isClosing()) {
+                return exceptionallyCompletedFuture(new IllegalStateException("closed already"));
             }
-        }
 
-        final UnmodifiableFuture<V> future = UnmodifiableFuture.wrap(
+            switch (state) {
+                case STARTING:
+                case STARTED:
+                    if (failIfStarted) {
+                        return exceptionallyCompletedFuture(
+                            new IllegalStateException("must be stopped to start; currently " + state));
+                    } else {
+                        @SuppressWarnings("unchecked")
+                        final UnmodifiableFuture<V> castFuture = (UnmodifiableFuture<V>) future;
+                        return castFuture;
+                    }
+                case STOPPING:
+                    // A user called start() to restart, but not stopped completely yet.
+                    // Try again once stopped.
+                    return UnmodifiableFuture.wrap(
+                        future.exceptionally(unused -> null)
+                            .thenComposeAsync(unused -> start(arg, failIfStarted), executor));
+            }
+
+            assert state == State.STOPPED : "state: " + state;
+            state = State.STARTING;
+
+            // Attempt to start.
+            final CompletableFuture<V> startFuture = new CompletableFuture<>();
+            boolean submitted = false;
+            try {
+                executor.execute(() -> {
+                    try {
+                        notifyListeners(State.STARTING, arg, null, null);
+                        final CompletionStage<V> f = doStart(arg);
+                        checkState(f != null, "doStart() returned null.");
+
+                        f.handle((result, cause) -> {
+                            if (cause != null) {
+                                startFuture.completeExceptionally(cause);
+                            } else {
+                                startFuture.complete(result);
+                            }
+                            return null;
+                        });
+                    } catch (Exception e) {
+                        startFuture.completeExceptionally(e);
+                    }
+                });
+                submitted = true;
+            } catch (Exception e) {
+                return exceptionallyCompletedFuture(e);
+            } finally {
+                if (!submitted) {
+                    state = State.STOPPED;
+                }
+            }
+
+            final UnmodifiableFuture<V> future = UnmodifiableFuture.wrap(
                 startFuture.handleAsync((result, cause) -> {
                     if (cause != null) {
                         // Failed to start. Stop and complete with the start failure cause.
                         final CompletableFuture<Void> rollbackFuture =
-                                stop(rollbackArg, true).exceptionally(stopCause -> {
-                                    rollbackFailed(Exceptions.peel(stopCause));
-                                    return null;
-                                });
+                            stop(rollbackArg, true).exceptionally(stopCause -> {
+                                rollbackFailed(Exceptions.peel(stopCause));
+                                return null;
+                            });
 
                         return rollbackFuture.<V>thenCompose(unused -> exceptionallyCompletedFuture(cause));
                     } else {
@@ -223,8 +228,11 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                     }
                 }, executor).thenCompose(Function.identity()));
 
-        this.future = future;
-        return future;
+            this.future = future;
+            return future;
+        } finally {
+            unlock();
+        }
     }
 
     /**
@@ -250,64 +258,69 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
         return stop0(arg, rollback);
     }
 
-    private synchronized UnmodifiableFuture<Void> stop0(@Nullable U arg, boolean rollback) {
-        switch (state) {
-            case STARTING:
-                if (!rollback) {
-                    // Try again once started.
-                    return UnmodifiableFuture.wrap(
-                            future.exceptionally(unused -> null) // Ignore the exception.
-                                  .thenComposeAsync(unused -> stop(arg), executor));
-                } else {
-                    break;
-                }
-            case STOPPING:
-            case STOPPED:
-                @SuppressWarnings("unchecked")
-                final UnmodifiableFuture<Void> castFuture =
-                        (UnmodifiableFuture<Void>) future;
-                return castFuture;
-        }
-
-        assert state == State.STARTED || rollback : "state: " + state + ", rollback: " + rollback;
-        final State oldState = state;
-        state = State.STOPPING;
-
-        final CompletableFuture<Void> stopFuture = new CompletableFuture<>();
-        boolean submitted = false;
+    private UnmodifiableFuture<Void> stop0(@Nullable U arg, boolean rollback) {
+        lock();
         try {
-            executor.execute(() -> {
-                try {
-                    notifyListeners(State.STOPPING, null, arg, null);
-                    final CompletionStage<Void> f = doStop(arg);
-                    checkState(f != null, "doStop() returned null.");
-
-                    f.handle((unused, cause) -> {
-                        if (cause != null) {
-                            stopFuture.completeExceptionally(cause);
-                        } else {
-                            stopFuture.complete(null);
-                        }
-                        return null;
-                    });
-                } catch (Exception e) {
-                    stopFuture.completeExceptionally(e);
-                }
-            });
-            submitted = true;
-        } catch (Exception e) {
-            return exceptionallyCompletedFuture(e);
-        } finally {
-            if (!submitted) {
-                state = oldState;
+            switch (state) {
+                case STARTING:
+                    if (!rollback) {
+                        // Try again once started.
+                        return UnmodifiableFuture.wrap(
+                            future.exceptionally(unused -> null) // Ignore the exception.
+                                .thenComposeAsync(unused -> stop(arg), executor));
+                    } else {
+                        break;
+                    }
+                case STOPPING:
+                case STOPPED:
+                    @SuppressWarnings("unchecked")
+                    final UnmodifiableFuture<Void> castFuture =
+                        (UnmodifiableFuture<Void>) future;
+                    return castFuture;
             }
-        }
 
-        final UnmodifiableFuture<Void> future = UnmodifiableFuture.wrap(
+            assert state == State.STARTED || rollback : "state: " + state + ", rollback: " + rollback;
+            final State oldState = state;
+            state = State.STOPPING;
+
+            final CompletableFuture<Void> stopFuture = new CompletableFuture<>();
+            boolean submitted = false;
+            try {
+                executor.execute(() -> {
+                    try {
+                        notifyListeners(State.STOPPING, null, arg, null);
+                        final CompletionStage<Void> f = doStop(arg);
+                        checkState(f != null, "doStop() returned null.");
+
+                        f.handle((unused, cause) -> {
+                            if (cause != null) {
+                                stopFuture.completeExceptionally(cause);
+                            } else {
+                                stopFuture.complete(null);
+                            }
+                            return null;
+                        });
+                    } catch (Exception e) {
+                        stopFuture.completeExceptionally(e);
+                    }
+                });
+                submitted = true;
+            } catch (Exception e) {
+                return exceptionallyCompletedFuture(e);
+            } finally {
+                if (!submitted) {
+                    state = oldState;
+                }
+            }
+
+            final UnmodifiableFuture<Void> future = UnmodifiableFuture.wrap(
                 stopFuture.whenCompleteAsync((unused1, cause) -> enter(State.STOPPED, null, arg, null),
-                                             executor));
-        this.future = future;
-        return future;
+                    executor));
+            this.future = future;
+            return future;
+        } finally {
+            unlock();
+        }
     }
 
     @Override
@@ -355,9 +368,12 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
     }
 
     private void enter(State state, @Nullable T startArg, @Nullable U stopArg, @Nullable V startResult) {
-        synchronized (this) {
+        lock();
+        try {
             assert this.state != state : "transition to the same state: " + state;
             this.state = state;
+        } finally {
+            unlock();
         }
         notifyListeners(state, startArg, stopArg, startResult);
     }
@@ -476,5 +492,13 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
     @Override
     public String toString() {
         return state.name();
+    }
+
+    private void lock() {
+        reentrantLock.lock();
+    }
+
+    private void unlock() {
+        reentrantLock.unlock();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/StartStopSupport.java
@@ -161,7 +161,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                 case STARTED:
                     if (failIfStarted) {
                         return exceptionallyCompletedFuture(
-                            new IllegalStateException("must be stopped to start; currently " + state));
+                                new IllegalStateException("must be stopped to start; currently " + state));
                     } else {
                         @SuppressWarnings("unchecked")
                         final UnmodifiableFuture<V> castFuture = (UnmodifiableFuture<V>) future;
@@ -171,8 +171,8 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                     // A user called start() to restart, but not stopped completely yet.
                     // Try again once stopped.
                     return UnmodifiableFuture.wrap(
-                        future.exceptionally(unused -> null)
-                            .thenComposeAsync(unused -> start(arg, failIfStarted), executor));
+                            future.exceptionally(unused -> null)
+                                  .thenComposeAsync(unused -> start(arg, failIfStarted), executor));
             }
 
             assert state == State.STOPPED : "state: " + state;
@@ -210,21 +210,21 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
             }
 
             final UnmodifiableFuture<V> future = UnmodifiableFuture.wrap(
-                startFuture.handleAsync((result, cause) -> {
-                    if (cause != null) {
-                        // Failed to start. Stop and complete with the start failure cause.
-                        final CompletableFuture<Void> rollbackFuture =
-                            stop(rollbackArg, true).exceptionally(stopCause -> {
-                                rollbackFailed(Exceptions.peel(stopCause));
-                                return null;
-                            });
+                    startFuture.handleAsync((result, cause) -> {
+                        if (cause != null) {
+                            // Failed to start. Stop and complete with the start failure cause.
+                            final CompletableFuture<Void> rollbackFuture =
+                                    stop(rollbackArg, true).exceptionally(stopCause -> {
+                                        rollbackFailed(Exceptions.peel(stopCause));
+                                        return null;
+                                    });
 
-                        return rollbackFuture.<V>thenCompose(unused -> exceptionallyCompletedFuture(cause));
-                    } else {
-                        enter(State.STARTED, arg, null, result);
-                        return completedFuture(result);
-                    }
-                }, executor).thenCompose(Function.identity()));
+                            return rollbackFuture.<V>thenCompose(unused -> exceptionallyCompletedFuture(cause));
+                        } else {
+                            enter(State.STARTED, arg, null, result);
+                            return completedFuture(result);
+                        }
+                    }, executor).thenCompose(Function.identity()));
 
             this.future = future;
             return future;
@@ -264,8 +264,8 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                     if (!rollback) {
                         // Try again once started.
                         return UnmodifiableFuture.wrap(
-                            future.exceptionally(unused -> null) // Ignore the exception.
-                                .thenComposeAsync(unused -> stop(arg), executor));
+                                future.exceptionally(unused -> null) // Ignore the exception.
+                                      .thenComposeAsync(unused -> stop(arg), executor));
                     } else {
                         break;
                     }
@@ -273,7 +273,7 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
                 case STOPPED:
                     @SuppressWarnings("unchecked")
                     final UnmodifiableFuture<Void> castFuture =
-                        (UnmodifiableFuture<Void>) future;
+                            (UnmodifiableFuture<Void>) future;
                     return castFuture;
             }
 
@@ -312,8 +312,8 @@ public abstract class StartStopSupport<T, U, V, L> implements ListenableAsyncClo
             }
 
             final UnmodifiableFuture<Void> future = UnmodifiableFuture.wrap(
-                stopFuture.whenCompleteAsync((unused1, cause) -> enter(State.STOPPED, null, arg, null),
-                    executor));
+                    stopFuture.whenCompleteAsync((unused1, cause) -> enter(State.STOPPED, null, arg, null),
+                                                 executor));
             this.future = future;
             return future;
         } finally {


### PR DESCRIPTION
Motivation:

for virtual threading, we should replace synchronized with reentrantLock
resolves part of https://github.com/line/armeria/issues/4510

Modifications:

- replace all synchronized with reetrantLock under `common/util`
