### PR TITLE
Fix to set cause correctly in RetryingClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -331,8 +331,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             response.aggregate().handle((aggregated, cause) -> {
                 if (cause != null) {
                     derivedCtx.logBuilder().endResponse(cause);
-                    handleMaybeErrorResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes,
-                                             future, derivedCtx, HttpResponse.ofFailure(cause), cause);
+                    handleResponseWithoutContent(config, ctx, rootReqDuplicator, originalReq, returnedRes,
+                                                 future, derivedCtx, HttpResponse.ofFailure(cause), cause);
                     return null;
                 }
                 handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
@@ -345,11 +345,11 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         }
     }
 
-    private void handleMaybeErrorResponse(RetryConfig<HttpResponse> config, ClientRequestContext ctx,
-                                          HttpRequestDuplicator rootReqDuplicator, HttpRequest originalReq,
-                                          HttpResponse returnedRes, CompletableFuture<HttpResponse> future,
-                                          ClientRequestContext derivedCtx, HttpResponse response,
-                                          @Nullable Throwable responseCause) {
+    private void handleResponseWithoutContent(RetryConfig<HttpResponse> config, ClientRequestContext ctx,
+                                              HttpRequestDuplicator rootReqDuplicator, HttpRequest originalReq,
+                                              HttpResponse returnedRes, CompletableFuture<HttpResponse> future,
+                                              ClientRequestContext derivedCtx, HttpResponse response,
+                                              @Nullable Throwable responseCause) {
         try {
             final RetryRule retryRule = retryRule(config);
             final CompletionStage<RetryDecision> f = retryRule.shouldRetry(derivedCtx, responseCause);
@@ -423,8 +423,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             }
             final HttpResponse response0 = aggregatedRes != null ? aggregatedRes.toHttpResponse()
                                                                  : response;
-            handleMaybeErrorResponse(retryConfig, ctx, rootReqDuplicator, originalReq, returnedRes,
-                                     future, derivedCtx, response0, responseCause);
+            handleResponseWithoutContent(retryConfig, ctx, rootReqDuplicator, originalReq, returnedRes,
+                                         future, derivedCtx, response0, responseCause);
         });
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -329,7 +329,13 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         if (!ctx.exchangeType().isResponseStreaming() || config.requiresResponseTrailers()) {
             // XXX(ikhoon): Should we use `response.aggregateWithPooledObjects()`?
             response.aggregate().handle((aggregated, cause) -> {
-                final HttpResponse response0 = cause != null ? HttpResponse.ofFailure(cause) : null;
+                final HttpResponse response0;
+                if (cause != null) {
+                    derivedCtx.logBuilder().endResponse(cause);
+                    response0 = HttpResponse.ofFailure(cause);
+                } else {
+                    response0 = null;
+                }
                 handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
                                response0, aggregated);
                 return null;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -329,20 +329,39 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         if (!ctx.exchangeType().isResponseStreaming() || config.requiresResponseTrailers()) {
             // XXX(ikhoon): Should we use `response.aggregateWithPooledObjects()`?
             response.aggregate().handle((aggregated, cause) -> {
-                final HttpResponse response0;
                 if (cause != null) {
                     derivedCtx.logBuilder().endResponse(cause);
-                    response0 = HttpResponse.ofFailure(cause);
-                } else {
-                    response0 = null;
+                    handleMaybeErrorResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes,
+                                             future, derivedCtx, HttpResponse.ofFailure(cause), cause);
+                    return null;
                 }
                 handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes, future, derivedCtx,
-                               response0, aggregated);
+                               null, aggregated);
                 return null;
             });
         } else {
             handleResponse(config, ctx, rootReqDuplicator, originalReq, returnedRes,
                            future, derivedCtx, response, null);
+        }
+    }
+
+    private void handleMaybeErrorResponse(RetryConfig<HttpResponse> config, ClientRequestContext ctx,
+                                          HttpRequestDuplicator rootReqDuplicator, HttpRequest originalReq,
+                                          HttpResponse returnedRes, CompletableFuture<HttpResponse> future,
+                                          ClientRequestContext derivedCtx, HttpResponse response,
+                                          @Nullable Throwable responseCause) {
+        try {
+            final RetryRule retryRule = retryRule(config);
+            final CompletionStage<RetryDecision> f = retryRule.shouldRetry(derivedCtx, responseCause);
+            f.handle((decision, shouldRetryCause) -> {
+                warnIfExceptionIsRaised(retryRule, shouldRetryCause);
+                handleRetryDecision(decision, ctx, derivedCtx, rootReqDuplicator,
+                                    originalReq, returnedRes, future, response);
+                return null;
+            });
+        } catch (Throwable cause) {
+            response.abort();
+            handleException(ctx, rootReqDuplicator, future, cause, false);
         }
     }
 
