### PR TITLE
Remove uncompressed JavaScript files from the core artifact.

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.linecorp.armeria.server.docs.DocService;
+
+class DocServiceAssetCompressionTest {
+
+    @ValueSource(strings = {"index.html", "main.js"})
+    @ParameterizedTest
+    void shouldNotIncludeUncompressedAssets(String file) {
+        assertThat(DocService.class.getResource(file)).isNull();
+        assertThat(DocService.class.getResource(file + ".br")).isNotNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -28,6 +28,9 @@ class DocServiceAssetCompressionTest {
     @ValueSource(strings = {"index.html", "main.js"})
     @ParameterizedTest
     void shouldNotIncludeUncompressedAssets(String file) {
+        // `doc-client` should produce compressed asserts when building bundle files for DocService and
+        // they should exist in the classpath of the core module.
+        // If Gradle build task is excuted with `-PnoWeb`, this test may be broken.
         assertThat(DocService.class.getResource(file)).isNull();
         assertThat(DocService.class.getResource(file + ".br")).isNotNull();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -30,7 +30,7 @@ class DocServiceAssetCompressionTest {
     void shouldNotIncludeUncompressedAssets(String file) {
         // `doc-client` should produce compressed asserts when building bundle files for DocService and
         // they should exist in the classpath of the core module.
-        // If Gradle build task is excuted with `-PnoWeb`, this test may be broken.
+        // If Gradle build task is executed with `-PnoWeb`, this test may be broken.
         assertThat(DocService.class.getResource(file)).isNull();
         assertThat(DocService.class.getResource(file + ".br")).isNotNull();
     }

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -143,6 +143,8 @@ if (!isDev) {
     test: /\.(js|css|html|svg)$/,
     algorithm: 'brotliCompress',
     filename: '[path][base].br',
+    // If a `Accept-Encoding` is not specified, `DocService` decompresses the compressed content on the fly.
+    deleteOriginalAssets: true
   }) as any);
 }
 


### PR DESCRIPTION
Motivation:

The size of an uncompressed js file for `DocService` is about 2.5MB. The size is quite huge. It would be worth compressing the file since modern browsers can decompress the file after receiving it. If some user agents do not support compression, DocService automatically uncompresses the content on the fly before sending out the file.

Modifications:

- Add `deleteOriginalAssets` option to `CompressionWebpackPlugin`
  https://webpack.js.org/plugins/compression-webpack-plugin/#deleteoriginalassets
- Add a unit test to ensure the original asserts are deleted

Result:

- Deleted uncompressed `DocService` assets that were added unintentionally.
- Fixes #4500
