### PR TITLE
Add `AsyncServerInterceptor` for gRPC services

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -44,13 +44,13 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.grpc.StackTraceElementProto;
@@ -132,7 +132,7 @@ public final class GrpcStatus {
             }
             return Status.INTERNAL.withCause(t);
         }
-        if (t instanceof ResponseTimeoutException) {
+        if (t instanceof TimeoutException) {
             return Status.DEADLINE_EXCEEDED.withCause(t);
         }
         if (t instanceof ContentTooLargeException) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -44,13 +44,13 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.grpc.StackTraceElementProto;
@@ -62,6 +62,8 @@ import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.grpc.protocol.StatusMessageEscaper;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.RequestTimeoutException;
 
 import io.grpc.Metadata;
 import io.grpc.Status;
@@ -81,7 +83,7 @@ public final class GrpcStatus {
      * well and the protocol package.
      */
     public static Status fromThrowable(Throwable t) {
-        t = unwrap(requireNonNull(t, "t"));
+        t = peelAndUnwrap(requireNonNull(t, "t"));
         return statusFromThrowable(t);
     }
 
@@ -93,7 +95,7 @@ public final class GrpcStatus {
      */
     public static Status fromThrowable(@Nullable GrpcStatusFunction statusFunction, RequestContext ctx,
                                        Throwable t, Metadata metadata) {
-        t = unwrap(requireNonNull(t, "t"));
+        t = peelAndUnwrap(requireNonNull(t, "t"));
 
         if (statusFunction != null) {
             final Status status = statusFunction.apply(ctx, t, metadata);
@@ -117,7 +119,7 @@ public final class GrpcStatus {
             // instead.
             return s;
         }
-        if (t instanceof ClosedStreamException) {
+        if (t instanceof ClosedStreamException || t instanceof RequestTimeoutException) {
             return Status.CANCELLED;
         }
         if (t instanceof UnprocessedRequestException || t instanceof IOException) {
@@ -130,7 +132,7 @@ public final class GrpcStatus {
             }
             return Status.INTERNAL.withCause(t);
         }
-        if (t instanceof TimeoutException) {
+        if (t instanceof ResponseTimeoutException) {
             return Status.DEADLINE_EXCEEDED.withCause(t);
         }
         if (t instanceof ContentTooLargeException) {
@@ -151,7 +153,7 @@ public final class GrpcStatus {
         if (statusFunction != null) {
             final Throwable cause = status.getCause();
             if (cause != null) {
-                final Throwable unwrapped = unwrap(cause);
+                final Throwable unwrapped = peelAndUnwrap(cause);
                 final Status newStatus = statusFunction.apply(ctx, unwrapped, metadata);
                 if (newStatus != null) {
                     return newStatus;
@@ -161,7 +163,8 @@ public final class GrpcStatus {
         return status;
     }
 
-    private static Throwable unwrap(Throwable t) {
+    private static Throwable peelAndUnwrap(Throwable t) {
+        t = Exceptions.peel(t);
         Throwable cause = t;
         while (cause != null) {
             if (cause instanceof ArmeriaStatusException) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -120,7 +120,7 @@ public final class GrpcStatus {
             return s;
         }
         if (t instanceof ClosedStreamException || t instanceof RequestTimeoutException) {
-            return Status.CANCELLED;
+            return Status.CANCELLED.withCause(t);
         }
         if (t instanceof UnprocessedRequestException || t instanceof IOException) {
             return Status.UNAVAILABLE.withCause(t);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AbstractServerCall.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.grpc.ForwardingCompressor;
 import com.linecorp.armeria.internal.common.grpc.ForwardingDecompressor;
@@ -206,6 +207,7 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     final void close(Throwable exception) {
+        exception = Exceptions.peel(exception);
         final Metadata metadata = generateMetadataFromThrowable(exception);
         close(GrpcStatus.fromThrowable(statusFunction, ctx, exception, metadata), metadata, exception);
     }
@@ -615,6 +617,10 @@ abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     @Nullable
     final Executor blockingExecutor() {
         return blockingExecutor;
+    }
+
+    final EventLoop eventLoop() {
+        return ctx.eventLoop();
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
@@ -31,21 +31,21 @@ import io.grpc.ServerInterceptor;
  * caller thread.
  * For example:
  * <pre>{@code
- * > class AuthServerInterceptor implements AsyncServerInterceptor {
- * >
- * >     @Override
- * >     <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(
- * >             ServerCall<I, O> call, Metadata headers, ServerCallHandler<I, O> next) {
- * >
- * >        return authorizer.authorize(headers).thenApply(result -> {
- * >             if (result) {
- * >                 return next.startCall(call, headers);
- * >             } else {
- * >                 throw new AuthenticationException("Invalid access");
- * >             }
- * >        });
- * >    }
- * > }
+ * class AuthServerInterceptor implements AsyncServerInterceptor {
+ *
+ *     @Override
+ *     <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(
+ *             ServerCall<I, O> call, Metadata headers, ServerCallHandler<I, O> next) {
+ *
+ *        return authorizer.authorize(headers).thenApply(result -> {
+ *             if (result) {
+ *                 return next.startCall(call, headers);
+ *             } else {
+ *                 throw new AuthenticationException("Invalid access");
+ *             }
+ *        });
+ *    }
+ * }
  * }</pre>
  */
 @UnstableApi

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
@@ -53,7 +53,7 @@ import io.grpc.ServerInterceptor;
 public interface AsyncServerInterceptor extends ServerInterceptor {
 
     /**
-     * Asynchronously intercept {@link ServerCall} dispatch by the {@code next} {@link ServerCallHandler}.
+     * Asynchronously intercepts {@link ServerCall} dispatch by the {@code next} {@link ServerCallHandler}.
      */
     <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(ServerCall<I, O> call, Metadata headers,
                                                              ServerCallHandler<I, O> next);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * A {@link ServerInterceptor} that is able to asynchronously execute the interceptor without blocking the
+ * caller thread.
+ * For example:
+ * <pre>{@code
+ * > class AuthServerInterceptor implements AsyncServerInterceptor {
+ * >
+ * >     @Override
+ * >     <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(
+ * >             ServerCall<I, O> call, Metadata headers, ServerCallHandler<I, O> next) {
+ * >
+ * >        return authorizer.authorize(headers).thenApply(result -> {
+ * >             if (result) {
+ * >                 return next.startCall(call, headers);
+ * >             } else {
+ * >                 throw new AuthenticationException("Invalid access");
+ * >             }
+ * >        });
+ * >    }
+ * > }
+ * }</pre>
+ */
+@UnstableApi
+@FunctionalInterface
+public interface AsyncServerInterceptor extends ServerInterceptor {
+
+    /**
+     * Asynchronously intercept {@link ServerCall} dispatch by the {@code next} {@link ServerCallHandler}.
+     */
+    <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(ServerCall<I, O> call, Metadata headers,
+                                                             ServerCallHandler<I, O> next);
+
+    @Override
+    default <I, O> Listener<I> interceptCall(ServerCall<I, O> call, Metadata headers,
+                                             ServerCallHandler<I, O> next) {
+        return new DeferredListener<>(call, asyncInterceptCall(call, headers, next));
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+
+final class DeferredListener<I> extends ServerCall.Listener<I> {
+
+    private static final List<?> NOOP_TASKS = ImmutableList.of();
+
+    private List<Consumer<Listener<I>>> pendingTasks = new ArrayList<>();
+    @Nullable
+    private Listener<I> delegate;
+    private boolean callClosed;
+
+    DeferredListener(ServerCall<I, ?> serverCall, CompletableFuture<ServerCall.Listener<I>> future) {
+        checkState(serverCall instanceof AbstractServerCall, "Cannot use %s with non-Armeria gRPC server",
+                   AsyncServerInterceptor.class.getName());
+        final AbstractServerCall<I, ?> armeriaServerCall = (AbstractServerCall<I, ?>) serverCall;
+
+        // `sequentialExecutor` is used to call callbacks of ServerCall.Listener by FramedGrpcService and
+        // Armeria's ServerCall implementations.
+        Executor sequentialExecutor = armeriaServerCall.blockingExecutor();
+        if (sequentialExecutor == null) {
+            sequentialExecutor = armeriaServerCall.eventLoop();
+        }
+
+        future.handleAsync((delegate, cause) -> {
+            if (cause != null) {
+                callClosed = true;
+                armeriaServerCall.close(cause);
+                return null;
+            }
+
+            this.delegate = delegate;
+            try {
+                for (Consumer<Listener<I>> task : pendingTasks) {
+                    task.accept(delegate);
+                }
+            } catch (Throwable ex) {
+                callClosed = true;
+                armeriaServerCall.close(ex);
+            }
+            //noinspection unchecked
+            pendingTasks = (List<Consumer<Listener<I>>>) NOOP_TASKS;
+            return null;
+        }, sequentialExecutor);
+    }
+
+    @Override
+    public void onMessage(I message) {
+        if (callClosed) {
+            return;
+        }
+
+        if (pendingTasks == NOOP_TASKS) {
+            delegate.onMessage(message);
+        } else {
+            pendingTasks.add(listener -> listener.onMessage(message));
+        }
+    }
+
+    @Override
+    public void onHalfClose() {
+        if (callClosed) {
+            return;
+        }
+
+        if (pendingTasks == NOOP_TASKS) {
+            delegate.onHalfClose();
+        } else {
+            pendingTasks.add(Listener::onHalfClose);
+        }
+    }
+
+    @Override
+    public void onCancel() {
+        if (callClosed) {
+            return;
+        }
+
+        if (pendingTasks == NOOP_TASKS) {
+            delegate.onCancel();
+        } else {
+            pendingTasks.add(Listener::onCancel);
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        if (callClosed) {
+            return;
+        }
+
+        if (pendingTasks == NOOP_TASKS) {
+            delegate.onComplete();
+        } else {
+            pendingTasks.add(Listener::onComplete);
+        }
+    }
+
+    @Override
+    public void onReady() {
+        if (callClosed) {
+            return;
+        }
+
+        if (pendingTasks == NOOP_TASKS) {
+            delegate.onReady();
+        } else {
+            pendingTasks.add(Listener::onReady);
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
@@ -81,6 +81,7 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
             } catch (Throwable ex) {
                 callClosed = true;
                 armeriaServerCall.close(ex);
+                return null;
             }
             //noinspection unchecked
             pendingTasks = (List<Consumer<Listener<I>>>) NOOP_TASKS;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
@@ -45,8 +45,8 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
                    AsyncServerInterceptor.class.getName());
         final AbstractServerCall<I, ?> armeriaServerCall = (AbstractServerCall<I, ?>) serverCall;
 
-        // `sequentialExecutor` is used to call callbacks of ServerCall.Listener by FramedGrpcService and
-        // Armeria's ServerCall implementations.
+        // `sequentialExecutor` is used to invoke callbacks of ServerCall.Listener by FramedGrpcService and
+        // Armeria's ServerCall implementations. So thread-safety and the execution order are guaranteed.
         Executor sequentialExecutor = armeriaServerCall.blockingExecutor();
         if (sequentialExecutor == null) {
             sequentialExecutor = armeriaServerCall.eventLoop();

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
@@ -49,7 +49,7 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
     private volatile boolean callClosed;
 
     DeferredListener(ServerCall<I, ?> serverCall, CompletableFuture<ServerCall.Listener<I>> listenerFuture) {
-        checkState(serverCall instanceof AbstractServerCall, "Cannot use %s with non-Armeria gRPC server",
+        checkState(serverCall instanceof AbstractServerCall, "Cannot use %s with a non-Armeria gRPC server",
                    AsyncServerInterceptor.class.getName());
         final AbstractServerCall<I, ?> armeriaServerCall = (AbstractServerCall<I, ?>) serverCall;
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -311,12 +311,11 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         call.setListener(listener);
         call.startDeframing();
         ctx.whenRequestCancelling().handle((cancellationCause, unused) -> {
-            final Metadata metadata = new Metadata();
-            Status status = GrpcStatus.fromThrowable(statusFunction, ctx, cancellationCause, metadata);
+            Status status = Status.CANCELLED.withCause(cancellationCause);
             if (cancellationCause instanceof RequestTimeoutException) {
                 status = status.withDescription("Request timed out");
             }
-            call.close(status, metadata);
+            call.close(status, new Metadata());
             return null;
         });
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -311,11 +311,12 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         call.setListener(listener);
         call.startDeframing();
         ctx.whenRequestCancelling().handle((cancellationCause, unused) -> {
-            Status status = Status.CANCELLED.withCause(cancellationCause);
+            final Metadata metadata = new Metadata();
+            Status status = GrpcStatus.fromThrowable(statusFunction, ctx, cancellationCause, metadata);
             if (cancellationCause instanceof RequestTimeoutException) {
                 status = status.withDescription("Request timed out");
             }
-            call.close(status, new Metadata());
+            call.close(status, metadata);
             return null;
         });
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.Authorizer;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+class AsyncServerInterceptorTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final GrpcStatusFunction statusFunction = (ctx, throwable, metadata) -> {
+                if (throwable instanceof AnticipatedException &&
+                    "Invalid access".equals(throwable.getMessage())) {
+                    return Status.UNAUTHENTICATED;
+                }
+                // Fallback to the default.
+                return null;
+            };
+            final AuthInterceptor authInterceptor = new AuthInterceptor();
+            sb.serviceUnder("/non-blocking", GrpcService.builder()
+                                                        .exceptionMapping(statusFunction)
+                                                        .intercept(authInterceptor)
+                                                        .addService(new TestService())
+                                                        .build());
+            sb.serviceUnder("/blocking", GrpcService.builder()
+                                                    .addService(new TestService())
+                                                    .exceptionMapping(statusFunction)
+                                                    .intercept(authInterceptor)
+                                                    .useBlockingTaskExecutor(true)
+                                                    .build());
+        }
+    };
+
+    @ValueSource(strings = { "/non-blocking", "/blocking" })
+    @ParameterizedTest
+    void authorizedRequest(String path) {
+        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+                                                          .pathPrefix(path)
+                                                          .auth(AuthToken.ofOAuth2("token-1234"))
+                                                          .build(TestServiceBlockingStub.class);
+        final SimpleResponse response = client.unaryCall(SimpleRequest.newBuilder()
+                                                                      .setFillUsername(true)
+                                                                      .build());
+        assertThat(response.getUsername()).isEqualTo("Armeria");
+    }
+
+    @ValueSource(strings = { "/non-blocking", "/blocking" })
+    @ParameterizedTest
+    void unauthorizedRequest(String path) {
+        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+                                                          .pathPrefix(path)
+                                                          .build(TestServiceBlockingStub.class);
+        assertThatThrownBy(() -> {
+            client.unaryCall(SimpleRequest.newBuilder()
+                                          .setFillUsername(true)
+                                          .build());
+        }).isInstanceOf(StatusRuntimeException.class)
+          .satisfies(cause -> {
+              assertThat(((StatusRuntimeException) cause).getStatus())
+                      .isEqualTo(Status.UNAUTHENTICATED);
+          });
+    }
+
+    private static final class AuthInterceptor implements AsyncServerInterceptor {
+
+        private final Authorizer<Metadata> authorizer = (ctx, metadata) -> {
+            final CompletableFuture<Boolean> future = new CompletableFuture<>();
+            // Simulate an asynchronous call.
+            ctx.eventLoop().schedule(() -> {
+                if (ctx.request().headers().contains("Authorization", "Bearer token-1234")) {
+                    future.complete(true);
+                } else {
+                    future.complete(false);
+                }
+            }, 100, TimeUnit.MILLISECONDS);
+            return future;
+        };
+
+        @Override
+        public <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(ServerCall<I, O> call, Metadata headers,
+                                                                        ServerCallHandler<I, O> next) {
+            // An interceptor should be called in a context-aware thread.
+            return authorizer.authorize(ServiceRequestContext.current(), headers)
+                             .thenApply(result -> {
+                                 if (result) {
+                                     return next.startCall(call, headers);
+                                 }
+                                 throw new AnticipatedException("Invalid access");
+                             }).toCompletableFuture();
+        }
+    }
+
+    private static final class TestService extends TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            if (request.getFillUsername()) {
+                responseObserver.onNext(SimpleResponse.newBuilder().setUsername("Armeria").build());
+            } else {
+                responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            }
+            responseObserver.onCompleted();
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -54,7 +54,7 @@ class DeferredListenerTest {
     void shouldHaveRequestContextInThread() {
         assertThatThrownBy(() -> new DeferredListener<>(mock(ServerCall.class), null))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Cannot use %s with non-Armeria gRPC server",
+                .hasMessage("Cannot use %s with a non-Armeria gRPC server",
                             AsyncServerInterceptor.class.getName());
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -71,7 +71,8 @@ class DeferredListenerTest {
         assertListenerEvents(blockingServerCall, blockingExecutor);
     }
 
-    private void assertListenerEvents(ServerCall<SimpleRequest, SimpleResponse> serverCall, Executor executor) {
+    private static void assertListenerEvents(ServerCall<SimpleRequest, SimpleResponse> serverCall,
+                                             Executor executor) {
         final TestListener testListener = new TestListener();
         final CompletableFuture<ServerCall.Listener<SimpleRequest>> future = new CompletableFuture<>();
         final DeferredListener<SimpleRequest> listener = new DeferredListener<>(serverCall, future);
@@ -87,7 +88,7 @@ class DeferredListenerTest {
             assertThat(testListener.events).containsExactly("onMessage", "onReady", "onHalfClose");
         });
 
-        // Should be invoked immediately
+        // Should be invoked immediately with `executor`.
         executeAndAwait(executor, listener::onComplete);
         assertThat(testListener.events)
                 .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete");
@@ -114,7 +115,7 @@ class DeferredListenerTest {
                                      ResponseHeaders.of(200), null, blockingTaskExecutor, false);
     }
 
-    private final class TestListener extends ServerCall.Listener<SimpleRequest> {
+    private static final class TestListener extends ServerCall.Listener<SimpleRequest> {
 
         final List<String> events = new CopyOnWriteArrayList<>();
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -89,10 +89,10 @@ class DeferredListenerTest {
         });
 
         // Should be invoked immediately with `executor`.
-        executeAndAwait(executor, listener::onComplete);
+        listener.onComplete();
         assertThat(testListener.events)
                 .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete");
-        executeAndAwait(executor, listener::onCancel);
+        listener.onCancel();
         assertThat(testListener.events)
                 .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete", "onCancel");
     }
@@ -115,7 +115,7 @@ class DeferredListenerTest {
                                      ResponseHeaders.of(200), null, blockingTaskExecutor, false);
     }
 
-    private static final class TestListener extends ServerCall.Listener<SimpleRequest> {
+    private static class TestListener extends ServerCall.Listener<SimpleRequest> {
 
         final List<String> events = new CopyOnWriteArrayList<>();
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.grpc.CompressorRegistry;
+import io.grpc.DecompressorRegistry;
+import io.grpc.ServerCall;
+import io.netty.channel.EventLoop;
+
+class DeferredListenerTest {
+
+    @Test
+    void shouldHaveRequestContextInThread() {
+        assertThatThrownBy(() -> new DeferredListener<>(mock(ServerCall.class), null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Cannot use %s with non-Armeria gRPC server",
+                            AsyncServerInterceptor.class.getName());
+    }
+
+    @Test
+    void shouldLazilyExecuteCallbacks() {
+        final EventLoop eventLoop = CommonPools.workerGroup().next();
+        final UnaryServerCall<SimpleRequest, SimpleResponse> serverCall = newServerCall(eventLoop, null);
+        assertListenerEvents(serverCall, eventLoop);
+
+        final Executor blockingExecutor =
+                MoreExecutors.newSequentialExecutor(CommonPools.blockingTaskExecutor());
+        final UnaryServerCall<SimpleRequest, SimpleResponse> blockingServerCall =
+                newServerCall(eventLoop, blockingExecutor);
+        assertListenerEvents(blockingServerCall, blockingExecutor);
+    }
+
+    private void assertListenerEvents(ServerCall<SimpleRequest, SimpleResponse> serverCall, Executor executor) {
+        final TestListener testListener = new TestListener();
+        final CompletableFuture<ServerCall.Listener<SimpleRequest>> future = new CompletableFuture<>();
+        final DeferredListener<SimpleRequest> listener = new DeferredListener<>(serverCall, future);
+        executeAndAwait(executor, () -> {
+            listener.onMessage(null);
+            listener.onReady();
+            listener.onHalfClose();
+        });
+
+        assertThat(testListener.events).isEmpty();
+        future.complete(testListener);
+        await().untilAsserted(() -> {
+            assertThat(testListener.events).containsExactly("onMessage", "onReady", "onHalfClose");
+        });
+
+        // Should be invoked immediately
+        executeAndAwait(executor, listener::onComplete);
+        assertThat(testListener.events)
+                .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete");
+        executeAndAwait(executor, listener::onCancel);
+        assertThat(testListener.events)
+                .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete", "onCancel");
+    }
+
+    private static void executeAndAwait(Executor executor, Runnable task) {
+        CompletableFuture.runAsync(task, executor).join();
+    }
+
+    @NotNull
+    private static UnaryServerCall<SimpleRequest, SimpleResponse> newServerCall(
+            EventLoop eventLoop, @Nullable Executor blockingTaskExecutor) {
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
+                                                               .eventLoop(eventLoop)
+                                                               .build();
+        return new UnaryServerCall<>(ctx.request(), TestServiceGrpc.getUnaryCallMethod(), "UnaryCall",
+                                     CompressorRegistry.getDefaultInstance(),
+                                     DecompressorRegistry.getDefaultInstance(),
+                                     HttpResponse.streaming(), new CompletableFuture<>(), 0, 0, ctx,
+                                     GrpcSerializationFormats.PROTO, null, false,
+                                     ResponseHeaders.of(200), null, blockingTaskExecutor, false);
+    }
+
+    private final class TestListener extends ServerCall.Listener<SimpleRequest> {
+
+        final List<String> events = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onMessage(SimpleRequest message) {
+            events.add("onMessage");
+        }
+
+        @Override
+        public void onHalfClose() {
+            events.add("onHalfClose");
+        }
+
+        @Override
+        public void onCancel() {
+            events.add("onCancel");
+        }
+
+        @Override
+        public void onComplete() {
+            events.add("onComplete");
+        }
+
+        @Override
+        public void onReady() {
+            events.add("onReady");
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The upstream `ServerInterceptor` of gRPC-Java does not allow executing an asynchronous task in an interceptor. The API is designed to return a `Listener` synchronously.
https://github.com/grpc/grpc-java/blob/b7164f0791d405e002d67c1e01603e0df9d1cc9f/api/src/main/java/io/grpc/ServerInterceptor.java#L55

It makes users difficult to use the existing asynchronous API in the interceptors. The blocking threads can be exhausted easily if there are slow responses from servers having problems.

It should be useful if you can use `CompletableFuture` to compose asynchronous tasks without blocking threads.

The original idea is suggested from https://github.com/line/armeria/issues/4275#issuecomment-1144604754 /cc @be-hase

Modifications:

- Add `AsyncServerInterceptor` that allow returning `ServerCall.Listener` with `CompletableFuture`.
- Add `DeferredListener` to execute pending tasks in order when the future returned by `AsyncServerInterceptor` completes.
  - `DeferredListener` also propagates `ServiceRequestContext` by performing the tasks with a context-aware executor.
- Fixed to peel exceptions before applying `GrpcStatusFunction`.

Result:

You can now execute asynchronous tasks in gRPC `ServerInterceptor` using `AsyncServerInterceptor`.

```java
class AuthServerInterceptor implements AsyncServerInterceptor {

    @Override
    <I, O> CompletableFuture<Listener<I>> asyncInterceptCall(
            ServerCall<I, O> call, Metadata headers, ServerCallHandler<I, O> next) {

       return authorizer.authorize(headers).thenApply(result -> {
            if (result) {
                return next.startCall(call, headers);
            } else {
                throw new AuthenticationException("Invalid access");
            }
       });
   }
}

GrpcService.builder()
           .intercept(new AuthServerInterceptor()
           .addService(...)
           ...
```