### PR TITLE
Support @Blocking annotation for gRPC services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -49,7 +49,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 /**
  * A utility class which helps to get annotations from an {@link AnnotatedElement}.
  */
-final class AnnotationUtil {
+public final class AnnotationUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(AnnotationUtil.class);
 
@@ -102,7 +102,7 @@ final class AnnotationUtil {
      * @param annotationType the type of the annotation to find
      */
     @Nullable
-    static <T extends Annotation> T findFirst(AnnotatedElement element, Class<T> annotationType) {
+    public static <T extends Annotation> T findFirst(AnnotatedElement element, Class<T> annotationType) {
         final List<T> found = findAll(element, annotationType);
         return found.isEmpty() ? null : found.get(0);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -272,7 +272,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
             SerializationFormat serializationFormat) {
         final MethodDescriptor<I, O> methodDescriptor = methodDef.getMethodDescriptor();
         final Executor blockingExecutor;
-        if (useBlockingTaskExecutor) {
+        if (useBlockingTaskExecutor || registry.needToUseBlockingTaskExecutor(methodDef)) {
             blockingExecutor = MoreExecutors.newSequentialExecutor(ctx.blockingTaskExecutor());
         } else {
             blockingExecutor = null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
@@ -147,6 +147,10 @@ final class HandlerRegistry {
         return !annotationDecorators.isEmpty() || !additionalDecorators.isEmpty();
     }
 
+    boolean needToUseBlockingTaskExecutor(ServerMethodDefinition<?, ?> methodDef) {
+        return needToUseBlockingMethodDefs.contains(methodDef);
+    }
+
     Map<ServerMethodDefinition<?, ?>, HttpService> applyDecorators(
             HttpService delegate, DependencyInjector dependencyInjector) {
         final Map<ServerMethodDefinition<?, ?>, HttpService> decorated = new HashMap<>();
@@ -168,10 +172,6 @@ final class HandlerRegistry {
         }
 
         return ImmutableMap.copyOf(decorated);
-    }
-
-    boolean needToUseBlockingTaskExecutor(ServerMethodDefinition<?, ?> methodDef) {
-        return needToUseBlockingMethodDefs.contains(methodDef);
     }
 
     private static HttpService applyDecorators(

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
@@ -97,7 +97,7 @@ final class HandlerRegistry {
     private final Map<ServerMethodDefinition<?, ?>, List<DecoratorAndOrder>> annotationDecorators;
     private final Map<ServerMethodDefinition<?, ?>, List<? extends Function<? super HttpService,
             ? extends HttpService>>> additionalDecorators;
-    private final Set<ServerMethodDefinition<?, ?>> needToUseBlockingMethodDefs;
+    private final Set<ServerMethodDefinition<?, ?>> blockingMethods;
 
     private HandlerRegistry(List<ServerServiceDefinition> services,
                             Map<String, ServerMethodDefinition<?, ?>> methods,
@@ -106,15 +106,14 @@ final class HandlerRegistry {
                             Map<ServerMethodDefinition<?, ?>, List<DecoratorAndOrder>> annotationDecorators,
                             Map<ServerMethodDefinition<?, ?>, List<? extends Function<? super HttpService,
                                     ? extends HttpService>>> additionalDecorators,
-                            Set<ServerMethodDefinition<?, ?>> needToUseBlockingMethodDefs) {
+                            Set<ServerMethodDefinition<?, ?>> blockingMethods) {
         this.services = requireNonNull(services, "services");
         this.methods = requireNonNull(methods, "methods");
         this.methodsByRoute = requireNonNull(methodsByRoute, "methodsByRoute");
         this.simpleMethodNames = requireNonNull(simpleMethodNames, "simpleMethodNames");
         this.annotationDecorators = requireNonNull(annotationDecorators, "annotationDecorators");
         this.additionalDecorators = requireNonNull(additionalDecorators, "additionalDecorators");
-        this.needToUseBlockingMethodDefs = requireNonNull(needToUseBlockingMethodDefs,
-                                                          "needToUseBlockingMethodDefs");
+        this.blockingMethods = requireNonNull(blockingMethods, "blockingMethods");
     }
 
     @Nullable
@@ -148,7 +147,7 @@ final class HandlerRegistry {
     }
 
     boolean needToUseBlockingTaskExecutor(ServerMethodDefinition<?, ?> methodDef) {
-        return needToUseBlockingMethodDefs.contains(methodDef);
+        return blockingMethods.contains(methodDef);
     }
 
     Map<ServerMethodDefinition<?, ?>, HttpService> applyDecorators(
@@ -253,7 +252,7 @@ final class HandlerRegistry {
             final ImmutableMap.Builder<ServerMethodDefinition<?, ?>,
                     List<? extends Function<? super HttpService, ? extends HttpService>>>
                     additionalDecoratorsBuilder = ImmutableMap.builder();
-            final ImmutableSet.Builder<ServerMethodDefinition<?, ?>> needToUseBlockingMethodDefs =
+            final ImmutableSet.Builder<ServerMethodDefinition<?, ?>> blockingMethods =
                     ImmutableSet.builder();
 
             for (Entry entry : entries) {
@@ -298,7 +297,7 @@ final class HandlerRegistry {
                                 annotationDecorators.put(methodDefinition, decoratorAndOrders);
                             }
                             if (needToUseBlockingTaskExecutor(type, method)) {
-                                needToUseBlockingMethodDefs.add(methodDefinition);
+                                blockingMethods.add(methodDefinition);
                             }
                         }
                     }
@@ -332,7 +331,7 @@ final class HandlerRegistry {
                                 annotationDecorators.put(methodDefinition, decoratorAndOrders);
                             }
                             if (needToUseBlockingTaskExecutor(type, method0)) {
-                                needToUseBlockingMethodDefs.add(methodDefinition);
+                                blockingMethods.add(methodDefinition);
                             }
                         }
                     }
@@ -345,7 +344,7 @@ final class HandlerRegistry {
                                        bareMethodNames.buildKeepingLast(),
                                        annotationDecorators.build(),
                                        additionalDecoratorsBuilder.build(),
-                                       needToUseBlockingMethodDefs.build());
+                                       blockingMethods.build());
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
@@ -23,7 +23,8 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer.MethodName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -47,7 +48,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.stub.StreamObserver;
 
-@TestMethodOrder(MethodName.class)
+@TestMethodOrder(OrderAnnotation.class)
 class GrpcServiceBlockingTest {
     private static final AtomicInteger blockingCount = new AtomicInteger();
 
@@ -83,6 +84,7 @@ class GrpcServiceBlockingTest {
     };
 
     @Test
+    @Order(1)
     void nonBlockingCall() {
         final TestServiceBlockingStub client =
                 GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
@@ -91,6 +93,7 @@ class GrpcServiceBlockingTest {
     }
 
     @Test
+    @Order(2)
     void blockingOnClass() {
         final UnitTestFooServiceBlockingStub client =
                 GrpcClients.newClient(server.httpUri(), UnitTestFooServiceBlockingStub.class);
@@ -104,6 +107,7 @@ class GrpcServiceBlockingTest {
     }
 
     @Test
+    @Order(3)
     void blockingOnMethod() {
         final UnitTestBarServiceBlockingStub client =
                 GrpcClients.newClient(server.httpUri(), UnitTestBarServiceBlockingStub.class);
@@ -117,6 +121,7 @@ class GrpcServiceBlockingTest {
     }
 
     @Test
+    @Order(4)
     void prefixServiceBlockingOnMethod() {
         final TestServiceBlockingStub client = GrpcClients
                 .builder(server.httpUri())
@@ -137,6 +142,7 @@ class GrpcServiceBlockingTest {
     }
 
     @Test
+    @Order(5)
     void solelyAddedMethodBlockingOnClass() {
         final TestServiceBlockingStub client = GrpcClients
                 .builder(server.httpUri())

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.ThreadFactories;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.grpc.testing.UnitTestBarServiceGrpc.UnitTestBarServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.UnitTestBarServiceGrpc.UnitTestBarServiceImplBase;
+import com.linecorp.armeria.grpc.testing.UnitTestFooServiceGrpc.UnitTestFooServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.UnitTestFooServiceGrpc.UnitTestFooServiceImplBase;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.Blocking;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.stub.StreamObserver;
+
+class GrpcServiceBlockingTest {
+    private static final AtomicInteger blockingCount = new AtomicInteger();
+
+    private static final ScheduledExecutorService executor =
+            new ScheduledThreadPoolExecutor(1, ThreadFactories.newThreadFactory("blocking-test", true)) {
+                @Override
+                protected void beforeExecute(Thread t, Runnable r) {
+                    blockingCount.incrementAndGet();
+                }
+            };
+
+    @BeforeEach
+    void clear() {
+        blockingCount.set(0);
+    }
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.requestTimeoutMillis(5000)
+              .decorator(LoggingService.newDecorator())
+              .service(GrpcService.builder()
+                                  .addService(new TestServiceImpl())
+                                  .addService(new UnitTestFooServiceImpl())
+                                  .addService(new UnitTestBarServiceImpl())
+                                  .addService("/foo", new FooTestServiceImpl())
+                                  .addService("/bar", new BarTestServiceImpl(),
+                                              TestServiceGrpc.getUnaryCallMethod())
+                                  .build())
+              .blockingTaskExecutor(executor, true);
+        }
+    };
+
+    @Test
+    void nonBlockingCall() {
+        final TestServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
+        assertThat(client.unaryCall(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasValue(0);
+    }
+
+    @Test
+    void blockingOnClass() {
+        final UnitTestFooServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), UnitTestFooServiceBlockingStub.class);
+        assertThat(client.staticUnaryCall(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasPositiveValue();
+
+        blockingCount.set(0);
+
+        assertThat(client.staticUnaryCall2(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasPositiveValue();
+    }
+
+    @Test
+    void blockingOnMethod() {
+        final UnitTestBarServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), UnitTestBarServiceBlockingStub.class);
+        assertThat(client.staticUnaryCall(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasPositiveValue();
+
+        blockingCount.set(0);
+
+        assertThat(client.staticUnaryCall2(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasValue(0);
+    }
+
+    @Test
+    void prefixServiceBlockingOnMethod() {
+        final TestServiceBlockingStub client = GrpcClients
+                .builder(server.httpUri())
+                .decorator((delegate, ctx, req) -> {
+                    final String path = req.path();
+                    final HttpRequest newReq = req.mapHeaders(
+                            headers -> headers.toBuilder()
+                                              .path(path.replace(
+                                                      "armeria.grpc.testing.TestService",
+                                                      "foo"))
+                                              .build());
+                    ctx.updateRequest(newReq);
+                    return delegate.execute(ctx, newReq);
+                })
+                .build(TestServiceBlockingStub.class);
+        assertThat(client.unaryCall(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasPositiveValue();
+    }
+
+    @Test
+    void solelyAddedMethodBlockingOnClass() {
+        final TestServiceBlockingStub client = GrpcClients
+                .builder(server.httpUri())
+                .decorator((delegate, ctx, req) -> {
+                    final HttpRequest newReq = req.mapHeaders(
+                            headers -> headers.toBuilder().path("/bar").build());
+                    ctx.updateRequest(newReq);
+                    return delegate.execute(ctx, newReq);
+                })
+                .build(TestServiceBlockingStub.class);
+        assertThat(client.unaryCall(SimpleRequest.getDefaultInstance())).isNotNull();
+        assertThat(blockingCount).hasPositiveValue();
+    }
+
+    private static class TestServiceImpl extends TestServiceImplBase {
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("test user")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Blocking
+    private static class UnitTestFooServiceImpl extends UnitTestFooServiceImplBase {
+        @Override
+        public void staticUnaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void staticUnaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static class UnitTestBarServiceImpl extends UnitTestBarServiceImplBase {
+
+        @Override
+        @Blocking
+        public void staticUnaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void staticUnaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+    }
+
+    private static class FooTestServiceImpl extends TestServiceImplBase {
+
+        @Override
+        @Blocking
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("foo user")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+
+    @Blocking
+    private static class BarTestServiceImpl extends TestServiceImplBase {
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("bar user")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void unaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.newBuilder()
+                                                  .setUsername("not registered")
+                                                  .build());
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBlockingTest.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.grpc.GrpcClients;
@@ -45,6 +47,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.stub.StreamObserver;
 
+@TestMethodOrder(MethodName.class)
 class GrpcServiceBlockingTest {
     private static final AtomicInteger blockingCount = new AtomicInteger();
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/test.proto
@@ -170,8 +170,10 @@ service ReconnectService {
 
 service UnitTestFooService {
   rpc StaticUnaryCall(SimpleRequest) returns (SimpleResponse);
+  rpc StaticUnaryCall2(SimpleRequest) returns (SimpleResponse);
 }
 
 service UnitTestBarService {
   rpc StaticUnaryCall(SimpleRequest) returns (SimpleResponse);
+  rpc StaticUnaryCall2(SimpleRequest) returns (SimpleResponse);
 }


### PR DESCRIPTION
Motivation:

It is described in the following Issue.
https://github.com/line/armeria/issues/4389

Modifications:

- When building `HandlerRegistry`, find `ServerMethodDefinition`  that needs to be executed on the blocking executor
- In `FramedGrpcService#startCall`, in addition to `useBlockingTaskExecutor` field, check if the blocking executor is used for each `ServerMethodDefinition`.

Result:

- Closes #4389
- Users can easily know whether a service runs on a blocking executor.
- Selectively apply a blocking executor to the methods.

```java
class MyGrpcServiceImpl extends MyGrpcServiceImplBase {
    @Blocking
    public void blockingCall(...) {
        ...
    }

    public void nonBlockingCall(...) {
        ...
    }
}

@Blocking
class MyBlockingGrpcServiceImpl extends MyGrpcServiceImplBase {
    
    public void blockingCall1(...) {
        ...
    }

    public void blockingCall2(...) {
        ...
    }
}

```