### PR TITLE
`Flags#meterRegistry` returns a `MeterRegistry`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -30,8 +30,8 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.TransientServiceOption;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 /**
  * Implementation of {@link FlagsProvider} which provides default values to {@link Flags}.
@@ -408,7 +408,7 @@ final class DefaultFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public CompositeMeterRegistry meterRegistry() {
+    public MeterRegistry meterRegistry() {
         return Metrics.globalRegistry;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -71,8 +71,8 @@ import com.linecorp.armeria.server.file.FileServiceBuilder;
 import com.linecorp.armeria.server.file.HttpFile;
 import com.linecorp.armeria.server.logging.LoggingService;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -379,7 +379,7 @@ public final class Flags {
     private static final Sampler<? super RequestContext> REQUEST_CONTEXT_LEAK_DETECTION_SAMPLER =
             getValue(FlagsProvider::requestContextLeakDetectionSampler, "requestContextLeakDetectionSampler");
 
-    private static final CompositeMeterRegistry METER_REGISTRY =
+    private static final MeterRegistry METER_REGISTRY =
             getValue(FlagsProvider::meterRegistry, "meterRegistry");
 
     /**
@@ -1317,12 +1317,12 @@ public final class Flags {
     }
 
     /**
-     * Returns the {@link CompositeMeterRegistry} where armeria records metrics to by default.
+     * Returns the {@link MeterRegistry} where armeria records metrics to by default.
      *
      * <p>The default value of this flag is {@link Metrics#globalRegistry}.
      */
     @UnstableApi
-    public static CompositeMeterRegistry meterRegistry() {
+    public static MeterRegistry meterRegistry() {
         return METER_REGISTRY;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -54,8 +54,8 @@ import com.linecorp.armeria.server.file.FileService;
 import com.linecorp.armeria.server.file.FileServiceBuilder;
 import com.linecorp.armeria.server.file.HttpFile;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -980,13 +980,13 @@ public interface FlagsProvider {
     }
 
     /**
-     * Returns the {@link CompositeMeterRegistry} where armeria records metrics to by default.
+     * Returns the {@link MeterRegistry} where armeria records metrics to by default.
      *
      * <p>The default value of this flag is {@link Metrics#globalRegistry}.
      */
     @Nullable
     @UnstableApi
-    default CompositeMeterRegistry meterRegistry() {
+    default MeterRegistry meterRegistry() {
         return null;
     }
 }

--- a/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
+++ b/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 
 import com.linecorp.armeria.common.util.InetAddressPredicates;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public final class BaseFlagsProvider implements FlagsProvider {
@@ -86,7 +87,7 @@ public final class BaseFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public CompositeMeterRegistry meterRegistry() {
+    public MeterRegistry meterRegistry() {
         return new CompositeMeterRegistry();
     }
 }


### PR DESCRIPTION
Motivation:

We've decided to return `MeterRegistry` for `Flags#meterRegistry` on the grounds that
1) We would be exposing a mutable API by returning a `CompositeMeterRegistry`
2) MeterRegistry is more general

Modifications:

- Modify all instances of `CompositeMeterRegistry` to `MeterRegistry`

Result:

- `Flags.meterRegistry` returns a `MeterRegistry`