### PR TITLE
Increase max heap size for each java fork

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,12 @@ gradle.buildFinished({ result ->
 allprojects {
     // Add common JVM options such as max memory and leak detection.
     tasks.withType(JavaForkOptions) {
-        maxHeapSize = '512m'
+        maxHeapSize = '1g'
+        // Specify the max heap size -PmaxHeapSize=512m
+        if (rootProject.hasProperty('maxHeapSize')) {
+            maxHeapSize = rootProject.findProperty('maxHeapSize')
+        }
+
         if (rootProject.ext.testJavaVersion >= 9) {
             jvmArgs '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED'
         }


### PR DESCRIPTION
Motivation:

While publishing jobs were running, I was able to observe the following warning even on the latest java version.
```
Expiring Daemon because JVM heap space is exhausted
```
https://github.com/line/armeria/actions/runs/4130787453/jobs/7137809757

We also recently observed builds in java 8 fail due to insufficient heap space.

- Machine specs
  - Windows: 2 cores, 7 GB
  - Mac: 3 cores, 14 GB
  - Linux: 8 cores, 16 GB (c5.2xlarge)

ref: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

By default, we use the number of cores as the count of forked processes:
https://github.com/line/armeria/blob/a5ab6f556c2d647b3a62080354c0d2bea77188c4/build.gradle#L91

We also allocate up to 1.5G for the main gradle task (although I believe when run with the `--parallel` option this heap isn't really used)

https://github.com/line/armeria/blob/a5ab6f556c2d647b3a62080354c0d2bea77188c4/gradle.properties#L24

I propose that we allocate 1G per forked process.
For Windows which has the lowest resource, this amounts to a maximum of (2 forked process * 1G/forked process) + 1.5G = 3.5G excluding other resources which I believe is low enough.

Modifications:

- Increase the max heap used by each forked task to 1g

Result:

- More stable builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
