### PR TITLE
Add a `java(\\d+)` flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,21 +184,6 @@ configure(projectsWithFlags('java')) {
         testImplementation libs.hamcrest.library
     }
 
-    tasks.withType(JavaCompile) { task ->
-        if (task.path.startsWith(':examples:')) {
-            // Target Java 11 for examples.
-            options.release.set(11)
-            // IntelliJ fails to compile example projects with IntelliJ compiler because of a wrong target
-            // bytecode version which is marked as Java 8 without the following options.
-            // See https://github.com/line/armeria/pull/3712
-            sourceCompatibility = '11'
-            targetCompatibility = '11'
-        } else {
-            // Target Java 8 for the rest of them.
-            options.release.set(8)
-        }
-    }
-
     // Configure the default DuplicatesStrategy for such as:
     // - c.l.armeria.versions.properties
     // - thrift/cassandra.json
@@ -210,13 +195,6 @@ configure(projectsWithFlags('java')) {
 }
 
 allprojects {
-
-    tasks.all { task ->
-        // Disables all tasks in examples when we use a JDK version under 11.
-        if (rootProject.ext.testJavaVersion < 11 && task.path.startsWith(':examples:')) {
-            task.enabled = false
-        }
-    }
 
     // Configure the Javadoc tasks of all projects.
     tasks.withType(Javadoc) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,8 +53,10 @@ mrJarVersions.each { version->
 }
 
 tasks.withType(JavaCompile) {
-    def version = releaseFlagFromVersion(sourceCompatibility)
-    options.release.set(Integer.parseInt(version))
+    if (project.rootProject.ext.buildJdkVersion >= 9) {
+        def version = releaseFlagFromVersion(sourceCompatibility)
+        options.release.set(Integer.parseInt(version))
+    }
 }
 
 tasks.withType(Jar) {

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -641,17 +641,17 @@ for more information.
 
 ## Setting a target version with the `java(\\d+)` flag.
 
-By default, setting the `java` flag compiles a module targeting minimum java compatibility with java 8.
-However, it is possible that certain modules need to be compiled targeting a higher java version than others.
+By default, setting the `java` flag compiles a module targeting minimum compatibility with Java 8.
+However, it is possible that certain modules need to be compiled targeting a higher Java version than others.
 
-Assume that `:moduleA` requires at least java 17 to compile, whereas `:moduleB` requires java 8.
-If `./gradlew assemble` is naively invoked on the root project with java 8, `:moduleA` would fail to compile
-since it requires at least java 17. This makes it difficult to test if `:moduleB` runs correctly with java 8.
+Assume that `:moduleA` requires at least Java 17 to compile, whereas `:moduleB` requires Java 8.
+If `./gradlew assemble` is naively invoked on the root project with Java 8, `:moduleA` would fail to compile
+since it requires at least Java 17. This makes it difficult to test if `:moduleB` runs correctly with Java 8.
 
 In such case, users may add a `java17` flag which provides the following functionalities:
-- Ensure that the target module is compiled to target minimum compatibility with java 17.
-- Skip tasks which require a jre version lower than the target version.
-  - Most notably, tests will be skipped if the jre version is lower than 17.
+- Ensure that the target module is compiled to target minimum compatibility with Java 17.
+- Skip tasks which require a JRE version lower than the target version.
+  - Most notably, tests will be skipped if the JRE version is lower than 17.
 
 The flag may be added like the following:
 
@@ -662,7 +662,7 @@ The flag may be added like the following:
    includeWithFlags ':moduleB', 'java'
    ```
 
-Note that if the target java version is greater than the build jdk version,
+Note that if the target Java version is greater than the build JDK version,
 an `UnsupportedClassVersionError` may be raised.
 
 ## Tagging conveniently with `release` task

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -641,7 +641,7 @@ for more information.
 
 ## Setting a target version with the `java(\\d+)` flag.
 
-By default, setting the `java` flag compiles a module targeting a minimum java version of 8.
+By default, setting the `java` flag compiles a module targeting minimum java compatibility with java 8.
 However, it is possible that certain modules need to be compiled targeting a higher java version than others.
 
 Assume that `:moduleA` requires at least java 17 to compile, whereas `:moduleB` requires java 8.
@@ -658,7 +658,7 @@ The flag may be added like the following:
    ```groovy
    // settings.gradle
    // ...
-   includeWithFlags ':moduleA', 'java', 'java17'
+   includeWithFlags ':moduleA', 'java17'
    includeWithFlags ':moduleB', 'java'
    ```
 

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -32,6 +32,7 @@ sensible defaults. By applying them, you can:
 - [Building shaded JARs with `shade` flag](#building-shaded-jars-with-shade-flag)
     - [Trimming a shaded JAR with `trim` flag](#trimming-a-shaded-jar-with-trim-flag)
     - [Shading a multi-module project with `relocate` flag](#shading-a-multi-module-project-with-relocate-flag)
+- [Setting a target version with the `java(\\d+)` flag](#setting-a-target-version-with-the-javad-flag)
 - [Tagging conveniently with `release` task](#tagging-conveniently-with-release-task)
 
 <!-- /MarkdownTOC -->
@@ -641,7 +642,8 @@ for more information.
 
 ## Setting a target version with the `java(\\d+)` flag.
 
-By default, setting the `java` flag compiles a module targeting minimum compatibility with Java 8.
+By default, setting the `java` flag compiles a module targeting minimum compatibility with the Java version
+specified by `javaTargetCompatibility`. `javaTargetCompatibility` is Java 8 by default if unspecified.
 However, it is possible that certain modules need to be compiled targeting a higher Java version than others.
 
 Assume that `:moduleA` requires at least Java 17 to compile, whereas `:moduleB` requires Java 8.

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -639,6 +639,32 @@ for more information.
    }
    ```
 
+## Setting a target version with the `java(\\d+)` flag.
+
+By default, setting the `java` flag compiles a module targeting a minimum java version of 8.
+However, it is possible that certain modules need to be compiled targeting a higher java version than others.
+
+Assume that `:moduleA` requires at least java 17 to compile, whereas `:moduleB` requires java 8.
+If `./gradlew assemble` is naively invoked on the root project with java 8, `:moduleA` would fail to compile
+since it requires at least java 17. This makes it difficult to test if `:moduleB` runs correctly with java 8.
+
+In such case, users may add a `java17` flag which provides the following functionalities:
+- Ensure that the target module is compiled to target minimum compatibility with java 17.
+- Skip tasks which require a jre version lower than the target version.
+  - Most notably, tests will be skipped if the jre version is lower than 17.
+
+The flag may be added like the following:
+
+   ```groovy
+   // settings.gradle
+   // ...
+   includeWithFlags ':moduleA', 'java', 'java17'
+   includeWithFlags ':moduleB', 'java'
+   ```
+
+Note that if the target java version is greater than the build jdk version,
+an `UnsupportedClassVersionError` may be raised.
+
 ## Tagging conveniently with `release` task
 
 The task called `release` is added at the top level project. It will update the

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -44,14 +44,14 @@ configure(rootProject) {
  * Note that the parsed value must be at least {@code defaultVersion} or an exception will be raised.
  */
 static def extractTargetJavaVersion(Project project, int defaultVersion) {
-    var pattern = Pattern.compile('^java(\\d+)$')
-    var flags = project.ext.flags
-    for (String flag: flags) {
-        var matcher = pattern.matcher(flag)
+    def pattern = Pattern.compile('^java(\\d+)$')
+    def flags = project.ext.flags
+    for (def flag: flags) {
+        def matcher = pattern.matcher(flag)
         if (!matcher.matches()) {
             continue
         }
-        var version = Integer.parseInt(matcher.group(1))
+        def version = Integer.parseInt(matcher.group(1))
         if (version < defaultVersion) {
             throw new IllegalArgumentException("The minimum java version ${version} specified " +
                     "by '${flag}' cannot be smaller than s${defaultVersion}")
@@ -79,7 +79,7 @@ configure(projectsWithFlags('java')) {
 
     // parse flags for the target java version with the default as java 8.
     // an exception will be thrown if a version <8 is specified in the flags.
-    var targetJavaVersion = extractTargetJavaVersion(project, 8)
+    def targetJavaVersion = extractTargetJavaVersion(project, 8)
 
     java {
         toolchain {

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -39,7 +39,7 @@ configure(rootProject) {
 
 /**
  * Checks each flag of the specified project for flags of format "java(\\d+)".
- * If such a flag exists, the minimum jre version is extracted and returned.
+ * If such a flag exists, the minimum Java version is extracted and returned.
  * Otherwise, {@code defaultVersion} is returned.
  * Note that the parsed value must be at least {@code defaultVersion} or an exception will be raised.
  */
@@ -53,8 +53,8 @@ static def extractTargetJavaVersion(Project project, int defaultVersion) {
         }
         def version = Integer.parseInt(matcher.group(1))
         if (version < defaultVersion) {
-            throw new IllegalArgumentException("The minimum java version ${version} specified " +
-                    "by '${flag}' cannot be smaller than s${defaultVersion}")
+            throw new IllegalArgumentException("The minimum Java version ${version} specified " +
+                    "by '${flag}' cannot be smaller than ${defaultVersion}")
         }
         return version
     }
@@ -122,8 +122,9 @@ configure(projectsWithFlags('java')) {
 
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
-        sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: "${targetJavaVersion}"
-        targetCompatibility = project.findProperty('javaTargetCompatibility') ?: "${targetJavaVersion}"
+        def targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
+        sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: targetJavaVersionStr
+        targetCompatibility = project.findProperty('javaTargetCompatibility') ?: targetJavaVersionStr
         if (buildJdkVersion >= 9) {
             // Supported since java 9 https://openjdk.org/jeps/247
             options.release.set(targetJavaVersion)
@@ -162,7 +163,10 @@ configure(projectsWithFlags('java')) {
         }
 
         // disable tests for projects which target a higher java version
-        if (testJavaVersion < targetJavaVersion) {
+        if (rootProject.ext.testJavaVersion < targetJavaVersion) {
+            project.logger.lifecycle("Skipping tests for ${project.name} since the " +
+                    "testJavaVersion(${testJavaVersion}) is smaller than the " +
+                    "targetJavaVersion(${targetJavaVersion})")
             it.enabled = false
         }
     }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -1,3 +1,5 @@
+import java.util.regex.Pattern
+
 def buildJdkVersion = Integer.parseInt(JavaVersion.current().getMajorVersion())
 if (rootProject.hasProperty('buildJdkVersion')) {
     def jdkVersion = Integer.parseInt(rootProject.findProperty('buildJdkVersion'))
@@ -34,6 +36,31 @@ configure(rootProject) {
     apply plugin: 'idea'
 }
 
+
+/**
+ * Checks each flag of the specified project for flags of format "java(\\d+)".
+ * If such a flag exists, the minimum jre version is extracted and returned.
+ * Otherwise, {@code defaultVersion} is returned.
+ * Note that the parsed value must be at least {@code defaultVersion} or an exception will be raised.
+ */
+static def extractTargetJavaVersion(Project project, int defaultVersion) {
+    var pattern = Pattern.compile('^java(\\d+)$')
+    var flags = project.ext.flags
+    for (String flag: flags) {
+        var matcher = pattern.matcher(flag)
+        if (!matcher.matches()) {
+            continue
+        }
+        var version = Integer.parseInt(matcher.group(1))
+        if (version < defaultVersion) {
+            throw new IllegalArgumentException("The minimum java version ${version} specified " +
+                    "by '${flag}' cannot be smaller than s${defaultVersion}")
+        }
+        return version
+    }
+    return defaultVersion
+}
+
 configure(projectsWithFlags('java')) {
 
     apply plugin: 'java-library'
@@ -49,6 +76,10 @@ configure(projectsWithFlags('java')) {
     clean {
         delete project.ext.genSrcDir
     }
+
+    // parse flags for the target java version with the default as java 8.
+    // an exception will be thrown if a version <8 is specified in the flags.
+    var targetJavaVersion = extractTargetJavaVersion(project, 8)
 
     java {
         toolchain {
@@ -91,8 +122,12 @@ configure(projectsWithFlags('java')) {
 
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
-        sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: '1.8'
-        targetCompatibility = project.findProperty('javaTargetCompatibility') ?: '1.8'
+        sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: "${targetJavaVersion}"
+        targetCompatibility = project.findProperty('javaTargetCompatibility') ?: "${targetJavaVersion}"
+        if (buildJdkVersion >= 9) {
+            // Supported since java 9 https://openjdk.org/jeps/247
+            options.release.set(targetJavaVersion)
+        }
         options.encoding = 'UTF-8'
         options.warnings = false
         options.compilerArgs += '-parameters'
@@ -124,6 +159,11 @@ configure(projectsWithFlags('java')) {
             javaLauncher = javaToolchains.launcherFor {
                 languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
             }
+        }
+
+        // disable tests for projects which target a higher java version
+        if (testJavaVersion < targetJavaVersion) {
+            it.enabled = false
         }
     }
 

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -41,7 +41,6 @@ configure(rootProject) {
  * Checks each flag of the specified project for flags of format "java(\\d+)".
  * If such a flag exists, the minimum Java version is extracted and returned.
  * Otherwise, {@code defaultVersion} is returned.
- * Note that the parsed value must be at least {@code defaultVersion} or an exception will be raised.
  */
 static def extractTargetJavaVersion(Project project, int defaultVersion) {
     def pattern = Pattern.compile('^java(\\d+)$')
@@ -51,12 +50,7 @@ static def extractTargetJavaVersion(Project project, int defaultVersion) {
         if (!matcher.matches()) {
             continue
         }
-        def version = Integer.parseInt(matcher.group(1))
-        if (version < defaultVersion) {
-            throw new IllegalArgumentException("The minimum Java version ${version} specified " +
-                    "by '${flag}' cannot be smaller than ${defaultVersion}")
-        }
-        return version
+        return Integer.parseInt(matcher.group(1))
     }
     return defaultVersion
 }
@@ -77,9 +71,17 @@ configure(projectsWithFlags('java')) {
         delete project.ext.genSrcDir
     }
 
-    // parse flags for the target java version with the default as java 8.
-    // an exception will be thrown if a version <8 is specified in the flags.
-    def targetJavaVersion = extractTargetJavaVersion(project, 8)
+    // the default targetJavaVersion is 'javaTargetCompatibility'
+    String defaultTargetJavaVersionStr = project.findProperty('javaTargetCompatibility') ?: '1.8'
+    def defaultTargetJavaVersion = Integer.parseInt(
+            JavaVersion.toVersion(defaultTargetJavaVersionStr).majorVersion)
+
+    // parse flags for the targetJavaVersion or return the default version
+    def targetJavaVersion = extractTargetJavaVersion(project, defaultTargetJavaVersion)
+    if (targetJavaVersion < 8) {
+        throw new IllegalArgumentException("The minimum target Java version ${version} specified " +
+                "for '${project.name}' cannot be smaller than 8")
+    }
 
     java {
         toolchain {

--- a/gradle/scripts/settings-flags.gradle
+++ b/gradle/scripts/settings-flags.gradle
@@ -109,7 +109,7 @@ static def addFlags(Set<String> actualFlags, ...flags) {
 
     // 'java(\\d+)' implies 'java'
     if (!actualFlags.contains('java')) {
-        var pattern = Pattern.compile('^java(\\d+)$')
+        def pattern = Pattern.compile('^java(\\d+)$')
         for (String flag: actualFlags) {
             if (pattern.matcher(flag).matches()) {
                 actualFlags.add('java')

--- a/gradle/scripts/settings-flags.gradle
+++ b/gradle/scripts/settings-flags.gradle
@@ -1,6 +1,7 @@
-import org.gradle.util.GradleVersion;
+import org.gradle.util.GradleVersion
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
 
 import static java.util.Objects.requireNonNull
 
@@ -104,6 +105,17 @@ static def addFlags(Set<String> actualFlags, ...flags) {
     // 'version-catalog' implies 'publish'.
     if (actualFlags.contains('version-catalog')) {
         actualFlags.add('publish')
+    }
+
+    // 'java(\\d+)' implies 'java'
+    if (!actualFlags.contains('java')) {
+        var pattern = Pattern.compile('^java(\\d+)$')
+        for (String flag: actualFlags) {
+            if (pattern.matcher(flag).matches()) {
+                actualFlags.add('java')
+                break
+            }
+        }
     }
 
     return Collections.unmodifiableSet(actualFlags)

--- a/settings.gradle
+++ b/settings.gradle
@@ -122,42 +122,42 @@ includeWithFlags ':docs-client'
 includeWithFlags ':site'
 
 // Examples
-includeWithFlags ':examples:annotated-http-service',               'java', 'java11'
-includeWithFlags ':examples:annotated-http-service-kotlin',        'java', 'kotlin', 'java11'
-includeWithFlags ':examples:context-propagation-dagger-example',   'java', 'java11'
+includeWithFlags ':examples:annotated-http-service',               'java11'
+includeWithFlags ':examples:annotated-http-service-kotlin',        'java11', 'kotlin'
+includeWithFlags ':examples:context-propagation-dagger-example',   'java11'
 project(':examples:context-propagation-dagger-example').projectDir = file('examples/context-propagation/dagger')
-includeWithFlags ':examples:context-propagation-kotlin-example',   'java', 'kotlin', 'java11'
+includeWithFlags ':examples:context-propagation-kotlin-example',   'java11', 'kotlin'
 project(':examples:context-propagation-kotlin-example').projectDir = file('examples/context-propagation/kotlin')
-includeWithFlags ':examples:context-propagation-manual-example',   'java', 'java11'
+includeWithFlags ':examples:context-propagation-manual-example',   'java11'
 project(':examples:context-propagation-manual-example').projectDir = file('examples/context-propagation/manual')
-includeWithFlags ':examples:context-propagation-reactor-example',  'java', 'java11'
+includeWithFlags ':examples:context-propagation-reactor-example',  'java11'
 project(':examples:context-propagation-reactor-example').projectDir = file('examples/context-propagation/reactor')
-includeWithFlags ':examples:context-propagation-rxjava-example',   'java', 'java11'
+includeWithFlags ':examples:context-propagation-rxjava-example',   'java11'
 project(':examples:context-propagation-rxjava-example').projectDir = file('examples/context-propagation/rxjava')
 // '*-example' pattern is used intentionally to avoid a cycling dependency issue between project('examples:*')
 // and project(':*'). See https://github.com/gradle/gradle/issues/847 for more information.
-includeWithFlags ':examples:dropwizard-example',                   'java', 'java11'
+includeWithFlags ':examples:dropwizard-example',                   'java11'
 project(':examples:dropwizard-example').projectDir = file('examples/dropwizard')
-includeWithFlags ':examples:graphql-example',                      'java', 'java11'
+includeWithFlags ':examples:graphql-example',                      'java11'
 project(':examples:graphql-example').projectDir = file('examples/graphql')
-includeWithFlags ':examples:graphql-kotlin-example',               'java', 'kotlin', 'java11'
+includeWithFlags ':examples:graphql-kotlin-example',               'java11', 'kotlin'
 project(':examples:graphql-kotlin-example').projectDir = file('examples/graphql-kotlin')
-includeWithFlags ':examples:graphql-sangria-example',              'java', 'scala_2.13', 'java11'
+includeWithFlags ':examples:graphql-sangria-example',              'java11', 'scala_2.13'
 project(':examples:graphql-sangria-example').projectDir = file('examples/graphql-sangria')
-includeWithFlags ':examples:grpc-example',                         'java', 'java11'
+includeWithFlags ':examples:grpc-example',                         'java11'
 project(':examples:grpc-example').projectDir = file('examples/grpc')
-includeWithFlags ':examples:grpc-kotlin',                          'java', 'kotlin-grpc', 'kotlin', 'java11'
-includeWithFlags ':examples:grpc-scala',                           'java', 'scala-grpc_2.13', 'scala_2.13', 'java11'
-includeWithFlags ':examples:grpc-reactor',                         'java', 'reactor-grpc', 'java11'
-includeWithFlags ':examples:proxy-server',                         'java', 'java11'
-includeWithFlags ':examples:saml-service-provider',                'java', 'java11'
-includeWithFlags ':examples:server-sent-events',                   'java', 'java11'
-includeWithFlags ':examples:spring-boot-minimal',                  'java', 'java11'
-includeWithFlags ':examples:spring-boot-minimal-kotlin',           'java', 'kotlin', 'java11'
-includeWithFlags ':examples:spring-boot-tomcat',                   'java', 'java11'
-includeWithFlags ':examples:spring-boot-webflux',                  'java', 'java11'
-includeWithFlags ':examples:static-files',                         'java', 'java11'
-includeWithFlags ':examples:thrift',                               'java', 'java11'
-includeWithFlags ':examples:tutorials:rest-api-annotated-service', 'java', 'java11'
-includeWithFlags ':examples:tutorials:grpc-tutorial',              'java', 'java11'
+includeWithFlags ':examples:grpc-kotlin',                          'java11', 'kotlin-grpc', 'kotlin'
+includeWithFlags ':examples:grpc-scala',                           'java11', 'scala-grpc_2.13', 'scala_2.13'
+includeWithFlags ':examples:grpc-reactor',                         'java11', 'reactor-grpc'
+includeWithFlags ':examples:proxy-server',                         'java11'
+includeWithFlags ':examples:saml-service-provider',                'java11'
+includeWithFlags ':examples:server-sent-events',                   'java11'
+includeWithFlags ':examples:spring-boot-minimal',                  'java11'
+includeWithFlags ':examples:spring-boot-minimal-kotlin',           'java11', 'kotlin'
+includeWithFlags ':examples:spring-boot-tomcat',                   'java11'
+includeWithFlags ':examples:spring-boot-webflux',                  'java11'
+includeWithFlags ':examples:static-files',                         'java11'
+includeWithFlags ':examples:thrift',                               'java11'
+includeWithFlags ':examples:tutorials:rest-api-annotated-service', 'java11'
+includeWithFlags ':examples:tutorials:grpc-tutorial',              'java11'
 project(':examples:tutorials:grpc-tutorial').projectDir = file('examples/tutorials/grpc')

--- a/settings.gradle
+++ b/settings.gradle
@@ -144,7 +144,7 @@ includeWithFlags ':examples:graphql-kotlin-example',               'java', 'kotl
 project(':examples:graphql-kotlin-example').projectDir = file('examples/graphql-kotlin')
 includeWithFlags ':examples:graphql-sangria-example',              'java', 'scala_2.13'
 project(':examples:graphql-sangria-example').projectDir = file('examples/graphql-sangria')
-includeWithFlags ':examples:grpc-example',                         'java'
+includeWithFlags ':examples:grpc-example',                         'java', 'java11'
 project(':examples:grpc-example').projectDir = file('examples/grpc')
 includeWithFlags ':examples:grpc-kotlin',                          'java', 'kotlin-grpc', 'kotlin'
 includeWithFlags ':examples:grpc-scala',                           'java', 'scala-grpc_2.13', 'scala_2.13'

--- a/settings.gradle
+++ b/settings.gradle
@@ -122,42 +122,42 @@ includeWithFlags ':docs-client'
 includeWithFlags ':site'
 
 // Examples
-includeWithFlags ':examples:annotated-http-service',               'java'
-includeWithFlags ':examples:annotated-http-service-kotlin',        'java', 'kotlin'
-includeWithFlags ':examples:context-propagation-dagger-example',   'java'
+includeWithFlags ':examples:annotated-http-service',               'java', 'java11'
+includeWithFlags ':examples:annotated-http-service-kotlin',        'java', 'kotlin', 'java11'
+includeWithFlags ':examples:context-propagation-dagger-example',   'java', 'java11'
 project(':examples:context-propagation-dagger-example').projectDir = file('examples/context-propagation/dagger')
-includeWithFlags ':examples:context-propagation-kotlin-example',   'java', 'kotlin'
+includeWithFlags ':examples:context-propagation-kotlin-example',   'java', 'kotlin', 'java11'
 project(':examples:context-propagation-kotlin-example').projectDir = file('examples/context-propagation/kotlin')
-includeWithFlags ':examples:context-propagation-manual-example',   'java'
+includeWithFlags ':examples:context-propagation-manual-example',   'java', 'java11'
 project(':examples:context-propagation-manual-example').projectDir = file('examples/context-propagation/manual')
-includeWithFlags ':examples:context-propagation-reactor-example',  'java'
+includeWithFlags ':examples:context-propagation-reactor-example',  'java', 'java11'
 project(':examples:context-propagation-reactor-example').projectDir = file('examples/context-propagation/reactor')
-includeWithFlags ':examples:context-propagation-rxjava-example',   'java'
+includeWithFlags ':examples:context-propagation-rxjava-example',   'java', 'java11'
 project(':examples:context-propagation-rxjava-example').projectDir = file('examples/context-propagation/rxjava')
 // '*-example' pattern is used intentionally to avoid a cycling dependency issue between project('examples:*')
 // and project(':*'). See https://github.com/gradle/gradle/issues/847 for more information.
-includeWithFlags ':examples:dropwizard-example',                   'java'
+includeWithFlags ':examples:dropwizard-example',                   'java', 'java11'
 project(':examples:dropwizard-example').projectDir = file('examples/dropwizard')
-includeWithFlags ':examples:graphql-example',                      'java'
+includeWithFlags ':examples:graphql-example',                      'java', 'java11'
 project(':examples:graphql-example').projectDir = file('examples/graphql')
-includeWithFlags ':examples:graphql-kotlin-example',               'java', 'kotlin'
+includeWithFlags ':examples:graphql-kotlin-example',               'java', 'kotlin', 'java11'
 project(':examples:graphql-kotlin-example').projectDir = file('examples/graphql-kotlin')
-includeWithFlags ':examples:graphql-sangria-example',              'java', 'scala_2.13'
+includeWithFlags ':examples:graphql-sangria-example',              'java', 'scala_2.13', 'java11'
 project(':examples:graphql-sangria-example').projectDir = file('examples/graphql-sangria')
 includeWithFlags ':examples:grpc-example',                         'java', 'java11'
 project(':examples:grpc-example').projectDir = file('examples/grpc')
-includeWithFlags ':examples:grpc-kotlin',                          'java', 'kotlin-grpc', 'kotlin'
-includeWithFlags ':examples:grpc-scala',                           'java', 'scala-grpc_2.13', 'scala_2.13'
-includeWithFlags ':examples:grpc-reactor',                         'java', 'reactor-grpc'
-includeWithFlags ':examples:proxy-server',                         'java'
-includeWithFlags ':examples:saml-service-provider',                'java'
-includeWithFlags ':examples:server-sent-events',                   'java'
-includeWithFlags ':examples:spring-boot-minimal',                  'java'
-includeWithFlags ':examples:spring-boot-minimal-kotlin',           'java', 'kotlin'
-includeWithFlags ':examples:spring-boot-tomcat',                   'java'
-includeWithFlags ':examples:spring-boot-webflux',                  'java'
-includeWithFlags ':examples:static-files',                         'java'
-includeWithFlags ':examples:thrift',                               'java'
-includeWithFlags ':examples:tutorials:rest-api-annotated-service', 'java'
-includeWithFlags ':examples:tutorials:grpc-tutorial',              'java'
+includeWithFlags ':examples:grpc-kotlin',                          'java', 'kotlin-grpc', 'kotlin', 'java11'
+includeWithFlags ':examples:grpc-scala',                           'java', 'scala-grpc_2.13', 'scala_2.13', 'java11'
+includeWithFlags ':examples:grpc-reactor',                         'java', 'reactor-grpc', 'java11'
+includeWithFlags ':examples:proxy-server',                         'java', 'java11'
+includeWithFlags ':examples:saml-service-provider',                'java', 'java11'
+includeWithFlags ':examples:server-sent-events',                   'java', 'java11'
+includeWithFlags ':examples:spring-boot-minimal',                  'java', 'java11'
+includeWithFlags ':examples:spring-boot-minimal-kotlin',           'java', 'kotlin', 'java11'
+includeWithFlags ':examples:spring-boot-tomcat',                   'java', 'java11'
+includeWithFlags ':examples:spring-boot-webflux',                  'java', 'java11'
+includeWithFlags ':examples:static-files',                         'java', 'java11'
+includeWithFlags ':examples:thrift',                               'java', 'java11'
+includeWithFlags ':examples:tutorials:rest-api-annotated-service', 'java', 'java11'
+includeWithFlags ':examples:tutorials:grpc-tutorial',              'java', 'java11'
 project(':examples:tutorials:grpc-tutorial').projectDir = file('examples/tutorials/grpc')


### PR DESCRIPTION
Motivation:

Some modules may need to target a java version higher than other modules to compile correctly.
This PR proposes a `java(\\d+)` flag which sets the target java version for compilation.

Modifications:

- Remove special logic for `:examples` in `build.gradle`
- Set the `-release` flag in `core/build.gradle` for `buildJdkVersion >= 9` to avoid compilation errors.
    - Without this change, the actual error message might be shadowed (i.e. invalid flag exception instead of invalid class version exception)
- Introduce an `extractTargetJavaVersion` method which extracts the target version from a `java(\\d+)` flag.
    - The default is set to 8. If a lower version than the default is specified an exception is thrown. (e.g. `java3`)
- Set the compatibility to `targetJavaVersion`, and skip tests if `testJavaVersion` is lower than the `targetJavaVersion`
- Imply the `java` flag if `java(\\d+)` flag is added

Result:

- Users can support modules with different minimum java versions easily.

Note: If multiple `java(\\d+)` flags are specified, only the first one will have effect.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
