### PR TITLE
Fix a `NullPointerException` raised while an aborted `FixedStreamMessage` is being collected.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -24,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -52,8 +52,8 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
     private static final Logger logger = LoggerFactory.getLogger(FixedStreamMessage.class);
 
     @SuppressWarnings("rawtypes")
-    private static final AtomicIntegerFieldUpdater<FixedStreamMessage> subscribedUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(FixedStreamMessage.class, "subscribed");
+    private static final AtomicReferenceFieldUpdater<FixedStreamMessage, EventExecutor> executorUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(FixedStreamMessage.class, EventExecutor.class, "executor");
 
     private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
 
@@ -64,13 +64,12 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
     private boolean notifyCancellation;
     private boolean completed;
 
+    // Updated only by executorUpdater
     @Nullable
     private volatile EventExecutor executor;
 
     @Nullable
     private volatile Throwable abortCause;
-    // Updated only via subscribedUpdater
-    private volatile int subscribed;
 
     /**
      * Clean up objects.
@@ -112,12 +111,19 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
         requireNonNull(executor, "executor");
         requireNonNull(options, "options");
         if (isOpen()) {
-            abortSubscriber(executor, subscriber, "a fixed stream is not closed yet");
+            abortSubscriber(executor, subscriber,
+                            new IllegalStateException("a fixed stream is not closed yet"));
             return;
         }
 
-        if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
-            abortSubscriber(executor, subscriber, "subscribed by other subscriber already");
+        if (!executorUpdater.compareAndSet(this, null, executor)) {
+            final Throwable abortCause = this.abortCause;
+            if (abortCause == null) {
+                abortSubscriber(executor, subscriber,
+                                new IllegalStateException("subscribed by other subscriber already"));
+            } else {
+                abortSubscriber(executor, subscriber, abortCause);
+            }
             return;
         }
 
@@ -129,23 +135,18 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             }
         }
         if (executor.inEventLoop()) {
-            subscribe0(subscriber, executor);
+            subscribe0(subscriber);
         } else {
-            executor.execute(() -> subscribe0(subscriber, executor));
+            executor.execute(() -> subscribe0(subscriber));
         }
     }
 
-    private void subscribe0(Subscriber<? super T> subscriber, EventExecutor executor) {
+    private void subscribe0(Subscriber<? super T> subscriber) {
         //noinspection unchecked
         this.subscriber = (Subscriber<T>) subscriber;
-        this.executor = executor;
         try {
             subscriber.onSubscribe(this);
-
-            final Throwable abortCause = this.abortCause;
-            if (abortCause != null) {
-                onError(abortCause);
-            } else if (isEmpty()) {
+            if (isEmpty()) {
                 onComplete();
             }
         } catch (Throwable t) {
@@ -157,17 +158,17 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
         }
     }
 
-    private void abortSubscriber(EventExecutor executor, Subscriber<? super T> subscriber, String message) {
+    private void abortSubscriber(EventExecutor executor, Subscriber<? super T> subscriber, Throwable cause) {
         if (executor.inEventLoop()) {
-            abortSubscriber0(subscriber, message);
+            abortSubscriber0(subscriber, cause);
         } else {
-            executor.execute(() -> abortSubscriber0(subscriber, message));
+            executor.execute(() -> abortSubscriber0(subscriber, cause));
         }
     }
 
-    private void abortSubscriber0(Subscriber<? super T> subscriber, String message) {
+    private void abortSubscriber0(Subscriber<? super T> subscriber, Throwable cause) {
         subscriber.onSubscribe(NoopSubscription.get());
-        subscriber.onError(new IllegalStateException(message));
+        subscriber.onError(cause);
     }
 
     @Override
@@ -175,7 +176,7 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
         requireNonNull(executor, "executor");
         requireNonNull(options, "options");
         final CompletableFuture<List<T>> collectingFuture = new CompletableFuture<>();
-        if (subscribedUpdater.compareAndSet(this, 0, 1)) {
+        if (executorUpdater.compareAndSet(this, null, executor)) {
             final Throwable abortCause = this.abortCause;
             if (abortCause != null) {
                 collectingFuture.completeExceptionally(abortCause);
@@ -188,8 +189,13 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
                 executor.execute(() -> collect(collectingFuture, executor, options, false));
             }
         } else {
-            collectingFuture.completeExceptionally(
-                    new IllegalStateException("subscribed by other subscriber already"));
+            final Throwable abortCause = this.abortCause;
+            if (abortCause != null) {
+                collectingFuture.completeExceptionally(abortCause);
+            } else {
+                collectingFuture.completeExceptionally(
+                        new IllegalStateException("subscribed by other subscriber already"));
+            }
         }
         return collectingFuture;
     }
@@ -216,7 +222,7 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             subscriber.onNext(touchOrCopyAndClose(item, withPooledObjects));
         } catch (Throwable t) {
             // Just abort this stream so subscriber().onError(e) is called and resources are cleaned up.
-            abort0(t);
+            abort1(t, true);
             throwIfFatal(t);
             logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
                         item, subscriber, t);
@@ -293,23 +299,13 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
 
     @Override
     public void abort() {
-        final EventExecutor executor = executor();
-        if (executor.inEventLoop()) {
-            abort0(null);
-        } else {
-            executor.execute(() -> abort0(null));
-        }
+        abort0(null);
     }
 
     @Override
     public void abort(Throwable cause) {
         requireNonNull(cause, "cause");
-        final EventExecutor executor = executor();
-        if (executor.inEventLoop()) {
-            abort0(cause);
-        } else {
-            executor.execute(() -> abort0(cause));
-        }
+        abort0(cause);
     }
 
     private void abort0(@Nullable Throwable cause) {
@@ -317,18 +313,36 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             return;
         }
 
-        if (cause == null) {
-            cause = AbortedStreamException.get();
-        }
-        cleanupObjects(cause);
+        final Throwable finalCause = cause != null ? cause : AbortedStreamException.get();
+        // Should set `abortCause` before `executor` is written and get after `executor` is written
+        // to preserve the atomicity.
+        abortCause = finalCause;
 
-        abortCause = cause;
-        if (executor == null) {
-            // 'abortCause' will be propagated and 'completed' will be set to true when subscribed
-            completionFuture.completeExceptionally(cause);
+        if (executorUpdater.compareAndSet(this, null, ImmediateEventExecutor.INSTANCE)) {
+            // No subscription was made. Safely clean the resources.
+            abort1(finalCause, false);
         } else {
-            // Subscribed already
+            final EventExecutor executor = this.executor;
+            assert executor != null;
+            // Subscribed already. Use the designated executor for thread-safety.
+            if (executor.inEventLoop()) {
+                abort1(finalCause, true);
+            } else {
+                executor.execute(() -> abort1(finalCause, true));
+            }
+        }
+    }
+
+    private void abort1(Throwable cause, boolean subscribed) {
+        if (completed) {
+            return;
+        }
+
+        cleanupObjects(cause);
+        if (subscribed) {
             onError(cause);
+        } else {
+            completionFuture.completeExceptionally(cause);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -314,8 +314,8 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
         }
 
         final Throwable finalCause = cause != null ? cause : AbortedStreamException.get();
-        // Should set `abortCause` before `executor` is written and get after `executor` is written
-        // to preserve the atomicity.
+        // Should set `abortCause` before `executor` is written and get after `executor` is written for
+        // atomicity.
         abortCause = finalCause;
 
         if (executorUpdater.compareAndSet(this, null, ImmediateEventExecutor.INSTANCE)) {
@@ -324,7 +324,6 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
         } else {
             final EventExecutor executor = this.executor;
             assert executor != null;
-            // Subscribed already. Use the designated executor for thread-safety.
             if (executor.inEventLoop()) {
                 abort1(finalCause, true);
             } else {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -17,13 +17,18 @@
 package com.linecorp.armeria.internal.common.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -31,9 +36,9 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import com.google.common.collect.ImmutableList;
-
 import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
@@ -41,14 +46,15 @@ class FixedStreamMessageTest {
 
     private static final Integer[] EMPTY_INTEGERS = new Integer[0];
 
-    @ArgumentsSource(IntsProvider.class)
+    @RegisterExtension
+    static EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
     @ParameterizedTest
-    void spec_306_requestAfterCancel(List<Integer> nums) throws InterruptedException {
-        final Integer[] array = nums.toArray(EMPTY_INTEGERS);
-        final StreamMessage<Integer> message = StreamMessage.of(array);
+    void spec_306_requestAfterCancel(StreamMessage<Integer> stream) throws InterruptedException {
         final CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
         final AtomicInteger received = new AtomicInteger();
-        message.subscribe(new Subscriber<Integer>() {
+        stream.subscribe(new Subscriber<Integer>() {
             @Override
             public void onSubscribe(Subscription s) {
                 subscriptionFuture.complete(s);
@@ -74,15 +80,69 @@ class FixedStreamMessageTest {
         assertThat(received).hasValue(0);
     }
 
-    private static final class IntsProvider implements ArgumentsProvider {
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenSubscriptionAndAbort(StreamMessage<Integer> stream) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicInteger delivered = new AtomicInteger();
+        stream.subscribe(new Subscriber<Integer>() {
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                try {
+                    // Wait for `abort()` to be called.
+                    latch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onNext(Integer integer) {}
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {}
+        }, eventLoop.get());
+
+        final AnticipatedException abortCause = new AnticipatedException("Abort a fixed stream");
+        stream.abort(abortCause);
+        latch.countDown();
+
+        // EmptyStreamMessage performs nothing.
+        if (!stream.isEmpty()) {
+            await().untilAsserted(() -> {
+                assertThat(causeRef).hasValue(abortCause);
+            });
+            assertThatThrownBy(() -> stream.whenComplete().join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCause(abortCause);
+        }
+        assertThat(delivered).hasValue(0);
+    }
+
+    private static final class FixedStreamMessageProvider implements ArgumentsProvider {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-            return Stream.of(ImmutableList.of(),
-                             ImmutableList.of(1),
-                             ImmutableList.of(1, 2),
-                             ImmutableList.of(1, 2, 3),
-                             ImmutableList.of(1, 2, 3, 4))
+            final AggregatingStreamMessage<Integer> aggregatingStreamMessage =
+                    new AggregatingStreamMessage<>(5);
+            aggregatingStreamMessage.write(1);
+            aggregatingStreamMessage.write(2);
+            aggregatingStreamMessage.write(3);
+            aggregatingStreamMessage.write(4);
+            aggregatingStreamMessage.close();
+            return Stream.of(StreamMessage.of(),           // EmptyFixedStreamMessage
+                             StreamMessage.of(1),          // OneElementFixedStreamMessage
+                             StreamMessage.of(1, 2),       // TwoElementFixedStreamMessage
+                             StreamMessage.of(1, 2, 3),    // ThreeElementFixedStreamMessage
+                             StreamMessage.of(1, 2, 3, 4), // RegularFixedStreamMessage
+                             aggregatingStreamMessage)
                          .map(Arguments::of);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -85,7 +85,6 @@ class FixedStreamMessageTest {
     void raceBetweenSubscriptionAndAbort(StreamMessage<Integer> stream) {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
-        final AtomicInteger delivered = new AtomicInteger();
         stream.subscribe(new Subscriber<Integer>() {
 
             @Override
@@ -123,7 +122,6 @@ class FixedStreamMessageTest {
                     .isInstanceOf(CompletionException.class)
                     .hasCause(abortCause);
         }
-        assertThat(delivered).hasValue(0);
     }
 
     private static final class FixedStreamMessageProvider implements ArgumentsProvider {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -44,8 +44,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 
 class FixedStreamMessageTest {
 
-    private static final Integer[] EMPTY_INTEGERS = new Integer[0];
-
     @RegisterExtension
     static EventLoopExtension eventLoop = new EventLoopExtension();
 
@@ -115,9 +113,7 @@ class FixedStreamMessageTest {
 
         // EmptyStreamMessage performs nothing.
         if (!stream.isEmpty()) {
-            await().untilAsserted(() -> {
-                assertThat(causeRef).hasValue(abortCause);
-            });
+            await().untilAsserted(() -> assertThat(causeRef).hasValue(abortCause));
             assertThatThrownBy(() -> stream.whenComplete().join())
                     .isInstanceOf(CompletionException.class)
                     .hasCause(abortCause);


### PR DESCRIPTION
Motivation:

We got a report about `NullPointerException` from LINE internally.
```
java.lang.NullPointerException: at index 0
	at com.linecorp.armeria.internal.shaded.guava.collect.ObjectArrays.checkElementNotNull(ObjectArrays.java:229)
	at com.linecorp.armeria.internal.shaded.guava.collect.ObjectArrays.checkElementsNotNull(ObjectArrays.java:219)
	at com.linecorp.armeria.internal.shaded.guava.collect.ObjectArrays.checkElementsNotNull(ObjectArrays.java:213)
	at com.linecorp.armeria.internal.shaded.guava.collect.ImmutableList.construct(ImmutableList.java:353)
	at com.linecorp.armeria.internal.shaded.guava.collect.ImmutableList.of(ImmutableList.java:109)
	at com.linecorp.armeria.internal.common.stream.TwoElementFixedStreamMessage.drainAll(TwoElementFixedStreamMessage.java:75)
	at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.collect(FixedStreamMessage.java:201)
	at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.lambda$collect$2(FixedStreamMessage.java:188)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:391)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```

The error occured because the elements of a `StreamMessage` are null when a `StreamMessage.collect()` is called. Double subscriptions aren't the cause of the problem since it is atomically checked by CAS operations.

One possible senario is `abort()` is called first and `collect()` is called right after. The two method calls are not thread safe because the `abort()` called first can't get a executor which is assigned when `subscribe()` is called. As a result, a direct executor is used and then two threads may access the elements simultaneously.

Modifications:

- Remove `subscribedUpdater` and use `executorUpdater` as a latch for a concurrent execution.
- Make `abort()` executed directly only when explicitly there is no subscription.
  - If a executor has already been assigned by another thread, the executor is used to avoid the race condition.

Result:

You no longer see `NullPointerException` when an aborted `StreamMessage` is collected.

