### PR TITLE
Fix a bug where an EndpointGroup is not copied to a derived client.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -303,7 +303,7 @@ public final class Clients {
     public static <T> T newDerivedClient(
             T client, Function<? super ClientOptions, ClientOptions> configurator) {
         final ClientBuilderParams params = builderParams(client);
-        final ClientBuilder builder = builder(params.uri());
+        final ClientBuilder builder = newDerivedBuilder(params);
         builder.options(configurator.apply(params.options()));
 
         return newDerivedClient(builder, params.clientType());

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultBlockingWebClient.java
@@ -71,7 +71,7 @@ final class DefaultBlockingWebClient implements BlockingWebClient {
 
     @Override
     public Class<?> clientType() {
-        return delegate.clientType();
+        return BlockingWebClient.class;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -100,12 +100,14 @@ final class DefaultClientFactory implements ClientFactory {
         this.httpClientFactory = httpClientFactory;
 
         final List<ClientFactory> availableClientFactories = new ArrayList<>();
-        availableClientFactories.add(httpClientFactory);
 
+        // Give priority to custom client factories.
         Streams.stream(ServiceLoader.load(ClientFactoryProvider.class,
                                           DefaultClientFactory.class.getClassLoader()))
                .map(provider -> provider.newFactory(httpClientFactory))
                .forEach(availableClientFactories::add);
+
+        availableClientFactories.add(httpClientFactory);
 
         final ImmutableListMultimap.Builder<Scheme, ClientFactory> builder = ImmutableListMultimap.builder();
         for (ClientFactory f : availableClientFactories) {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRestClient.java
@@ -64,7 +64,7 @@ final class DefaultRestClient implements RestClient {
 
     @Override
     public Class<?> clientType() {
-        return delegate.clientType();
+        return RestClient.class;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/DerivedClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DerivedClientTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class DerivedClientTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.http(0);
+            sb.service("/", (ctx, req) -> {
+                return HttpResponse.of("OK");
+            });
+        }
+    };
+
+    @Test
+    void shouldDeriveWebClients() {
+        final ClientOptionValue<SuccessFunction> successFunction =
+                ClientOptions.SUCCESS_FUNCTION.doNewValue((ctx, log) -> true);
+        final WebClient webClient = WebClient.builder(server.httpUri())
+                                             .options(successFunction)
+                                             .build();
+
+        final ClientOptionValue<HttpHeaders> blockingClientOption =
+                ClientOptions.HEADERS.newValue(HttpHeaders.of("foo", "bar"));
+        final BlockingWebClient blockingClient =
+                Clients.newDerivedClient(webClient.blocking(), blockingClientOption);
+        final ClientOptions blockingClientOptions = blockingClient.options();
+        assertThat(blockingClientOptions.get(ClientOptions.SUCCESS_FUNCTION))
+                .isEqualTo(successFunction.value());
+        assertThat(blockingClientOptions.get(blockingClientOption.option()))
+                .isEqualTo(blockingClientOption.value());
+
+        final ClientOptionValue<HttpHeaders> restClientOption =
+                ClientOptions.HEADERS.newValue(HttpHeaders.of("foo", "baz"));
+        final RestClient restClient =
+                Clients.newDerivedClient(webClient.asRestClient(), restClientOption);
+
+        final ClientOptions restClientOptions = restClient.options();
+        assertThat(restClientOptions.get(ClientOptions.SUCCESS_FUNCTION))
+                .isEqualTo(successFunction.value());
+        assertThat(restClientOptions.get(restClientOption.option()))
+                .isEqualTo(restClientOption.value());
+    }
+
+    @Test
+    void shouldCopyEndpoint() throws InterruptedException {
+        final List<Endpoint> endpoints =
+                server.server().activePorts().values().stream()
+                      .map(serverPort -> {
+                          return Endpoint.of("127.0.0.1", serverPort.localAddress().getPort());
+                      }).collect(toImmutableList());
+        final EndpointGroup endpointGroup = EndpointGroup.of(endpoints);
+        final BlockingWebClient client = WebClient.builder(SessionProtocol.HTTP, endpointGroup)
+                                                  .factory(ClientFactory.insecure())
+                                                  .build()
+                                                  .blocking();
+        assertThat(client.get("/").status()).isEqualTo(HttpStatus.OK);
+        server.requestContextCaptor().take();
+
+        BlockingWebClient derivedWithAdditionalOptions =
+                Clients.newDerivedClient(client, ClientOptions.HEADERS.newValue(HttpHeaders.of("foo", "bar")));
+        assertThat(derivedWithAdditionalOptions.endpointGroup())
+                .isEqualTo(endpointGroup);
+        assertThat(derivedWithAdditionalOptions.get("/").status()).isEqualTo(HttpStatus.OK);
+        server.requestContextCaptor().take().request().headers().contains("foo", "bar");
+
+        derivedWithAdditionalOptions =
+                Clients.newDerivedClient(client, ImmutableList.of(
+                        ClientOptions.HEADERS.newValue(HttpHeaders.of("foo", "bar"))));
+        assertThat(derivedWithAdditionalOptions.endpointGroup())
+                .isEqualTo(endpointGroup);
+        assertThat(derivedWithAdditionalOptions.get("/").status()).isEqualTo(HttpStatus.OK);
+        server.requestContextCaptor().take().request().headers().contains("foo", "bar");
+
+        derivedWithAdditionalOptions =
+                Clients.newDerivedClient(client, options -> {
+                    return options.toBuilder()
+                                  .options(options)
+                                  .setHeader("foo", "bar")
+                                  .build();
+                });
+        assertThat(derivedWithAdditionalOptions.endpointGroup())
+                .isEqualTo(endpointGroup);
+        assertThat(derivedWithAdditionalOptions.get("/").status()).isEqualTo(HttpStatus.OK);
+        server.requestContextCaptor().take().request().headers().contains("foo", "bar");
+    }
+}

--- a/scala/scala_2.13/src/main/resources/META-INF/services/com.linecorp.armeria.client.ClientFactoryProvider
+++ b/scala/scala_2.13/src/main/resources/META-INF/services/com.linecorp.armeria.client.ClientFactoryProvider
@@ -1,0 +1,1 @@
+com.linecorp.armeria.client.scala.ScalaRestClientFactoryProvider

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClient.scala
@@ -180,7 +180,7 @@ private final class DefaultScalaRestClient(delegate: RestClient) extends ScalaRe
 
   override def uri(): URI = delegate.uri()
 
-  override def clientType(): Class[_] = delegate.clientType()
+  override def clientType(): Class[_] = classOf[ScalaRestClient]
 
   override def options(): ClientOptions = delegate.options()
 

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientFactory.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientFactory.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.scala
+
+import com.linecorp.armeria.client.{ClientBuilderParams, ClientFactory, DecoratingClientFactory, WebClient}
+import com.linecorp.armeria.common.{Scheme, SerializationFormat}
+
+private[scala] final class ScalaRestClientFactory(delegate: ClientFactory)
+    extends DecoratingClientFactory(delegate) {
+
+  override def isClientTypeSupported(clientType: Class[_]): Boolean =
+    classOf[ScalaRestClient].isAssignableFrom(clientType)
+
+  override def newClient(params: ClientBuilderParams): ScalaRestClient = {
+    val scheme = params.scheme()
+    val newParams = ClientBuilderParams.of(
+      Scheme.of(SerializationFormat.NONE, scheme.sessionProtocol()),
+      params.endpointGroup(),
+      params.absolutePathRef(),
+      classOf[WebClient],
+      params.options())
+    val webClient = super.newClient(newParams).asInstanceOf[WebClient]
+    ScalaRestClient(webClient)
+  }
+}

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientFactoryProvider.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientFactoryProvider.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.scala
+
+import com.linecorp.armeria.client.{ClientFactory, ClientFactoryProvider}
+
+/**
+ * A `ClientFactoryProvider` that creates a [[ScalaRestClient]].
+ */
+final class ScalaRestClientFactoryProvider extends ClientFactoryProvider {
+  override def newFactory(httpClientFactory: ClientFactory) =
+    new ScalaRestClientFactory(httpClientFactory)
+}

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/client/scala/RestClientSuite.scala
@@ -17,7 +17,7 @@
 package com.linecorp.armeria.client.scala
 
 import com.google.common.collect.Iterables
-import com.linecorp.armeria.client.RequestPreparationSetters
+import com.linecorp.armeria.client.{ClientOptions, Clients, RequestPreparationSetters, WebClient}
 import com.linecorp.armeria.common.{AggregatedHttpRequest, Cookie, ResponseEntity}
 import com.linecorp.armeria.scala.implicits._
 import com.linecorp.armeria.server.annotation._
@@ -127,6 +127,19 @@ class RestClientSuite extends FunSuite with ServerSuite {
           assert(overridden.getReturnType == classOf[ScalaRestClientPreparation])
         }
       })
+  }
+
+  test("should derive a new client") {
+    val webClient = WebClient
+      .builder("http://example.com")
+      .setHeader("foo", "bar")
+      .build()
+    val maxResponseLength = webClient.options().maxResponseLength()
+    val restClient = ScalaRestClient(webClient)
+    val derivedClient =
+      Clients.newDerivedClient(restClient, ClientOptions.MAX_RESPONSE_LENGTH.newValue(maxResponseLength + 1))
+    assertEquals(derivedClient.options().headers().get("foo"), "bar")
+    assertEquals(derivedClient.options().maxResponseLength(), maxResponseLength + 1)
   }
 }
 


### PR DESCRIPTION
Motivation:

When a new client is derived from an existing client using `Clients.newDerivedClient()`, all options should be copied to the new client and the original `EndpointGroup` should be reserved. It seems to have already been considered by `newDerivedBuilder()` but there is one API missing. https://github.com/line/armeria/blob/81ac954d41ee8420898ba298f9d0a766c3d37b71/core/src/main/java/com/linecorp/armeria/client/Clients.java#L317-L319
The following API called `builder` instead of `newDerivedBuilder`. 
https://github.com/line/armeria/blob/81ac954d41ee8420898ba298f9d0a766c3d37b71/core/src/main/java/com/linecorp/armeria/client/Clients.java#L303-L306
As a consequence, a derived client tries to send a request to `armeria-group-`.
https://github.com/line/armeria/blob/81ac954d41ee8420898ba298f9d0a766c3d37b71/core/src/main/java/com/linecorp/armeria/client/DefaultClientBuilderParams.java#L92-L92

Modifications:

- Fixed `newDerivedClient(T, Function)` to call `newDerivedBuilder()`

Result:

`EndpointGroup` is now correctly copied to a newly derived client.
