### PR TITLE
Fix HttpJsonTranscodingService to find field descriptor with `field.getMessageType()`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -339,17 +339,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         throw new RecursiveTypeException(field.getMessageType());
                     }
 
-                    @Nullable
-                    Descriptor typeDesc =
-                            desc.getNestedTypes().stream()
-                                .filter(d -> d.getFullName().equals(field.getMessageType().getFullName()))
-                                .findFirst().orElse(null);
-                    if (typeDesc == null) {
-                        typeDesc = field.getMessageType();
-                    }
-                    checkState(typeDesc != null,
-                               "Descriptor for the type '%s' does not exist.",
-                               field.getMessageType().getFullName());
+                    final Descriptor typeDesc = field.getMessageType();
                     try {
                         builder.putAll(buildFields(typeDesc,
                                                    ImmutableList.<String>builder()

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -31,7 +31,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
@@ -63,7 +62,6 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
-import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.protobuf.DoubleValue;
@@ -347,16 +345,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                                 .filter(d -> d.getFullName().equals(field.getMessageType().getFullName()))
                                 .findFirst().orElse(null);
                     if (typeDesc == null) {
-                        // From the proto file.
                         typeDesc = field.getMessageType();
-                    }
-                    if (typeDesc == null) {
-                        // According to the Language guide, the public import functionality is not available
-                        // in Java. We will try to find dependencies only with "import" keyword.
-                        // https://developers.google.com/protocol-buffers/docs/proto3#importing_definitions
-                        typeDesc = desc.getFile().getDependencies().stream()
-                                       .map(fd -> findTypeDescriptor(fd, field))
-                                       .filter(Objects::nonNull).findFirst().orElse(null);
                     }
                     checkState(typeDesc != null,
                                "Descriptor for the type '%s' does not exist.",
@@ -434,15 +423,6 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         }
 
         return null;
-    }
-
-    @Nullable
-    private static Descriptor findTypeDescriptor(FileDescriptor file, FieldDescriptor field) {
-        final Descriptor messageType = field.getMessageType();
-        if (!file.getPackage().equals(messageType.getFile().getPackage())) {
-            return null;
-        }
-        return file.findMessageTypeByName(messageType.getName());
     }
 
     // to make it more efficient, we calculate whether extract response body one time

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -348,7 +348,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                                 .findFirst().orElse(null);
                     if (typeDesc == null) {
                         // From the proto file.
-                        typeDesc = findTypeDescriptor(desc.getFile(), field);
+                        typeDesc = field.getMessageType();
                     }
                     if (typeDesc == null) {
                         // According to the Language guide, the public import functionality is not available

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.server.grpc;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -66,6 +66,8 @@ import com.linecorp.armeria.grpc.testing.Transcoding.EchoAnyRequest;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoAnyResponse;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoListValueRequest;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoListValueResponse;
+import com.linecorp.armeria.grpc.testing.Transcoding.EchoNestedMessageRequest;
+import com.linecorp.armeria.grpc.testing.Transcoding.EchoNestedMessageResponse;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoRecursiveRequest;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoRecursiveResponse;
 import com.linecorp.armeria.grpc.testing.Transcoding.EchoResponseBodyRequest;
@@ -281,6 +283,14 @@ public class HttpJsonTranscodingTest {
                                                StreamObserver<EchoResponseBodyResponse>
                                                        responseObserver) {
             responseObserver.onNext(getResponseBodyResponse(request));
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void echoNestedMessageField(EchoNestedMessageRequest request,
+                                           StreamObserver<EchoNestedMessageResponse> responseObserver) {
+            responseObserver
+                    .onNext(EchoNestedMessageResponse.newBuilder().setNested(request.getNested()).build());
             responseObserver.onCompleted();
         }
     }
@@ -878,6 +888,23 @@ public class HttpJsonTranscodingTest {
                                                             .execute()
                                                             .content();
         assertThat(response2.get("text").asText()).isEqualTo("1:testQuery:testChildField:testChildField2");
+    }
+
+    @Test
+    void shouldAcceptNestedMessageTypeFields() throws JsonProcessingException {
+        final String jsonContent =
+                '{' +
+                "  \"nested\": {" +
+                "    \"name\": \"Armeria\"" +
+                "  }" +
+                '}';
+        final AggregatedHttpResponse response = jsonPostRequest(webClient,
+                                                                "/v1/echo/nested_message", jsonContent);
+        final JsonNode root = mapper.readTree(response.contentUtf8());
+        final JsonNode nested = root.get("nested");
+        assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThat(nested).isNotNull().matches(v -> ((TreeNode) v).isObject());
+        assertThat(nested.get("name").asText()).isEqualTo("Armeria");
     }
 
     public static JsonNode findMethod(JsonNode methods, String name) {

--- a/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
+++ b/grpc/src/test/proto/com/linecorp/armeria/grpc/testing/transcoding.proto
@@ -187,6 +187,15 @@ service HttpJsonTranscodingTestService {
     };
   }
 
+  rpc EchoNestedMessageField(EchoNestedMessageRequest) returns (EchoNestedMessageResponse) {
+    option (google.api.http) = {
+      get: "/v1/echo/nested_message"
+      additional_bindings {
+        post: "/v1/echo/nested_message"
+        body: "*"
+      }
+    };
+  }
 }
 
 message GetMessageRequestV1 {
@@ -325,4 +334,20 @@ message EchoResponseBodyResponse {
   string value = 1;
   StructBody struct_body = 2;
   repeated string array_field = 3;
+}
+
+message TopLevelMessage {
+  string name = 1;
+  NestedMessage nested = 2;
+  message NestedMessage {
+    string name = 1;
+  }
+}
+
+message EchoNestedMessageRequest {
+  TopLevelMessage.NestedMessage nested = 1;
+}
+
+message EchoNestedMessageResponse {
+  TopLevelMessage.NestedMessage nested = 1;
 }


### PR DESCRIPTION

Motivation:

Bug in HttpJsonTranscodingService when finding descriptor for nested message types

Result:

- Closes #4631 
