### PR TITLE
Add documentation on `@Produces` annotation on void methods

### DIFF
--- a/site/src/pages/docs/server-annotated-service.mdx
+++ b/site/src/pages/docs/server-annotated-service.mdx
@@ -136,6 +136,19 @@ public class MyAnnotatedService {
 }
 ```
 
+<Tip>
+
+  Note that even if the return is `void` or `Void`, `200 OK` will be returned if a <type://@Produces>
+  annotation is added.
+
+  ```java
+  @ProducesJson
+  @Post("/users/{name}")
+  public void createUser(@Param("name") String name) { ... } // 200 is returned
+  ```
+
+</Tip>
+
 You can define a service method which handles a request only if it contains a header or parameter the method
 requires. The following methods are bound to the same path `/users` but a request may be routed based on the
 `client-type` header.


### PR DESCRIPTION
Motivation:

There is a nuance change in armeria's behavior when a void method is annotated with `@Produces`. https://github.com/line/armeria/issues/4390

Modifications:

- Add documentation
![Screen Shot 2022-12-12 at 10 45 12 PM](https://user-images.githubusercontent.com/8510579/207062748-bdcbe4a9-12d0-4114-81d8-986c8b847414.png)


Result:

- Less confusion

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
