### PR TITLE
Fix to limit the max length for compressed chunked data

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
@@ -34,14 +34,11 @@ class AbstractStreamDecoder implements StreamDecoder {
 
     private final EmbeddedChannel decoder;
     private final int maxLength;
-    private final boolean checkOverflow;
 
-    protected AbstractStreamDecoder(ChannelHandler handler, ByteBufAllocator alloc, int maxLength,
-                                    boolean checkOverflow) {
+    protected AbstractStreamDecoder(ChannelHandler handler, ByteBufAllocator alloc, int maxLength) {
         decoder = new EmbeddedChannel(false, handler);
         decoder.config().setAllocator(alloc);
         this.maxLength = maxLength;
-        this.checkOverflow = maxLength > 0 && checkOverflow;
     }
 
     @Override
@@ -107,7 +104,7 @@ class AbstractStreamDecoder implements StreamDecoder {
     }
 
     private void maybeCheckOverflow(@Nullable ByteBuf decoded, ByteBuf newBuf) {
-        if (!checkOverflow) {
+        if (maxLength <= 0) {
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/AbstractStreamDecoder.java
@@ -104,7 +104,7 @@ class AbstractStreamDecoder implements StreamDecoder {
     }
 
     private void maybeCheckOverflow(@Nullable ByteBuf decoded, ByteBuf newBuf) {
-        if (maxLength <= 0) {
+        if (maxLength <= 0 || maxLength == Integer.MAX_VALUE) {
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/BrotliStreamDecoder.java
@@ -28,6 +28,6 @@ final class BrotliStreamDecoder extends AbstractStreamDecoder {
         // BrotliDecoder does not limit the max output size. If the output buffer exceeds 4MiB, it is
         // chunked into pieces of 4MiB. As a workaround, the max length is checked at the `StreamDecoder`
         // level after decoding.
-        super(brotliDecoder, alloc, maxLength, true);
+        super(brotliDecoder, alloc, maxLength);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/encoding/ZlibStreamDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/encoding/ZlibStreamDecoder.java
@@ -32,7 +32,7 @@ final class ZlibStreamDecoder extends AbstractStreamDecoder {
             SystemPropertyUtil.getBoolean("io.netty.noJdkZlibDecoder", false);
 
     ZlibStreamDecoder(ZlibWrapper zlibWrapper, ByteBufAllocator alloc, int maxLength) {
-        super(newZlibDecoder(zlibWrapper, maxLength), alloc, maxLength, false);
+        super(newZlibDecoder(zlibWrapper, maxLength), alloc, maxLength);
     }
 
     private static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper, int maxLength) {


### PR DESCRIPTION
Motivation:

`maxAllocation` of `ZlibDecoder` does not limit the max length of the entire stream data. It only limits the length of each chunk of data.

Modifications:

- Make `ZlibStreamDecoder` check the total length after decompression to validate the streaming content length.

Result:

`DecodingService` and `DecodingClient` now correctly limit the max length of decompressed streaming data.


