### PR TITLE
Replace synchonized blocks in retrofit2 with ReentrantLock

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactory.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 
 import com.linecorp.armeria.client.Endpoint;


### PR DESCRIPTION
Motivation:

loom compatibility: synchronized should be removed to favour virtual threads friendliness. Resolves part of [#4510](https://github.com/line/armeria/issues/4510)

Modifications:

- Replaced all synchronized in retrofit2 module with ReentrantLock

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
