### PR TITLE
Return 204 on void return types irregardless of `@Produces`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -259,13 +259,12 @@ class AnnotatedServiceTest {
         @ResponseConverter(VoidTo200ResponseConverter.class)
         public void void200() {}
 
-        @Get("/void/json/200")
+        @Get("/void/produces/204")
         @ProducesJson
-        public void voidJson200() {}
+        public void voidProduces204() {}
 
         @Get("/void/json/204")
         @StatusCode(204)
-        @ProducesJson
         public void voidJson204() {}
 
         @Get("/voidPublisher/204")
@@ -279,15 +278,14 @@ class AnnotatedServiceTest {
             return Mono.empty();
         }
 
-        @Get("/voidPublisher/json/200")
+        @Get("/voidPublisher/produces/204")
         @ProducesJson
-        public Publisher<Void> voidPublisherJson200() {
+        public Publisher<Void> voidPublisherProduces204() {
             return Mono.empty();
         }
 
         @Get("/voidPublisher/json/204")
         @StatusCode(204)
-        @ProducesJson
         public Publisher<Void> voidPublisherJson204() {
             return Mono.empty();
         }
@@ -303,15 +301,14 @@ class AnnotatedServiceTest {
             return UnmodifiableFuture.completedFuture(null);
         }
 
-        @Get("/voidFuture/json/200")
+        @Get("/voidFuture/produces/204")
         @ProducesJson
-        public CompletionStage<Void> voidFutureJson200() {
+        public CompletionStage<Void> voidFutureProduces204() {
             return UnmodifiableFuture.completedFuture(null);
         }
 
         @Get("/voidFuture/json/204")
         @StatusCode(204)
-        @ProducesJson
         public CompletionStage<Void> voidFutureJson204() {
             return UnmodifiableFuture.completedFuture(null);
         }
@@ -1147,9 +1144,8 @@ class AnnotatedServiceTest {
             testStatusCode(hc, get("/1/" + returnType + "/204"), 204);
             testBodyAndContentType(hc, get("/1/" + returnType + "/200"),
                                    "200 OK", MediaType.PLAIN_TEXT_UTF_8.toString());
+            testStatusCode(hc, get("/1/" + returnType + "/produces/204"), 204);
             testStatusCode(hc, get("/1/" + returnType + "/json/204"), 204);
-            testBodyAndContentType(hc, get("/1/" + returnType + "/json/200"),
-                                   "null", MediaType.JSON_UTF_8.toString());
         }
     }
 


### PR DESCRIPTION
Motivation:

Currently for annotated services, the return type of void methods can be `200` if a `@Produces` annotation is added.
```
@Get("/")
public void get() {
    // 204
}

@Get("/")
@ProducesJson
public void getJson() {
    // 200
}
```

We have decided to always return 204 (with the exception of `@StatusCode`) for void methods.
1. It may be more confusing for users under what conditions 200/204 is returned.
2. It is difficult to keep track and return valid values for each `Content-Type`. For instance, `200` with `Content-Type: application/json` returns `null` with the current implementation by default.
However, `200 OK` with `Content-Type: application/xml` won't return a valid `xml`. (`armeria` returns an empty response)

Modifications:

- Set the default return status code to 204 irregardless of `@Produces` annotation
- Leave a warning log if `@Produces` is annotated on the method level for a `void` returning method.

Result:

- Clearer behavior of annotated services.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
