### PR TITLE
Fix broken emoji in web site

### DIFF
--- a/site/src/components/emoji.tsx
+++ b/site/src/components/emoji.tsx
@@ -10,7 +10,9 @@ const Emoji: React.FC<EmojiProps> = (props) => svgEmoji(props.text);
 function svgEmoji(input: string) {
   try {
     return emoji(input, {
-      baseUrl: 'https://twemoji.maxcdn.com/2/svg/',
+      // baseUrl shouldn't end with '/'.
+      // https://github.com/appfigures/react-easy-emoji/issues/25
+      baseUrl: 'https://twemoji.maxcdn.com/2/svg',
       ext: '.svg',
       size: '',
     });


### PR DESCRIPTION
Motivation:
Emoji link is broken in https://armeria.dev/.

<img width="40%" alt="image" src="https://user-images.githubusercontent.com/13622816/215762463-2cd34ffd-3fe9-4243-acaa-708ba551f918.png"> <img width="40%" alt="image" src="https://user-images.githubusercontent.com/13622816/215762541-e86870be-ca75-4b0b-b3b7-bb28ddeb8be2.png">


The emoji URL generated by `Emoji` is https://twemoji.maxcdn.com/2/svg//2728.svg,
but expected link is https://twemoji.maxcdn.com/2/svg/2728.svg.

Basically, this is a bug of library `react-easy-emoji`.
The library should remove `/` from `baseUrl` when `option.size` is empty string.
https://github.com/appfigures/react-easy-emoji/blob/v1.8.1/lib/makeTwemojiRenderer.js#L35

As a workaround, we can specify `baseUrl` as URL without ending with `/` and `size` as empty string.


Modifications:
- Modify `baseUrl` parameter in `site/src/components/emoji.tsx` not to end with `/`.


Result:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/13622816/215762850-dee8a420-c2fb-48d9-a994-1cdd64b1441e.png">


Upstream issue:
- https://github.com/appfigures/react-easy-emoji/issues/25