### PR TITLE
Raise an exception if TLS is set to port-based virtual host

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
@@ -28,7 +28,11 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.netty.util.AttributeKey;
 
-interface RequestOptionsSetters {
+/**
+ * Provides the setters for building {@link RequestOptions}.
+ */
+@UnstableApi
+public interface RequestOptionsSetters {
 
     /**
      * Schedules the response timeout that is triggered when the {@link Response} is not fully received within

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1392,6 +1392,9 @@ public final class ServerBuilder implements TlsSetters {
      * with the specified {@code port}. The returned virtual host will have a catch-all (wildcard host) name
      * pattern that allows all host names.
      *
+     * <p>Note that you cannot configure TLS to the port-based virtual host. Configure it to the
+     * {@link ServerBuilder} or a {@linkplain #virtualHost(String) name-based virtual host}.
+     *
      * @param port the port number that this virtual host binds to
      * @return {@link VirtualHostBuilder} for building the virtual host
      */

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -106,6 +106,7 @@ public final class VirtualHostBuilder implements TlsSetters {
 
     private final ServerBuilder serverBuilder;
     private final boolean defaultVirtualHost;
+    private final boolean portBased;
     private final List<ServiceConfigSetters> serviceConfigSetters = new ArrayList<>();
     private final List<ShutdownSupport> shutdownSupports = new ArrayList<>();
     private final HttpHeadersBuilder defaultHeaders = HttpHeaders.builder();
@@ -158,6 +159,7 @@ public final class VirtualHostBuilder implements TlsSetters {
     VirtualHostBuilder(ServerBuilder serverBuilder, boolean defaultVirtualHost) {
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
         this.defaultVirtualHost = defaultVirtualHost;
+        portBased = false;
     }
 
     /**
@@ -169,6 +171,7 @@ public final class VirtualHostBuilder implements TlsSetters {
     VirtualHostBuilder(ServerBuilder serverBuilder, int port) {
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
         this.port = port;
+        portBased = true;
         defaultVirtualHost = true;
     }
 
@@ -303,6 +306,8 @@ public final class VirtualHostBuilder implements TlsSetters {
     private VirtualHostBuilder tls(Supplier<SslContextBuilder> sslContextBuilderSupplier) {
         requireNonNull(sslContextBuilderSupplier, "sslContextBuilderSupplier");
         checkState(this.sslContextBuilderSupplier == null, "TLS has been configured already.");
+        checkState(!portBased, "Cannot configure TLS to a port-based virtual host. Please configure to %s.",
+                   ServerBuilder.class.getSimpleName());
         this.sslContextBuilderSupplier = sslContextBuilderSupplier;
         return this;
     }
@@ -314,8 +319,7 @@ public final class VirtualHostBuilder implements TlsSetters {
      * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tlsSelfSigned() {
-        tlsSelfSigned = true;
-        return this;
+        return tlsSelfSigned(true);
     }
 
     /**
@@ -325,6 +329,9 @@ public final class VirtualHostBuilder implements TlsSetters {
      * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tlsSelfSigned(boolean tlsSelfSigned) {
+        checkState(!portBased,
+                   "Cannot configure self-signed to a port-based virtual host. Please configure to %s.",
+                   ServerBuilder.class.getSimpleName());
         this.tlsSelfSigned = tlsSelfSigned;
         return this;
     }
@@ -332,6 +339,8 @@ public final class VirtualHostBuilder implements TlsSetters {
     @Override
     public VirtualHostBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         requireNonNull(tlsCustomizer, "tlsCustomizer");
+        checkState(!portBased, "Cannot configure TLS to a port-based virtual host. Please configure to %s.",
+                   ServerBuilder.class.getSimpleName());
         tlsCustomizers.add(tlsCustomizer);
         return this;
     }
@@ -1174,6 +1183,48 @@ public final class VirtualHostBuilder implements TlsSetters {
                                accessLogWriter, blockingTaskExecutor, successFunction,
                                multipartUploadsLocation, defaultHeaders);
 
+        final Builder<ShutdownSupport> builder = ImmutableList.builder();
+        builder.addAll(shutdownSupports);
+        builder.addAll(template.shutdownSupports);
+
+        final VirtualHost virtualHost =
+                new VirtualHost(defaultHostname, hostnamePattern, port, sslContext(template),
+                                serviceConfigs, fallbackServiceConfig, rejectedRouteHandler,
+                                accessLoggerMapper, defaultServiceNaming, requestTimeoutMillis,
+                                maxRequestLength, verboseResponses, accessLogWriter,
+                                blockingTaskExecutor, builder.build());
+
+        final Function<? super HttpService, ? extends HttpService> decorator =
+                getRouteDecoratingService(template);
+        final VirtualHost decoratedVirtualHost = decorator != null ? virtualHost.decorate(decorator)
+                                                                   : virtualHost;
+        return decoratedVirtualHost;
+    }
+
+    static HttpHeaders mergeDefaultHeaders(HttpHeadersBuilder lowPriorityHeaders,
+                                           HttpHeaders highPriorityHeaders) {
+        if (lowPriorityHeaders.isEmpty()) {
+            return highPriorityHeaders;
+        }
+
+        if (highPriorityHeaders.isEmpty()) {
+            return lowPriorityHeaders.build();
+        }
+
+        final HttpHeadersBuilder headersBuilder = highPriorityHeaders.toBuilder();
+        for (final AsciiString name : lowPriorityHeaders.names()) {
+            if (!headersBuilder.contains(name)) {
+                headersBuilder.add(name, lowPriorityHeaders.getAll(name));
+            }
+        }
+        return headersBuilder.build();
+    }
+
+    @Nullable
+    private SslContext sslContext(VirtualHostBuilder template) {
+        if (portBased) {
+            return null;
+        }
         SslContext sslContext = null;
         boolean releaseSslContextOnFailure = false;
         try {
@@ -1234,48 +1285,13 @@ public final class VirtualHostBuilder implements TlsSetters {
                 validateSslContext(sslContext);
                 checkState(sslContext.isServer(), "sslContextBuilder built a client SSL context.");
             }
-
-            final Builder<ShutdownSupport> builder = ImmutableList.builder();
-            builder.addAll(shutdownSupports);
-            builder.addAll(template.shutdownSupports);
-
-            final VirtualHost virtualHost =
-                    new VirtualHost(defaultHostname, hostnamePattern, port, sslContext,
-                                    serviceConfigs, fallbackServiceConfig, rejectedRouteHandler,
-                                    accessLoggerMapper, defaultServiceNaming, requestTimeoutMillis,
-                                    maxRequestLength, verboseResponses, accessLogWriter,
-                                    blockingTaskExecutor, builder.build());
-
-            final Function<? super HttpService, ? extends HttpService> decorator =
-                    getRouteDecoratingService(template);
-            final VirtualHost decoratedVirtualHost = decorator != null ? virtualHost.decorate(decorator)
-                                                                       : virtualHost;
             releaseSslContextOnFailure = false;
-            return decoratedVirtualHost;
         } finally {
             if (releaseSslContextOnFailure) {
                 ReferenceCountUtil.release(sslContext);
             }
         }
-    }
-
-    static HttpHeaders mergeDefaultHeaders(HttpHeadersBuilder lowPriorityHeaders,
-                                           HttpHeaders highPriorityHeaders) {
-        if (lowPriorityHeaders.isEmpty()) {
-            return highPriorityHeaders;
-        }
-
-        if (highPriorityHeaders.isEmpty()) {
-            return lowPriorityHeaders.build();
-        }
-
-        final HttpHeadersBuilder headersBuilder = highPriorityHeaders.toBuilder();
-        for (final AsciiString name : lowPriorityHeaders.names()) {
-            if (!headersBuilder.contains(name)) {
-                headersBuilder.add(name, lowPriorityHeaders.getAll(name));
-            }
-        }
-        return headersBuilder.build();
+        return sslContext;
     }
 
     private SelfSignedCertificate selfSignedCertificate() throws CertificateException {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.HostAndPort;
 
@@ -306,7 +305,8 @@ public final class VirtualHostBuilder implements TlsSetters {
     private VirtualHostBuilder tls(Supplier<SslContextBuilder> sslContextBuilderSupplier) {
         requireNonNull(sslContextBuilderSupplier, "sslContextBuilderSupplier");
         checkState(this.sslContextBuilderSupplier == null, "TLS has been configured already.");
-        checkState(!portBased, "Cannot configure TLS to a port-based virtual host. Please configure to %s.",
+        checkState(!portBased,
+                   "Cannot configure TLS to a port-based virtual host. Please configure to %s.tls()",
                    ServerBuilder.class.getSimpleName());
         this.sslContextBuilderSupplier = sslContextBuilderSupplier;
         return this;
@@ -329,9 +329,8 @@ public final class VirtualHostBuilder implements TlsSetters {
      * @see #tlsCustomizer(Consumer)
      */
     public VirtualHostBuilder tlsSelfSigned(boolean tlsSelfSigned) {
-        checkState(!portBased,
-                   "Cannot configure self-signed to a port-based virtual host. Please configure to %s.",
-                   ServerBuilder.class.getSimpleName());
+        checkState(!portBased, "Cannot configure self-signed to a port-based virtual host." +
+                               " Please configure to %s.tlsSelfSigned()", ServerBuilder.class.getSimpleName());
         this.tlsSelfSigned = tlsSelfSigned;
         return this;
     }
@@ -339,7 +338,8 @@ public final class VirtualHostBuilder implements TlsSetters {
     @Override
     public VirtualHostBuilder tlsCustomizer(Consumer<? super SslContextBuilder> tlsCustomizer) {
         requireNonNull(tlsCustomizer, "tlsCustomizer");
-        checkState(!portBased, "Cannot configure TLS to a port-based virtual host. Please configure to %s.",
+        checkState(!portBased,
+                   "Cannot configure TLS to a port-based virtual host. Please configure to %s.tlsCustomizer()",
                    ServerBuilder.class.getSimpleName());
         tlsCustomizers.add(tlsCustomizer);
         return this;
@@ -1148,6 +1148,7 @@ public final class VirtualHostBuilder implements TlsSetters {
         final HttpHeaders defaultHeaders =
                 mergeDefaultHeaders(template.defaultHeaders, this.defaultHeaders.build());
 
+        assert defaultServiceNaming != null;
         assert rejectedRouteHandler != null;
         assert accessLoggerMapper != null;
         assert extensions != null;
@@ -1183,7 +1184,7 @@ public final class VirtualHostBuilder implements TlsSetters {
                                accessLogWriter, blockingTaskExecutor, successFunction,
                                multipartUploadsLocation, defaultHeaders);
 
-        final Builder<ShutdownSupport> builder = ImmutableList.builder();
+        final ImmutableList.Builder<ShutdownSupport> builder = ImmutableList.builder();
         builder.addAll(shutdownSupports);
         builder.addAll(template.shutdownSupports);
 
@@ -1196,9 +1197,7 @@ public final class VirtualHostBuilder implements TlsSetters {
 
         final Function<? super HttpService, ? extends HttpService> decorator =
                 getRouteDecoratingService(template);
-        final VirtualHost decoratedVirtualHost = decorator != null ? virtualHost.decorate(decorator)
-                                                                   : virtualHost;
-        return decoratedVirtualHost;
+        return decorator != null ? virtualHost.decorate(decorator) : virtualHost;
     }
 
     static HttpHeaders mergeDefaultHeaders(HttpHeadersBuilder lowPriorityHeaders,

--- a/core/src/test/java/com/linecorp/armeria/server/PortBasedVirtualHostTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/PortBasedVirtualHostTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.ServerSocket;
 
+import javax.net.ssl.KeyManagerFactory;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -155,6 +157,20 @@ class PortBasedVirtualHostTest {
         assertThatThrownBy(() -> Server.builder().virtualHost(0))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("port: 0 (expected: 1-65535)");
+    }
+
+    @Test
+    void cannotSetTls() {
+        assertThatThrownBy(() -> {
+            Server.builder()
+                  .http(18080)
+                  .virtualHost(18080)
+                  .tls(KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm()))
+                  .service("/", (ctx, req) -> HttpResponse.of("OK"))
+                  .and()
+                  .build();
+        }).isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Cannot configure TLS to a port-based virtual host");
     }
 
     @Test


### PR DESCRIPTION
Motivation:
A port-based virtual host does not have a specific hostname so it doesn't make sense to configure TLS. Users need to configure TLS to the `ServerBuilder` which is the default host or create a name-based virtual host to apply different TLS settings.

Modification:
- Raise an exception if TLS is set to a port-based virtual host.
- Make `RequestOptionsSetters` public to render the Javadoc correctly.

Result:
- An exception is raised if TLS is set to a port-based virtual host.