### PR TITLE
Fix a typo of grpc tutorials

### DIFF
--- a/site/src/pages/tutorials/grpc/blog/define-service.mdx
+++ b/site/src/pages/tutorials/grpc/blog/define-service.mdx
@@ -108,7 +108,7 @@ Compile the `blog.proto` file to generate Java code.
 
 <Tip>
 
-  If you cannot execute the command with message `Task 'generateProto' not found in root project 'armeria-grpc'`, you need to configure the build.gradle by referring to [line/armeria-examples](https://github.com/line/armeria-examples/blob/master/tutorials/grpc/build.gradle).
+  Please refer to [build.gradle](https://github.com/line/armeria-examples/blob/master/tutorials/grpc/build.gradle) for generating code with [Protobuf Plugin for Gradle](https://github.com/google/protobuf-gradle-plugin).
 
 </Tip>
 

--- a/site/src/pages/tutorials/grpc/blog/define-service.mdx
+++ b/site/src/pages/tutorials/grpc/blog/define-service.mdx
@@ -106,6 +106,12 @@ Compile the `blog.proto` file to generate Java code.
 ./gradlew generateProto
 ```
 
+<Tip>
+
+  If you cannot execute the command with message `Task 'generateProto' not found in root project 'armeria-grpc-practice'`, you need to configure the build.gradle by referring to [examples of google/protobuf-gradle-plugin README](https://github.com/google/protobuf-gradle-plugin/blob/master/examples/exampleProject/build.gradle) or [grpc/grpc-java README](https://github.com/grpc/grpc-java#getting-started).
+
+</Tip>
+
 Find the Java code output in the directory, `{project_root}/build/generated/source/proto/main`.
 
 ## Next step

--- a/site/src/pages/tutorials/grpc/blog/define-service.mdx
+++ b/site/src/pages/tutorials/grpc/blog/define-service.mdx
@@ -108,7 +108,7 @@ Compile the `blog.proto` file to generate Java code.
 
 <Tip>
 
-  If you cannot execute the command with message `Task 'generateProto' not found in root project 'armeria-grpc-practice'`, you need to configure the build.gradle by referring to [examples of google/protobuf-gradle-plugin README](https://github.com/google/protobuf-gradle-plugin/blob/master/examples/exampleProject/build.gradle) or [grpc/grpc-java README](https://github.com/grpc/grpc-java#getting-started).
+  If you cannot execute the command with message `Task 'generateProto' not found in root project 'armeria-grpc'`, you need to configure the build.gradle by referring to [line/armeria-examples](https://github.com/line/armeria-examples/blob/master/tutorials/grpc/build.gradle).
 
 </Tip>
 

--- a/site/src/pages/tutorials/grpc/blog/implement-create.mdx
+++ b/site/src/pages/tutorials/grpc/blog/implement-create.mdx
@@ -32,9 +32,8 @@ Let's implement a service method `createBlogPost()` in `BlogService.java`.
   import java.util.Map;
   import java.util.concurrent.ConcurrentHashMap;
   import java.util.concurrent.atomic.AtomicInteger;
-  
+
   public final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
-    private static final Logger logger = LoggerFactory.getLogger(BlogService.class);
     private final AtomicInteger idGenerator = new AtomicInteger();
     private final Map<Integer, BlogPost> blogPosts = new ConcurrentHashMap<>();
   }
@@ -102,7 +101,7 @@ Now, let's make a call from the client. Note the code is minimal to keep things 
     blogClient.testRun();
   }
 
-  void testRun(){
+  void testRun() {
     createBlogPost("Another blog post", "Creating a post via createBlogPost().");
   }
   ```
@@ -113,11 +112,6 @@ Now, let's make a call from the client. Note the code is minimal to keep things 
 3. Run the client. You'll see only a single message for blog posting, because we haven't added logging for creating a post in the `main()` method.
   ```bash
   [main] INFO  e.a.client.blog.grpc.BlogClient - [Create response] Title: Another blog post Content: Creating a post via createBlogPost().
-  ```
-  You can check that indeed two posts have been created by checking the server side.
-  ```bash
-  [armeria-common-worker-nio-2-1] INFO  e.a.server.blog.grpc.ServerMain - Created at 0 - My first blog
-  [armeria-common-worker-nio-2-1] INFO  e.a.server.blog.grpc.ServerMain - Created at 1 - Another blog post
   ```
 
 ## What's next

--- a/site/src/pages/tutorials/grpc/blog/implement-delete.mdx
+++ b/site/src/pages/tutorials/grpc/blog/implement-delete.mdx
@@ -46,7 +46,7 @@ Let's implement a service method `deleteBlogPost()` in `BlogService.java` we've 
       final BlogPost removed = blogPosts.remove(request.getId());
       if (removed == null) {
         responseObserver.onError(
-          throw new IllegalArgumentException("The blog post does not exist. ID: " + request.getId());
+          new BlogNotFoundException("The blog post does not exist. ID: " + request.getId()));
       } else {
           responseObserver.onNext(Empty.getDefaultInstance());
           responseObserver.onCompleted();

--- a/site/src/pages/tutorials/grpc/blog/implement-read.mdx
+++ b/site/src/pages/tutorials/grpc/blog/implement-read.mdx
@@ -100,7 +100,7 @@ This time, we'll implement a client method for each corresponding server method.
   ```java filename=BlogClient.java
   import example.armeria.blog.grpc.Blog.GetBlogPostRequest;
   ...
-  static void getBlogPost(int id){
+  static void getBlogPost(int id) {
     final BlogPost blogPost = client.getBlogPost(GetBlogPostRequest.newBuilder().setId(id).build());
   }
   ```
@@ -217,7 +217,7 @@ Let's retrieve the second blog post. Apparently, the ID to use is `1`.
 
 1. Call the `getBlogPost()` method.
   ```java filename=BlogClient.java
-  static void testRun(){
+  static void testRun() {
     createBlogPost("Another blog post", "Creating a post via createBlogPost().");
     listBlogPosts();  // feel free to comment this out or leave it
     getBlogPost(1);   // add this

--- a/site/src/pages/tutorials/grpc/blog/implement-update.mdx
+++ b/site/src/pages/tutorials/grpc/blog/implement-update.mdx
@@ -71,6 +71,8 @@ You need to have the files obtained from previous steps:
  ```
 3. Add an exception handler class for the blog service.
   ```java filename=GrpcExceptionHandler.java
+  package example.armeria.blog.grpc;
+
   import com.linecorp.armeria.common.RequestContext;
   import com.linecorp.armeria.common.annotation.Nullable;
   import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
@@ -113,7 +115,7 @@ Add a method `updateBlogPost()` to send a request to update a blog post.
 import example.armeria.blog.grpc.Blog.UpdateBlogPostRequest;
 
 class BlogClient {
-  static void updateBlogPost(Integer id, String newTitle, String newContent){
+  static void updateBlogPost(Integer id, String newTitle, String newContent) {
     final UpdateBlogPostRequest request = UpdateBlogPostRequest.newBuilder()
                                                                .setId(id)
                                                                .setTitle(newTitle)

--- a/site/src/pages/tutorials/grpc/blog/index.mdx
+++ b/site/src/pages/tutorials/grpc/blog/index.mdx
@@ -79,6 +79,7 @@ repositories {
 }\n
 dependencies {
   implementation "com.linecorp.armeria:armeria:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  implementation "com.linecorp.armeria:armeria-grpc:${versions['com.linecorp.armeria:armeria-bom']}"\n
   // Logging
   runtimeOnly "ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}"
 }

--- a/site/src/pages/tutorials/grpc/blog/run-service.mdx
+++ b/site/src/pages/tutorials/grpc/blog/run-service.mdx
@@ -37,7 +37,12 @@ Build a service and server using Armeria's <type://ServerBuilder> to serve our s
   ```java filename=Main.java
   package example.armeria.blog.grpc;
 
-  public final class Main {}
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+  public final class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+  }
   ```
 2. Create a service instance using Armeria's <type://GrpcService#builder()>.
   ```java filename=Main.java
@@ -113,7 +118,7 @@ We've only tested running the service on a server. This time, let's try calling 
   }
   ```
 3. Although we haven't implemented any service methods, we'll call one just to check whether our client can communicate with the server.
-  ```java
+  ```java filename=BlogClient.java
   import example.armeria.blog.grpc.Blog.BlogPost;
   import example.armeria.blog.grpc.Blog.CreateBlogPostRequest;
 
@@ -123,7 +128,7 @@ We've only tested running the service on a server. This time, let's try calling 
                                                          .setTitle("My first blog")
                                                          .setContent("Yay")
                                                          .build();
-    BlogPost response = blogService.createBlogPost(request);
+    BlogPost response = client.createBlogPost(request);
   }
   ```
 


### PR DESCRIPTION
Motivation:

1. build.gradle code blocks in [grpc tutorial introduction - Try writing blog service yourself](https://armeria.dev/tutorials/grpc/blog#try-writing-blog-service-yourself) miss the armeria-grpc artifact.
2. BlogService.java code blocks in [Test run service - 1. Declare an empty service](https://armeria.dev/tutorials/grpc/blog/run-service#1-declare-an-empty-service) miss the declaration of logger. It may have been omitted by the author's intention but [REST tutorials](https://armeria.dev/tutorials/rest/blog/create-server/#1-create-a-server-instance) have explicitly declared logger variable. Therefore, I think it is good to specify it in the grpc tutorial as well.
3. Typo in code blocks of step 3 of [Test run service - 4. Write a client](https://armeria.dev/tutorials/grpc/blog/run-service/#4-write-a-client). The variable name `blogService` does not exist. The correct variable name is `client`.
4. Because there is no logging code in BlogService.java in [Implement CREATE - 1. Implement server-side](https://armeria.dev/tutorials/grpc/blog/implement-create#1-implement-server-side), server side log of step 3 of [Implement CREATE - 3. Test run](https://armeria.dev/tutorials/grpc/blog/implement-create/#3-test-run) can not occur.
5. Typo in code blocks of step 1 of [Implement DELETE - 1. Implement server-side](https://armeria.dev/tutorials/grpc/blog/implement-delete/#1-implement-server-side). `responseObserver.onError(throw new IllegalArgumentException("The blog post does not exist. ID: " + request.getId());`. `throw` statement cannot come in place of arguments and one closing parenthesis is missing. Also, because error log at [step 4 of Test run](https://armeria.dev/tutorials/grpc/blog/implement-delete#3-test-run) shows NOT_FOUND, it should generates `BlogNotFoundException`, not `IllegalArgumentException`.

Modifications:

1. Add armeria-grpc artifact to build.gradle.
2. Add logger declaration to code blocks.
3. Fix the typo `blogService` to `client`.
4. Remove the mention of server side log at "3. Test run" and because it is no longer used, remove the declaration of logger at "1. Implement server-side".
    - Alternatively, Add `logger.info("Created at {} - {}", updated.getId(), updated.getTitle());` to BlogService.java code blocks of step 2 of "1. Implement server-side".
5. Fix the line to `responseObserver.onError(new BlogNotFoundException("The blog post does not exist. ID: " + request.getId()));`.
6. Add a tip to [Define service - 6. Compile proto file](https://armeria.dev/tutorials/grpc/blog/define-service#6-compile-proto-file) based on my experience. However, if this tip is confusing, I will delete it.

Result:

- Typos in the documentation will be fixed.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
