### PR TITLE
Support Thrift TypeDef in DocService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -35,6 +35,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -81,6 +82,8 @@ import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.docs.StructInfo;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.server.docs.TypeSignatureType;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * A {@link DocServicePlugin} implementation that supports the {@link AnnotatedService}.
@@ -350,7 +353,8 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         if (type == String.class) {
             return STRING;
         }
-        if (type == byte[].class || type == Byte[].class) {
+        if (type == byte[].class || type == Byte[].class ||
+            type == ByteBuffer.class || type == ByteBuf.class) {
             return BINARY;
         }
         // End of data types defined by the OpenAPI Specification.

--- a/it/thrift0.9.1/src/test/thrift/main.thrift
+++ b/it/thrift0.9.1/src/test/thrift/main.thrift
@@ -109,3 +109,28 @@ service HeaderService {
 service BinaryService {
     binary process(1: binary data)
 }
+
+typedef list<TypedefedString> TypedefedListString
+typedef bool                  TypedefedBool
+typedef list<TypedefedBool>   TypedefedListBool
+typedef byte                  TypedefedByte
+typedef list<TypedefedByte>   TypedefedListByte
+typedef i16                   TypedefedI16
+typedef list<TypedefedI16>    TypedefedListI16
+typedef i32                   TypedefedI32
+typedef list<TypedefedI32>    TypedefedListI32
+typedef i64                   TypedefedI64
+typedef list<TypedefedI64>    TypedefedListI64
+typedef double                TypedefedDouble
+typedef list<TypedefedDouble> TypedefedListDouble
+typedef binary                TypedefedBinary
+typedef list<TypedefedBinary> TypedefedListBinary
+
+service TypeDefService {
+    void typeDefs(1: TypedefedString td1, 2: TypedefedListString td2, 3: TypedefedBool td3,
+                  4: TypedefedListBool td4, 5: TypedefedByte td5, 6: TypedefedListByte td6,
+                  7: TypedefedI16 td7, 8: TypedefedListI16 td8, 9: TypedefedI32 td9,
+                  10: TypedefedListI32 td10, 11: TypedefedI64 td11, 12: TypedefedListI64 td12,
+                  13: TypedefedDouble td13, 14: TypedefedListDouble td14, 15: TypedefedBinary td15,
+                  16: TypedefedListBinary td16)
+}

--- a/thrift/thrift0.12/build.gradle
+++ b/thrift/thrift0.12/build.gradle
@@ -33,7 +33,7 @@ tasks.processTestResources.from "${rootProject.projectDir}/thrift/thrift0.13/src
 // Use the old compiler.
 def thriftFullVersion = libs.thrift012.get().versionConstraint.requiredVersion
 ext {
-    thriftVersion = thriftFullVersion.substring(0, thriftFullVersion.lastIndexOf('.'));
+    thriftVersion = thriftFullVersion.substring(0, thriftFullVersion.lastIndexOf('.'))
 }
 
 // Disable checkstyle because it's checked by ':thrift0.13'.

--- a/thrift/thrift0.12/src/test/thrift/TTextProtocolTest.thrift
+++ b/thrift/thrift0.12/src/test/thrift/TTextProtocolTest.thrift
@@ -74,7 +74,7 @@ struct TTextProtocolTestMsg {
 
   6: required bool f;
 
-  7: required byte g;
+  7: required i8 g;
 
   8: required map<i32, i64> h;
 

--- a/thrift/thrift0.12/src/test/thrift/main.thrift
+++ b/thrift/thrift0.12/src/test/thrift/main.thrift
@@ -64,7 +64,7 @@ union FooUnion {
 
 struct FooStruct {
     1: bool boolVal,
-    2: byte byteVal,
+    2: i8 byteVal,
     3: i16 i16Val,
     4: i32 i32Val,
     5: i64 i64Val,
@@ -109,4 +109,29 @@ service HeaderService {
 // Tests a binary parameter
 service BinaryService {
     binary process(1: binary data)
+}
+
+typedef list<TypedefedString> TypedefedListString
+typedef bool                  TypedefedBool
+typedef list<TypedefedBool>   TypedefedListBool
+typedef i8                    TypedefedByte
+typedef list<TypedefedByte>   TypedefedListByte
+typedef i16                   TypedefedI16
+typedef list<TypedefedI16>    TypedefedListI16
+typedef i32                   TypedefedI32
+typedef list<TypedefedI32>    TypedefedListI32
+typedef i64                   TypedefedI64
+typedef list<TypedefedI64>    TypedefedListI64
+typedef double                TypedefedDouble
+typedef list<TypedefedDouble> TypedefedListDouble
+typedef binary                TypedefedBinary
+typedef list<TypedefedBinary> TypedefedListBinary
+
+service TypeDefService {
+    void typeDefs(1: TypedefedString td1, 2: TypedefedListString td2, 3: TypedefedBool td3,
+                  4: TypedefedListBool td4, 5: TypedefedByte td5, 6: TypedefedListByte td6,
+                  7: TypedefedI16 td7, 8: TypedefedListI16 td8, 9: TypedefedI32 td9,
+                  10: TypedefedListI32 td10, 11: TypedefedI64 td11, 12: TypedefedListI64 td12,
+                  13: TypedefedDouble td13, 14: TypedefedListDouble td14, 15: TypedefedBinary td15,
+                  16: TypedefedListBinary td16)
 }

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDescriptiveTypeInfoProviderTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDescriptiveTypeInfoProviderTest.java
@@ -20,7 +20,6 @@ import static com.linecorp.armeria.internal.server.thrift.ThriftDescriptiveTypeI
 import static com.linecorp.armeria.internal.server.thrift.ThriftDescriptiveTypeInfoProvider.newExceptionInfo;
 import static com.linecorp.armeria.internal.server.thrift.ThriftDescriptiveTypeInfoProvider.newFieldInfo;
 import static com.linecorp.armeria.internal.server.thrift.ThriftDescriptiveTypeInfoProvider.newStructInfo;
-import static com.linecorp.armeria.internal.server.thrift.ThriftDescriptiveTypeInfoProvider.toTypeSignature;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -94,11 +93,5 @@ class ThriftDescriptiveTypeInfoProviderTest {
 
         final StructInfo fooStruct = newStructInfo(FooStruct.class);
         assertThat(fooStruct).isEqualTo(new StructInfo(FooStruct.class.getName(), fields));
-    }
-
-    @Test
-    void incompleteStructMetadata() throws Exception {
-        assertThat(toTypeSignature(new FieldValueMetaData(TType.STRUCT)))
-                .isEqualTo(TypeSignature.ofUnresolved("unknown"));
     }
 }

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -43,10 +43,12 @@ import com.linecorp.armeria.server.docs.ServiceInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.FooEnum;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.FooStruct;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+import com.linecorp.armeria.service.test.thrift.main.TypeDefService;
 
 class ThriftDocServicePluginTest {
 
@@ -274,14 +276,15 @@ class ThriftDocServicePluginTest {
         final MethodInfo bar6 = methods.get("bar6");
         assertThat(bar6.parameters()).containsExactly(
                 FieldInfo.of("foo1", string),
-                FieldInfo.of("foo2", TypeSignature.ofUnresolved("TypedefedStruct")),
-                FieldInfo.of("foo3", TypeSignature.ofUnresolved("TypedefedEnum")),
-                FieldInfo.of("foo4", TypeSignature.ofUnresolved("TypedefedMap")),
-                FieldInfo.of("foo5", TypeSignature.ofUnresolved("TypedefedList")),
-                FieldInfo.of("foo6", TypeSignature.ofUnresolved("TypedefedSet")),
-                FieldInfo.of("foo7", TypeSignature.ofUnresolved("NestedTypedefedStructs")),
+                FieldInfo.of("foo2", TypeSignature.ofStruct(FooStruct.class)),
+                FieldInfo.of("foo3", TypeSignature.ofEnum(FooEnum.class)),
+                FieldInfo.of("foo4", TypeSignature.ofMap(string, string)),
+                FieldInfo.of("foo5", TypeSignature.ofList(string)),
+                FieldInfo.of("foo6", TypeSignature.ofSet(string)),
+                FieldInfo.of("foo7", TypeSignature.ofList(TypeSignature.ofList(
+                        TypeSignature.ofStruct(FooStruct.class)))),
                 FieldInfo.of("foo8", TypeSignature.ofList(TypeSignature.ofList(
-                        TypeSignature.ofUnresolved("TypedefedStruct")))));
+                        TypeSignature.ofStruct(FooStruct.class)))));
 
         assertThat(bar6.returnTypeSignature()).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(bar6.exceptionTypeSignatures()).isEmpty();
@@ -289,5 +292,38 @@ class ThriftDocServicePluginTest {
 
         final List<HttpHeaders> exampleHeaders = service.exampleHeaders();
         assertThat(exampleHeaders).isEmpty();
+    }
+
+    @Test
+    void typeDefService() {
+        final ServiceInfo service = generator.newServiceInfo(
+                TypeDefService.class,
+                ImmutableList.of(EndpointInfo.builder("*", "/typeDef")
+                                             .defaultFormat(ThriftSerializationFormats.BINARY)
+                                             .build()),
+                (pluginName, serviceName, methodName) -> true);
+
+        final Map<String, MethodInfo> methods =
+                service.methods().stream().collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).hasSize(1);
+
+        final MethodInfo typeDefs = methods.get("typeDefs");
+        assertThat(typeDefs.parameters()).containsExactly(
+                FieldInfo.of("td1", TypeSignature.ofBase("string")),
+                FieldInfo.of("td2", TypeSignature.ofList(TypeSignature.ofBase("string"))),
+                FieldInfo.of("td3", TypeSignature.ofBase("bool")),
+                FieldInfo.of("td4", TypeSignature.ofList(TypeSignature.ofBase("bool"))),
+                FieldInfo.of("td5", TypeSignature.ofBase("i8")),
+                FieldInfo.of("td6", TypeSignature.ofList(TypeSignature.ofBase("i8"))),
+                FieldInfo.of("td7", TypeSignature.ofBase("i16")),
+                FieldInfo.of("td8", TypeSignature.ofList(TypeSignature.ofBase("i16"))),
+                FieldInfo.of("td9", TypeSignature.ofBase("i32")),
+                FieldInfo.of("td10", TypeSignature.ofList(TypeSignature.ofBase("i32"))),
+                FieldInfo.of("td11", TypeSignature.ofBase("i64")),
+                FieldInfo.of("td12", TypeSignature.ofList(TypeSignature.ofBase("i64"))),
+                FieldInfo.of("td13", TypeSignature.ofBase("double")),
+                FieldInfo.of("td14", TypeSignature.ofList(TypeSignature.ofBase("double"))),
+                FieldInfo.of("td15", TypeSignature.ofBase("binary")),
+                FieldInfo.of("td16", TypeSignature.ofList(TypeSignature.ofBase("binary"))));
     }
 }

--- a/thrift/thrift0.13/src/test/thrift/main.thrift
+++ b/thrift/thrift0.13/src/test/thrift/main.thrift
@@ -110,3 +110,28 @@ service HeaderService {
 service BinaryService {
     binary process(1: binary data)
 }
+
+typedef list<TypedefedString> TypedefedListString
+typedef bool                  TypedefedBool
+typedef list<TypedefedBool>   TypedefedListBool
+typedef i8                    TypedefedByte
+typedef list<TypedefedByte>   TypedefedListByte
+typedef i16                   TypedefedI16
+typedef list<TypedefedI16>    TypedefedListI16
+typedef i32                   TypedefedI32
+typedef list<TypedefedI32>    TypedefedListI32
+typedef i64                   TypedefedI64
+typedef list<TypedefedI64>    TypedefedListI64
+typedef double                TypedefedDouble
+typedef list<TypedefedDouble> TypedefedListDouble
+typedef binary                TypedefedBinary
+typedef list<TypedefedBinary> TypedefedListBinary
+
+service TypeDefService {
+    void typeDefs(1: TypedefedString td1, 2: TypedefedListString td2, 3: TypedefedBool td3,
+                  4: TypedefedListBool td4, 5: TypedefedByte td5, 6: TypedefedListByte td6,
+                  7: TypedefedI16 td7, 8: TypedefedListI16 td8, 9: TypedefedI32 td9,
+                  10: TypedefedListI32 td10, 11: TypedefedI64 td11, 12: TypedefedListI64 td12,
+                  13: TypedefedDouble td13, 14: TypedefedListDouble td14, 15: TypedefedBinary td15,
+                  16: TypedefedListBinary td16)
+}

--- a/thrift/thrift0.17/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/thrift0.17/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -43,10 +43,12 @@ import com.linecorp.armeria.server.docs.ServiceInfo;
 import com.linecorp.armeria.server.docs.ServiceSpecification;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.FooEnum;
 import com.linecorp.armeria.service.test.thrift.main.FooService;
 import com.linecorp.armeria.service.test.thrift.main.FooStruct;
 import com.linecorp.armeria.service.test.thrift.main.HelloService;
 import com.linecorp.armeria.service.test.thrift.main.HelloService.AsyncIface;
+import com.linecorp.armeria.service.test.thrift.main.TypeDefService;
 
 /**
  * The generated code of `FooService` is different from thrift0.13 compiler.
@@ -282,13 +284,15 @@ class ThriftDocServicePluginTest {
         final MethodInfo bar6 = methods.get("bar6");
         assertThat(bar6.parameters()).containsExactly(
                 FieldInfo.of("foo1", string),
-                FieldInfo.of("foo2", foo),
-                FieldInfo.of("foo3", TypeSignature.ofUnresolved("TypedefedEnum")),
-                FieldInfo.of("foo4", TypeSignature.ofUnresolved("TypedefedMap")),
-                FieldInfo.of("foo5", TypeSignature.ofUnresolved("TypedefedList")),
-                FieldInfo.of("foo6", TypeSignature.ofUnresolved("TypedefedSet")),
-                FieldInfo.of("foo7", TypeSignature.ofUnresolved("NestedTypedefedStructs")),
-                FieldInfo.of("foo8", TypeSignature.ofList(TypeSignature.ofList(foo))));
+                FieldInfo.of("foo2", TypeSignature.ofStruct(FooStruct.class)),
+                FieldInfo.of("foo3", TypeSignature.ofEnum(FooEnum.class)),
+                FieldInfo.of("foo4", TypeSignature.ofMap(string, string)),
+                FieldInfo.of("foo5", TypeSignature.ofList(string)),
+                FieldInfo.of("foo6", TypeSignature.ofSet(string)),
+                FieldInfo.of("foo7", TypeSignature.ofList(TypeSignature.ofList(
+                        TypeSignature.ofStruct(FooStruct.class)))),
+                FieldInfo.of("foo8", TypeSignature.ofList(TypeSignature.ofList(
+                        TypeSignature.ofStruct(FooStruct.class)))));
 
         assertThat(bar6.returnTypeSignature()).isEqualTo(TypeSignature.ofBase("void"));
         assertThat(bar6.exceptionTypeSignatures()).isEmpty();
@@ -296,5 +300,38 @@ class ThriftDocServicePluginTest {
 
         final List<HttpHeaders> exampleHeaders = service.exampleHeaders();
         assertThat(exampleHeaders).isEmpty();
+    }
+
+    @Test
+    void typeDefService() {
+        final ServiceInfo service = GENERATOR.newServiceInfo(
+                TypeDefService.class,
+                ImmutableList.of(EndpointInfo.builder("*", "/typeDef")
+                                             .defaultFormat(ThriftSerializationFormats.BINARY)
+                                             .build()),
+                (pluginName, serviceName, methodName) -> true);
+
+        final Map<String, MethodInfo> methods =
+                service.methods().stream().collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).hasSize(1);
+
+        final MethodInfo typeDefs = methods.get("typeDefs");
+        assertThat(typeDefs.parameters()).containsExactly(
+                FieldInfo.of("td1", TypeSignature.ofBase("string")),
+                FieldInfo.of("td2", TypeSignature.ofList(TypeSignature.ofBase("string"))),
+                FieldInfo.of("td3", TypeSignature.ofBase("bool")),
+                FieldInfo.of("td4", TypeSignature.ofList(TypeSignature.ofBase("bool"))),
+                FieldInfo.of("td5", TypeSignature.ofBase("i8")),
+                FieldInfo.of("td6", TypeSignature.ofList(TypeSignature.ofBase("i8"))),
+                FieldInfo.of("td7", TypeSignature.ofBase("i16")),
+                FieldInfo.of("td8", TypeSignature.ofList(TypeSignature.ofBase("i16"))),
+                FieldInfo.of("td9", TypeSignature.ofBase("i32")),
+                FieldInfo.of("td10", TypeSignature.ofList(TypeSignature.ofBase("i32"))),
+                FieldInfo.of("td11", TypeSignature.ofBase("i64")),
+                FieldInfo.of("td12", TypeSignature.ofList(TypeSignature.ofBase("i64"))),
+                FieldInfo.of("td13", TypeSignature.ofBase("double")),
+                FieldInfo.of("td14", TypeSignature.ofList(TypeSignature.ofBase("double"))),
+                FieldInfo.of("td15", TypeSignature.ofBase("binary")),
+                FieldInfo.of("td16", TypeSignature.ofList(TypeSignature.ofBase("binary"))));
     }
 }

--- a/thrift/thrift0.9/build.gradle
+++ b/thrift/thrift0.9/build.gradle
@@ -37,7 +37,7 @@ tasks.javadoc.source "${rootProject.projectDir}/thrift/thrift0.13/src/main/java"
 // Use the old compiler.
 def thriftFullVersion = libs.thrift09.get().versionConstraint.requiredVersion
 ext {
-    thriftVersion = thriftFullVersion.substring(0, thriftFullVersion.lastIndexOf('.'));
+    thriftVersion = thriftFullVersion.substring(0, thriftFullVersion.lastIndexOf('.'))
     disableThriftJson()
 }
 

--- a/thrift/thrift0.9/src/test/thrift/main.thrift
+++ b/thrift/thrift0.9/src/test/thrift/main.thrift
@@ -110,3 +110,28 @@ service HeaderService {
 service BinaryService {
     binary process(1: binary data)
 }
+
+typedef list<TypedefedString> TypedefedListString
+typedef bool                  TypedefedBool
+typedef list<TypedefedBool>   TypedefedListBool
+typedef byte                  TypedefedByte
+typedef list<TypedefedByte>   TypedefedListByte
+typedef i16                   TypedefedI16
+typedef list<TypedefedI16>    TypedefedListI16
+typedef i32                   TypedefedI32
+typedef list<TypedefedI32>    TypedefedListI32
+typedef i64                   TypedefedI64
+typedef list<TypedefedI64>    TypedefedListI64
+typedef double                TypedefedDouble
+typedef list<TypedefedDouble> TypedefedListDouble
+typedef binary                TypedefedBinary
+typedef list<TypedefedBinary> TypedefedListBinary
+
+service TypeDefService {
+    void typeDefs(1: TypedefedString td1, 2: TypedefedListString td2, 3: TypedefedBool td3,
+                  4: TypedefedListBool td4, 5: TypedefedByte td5, 6: TypedefedListByte td6,
+                  7: TypedefedI16 td7, 8: TypedefedListI16 td8, 9: TypedefedI32 td9,
+                  10: TypedefedListI32 td10, 11: TypedefedI64 td11, 12: TypedefedListI64 td12,
+                  13: TypedefedDouble td13, 14: TypedefedListDouble td14, 15: TypedefedBinary td15,
+                  16: TypedefedListBinary td16)
+}


### PR DESCRIPTION
Motivation:
Currently, we don't resolve the Thrift [typedef](https://thrift.apache.org/docs/idl#typedef) fields correctly.
![image](https://user-images.githubusercontent.com/25103250/212018060-9d88d2f7-d90d-4513-a188-29ad741a1ee9.png)

Modifications:
- Resolve Thrift typedef fields correctly using `Field.getGenericType()`.
- Use `i8` instead of `byte` for Thrift 0.12+ to remove the warning.

Result:
- The Thrift typedefs are correctly resolved. 
<img width="946" alt="image" src="https://user-images.githubusercontent.com/25103250/212018732-f7b4a850-8c9d-45ca-b914-fbb84618a0db.png">
