### PR TITLE
Fix a bug where `ClosedSessionException` is set to `responseCause` for a success response.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -404,7 +404,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
     }
 
     protected final boolean isWritable(int id) {
-        return id < minClosedId;
+        return id < minClosedId && !isClosed();
     }
 
     protected final void updateClosedId(int id) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
@@ -314,11 +315,33 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                 responseEncoder.writeTrailers(req.id(), req.streamId(), additionalTrailers)
                                .addListener(writeHeadersFutureListener(true));
                 ctx.flush();
-            } else if (responseEncoder.isWritable(req.id(), req.streamId())) {
-                responseEncoder.writeData(req.id(), req.streamId(), HttpData.empty(), true)
-                               .addListener(writeDataFutureListener(true, true));
-                ctx.flush();
+            } else {
+                if (isWritable()) {
+                    responseEncoder.writeData(req.id(), req.streamId(), HttpData.empty(), true)
+                                   .addListener(writeDataFutureListener(true, true));
+                    ctx.flush();
+                } else {
+                    if (!reqCtx.sessionProtocol().isMultiplex()) {
+                        // An HTTP/1 connection is closed by a remote peer after all data is sent,
+                        // so we can assume the HTTP/1 request is complete successfully.
+                        succeed();
+                    } else {
+                        fail(ClosedStreamException.get());
+                    }
+                }
             }
+        }
+    }
+
+    private void succeed() {
+        if (tryComplete(null)) {
+            final Throwable capturedException = CapturedServiceException.get(reqCtx);
+            if (capturedException != null) {
+                endLogRequestAndResponse(capturedException);
+            } else {
+                endLogRequestAndResponse();
+            }
+            maybeWriteAccessLog();
         }
     }
 
@@ -451,15 +474,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
             maybeLogFirstResponseBytesTransferred();
 
             if (endOfStream) {
-                if (tryComplete(null)) {
-                    final Throwable capturedException = CapturedServiceException.get(reqCtx);
-                    if (capturedException != null) {
-                        endLogRequestAndResponse(capturedException);
-                    } else {
-                        endLogRequestAndResponse();
-                    }
-                    maybeWriteAccessLog();
-                }
+                succeed();
             }
 
             if (!isSubscriptionCompleted) {

--- a/core/src/test/java/com/linecorp/armeria/server/Http1ServerEarlyDisconnectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1ServerEarlyDisconnectionTest.java
@@ -67,7 +67,6 @@ class Http1ServerEarlyDisconnectionTest {
         }
     };
 
-
     @Test
     void closeConnectionWhenAllContentAreReceived() throws InterruptedException {
         final ClientFactory clientFactory = ClientFactory.builder().build();
@@ -91,7 +90,7 @@ class Http1ServerEarlyDisconnectionTest {
             public void onNext(HttpData httpData) {
                 received += httpData.length();
                 if (received >= contentLength) {
-                    // All data is received. It should be safe to close the connection.
+                    // All data is received, so it should be safe to close the connection.
                     clientFactory.close();
                 }
             }

--- a/core/src/test/java/com/linecorp/armeria/server/Http1ServerEarlyDisconnectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1ServerEarlyDisconnectionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.SplitHttpResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.internal.testing.FlakyTest;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+@FlakyTest
+class Http1ServerEarlyDisconnectionTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> {
+                final HttpResponseWriter writer = HttpResponse.streaming();
+                writer.write(ResponseHeaders.builder(200)
+                                            .contentLength(10)
+                                            .build());
+                ctx.blockingTaskExecutor().execute(() -> {
+                    writer.write(HttpData.ofUtf8("0123456789"));
+
+                    // Wait for the client to close the connection.
+                    // Note: The sleep duration should be less than 1 second after which `ServerHandler`
+                    //       calls `cleanup()` to remove `unfinishedRequests`.
+                    Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(200));
+
+                    writer.close();
+                });
+
+                return writer;
+            });
+        }
+    };
+
+
+    @Test
+    void closeConnectionWhenAllContentAreReceived() throws InterruptedException {
+        final ClientFactory clientFactory = ClientFactory.builder().build();
+        final WebClient client = WebClient.builder(server.uri(SessionProtocol.H1C))
+                                          .factory(clientFactory)
+                                          .build();
+        final HttpResponse response = client.get("/");
+        final SplitHttpResponse split = response.split();
+        final ResponseHeaders headers = split.headers().join();
+        final long contentLength = headers.contentLength();
+        split.body().subscribe(new Subscriber<HttpData>() {
+
+            private int received;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(HttpData httpData) {
+                received += httpData.length();
+                if (received >= contentLength) {
+                    // All data is received. It should be safe to close the connection.
+                    clientFactory.close();
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {}
+        });
+
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        final RequestLog log = ctx.log().whenComplete().join();
+        assertThat(log.responseCause()).isNull();
+    }
+}


### PR DESCRIPTION
Motivation:

It would be legitimate that an HTTP/1 client closes a connection after data is fully received. Although the connection is closed, the stream on the server side can be still open. Because `HttpResponseSubscriber` may be complete after fully sending data and then receiving `onComplete()` signal. Receiving `onComplete()`, `HttpResponseSubscriber` tries to write an empty chunk as a mark of EOS to the disconnected channel. https://github.com/line/armeria/blob/fee87f8da942d0e6343e814489524b73db60ef3b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L317-L320

The write attempt would fail with `ClosedSessionException` and the failure is set to `responseCause`. Practically, `responseCause` is meaningless and false positive.

Modifications:

- Check a connection is active as well when `Http1ObjectEncoder` determines a session is writable.
- Do not send EOS and mark a request as success when an HTTP/1 session is inactive when handling `onComplete()` in `HttpResponseSubscriber`

Result:

You no longer see `ClosedSessionException` when a connection is closed after a response data has been fully sent in HTTP/1.