### PR TITLE
Use Gzip for compressing DocService front-end assets by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -88,13 +88,6 @@ import com.linecorp.armeria.server.file.MediaTypeResolver;
  * using Java SPI (Service Provider Interface). The {@link DocServicePlugin} implementations will
  * generate {@link ServiceSpecification}s for the {@link Service}s they support.
  *
- * <p>Front-end assets are compressed via <a href="https://www.gnu.org/software/gzip/">Gzip</a>by default.
- * If you want to compress them using <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli</a>,
- * pass the {@code docServiceCompression} Gradle property when building:
- * <pre>{@code
- * $./gradlew build -PdocServiceCompression=brotli
- * }</pre>
- *
  * @see DocServiceBuilder#include(DocServiceFilter)
  * @see DocServiceBuilder#exclude(DocServiceFilter)
  */

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -88,6 +88,13 @@ import com.linecorp.armeria.server.file.MediaTypeResolver;
  * using Java SPI (Service Provider Interface). The {@link DocServicePlugin} implementations will
  * generate {@link ServiceSpecification}s for the {@link Service}s they support.
  *
+ * <p>Front-end assets are compressed via <a href="https://www.gnu.org/software/gzip/">Gzip</a>by default.
+ * If you want to compress them using <a href="https://datatracker.ietf.org/doc/html/rfc7932">Brotli</a>,
+ * pass the {@code docServiceCompression} Gradle property when building:
+ * <pre>{@code
+ * $./gradlew build -PdocServiceCompression=brotli
+ * }</pre>
+ *
  * @see DocServiceBuilder#include(DocServiceFilter)
  * @see DocServiceBuilder#exclude(DocServiceFilter)
  */

