### PR TITLE
Add `RequestLog.authenticatedUser()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -141,6 +141,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private String name;
     @Nullable
     private String fullName;
+    @Nullable
+    private String authenticatedUser;
 
     @Nullable
     private RequestHeaders requestHeaders;
@@ -836,6 +838,20 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         } else {
             return fullName = name;
         }
+    }
+
+    @Override
+    public String authenticatedUser() {
+        ensureAvailable(RequestLogProperty.AUTHENTICATED_USER);
+        return authenticatedUser;
+    }
+
+    @Override
+    public void authenticatedUser(String authenticatedUser) {
+        if (isAvailable(RequestLogProperty.AUTHENTICATED_USER)) {
+            return;
+        }
+        this.authenticatedUser = requireNonNull(authenticatedUser, "authenticatedUser");
     }
 
     @Override
@@ -1897,6 +1913,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         @Override
         public String fullName() {
             return DefaultRequestLog.this.fullName();
+        }
+
+        @Override
+        public String authenticatedUser() {
+            return authenticatedUser;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.netty.channel.Channel;
 
@@ -116,6 +117,14 @@ public interface RequestLogBuilder extends RequestLogAccess {
      * name or HTTP method name. This property is often used as a meter tag or distributed trace's span name.
      */
     void name(String name);
+
+    /**
+     * Sets the remote user of the request if it's authenticated. The value will be printed out if the
+     * {@linkplain AccessLogWriter access log} has {@code %u} format.
+     *
+     * @see <a href="https://httpd.apache.org/docs/current/mod/mod_log_config.html">Custom Log Formats</a>
+     */
+    void authenticatedUser(String authenticatedUser);
 
     /**
      * Increases the {@link RequestLog#requestLength()} by {@code deltaBytes}.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogProperty.java
@@ -64,6 +64,11 @@ public enum RequestLogProperty {
     NAME(true),
 
     /**
+     * {@link RequestLog#authenticatedUser()}.
+     */
+    AUTHENTICATED_USER(true),
+
+    /**
      * {@link RequestLog#requestHeaders()}.
      */
     REQUEST_HEADERS(true),

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -211,6 +211,14 @@ public interface RequestOnlyLog extends RequestLogAccess {
     String fullName();
 
     /**
+     * Returns the authenticated user which is used to print {@code %u} format of an access log.
+     *
+     * @see <a href="https://httpd.apache.org/docs/current/mod/mod_log_config.html">Custom Log Formats</a>
+     */
+    @Nullable
+    String authenticatedUser();
+
+    /**
      * Returns the {@link RequestHeaders}. If the {@link Request} was not received or sent at all,
      * it will return a dummy {@link RequestHeaders} whose {@code :authority} and {@code :path} are
      * set to {@code "?"}, {@code :scheme} is set to {@code "http"} or {@code "https"}, and {@code :method} is

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -290,7 +290,7 @@ interface AccessLogComponent {
                     // We do not support this log type now.
                     return null;
                 case AUTHENTICATED_USER:
-                    return firstNonNull(log.authenticatedUser(), "-");
+                    return log.authenticatedUser();
                 case REQUEST_LINE:
                     final String httpMethodName = log.requestHeaders().method().name();
                     final String path = log.requestHeaders().path();

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -287,10 +287,10 @@ interface AccessLogComponent {
                     return ra instanceof InetSocketAddress ? ((InetSocketAddress) ra).getHostString() : null;
 
                 case RFC931:
-                case AUTHENTICATED_USER:
-                    // We do not support these kinds of log types now.
+                    // We do not support this log type now.
                     return null;
-
+                case AUTHENTICATED_USER:
+                    return firstNonNull(log.authenticatedUser(), "-");
                 case REQUEST_LINE:
                     final String httpMethodName = log.requestHeaders().method().name();
                     final String path = log.requestHeaders().path();
@@ -300,7 +300,7 @@ interface AccessLogComponent {
                                            GRPC_SERVICE_NAME.equals(rpcRequest.serviceType().getName());
 
                     final String logName;
-                    if (name != null && !isGrpc) {
+                    if (!isGrpc) {
                         String serviceName = log.serviceName();
                         if (serviceName != null) {
                             final int idx = serviceName.lastIndexOf('.') + 1;

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -194,8 +194,8 @@ class AccessLogFormatsTest {
                                      .id(id)
                                      .build();
         ctx.setAttr(Attr.ATTR_KEY, new Attr("line"));
-
         final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.authenticatedUser("foo");
         logBuilder.endRequest();
         ctx.log().ensureRequestComplete();
 
@@ -218,12 +218,13 @@ class AccessLogFormatsTest {
 
         message = AccessLogger.format(AccessLogFormats.COMMON, log);
         assertThat(message).isEqualTo(
-                localhostAddress + " - - " + timestamp + " \"GET /armeria/log#" + logName + " h2c\" 200 1024");
+                localhostAddress + " - foo " + timestamp + " \"GET /armeria/log#" + logName +
+                " h2c\" 200 1024");
 
         message = AccessLogger.format(AccessLogFormats.COMBINED, log);
         assertThat(message).isEqualTo(
-                localhostAddress + " - - " + timestamp + " \"GET /armeria/log#" + logName + " h2c\" 200 1024" +
-                " \"http://log.example.com\" \"armeria/x.y.z\" \"a=1;b=2\"");
+                localhostAddress + " - foo " + timestamp + " \"GET /armeria/log#" + logName +
+                " h2c\" 200 1024 \"http://log.example.com\" \"armeria/x.y.z\" \"a=1;b=2\"");
 
         // Check conditions with custom formats.
         format = AccessLogFormats.parseCustom(
@@ -232,16 +233,16 @@ class AccessLogFormatsTest {
 
         message = AccessLogger.format(format, log);
         assertThat(message).isEqualTo(
-                localhostAddress + " - - " + timestamp + " \"GET /armeria/log#" + logName + " h2c\" 200 1024" +
-                " \"http://log.example.com\" \"-\" some-text -");
+                localhostAddress + " - foo " + timestamp + " \"GET /armeria/log#" + logName +
+                " h2c\" 200 1024 \"http://log.example.com\" \"-\" some-text -");
 
         format = AccessLogFormats.parseCustom(
                 "%h %l %u %t \"%r\" %s %b \"%!200,302{Referer}i\" \"%200,304{User-Agent}i\"" +
                 " some-text %{Non-Existing-Header}i");
         message = AccessLogger.format(format, log);
         assertThat(message).isEqualTo(
-                localhostAddress + " - - " + timestamp + " \"GET /armeria/log#" + logName + " h2c\" 200 1024" +
-                " \"-\" \"armeria/x.y.z\" some-text -");
+                localhostAddress + " - foo " + timestamp + " \"GET /armeria/log#" + logName +
+                " h2c\" 200 1024 \"-\" \"armeria/x.y.z\" some-text -");
 
         format = AccessLogFormats.parseCustom(
                 "%{com.linecorp.armeria.server.logging.AccessLogFormatsTest$Attr#KEY" +


### PR DESCRIPTION
Motivation:
A server admin might want to track the usage of an API that who calls it. If we provide a way to set the authenticated user and print it out using the `%u` format of the access log, the admin can easily track it.
Related: https://httpd.apache.org/docs/current/mod/mod_log_config.html

Modifications:
- Add `RequestLogBuilder.authenticatedUser(name)` and `RequestLog.authenticatedUser()`.
- Print `RequestLog.authenticatedUser()` using `%u` format of the access log.

Result:
- You can now set and see the authenticated user of a request in an access log.