### PR TITLE
Fix local build failure from no such file exception caused by space character in path to server-list.properties

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
@@ -23,6 +23,7 @@ import static org.awaitility.Awaitility.await;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -130,7 +131,7 @@ public class PropertiesEndpointGroupTest {
     public void pathWithDefaultPort() throws Exception {
         final URL resourceUrl = getClass().getClassLoader().getResource("server-list.properties");
         assert resourceUrl != null;
-        final Path resourcePath = new File(resourceUrl.getFile()).toPath();
+        final Path resourcePath = new File(resourceUrl.toURI().getPath()).toPath();
         final PropertiesEndpointGroup endpointGroupA = PropertiesEndpointGroup.builder(
                 resourcePath, "serverA.hosts").defaultPort(80).build();
         assertThat(endpointGroupA.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),
@@ -140,10 +141,10 @@ public class PropertiesEndpointGroupTest {
     }
 
     @Test
-    public void pathWithoutDefaultPort() {
+    public void pathWithoutDefaultPort() throws URISyntaxException {
         final URL resourceUrl = getClass().getClassLoader().getResource("server-list.properties");
         assert resourceUrl != null;
-        final Path resourcePath = new File(resourceUrl.getFile()).toPath();
+        final Path resourcePath = new File(resourceUrl.toURI().getPath()).toPath();
         final PropertiesEndpointGroup endpointGroup = PropertiesEndpointGroup.of(
                 resourcePath, "serverA.hosts");
         assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(Endpoint.parse("127.0.0.1:8080"),


### PR DESCRIPTION


Motivation:

This change resolves local build failure for some users with space character in their home directory's folder names path leading up to server-list.properties file.
<img width="1354" alt="Screenshot 2023-01-05 at 19 31 44" src="https://user-images.githubusercontent.com/36740791/211115440-12e915de-55b2-4cad-bfa8-978cf661ccbc.png">

Modifications:

- `final Path resourcePath = new File(resourceUrl.getFile()).toPath();` was replaced with `final Path resourcePath = new File(resourceUrl.toURI().getPath()).toPath();` in PropertiesEndpointGroupTest.java

Result:

- Users facing this issue now have a successful local build.
<img width="1424" alt="Screenshot 2023-01-07 at 00 20 49" src="https://user-images.githubusercontent.com/36740791/211115813-f47c329c-47e0-4604-bc08-27224c49bdb0.png">


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