@@ -402,23 +421,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                 }
                 return;
             }
-            try {
-                final RetryRule retryRule = retryRule(retryConfig);
-                final CompletionStage<RetryDecision> f = retryRule.shouldRetry(derivedCtx, responseCause);
-                final HttpResponse response0 = aggregatedRes != null ? aggregatedRes.toHttpResponse()
-                                                                     : response;
-                f.handle((decision, cause) -> {
-                    warnIfExceptionIsRaised(retryRule, cause);
-                    handleRetryDecision(decision, ctx, derivedCtx, rootReqDuplicator,
-                                        originalReq, returnedRes, future, response0);
-                    return null;
-                });
-            } catch (Throwable cause) {
-                if (response != null) {
-                    response.abort(cause);
-                }
-                handleException(ctx, rootReqDuplicator, future, cause, false);
-            }
+            final HttpResponse response0 = aggregatedRes != null ? aggregatedRes.toHttpResponse()
+                                                                 : response;
+            handleMaybeErrorResponse(retryConfig, ctx, rootReqDuplicator, originalReq, returnedRes,
+                                     future, derivedCtx, response0, responseCause);
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithDecoratorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithDecoratorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RetryingClientWithDecoratorTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void responseCauseIsSetWhenExceptionIsRaisedInDecorator() throws InterruptedException {
+        final AtomicInteger onExceptionCounter = new AtomicInteger();
+        final AtomicInteger logExceptionCounter = new AtomicInteger();
+        // Retry only 3 times.
+        final RetryRule retryRule = RetryRule.builder()
+                                             .onException((ctx, cause) -> {
+                                                 assert cause instanceof AnticipatedException;
+                                                 return onExceptionCounter.incrementAndGet() != 3;
+                                             })
+                                             .onResponseTrailers((ctx, trailers) -> false)
+                                             .thenBackoff();
+        final WebClient client =
+                WebClient.builder(server.httpUri())
+                         .decorator((delegate, ctx, req) -> {
+                             ctx.log()
+                                .whenAvailable(RequestLogProperty.RESPONSE_CAUSE)
+                                .thenAccept(log -> logExceptionCounter.incrementAndGet());
+                             return delegate.execute(ctx, req);
+                         })
+                         .decorator((delegate, ctx, req) -> delegate.execute(ctx, req)
+                                                                    .mapHeaders(headers -> {
+                                                                        throw new AnticipatedException();
+                                                                    }))
+                         .decorator(RetryingClient.builder(retryRule).newDecorator())
+                         .build();
+        assertThatThrownBy(() -> client.get("/hello").aggregate().join())
+                .hasCauseInstanceOf(AnticipatedException.class);
+        assertThat(onExceptionCounter.get()).isSameAs(3);
+        assertThat(logExceptionCounter.get()).isSameAs(3);
+    }
+}


### PR DESCRIPTION
Motivation:
When an exception is raised in the decorator between `RetryingClient` and the network layer, the exception is not correctly set to `RequestLog.responseCause()` so that users cannot use the exception to make a decision.

Modification:
- Call `derivedCtx`'s `RequestLogBuilder.endResponse(cause)` when the response is completed exceptionally.

Result:
- Close #4558 
- You can now use the exception, which is raised in the decorator, to make a decision for retrying.