### PR TITLE
Fix HttpJsonTranscodingService to accept google.protobuf.FieldMask field as string

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -68,6 +68,7 @@ import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
@@ -397,7 +398,8 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         final String fullName = messageType.getFullName();
 
         if (Timestamp.getDescriptor().getFullName().equals(fullName) ||
-            Duration.getDescriptor().getFullName().equals(fullName)) {
+            Duration.getDescriptor().getFullName().equals(fullName) ||
+            FieldMask.getDescriptor().getFullName().equals(fullName)) {
             return JavaType.STRING;
         }
 

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -26,6 +26,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/field_mask.proto";
 
 service HttpJsonTranscodingTestService {
   rpc GetMessageV1(GetMessageRequestV1) returns (Message) {
@@ -65,6 +66,12 @@ service HttpJsonTranscodingTestService {
   rpc EchoTimestampAndDuration(EchoTimestampAndDurationRequest) returns (EchoTimestampAndDurationResponse) {
     option (google.api.http) = {
       get: "/v1/echo/{timestamp}/{duration}"
+    };
+  }
+
+  rpc EchoFieldMask(EchoFieldMaskRequest) returns (EchoFieldMaskResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/field_mask"
     };
   }
 
@@ -240,6 +247,15 @@ message EchoTimestampAndDurationRequest {
 message EchoTimestampAndDurationResponse {
   google.protobuf.Timestamp timestamp = 1;
   google.protobuf.Duration duration = 2;
+}
+
+message EchoFieldMaskRequest {
+  google.protobuf.FieldMask field_mask = 1;
+}
+
+message EchoFieldMaskResponse {
+  google.protobuf.FieldMask field_mask = 1;
+  int32 path_count = 2;
 }
 
 message EchoWrappersRequest {


### PR DESCRIPTION
Motivation:
Bug in HttpJsonTranscodingService when serializing FieldMask parameter

Result:

- Closes #4633 