--- a/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
+++ b/core/src/main/java/com/linecorp/armeria/server/encoding/HttpEncoders.java
@@ -83,7 +83,6 @@ final class HttpEncoders {
 
     // Copied from netty's HttpContentCompressor.
     @Nullable
-    @SuppressWarnings("FloatingPointEquality")
     private static HttpEncodingType determineEncoding(String acceptEncoding) {
         float starQ = -1.0f;
         final Map<HttpEncodingType, Float> encodings = new LinkedHashMap<>();

--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -32,8 +32,6 @@ class DocServiceAssetCompressionTest {
         // they should exist in the classpath of the core module.
         // If Gradle build task is executed with `-PnoWeb`, this test may be broken.
         assertThat(DocService.class.getResource(file)).isNull();
-        assertThat(DocService.class.getResource(file + ".gz") != null ||
-                   // brotily is used if `-PdocServiceCompression=brotli` is specified.
-                   DocService.class.getResource(file + ".br") != null).isTrue();
+        assertThat(DocService.class.getResource(file + ".gz")).isNotNull();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -28,10 +28,12 @@ class DocServiceAssetCompressionTest {
     @ValueSource(strings = {"index.html", "main.js"})
     @ParameterizedTest
     void shouldNotIncludeUncompressedAssets(String file) {
-        // `doc-client` should produce compressed asserts when building bundle files for DocService and
+        // `doc-client` should produce compressed assets when building bundle files for DocService and
         // they should exist in the classpath of the core module.
         // If Gradle build task is executed with `-PnoWeb`, this test may be broken.
         assertThat(DocService.class.getResource(file)).isNull();
-        assertThat(DocService.class.getResource(file + ".br")).isNotNull();
+        assertThat(DocService.class.getResource(file + ".gz") != null ||
+                   // brotily is used if `-PdocServiceCompression=brotli` is specified.
+                   DocService.class.getResource(file + ".br") != null).isTrue();
     }
 }

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -25,10 +25,10 @@ task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall
 
     args = ['run', 'build']
+    environment = [COMPRESSION: rootProject.findProperty('docServiceCompression') ?: 'gzip']
 
     inputs.dir('src')
-    inputs.file('package.json')
-    inputs.file('package-lock.json')
+    inputs.files('package.json', 'package-lock.json')
     outputs.dir('build/web')
 }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -25,7 +25,6 @@ task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall
 
     args = ['run', 'build']
-    environment = [COMPRESSION: rootProject.findProperty('docServiceCompression') ?: 'gzip']
 
     inputs.dir('src')
     inputs.files('package.json', 'package-lock.json')

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -2,11 +2,11 @@ import path from 'path';
 
 import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import {LicenseWebpackPlugin} from 'license-webpack-plugin';
+import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import CompressionWebpackPlugin from 'compression-webpack-plugin';
-import {Configuration, DefinePlugin} from 'webpack';
+import { Configuration, DefinePlugin } from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
-import {docServiceDebug} from './src/lib/header-provider';
+import { docServiceDebug } from './src/lib/header-provider';
 
 declare module 'webpack' {
   interface Configuration {

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -15,6 +15,8 @@ declare module 'webpack' {
 import { docServiceDebug } from './src/lib/header-provider';
 
 const armeriaPort = process.env.ARMERIA_PORT || '8080';
+const compression = process.env.COMPRESSION === 'brotli' ? 'brotliCompress' : 'gzip'
+const fileExtension = compression === 'brotliCompress' ? 'br' : 'gz'
 
 const isDev = !!process.env.WEBPACK_DEV;
 const isWindows = process.platform === 'win32';
@@ -141,8 +143,8 @@ plugins.push(new DefinePlugin({
 if (!isDev) {
   plugins.push(new CompressionWebpackPlugin({
     test: /\.(js|css|html|svg)$/,
-    algorithm: 'brotliCompress',
-    filename: '[path][base].br',
+    algorithm: compression,
+    filename: `[path][base].${fileExtension}`,
     // If a `Accept-Encoding` is not specified, `DocService` decompresses the compressed content on the fly.
     deleteOriginalAssets: true
   }) as any);

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -2,21 +2,19 @@ import path from 'path';
 
 import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import { LicenseWebpackPlugin } from 'license-webpack-plugin';
+import {LicenseWebpackPlugin} from 'license-webpack-plugin';
 import CompressionWebpackPlugin from 'compression-webpack-plugin';
-import { Configuration, DefinePlugin } from 'webpack';
+import {Configuration, DefinePlugin} from 'webpack';
 import WebpackDevServer from 'webpack-dev-server';
+import {docServiceDebug} from './src/lib/header-provider';
+
 declare module 'webpack' {
   interface Configuration {
     devServer?: WebpackDevServer.Configuration;
   }
 }
 
-import { docServiceDebug } from './src/lib/header-provider';
-
 const armeriaPort = process.env.ARMERIA_PORT || '8080';
-const compression = process.env.COMPRESSION === 'brotli' ? 'brotliCompress' : 'gzip'
-const fileExtension = compression === 'brotliCompress' ? 'br' : 'gz'
 
 const isDev = !!process.env.WEBPACK_DEV;
 const isWindows = process.platform === 'win32';
@@ -143,8 +141,8 @@ plugins.push(new DefinePlugin({
 if (!isDev) {
   plugins.push(new CompressionWebpackPlugin({
     test: /\.(js|css|html|svg)$/,
-    algorithm: compression,
-    filename: `[path][base].${fileExtension}`,
+    algorithm: 'gzip',
+    filename: '[path][base].gz',
     // If a `Accept-Encoding` is not specified, `DocService` decompresses the compressed content on the fly.
     deleteOriginalAssets: true
   }) as any);


### PR DESCRIPTION
Motivation:
Some platforms do not support Brotli by default.
If the DocService assets are created using brotli and a client sends the request with `accept-encoding: gzip`, the client wouldn't be able to use DocService.

Modification:
- Use Gzip by default for compressing assets

Result:
- DocService front-end assets are now compressed using Gzip.