### PR TITLE
Make `AuthFailureHandler` take peeled exceptions

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
@@ -123,6 +123,6 @@ public final class AuthService extends SimpleDecoratingHttpService {
                                        @Nullable Throwable cause) throws Exception {
         final AuthFailureHandler handler = authorizerFailureHandler == null ? defaultFailureHandler
                                                                             : authorizerFailureHandler;
-        return handler.authFailed(delegate, ctx, req, cause);
+        return handler.authFailed(delegate, ctx, req, Exceptions.peel(cause));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -26,6 +26,8 @@ import java.util.Base64.Encoder;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -41,15 +43,19 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.HttpService;
@@ -418,6 +424,25 @@ class AuthServiceTest {
                         "HTTP/1.1 500 Internal Server Error");
             }
         }
+    }
+
+    @Test
+    void shouldPeelRedundantAuthorizerExceptions() throws Exception {
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AuthService service =
+                AuthService.builder()
+                           .add((ctx, data) -> {
+                               return UnmodifiableFuture.exceptionallyCompletedFuture(
+                                       new AnticipatedException());
+                           })
+                           .onFailure((delegate, ctx, req, cause) -> {
+                               causeRef.set(cause);
+                               return HttpResponse.of(HttpStatus.FORBIDDEN);
+                           }).build((ctx, req) -> HttpResponse.of("OK"));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final HttpResponse response = service.serve(ctx, ctx.request());
+        assertThat(response.aggregate().join().status()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(causeRef.get()).isInstanceOf(AnticipatedException.class);
     }
 
     private static HttpRequestBase getRequest(String path, String authorization) {


### PR DESCRIPTION
Motivation:

An `AuthFailureHandler` could receive an exception wrapped by `CompletionException`. See #4502 for the detail.

Modifications:

- Peel redundant exceptions before invoking `AuthFailureHandler.authFailed()`

Result:

- An exception raised in `Authorizer` is now properly peeled using `Exceptions.peel()`.
- Fixes #4502