### PR TITLE
Remove [] from allowed path chars

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -66,7 +66,7 @@ public final class PathAndQuery {
 
     static {
         final String allowedPathChars =
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;=";
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#@!$&'()*+,;=";
         for (int i = 0; i < allowedPathChars.length(); i++) {
             ALLOWED_PATH_CHARS.set(allowedPathChars.charAt(i));
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -556,5 +556,4 @@ class PathAndQueryTest {
         assertThat(res2).isNotNull();
         assertThat(res2.path()).isNotEqualTo("/#%2F:@!$&'()*+,;=?");
     }
-
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -547,13 +547,13 @@ class PathAndQueryTest {
 
     @Test
     void assertSquareBracketsInPath() {
-                final PathAndQuery res = parse("/#/:@[]!$&'()*+,;=");
+        final PathAndQuery res = parse("/#/:@[]!$&'()*+,;=");
         assertThat(res).isNotNull();
-        assertThat(res.path()).isNotEqualTo("/#/:@!$&'()*+,;=");
+        assertThat(res.path()).isEqualTo("/#/:@%5B%5D!$&'()*+,;=");
 
         final PathAndQuery res2 =
                 parse("/%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
         assertThat(res2).isNotNull();
-        assertThat(res2.path()).isNotEqualTo("/#%2F:@!$&'()*+,;=?");
+        assertThat(res2.path()).isEqualTo("/#%2F:%5B%5D@!$&'()*+,;=?");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -477,16 +477,16 @@ class PathAndQueryTest {
 
     @Test
     void allReservedCharacters() {
-        final PathAndQuery res = parse("/#/:[]@!$&'()*+,;=?a=/#/:[]@!$&'()*+,;=");
+        final PathAndQuery res = parse("/#/:@!$&'()*+,;=?a=/#/:[]@!$&'()*+,;=");
         assertThat(res).isNotNull();
-        assertThat(res.path()).isEqualTo("/#/:[]@!$&'()*+,;=");
+        assertThat(res.path()).isEqualTo("/#/:@!$&'()*+,;=");
         assertThat(res.query()).isEqualTo("a=/#/:[]@!$&'()*+,;=");
 
         final PathAndQuery res2 =
-                parse("/%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
+                parse("/%23%2F%3A%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
                       "?a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
         assertThat(res2).isNotNull();
-        assertThat(res2.path()).isEqualTo("/#%2F:[]@!$&'()*+,;=?");
+        assertThat(res2.path()).isEqualTo("/#%2F:@!$&'()*+,;=?");
         assertThat(res2.query()).isEqualTo("a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -544,4 +544,17 @@ class PathAndQueryTest {
         }
         return res;
     }
+
+    @Test
+    void assertSquareBracketsInPath() {
+                final PathAndQuery res = parse("/#/:@[]!$&'()*+,;=");
+        assertThat(res).isNotNull();
+        assertThat(res.path()).isNotEqualTo("/#/:@!$&'()*+,;=");
+
+        final PathAndQuery res2 =
+                parse("/%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
+        assertThat(res2).isNotNull();
+        assertThat(res2.path()).isNotEqualTo("/#%2F:@!$&'()*+,;=?");
+    }
+
 }


### PR DESCRIPTION
Motivation:

According to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) the valid characters for the path component are:
a-z A-Z 0-9 . - _ ~ ! $ & ' ( ) * + , ; = : @

Modifications:

- [] was removed from allowedPathChars in PathAndQuery.java
- broken tests was fixed in PathAndQueryTest.java by removing [] and %5B%5D from declared and expected values respectively in method allReservedCharacters().

Result:

- Should close #4607
- [] no longer allowed as path chars

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
