### PR TITLE
Fix a bug where duplicate parameters are shown in DocService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -128,7 +128,7 @@ final class AnnotatedBeanFactoryRegistry {
 
             // TreeSet internally creates a binary tree. A consistent comparison for the two inputs is
             // necessary to traverse the binary tree correctly and check uniqueness.
-            // If compare(o1, o2) returns -1, compare(o2, o1) should return 1.
+            // If compare(o1, o2) returns -1, compare(o2, o1) should return 1 or a positive number.
             if (o1AnnotationType != null) {
                 o1Name += '/' + o1AnnotationType.getName();
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -139,6 +139,10 @@ final class AnnotatedBeanFactoryRegistry {
             if (result != 0) {
                 return result;
             }
+            // It is still not a good idea to return 0 since the equality for `httpElementName()` and
+            // `annotationType()` have not passed. `o1AnnotationType` and `o2AnnotationType` may be the same
+            // class but loaded by two class different loaders. The hash comparison is used to return a non-zero
+            // value for the different classes.
             return Ints.compare(Objects.hashCode(o1AnnotationType), Objects.hashCode(o2AnnotationType));
         });
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -140,9 +140,9 @@ final class AnnotatedBeanFactoryRegistry {
                 return result;
             }
             // It is still not a good idea to return 0 since the equality for `httpElementName()` and
-            // `annotationType()` have not passed. `o1AnnotationType` and `o2AnnotationType` may be the same
-            // class but loaded by two class different loaders. The hash comparison is used to return a non-zero
-            // value for the different classes.
+            // `annotationType()` is broken. `o1AnnotationType` and `o2AnnotationType` may be the same
+            // class, but loaded by two class different loaders. The hash comparison is used to return a
+            // non-zero value for the different classes.
             return Ints.compare(Objects.hashCode(o1AnnotationType), Objects.hashCode(o2AnnotationType));
         });
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -122,7 +122,7 @@ final class AnnotatedBeanFactoryRegistry {
             String o2Name = o2.httpElementName();
             final Class<? extends Annotation> o1AnnotationType = o1.annotationType();
             final Class<? extends Annotation> o2AnnotationType = o2.annotationType();
-            if (o1Name.equals(o2Name) && o1AnnotationType == o2AnnotationType) {
+            if (o1AnnotationType == o2AnnotationType && o1Name.equals(o2Name)) {
                 return 0;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistry.java
@@ -136,7 +136,7 @@ final class AnnotatedBeanFactoryRegistry {
                 o2Name += '/' + o2AnnotationType.getName();
             }
             final int result = o1Name.compareTo(o2Name);
-            if(result != 0) {
+            if (result != 0) {
                 return result;
             }
             return Ints.compare(Objects.hashCode(o1AnnotationType), Objects.hashCode(o2AnnotationType));

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/DataClassDocServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/DataClassDocServiceTest.kt
@@ -40,14 +40,25 @@ class DataClassDocServiceTest {
             .execute()
             .content()
 
+        println(jsonNode)
         assertThat(jsonNode.get("services")[0]["methods"][0]["parameters"][0]["typeSignature"].asText())
-            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries")
+            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries1")
         assertThat(jsonNode.get("structs")[0]["name"].asText())
-            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries")
-        val fields = jsonNode.get("structs")[0]["fields"] as ArrayNode
-        assertThat(fields).hasSize(2)
-        assertThat(fields[0]["name"].asText()).isEqualTo("name")
-        assertThat(fields[1]["name"].asText()).isEqualTo("limit")
+            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries1")
+        val fields1 = jsonNode.get("structs")[0]["fields"] as ArrayNode
+        assertThat(fields1).hasSize(2)
+        assertThat(fields1[0]["name"].asText()).isEqualTo("name")
+        assertThat(fields1[1]["name"].asText()).isEqualTo("limit")
+
+        assertThat(jsonNode.get("services")[0]["methods"][1]["parameters"][0]["typeSignature"].asText())
+            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries2")
+        assertThat(jsonNode.get("structs")[1]["name"].asText())
+            .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries2")
+        val fields2 = jsonNode.get("structs")[1]["fields"] as ArrayNode
+        assertThat(fields2).hasSize(3)
+        assertThat(fields2[0]["name"].asText()).isEqualTo("application")
+        assertThat(fields2[1]["name"].asText()).isEqualTo("topic")
+        assertThat(fields2[2]["name"].asText()).isEqualTo("group")
     }
 
     companion object {
@@ -55,6 +66,7 @@ class DataClassDocServiceTest {
         @RegisterExtension
         val server = object : ServerExtension() {
             override fun configure(sb: ServerBuilder) {
+                sb.http(8080)
                 sb.annotatedService()
                     .requestConverters()
                 sb.annotatedService(MyKotlinService())
@@ -65,18 +77,32 @@ class DataClassDocServiceTest {
 }
 
 class MyKotlinService {
-    @Get("/example")
-    fun getId(@Suppress("UNUSED_PARAMETER") queries: ExampleQueries): String {
+    @Get("/example1")
+    fun getIdV1(@Suppress("UNUSED_PARAMETER") queries: ExampleQueries1): String {
+        return "example"
+    }
+
+    @Get("/example2")
+    fun getIdV2(@Suppress("UNUSED_PARAMETER") queries: ExampleQueries2): String {
         return "example"
     }
 }
 
-data class ExampleQueries(
+data class ExampleQueries1(
     @Param
     val name: String,
 
     @Param @Default
     val limit: Int?
+)
+
+data class ExampleQueries2(
+    @Param
+    val application: String,
+    @Param
+    val topic: String,
+    @Param
+    val group: String,
 )
 
 data class ExampleBody(val name: String, val limit: Int?)

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/DataClassDocServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/DataClassDocServiceTest.kt
@@ -40,7 +40,6 @@ class DataClassDocServiceTest {
             .execute()
             .content()
 
-        println(jsonNode)
         assertThat(jsonNode.get("services")[0]["methods"][0]["parameters"][0]["typeSignature"].asText())
             .isEqualTo("com.linecorp.armeria.server.kotlin.ExampleQueries1")
         assertThat(jsonNode.get("structs")[0]["name"].asText())
@@ -66,7 +65,6 @@ class DataClassDocServiceTest {
         @RegisterExtension
         val server = object : ServerExtension() {
             override fun configure(sb: ServerBuilder) {
-                sb.http(8080)
                 sb.annotatedService()
                     .requestConverters()
                 sb.annotatedService(MyKotlinService())


### PR DESCRIPTION
Motivation:

When an annotation is applied to Kotlin data class, Kotlin compiler constructor parameters with the annotation and adds the fields as well.
```kt
data class ExampleQueries(
    @Param
    val application: String,
    @Param
    val topic: String,
    @Param
    val group: String,
)
```

Annotated services extract both the fields from the constructor and fields using reflection. The problem was reported by #3454 and fixed by #3461. However, there is a bug in detecting duplicates.
See for the detail. https://github.com/line/armeria/issues/3454#issuecomment-1408392569

Modifications:

- Check both `httpElementName` and `anntationType()` if they are not equal to provide a consistent comparison.

Result:

You no longer see duplicate parameters in `DocService` when parameter annotations for a request object are added to Kotlin data class.
