### PR TITLE
Support example request dropdown for `DocService`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -119,7 +119,8 @@ class AnnotatedDocServiceTest {
                                       .exampleQueries(MyService.class, "foo", "query=10", "query=20")
                                       .exampleRequests(MyService.class, "pathParams",
                                                        ImmutableList.of(
-                                                               mapper.readTree("{\"hello\":\"armeria\"}")))
+                                                               mapper.readTree("{\"hello\":\"armeria\"}"),
+                                                               mapper.readTree("{\"hello\":\"armeria2\"}")))
                                       .examplePaths(MyService.class, "pathParamsWithQueries",
                                                     "/service/hello1/foo", "/service/hello1/bar")
                                       .exampleQueries(MyService.class, "pathParamsWithQueries", "hello3=hello4")
@@ -135,7 +136,7 @@ class AnnotatedDocServiceTest {
     };
 
     @Test
-    void jsonSpecification() throws InterruptedException, JsonProcessingException {
+    void jsonSpecification() throws Exception {
         if (TestUtil.isDocServiceDemoMode()) {
             Thread.sleep(Long.MAX_VALUE);
         }
@@ -148,7 +149,7 @@ class AnnotatedDocServiceTest {
         addRegexMethodInfo(methodInfos);
         addPrefixMethodInfo(methodInfos);
         addConsumesMethodInfo(methodInfos);
-         addBeanMethodInfo(methodInfos);
+        addBeanMethodInfo(methodInfos);
         addMultiMethodInfo(methodInfos);
         addJsonMethodInfo(methodInfos);
         addOverloadMethodInfo(methodInfos);
@@ -417,6 +418,9 @@ class AnnotatedDocServiceTest {
                     final ArrayNode exampleRequests = (ArrayNode) method.get("exampleRequests");
                     exampleRequests.add('{' + System.lineSeparator() +
                                         "  \"hello\" : \"armeria\"" + System.lineSeparator() +
+                                        '}');
+                    exampleRequests.add('{' + System.lineSeparator() +
+                                        "  \"hello\" : \"armeria2\"" + System.lineSeparator() +
                                         '}');
                     final ArrayNode examplePaths = (ArrayNode) method.get("examplePaths");
                     examplePaths.add(TextNode.valueOf("/service/hello1/foo/hello3/bar"));

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -263,6 +263,13 @@ const DebugPage: React.FunctionComponent<Props> = ({
     [],
   );
 
+  const onSelectedRequestBodyChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setRequestBody(e.target.value as string);
+    },
+    [],
+  );
+
   const onHeadersFormChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       setAdditionalHeaders(e.target.value);
@@ -588,6 +595,8 @@ const DebugPage: React.FunctionComponent<Props> = ({
               />
             ) : (
               <RequestBody
+                exampleRequests={method.exampleRequests}
+                onSelectedRequestBodyChange={onSelectedRequestBodyChange}
                 requestBodyOpen={requestBodyOpen}
                 requestBody={requestBody}
                 onEditRequestBodyClick={toggleRequestBodyOpen}

--- a/docs-client/src/containers/MethodPage/RequestBody.tsx
+++ b/docs-client/src/containers/MethodPage/RequestBody.tsx
@@ -50,12 +50,12 @@ const RequestBody: React.FunctionComponent<Props> = (props) => (
               fullWidth
               displayEmpty
               value=""
-              renderValue={() => 'Select example headers...'}
+              renderValue={() => 'Select example requests...'}
               onChange={props.onSelectedRequestBodyChange}
             >
-              {props.exampleRequests.map((header) => (
-                <MenuItem key={header} value={header}>
-                  {truncate(header, 30)}
+              {props.exampleRequests.map((body) => (
+                <MenuItem key={body} value={body}>
+                  {truncate(body, 30)}
                 </MenuItem>
               ))}
             </Select>

--- a/docs-client/src/containers/MethodPage/RequestBody.tsx
+++ b/docs-client/src/containers/MethodPage/RequestBody.tsx
@@ -21,6 +21,7 @@ import React, { ChangeEvent } from 'react';
 
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import { Tooltip } from '@material-ui/core';
 import jsonPrettify from '../../lib/json-prettify';
 import { truncate } from '../../lib/strings';
 
@@ -54,9 +55,11 @@ const RequestBody: React.FunctionComponent<Props> = (props) => (
               onChange={props.onSelectedRequestBodyChange}
             >
               {props.exampleRequests.map((body) => (
-                <MenuItem key={body} value={body}>
-                  {truncate(body, 30)}
-                </MenuItem>
+                <Tooltip title={body} placement="right">
+                  <MenuItem key={body} value={body}>
+                    {truncate(body, 30)}
+                  </MenuItem>
+                </Tooltip>
               ))}
             </Select>
           </>

--- a/docs-client/src/containers/MethodPage/RequestBody.tsx
+++ b/docs-client/src/containers/MethodPage/RequestBody.tsx
@@ -17,13 +17,18 @@
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
 import jsonPrettify from '../../lib/json-prettify';
+import { truncate } from '../../lib/strings';
 
 const jsonPlaceHolder = jsonPrettify('{"foo":"bar"}');
 
 interface Props {
+  exampleRequests: string[];
+  onSelectedRequestBodyChange: (e: ChangeEvent<{ value: unknown }>) => void;
   requestBodyOpen: boolean;
   requestBody: string;
   onEditRequestBodyClick: React.Dispatch<unknown>;
@@ -38,6 +43,24 @@ const RequestBody: React.FunctionComponent<Props> = (props) => (
     </Button>
     {props.requestBodyOpen && (
       <>
+        {props.exampleRequests.length > 0 && (
+          <>
+            <Typography variant="body2" paragraph />
+            <Select
+              fullWidth
+              displayEmpty
+              value=""
+              renderValue={() => 'Select example headers...'}
+              onChange={props.onSelectedRequestBodyChange}
+            >
+              {props.exampleRequests.map((header) => (
+                <MenuItem key={header} value={header}>
+                  {truncate(header, 30)}
+                </MenuItem>
+              ))}
+            </Select>
+          </>
+        )}
         <Typography variant="body2" paragraph />
         <TextField
           multiline

--- a/docs-client/src/containers/MethodPage/RequestBody.tsx
+++ b/docs-client/src/containers/MethodPage/RequestBody.tsx
@@ -55,11 +55,11 @@ const RequestBody: React.FunctionComponent<Props> = (props) => (
               onChange={props.onSelectedRequestBodyChange}
             >
               {props.exampleRequests.map((body) => (
-                <Tooltip title={body} placement="right">
-                  <MenuItem key={body} value={body}>
-                    {truncate(body, 30)}
-                  </MenuItem>
-                </Tooltip>
+                <MenuItem key={body} value={body}>
+                  <Tooltip title={body} placement="right">
+                    <span>{truncate(body, 30)}</span>
+                  </Tooltip>
+                </MenuItem>
               ))}
             </Select>
           </>

--- a/docs-client/src/lib/strings.ts
+++ b/docs-client/src/lib/strings.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+export function truncate(input: string, len: number): string {
+  if (input.length > len) {
+    return `${input.substring(0, len)}...`;
+  }
+  return input;
+}


### PR DESCRIPTION
Motivation:

Setting multiple example requests aren't displayed contrary to multiple headers/queries/paths.

Modifications:

- Add a select component which allows users to select a request.
- Truncate the displayed value in case the example request is too long.

Result:

- #4576