### PR TITLE
Make TLS settings updated with `Server.reconfigure()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -126,21 +126,17 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             new Http2FrameLogger(LogLevel.TRACE, "com.linecorp.armeria.logging.traffic.server.http2");
 
     private final ServerPort port;
-    private final ServerConfig config;
-    @Nullable
-    private final Mapping<String, SslContext> sslContexts;
+    private final UpdatableServerConfig config;
     private final GracefulShutdownSupport gracefulShutdownSupport;
 
     /**
      * Creates a new instance.
      */
     HttpServerPipelineConfigurator(
-            ServerConfig config, ServerPort port,
-            @Nullable Mapping<String, SslContext> sslContexts,
+            UpdatableServerConfig config, ServerPort port,
             GracefulShutdownSupport gracefulShutdownSupport) {
         this.config = config;
         this.port = requireNonNull(port, "port");
-        this.sslContexts = sslContexts;
         this.gracefulShutdownSupport = requireNonNull(gracefulShutdownSupport, "gracefulShutdownSupport");
     }
 
@@ -231,7 +227,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private void configureHttps(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
-        assert sslContexts != null;
+        final Mapping<String, SslContext> sslContexts =
+                requireNonNull(config.sslContextMapping(), "config.sslContextMapping() returned null");
         p.addLast(new SniHandler(sslContexts));
         p.addLast(TrafficLoggingHandler.SERVER);
         p.addLast(new Http2OrHttpHandler(proxiedAddresses));

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -90,7 +90,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.handler.ssl.SslContext;
-import io.netty.util.Mapping;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -112,9 +111,6 @@ public final class Server implements ListenableAsyncCloseable {
     }
 
     private final UpdatableServerConfig config;
-    @Nullable
-    private final Mapping<String, SslContext> sslContexts;
-
     private final StartStopSupport<Void, Void, Void, ServerListener> startStop;
     private final Set<ServerChannel> serverChannels = new NonBlockingHashSet<>();
     private final Map<InetSocketAddress, ServerPort> activePorts = new LinkedHashMap<>();
@@ -127,7 +123,6 @@ public final class Server implements ListenableAsyncCloseable {
     Server(DefaultServerConfig serverConfig) {
         serverConfig.setServer(this);
         config = new UpdatableServerConfig(requireNonNull(serverConfig, "serverConfig"));
-        sslContexts = config.sslContextMapping();
         startStop = new ServerStartStopSupport(config.startStopExecutor());
         connectionLimitingHandler = new ConnectionLimitingHandler(config.maxNumConnections());
 

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -546,8 +546,7 @@ public final class Server implements ListenableAsyncCloseable {
             b.group(bossGroup, config.workerGroup());
             b.channel(Flags.transportType().serverChannelType());
             b.handler(connectionLimitingHandler);
-            b.childHandler(new HttpServerPipelineConfigurator(config, port,
-                                                              sslContexts, gracefulShutdownSupport));
+            b.childHandler(new HttpServerPipelineConfigurator(config, port, gracefulShutdownSupport));
             return b.bind(port.localAddress());
         }
 

--- a/core/src/test/java/com/linecorp/armeria/ReconfigureTlsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/ReconfigureTlsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
+import com.linecorp.armeria.server.Server;
+
+class ReconfigureTlsTest {
+
+    @Test
+    void shouldUpdateTlsSettings() throws CertificateException {
+        final SelfSignedCertificate oldCert =
+                new SelfSignedCertificate(Date.from(Instant.parse("2022-01-01T00:00:00.00Z")),
+                                          Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
+        final AtomicReference<X509Certificate> sslContextRef = new AtomicReference<>();
+        final Server server =
+                Server.builder()
+                      .https(0)
+                      .tls(oldCert.certificate(), oldCert.privateKey())
+                      .service("/", (ctx, req) -> {
+                          sslContextRef.set((X509Certificate) ctx.sslSession().getLocalCertificates()[0]);
+                          return HttpResponse.of("OK");
+                      })
+                      .build();
+
+        server.start().join();
+
+        final BlockingWebClient client =
+                WebClient.builder("https://127.0.0.1:" + server.activeLocalPort())
+                         .factory(ClientFactory.builder()
+                                               .tlsCustomizer(sslContextBuilder -> {
+                                                   sslContextBuilder.trustManager(
+                                                           oldCert.certificate());
+                                               })
+                                               .build())
+                         .build()
+                         .blocking();
+        final AggregatedHttpResponse response = client.get("/");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(sslContextRef.get().getNotBefore()).isEqualTo(oldCert.cert().getNotBefore());
+
+        final SelfSignedCertificate newCert =
+                new SelfSignedCertificate(Date.from(Instant.parse("2023-01-01T00:00:00.00Z")),
+                                          Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
+        server.reconfigure(sb -> {
+            sb.tls(newCert.certificate(), newCert.privateKey())
+              .service("/", (ctx, req) -> {
+                  sslContextRef.set((X509Certificate) ctx.sslSession().getLocalCertificates()[0]);
+                  return HttpResponse.of("OK");
+              });
+        });
+
+        // Create a new client with a new ClientFactory to establish a new connection with the new certificate.
+        final BlockingWebClient client2 =
+                WebClient.builder("https://127.0.0.1:" + server.activeLocalPort())
+                          .factory(ClientFactory.builder()
+                                                .tlsCustomizer(sslContextBuilder -> {
+                                                    sslContextBuilder.trustManager(
+                                                            newCert.certificate());
+                                                })
+                                                .build())
+                          .build()
+                          .blocking();
+        final AggregatedHttpResponse response2 = client2.get("/");
+        assertThat(response2.status()).isEqualTo(HttpStatus.OK);
+        assertThat(sslContextRef.get().getNotBefore()).isEqualTo(newCert.cert().getNotBefore());
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/ReconfigureTlsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/ReconfigureTlsTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -41,7 +42,7 @@ class ReconfigureTlsTest {
     void shouldUpdateTlsSettings() throws CertificateException {
         final SelfSignedCertificate oldCert =
                 new SelfSignedCertificate(Date.from(Instant.parse("2022-01-01T00:00:00.00Z")),
-                                          Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
+                                          Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
         final AtomicReference<X509Certificate> sslContextRef = new AtomicReference<>();
         final Server server =
                 Server.builder()
@@ -71,7 +72,7 @@ class ReconfigureTlsTest {
 
         final SelfSignedCertificate newCert =
                 new SelfSignedCertificate(Date.from(Instant.parse("2023-01-01T00:00:00.00Z")),
-                                          Date.from(Instant.parse("2024-01-01T00:00:00.00Z")));
+                                          Date.from(Instant.now().plus(10, ChronoUnit.DAYS)));
         server.reconfigure(sb -> {
             sb.tls(newCert.certificate(), newCert.privateKey())
               .service("/", (ctx, req) -> {

--- a/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
@@ -55,7 +55,7 @@ class ReconfigureTlsTest {
 
         server.start().join();
 
-        final BlockingWebClient client =
+        final BlockingWebClient client0 =
                 WebClient.builder("https://127.0.0.1:" + server.activeLocalPort())
                          .factory(ClientFactory.builder()
                                                .tlsCustomizer(sslContextBuilder -> {
@@ -65,7 +65,7 @@ class ReconfigureTlsTest {
                                                .build())
                          .build()
                          .blocking();
-        final AggregatedHttpResponse response = client.get("/");
+        final AggregatedHttpResponse response = client0.get("/");
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(sslContextRef.get().getNotBefore()).isEqualTo(oldCert.cert().getNotBefore());
 
@@ -81,7 +81,7 @@ class ReconfigureTlsTest {
         });
 
         // Create a new client with a new ClientFactory to establish a new connection with the new certificate.
-        final BlockingWebClient client2 =
+        final BlockingWebClient client1 =
                 WebClient.builder("https://127.0.0.1:" + server.activeLocalPort())
                           .factory(ClientFactory.builder()
                                                 .tlsCustomizer(sslContextBuilder -> {
@@ -91,8 +91,11 @@ class ReconfigureTlsTest {
                                                 .build())
                           .build()
                           .blocking();
-        final AggregatedHttpResponse response2 = client2.get("/");
+        final AggregatedHttpResponse response2 = client1.get("/");
         assertThat(response2.status()).isEqualTo(HttpStatus.OK);
         assertThat(sslContextRef.get().getNotBefore()).isEqualTo(newCert.cert().getNotBefore());
+
+        client0.options().factory().closeAsync();
+        client1.options().factory().closeAsync();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
@@ -72,8 +72,7 @@ class ReconfigureTlsTest {
                 WebClient.builder(server.httpsUri())
                          .factory(ClientFactory.builder()
                                                .tlsCustomizer(sslContextBuilder -> {
-                                                   sslContextBuilder.trustManager(
-                                                           oldCert.certificate());
+                                                   sslContextBuilder.trustManager(oldCert.certificate());
                                                }).build())
                          .build()
                          .blocking();
@@ -99,8 +98,7 @@ class ReconfigureTlsTest {
                 WebClient.builder(server.httpsUri())
                          .factory(ClientFactory.builder()
                                                .tlsCustomizer(sslContextBuilder -> {
-                                                   sslContextBuilder.trustManager(
-                                                           newCert.certificate());
+                                                   sslContextBuilder.trustManager(newCert.certificate());
                                                }).build())
                          .build()
                          .blocking();

--- a/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ReconfigureTlsTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria;
+package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +34,6 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
-import com.linecorp.armeria.server.Server;
 
 class ReconfigureTlsTest {
 


### PR DESCRIPTION
Motivation:

Currently, a TLS configuration is not updated with `Server.reconfigure()` because `HttpServerPipelineConfigurator` refers to the `sslContexts` made when a server is built initially and the reference won't change.

Modifications:

- Make `HttpServerPipelineConfigurator` read `sslContexts` from `UpdatableServerConfig` whenever a new HTTPS connection starts.

Result:

You can now dynamically update TLS configurations with `Server.reconfigure()`.

