### PR TITLE
Use Eclipse Temurin instead of AdoptOpenJDK

### DIFF
--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts
 	branch = master
-	commit = 1a58ba8991d5c51f5dfa8d3f10277ca2c4aea02e
-	parent = b66705894d662a3d1614b600339898be7253348a
+	commit = a706e2826247c958aed17a1d7ec1168bb1a9c7e1
+	parent = 506e1b3c1236579d7344e3f10f3de13f811af5b1
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.5

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -451,7 +451,7 @@ When a project has a `java` flag:
 ## Overriding JDK version
 
 The scripts use [Toolchains](https://docs.gradle.org/current/userguide/toolchains.html) to build a Java
-project. It uses [AdoptOpenJDK](https://adoptopenjdk.net/) 15 by default. If you want to use a
+project. It uses [Adoptium OpenJDK](https://adoptium.net/) 19 by default. If you want to use a
 different JDK version, you can specify `buildJdkVersion` gradle property:
 
 ```

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -653,7 +653,7 @@ since it requires at least Java 17. This makes it difficult to test if `:moduleB
 In such case, users may add a `java17` flag which provides the following functionalities:
 - Ensure that the target module is compiled to target minimum compatibility with Java 17.
 - Skip tasks which require a JRE version lower than the target version.
-  - Most notably, tests will be skipped if the JRE version is lower than 17.
+    - Most notably, tests will be skipped if the JRE version is lower than 17.
 
 The flag may be added like the following:
 

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -36,7 +36,6 @@ configure(rootProject) {
     apply plugin: 'idea'
 }
 
-
 /**
  * Checks each flag of the specified project for flags of format "java(\\d+)".
  * If such a flag exists, the minimum Java version is extracted and returned.

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Build requirements
 
-- [OpenJDK 11-17](https://adoptium.net/)
+- [OpenJDK 11-19](https://adoptium.net/)
   - Consider using a version manager for convenient installation of JDK, such as
     [asdf](https://asdf-vm.com/) and [jabba](https://github.com/shyiko/jabba).
 

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Build requirements
 
-- [OpenJDK 11-17](https://adoptopenjdk.net/archive.html?variant=openjdk17&jvmVariant=hotspot)
+- [OpenJDK 11-17](https://adoptium.net/)
   - Consider using a version manager for convenient installation of JDK, such as
     [asdf](https://asdf-vm.com/) and [jabba](https://github.com/shyiko/jabba).
 

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -8,7 +8,7 @@ import versions from '../../../gen-src/versions.json';
 
 <Tip>
 
-Use Java 13 (or later) if you are a contributor who tries to build Armeria itself.
+Use Java 19 (or later) if you are a contributor who tries to build Armeria itself.
 See [CONTRIBUTING.md](https://github.com/line/armeria/blob/master/CONTRIBUTING.md) for more information.
 
 </Tip>

--- a/site/src/pages/docs/setup.mdx
+++ b/site/src/pages/docs/setup.mdx
@@ -4,7 +4,7 @@ import versions from '../../../gen-src/versions.json';
 
 ## Requirements
 
-[Java 8 (or later)](https://adoptopenjdk.net/) is required to build and run an application based on Armeria.
+[Java 8 (or later)](https://adoptium.net/) is required to build and run an application based on Armeria.
 
 <Tip>
 


### PR DESCRIPTION
Motivation:

Update the URLs of OpenJDK in the documents because the new OpenJDK binaries from AdoptOpenJDK are no longer distributed and have been migrated to Eclipse Temurin.
It seems that this project have already used Eclipse Temurin on CI.

Modifications:

- Update the documents and URLs

Result:

- The URLs refer to Eclipse Temurin