### PR TITLE
Fix another `NullPointerException` in `FixedStreamMessage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -367,8 +367,8 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             if (subscriber != null) {
                 onError0(cause);
             } else {
-                // subscribe0() isn't called yet.
-                // delegate abortSubscriber() to send abortCause via onError().
+                // A subscription is started but subscribe0() isn't called yet.
+                // Delegate abortSubscriber() to propagate abortCause via onError().
                 completionFuture.completeExceptionally(cause);
             }
         } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -367,8 +367,9 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             if (subscriber != null) {
                 onError0(cause);
             } else {
-                // A subscription is started but subscribe0() isn't called yet.
-                // Delegate abortSubscriber() to propagate abortCause via onError().
+                // A subscription is started but `subscribe0()` isn't called yet. Since `completed` set to true,
+                // `abortSubscriber()` will propagate `abortCause` via `onError()` when `subscribe0()` is
+                // scheduled.
                 completionFuture.completeExceptionally(cause);
             }
         } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -350,8 +350,7 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
             if (executor == ImmediateEventExecutor.INSTANCE) {
                 // Double abortion
                 abort1(finalCause, false);
-            } else
-                if (executor.inEventLoop()) {
+            } else if (executor.inEventLoop()) {
                 abort1(finalCause, true);
             } else {
                 executor.execute(() -> abort1(finalCause, true));

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -71,6 +71,7 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
     @Nullable
     private volatile EventExecutor executor;
 
+    // Updated only by abortCauseUpdater
     @Nullable
     private volatile Throwable abortCause;
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
@@ -32,10 +32,10 @@ import io.netty.util.concurrent.ProgressivePromise;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 
-public class EventExecutorWrapper implements EventExecutor {
+class EventExecutorWrapper implements EventExecutor {
     private final EventExecutor delegate;
 
-    public EventExecutorWrapper(EventExecutor delegate) {
+    EventExecutorWrapper(EventExecutor delegate) {
         this.delegate = delegate;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.linecorp.armeria.internal.common.stream;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ProgressivePromise;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+public class EventExecutorWrapper implements EventExecutor {
+    private final EventExecutor delegate;
+
+    public EventExecutorWrapper(EventExecutor delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return false;
+    }
+
+    @Override
+    public Future<?> shutdownGracefully() {
+        return delegate.shutdownGracefully();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+        return delegate.shutdownGracefully(quietPeriod, timeout, unit);
+    }
+
+    @Override
+    public Future<?> terminationFuture() {
+        return delegate.terminationFuture();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public EventExecutor next() {
+        return delegate.next();
+    }
+
+    @Override
+    public Iterator<EventExecutor> iterator() {
+        return delegate.iterator();
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks,
+                                                              long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
+                                                  TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                                                     TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public EventExecutorGroup parent() {
+        return delegate.parent();
+    }
+
+    @Override
+    public boolean inEventLoop() {
+        return delegate.inEventLoop();
+    }
+
+    @Override
+    public boolean inEventLoop(Thread thread) {
+        return delegate.inEventLoop(thread);
+    }
+
+    @Override
+    public <V> Promise<V> newPromise() {
+        return delegate.newPromise();
+    }
+
+    @Override
+    public <V> ProgressivePromise<V> newProgressivePromise() {
+        return delegate.newProgressivePromise();
+    }
+
+    @Override
+    public <V> Future<V> newSucceededFuture(V result) {
+        return delegate.newSucceededFuture(result);
+    }
+
+    @Override
+    public <V> Future<V> newFailedFuture(Throwable cause) {
+        return delegate.newFailedFuture(cause);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/EventExecutorWrapper.java
@@ -41,7 +41,7 @@ class EventExecutorWrapper implements EventExecutor {
 
     @Override
     public boolean isShuttingDown() {
-        return false;
+        return delegate.isShuttingDown();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -17,12 +17,18 @@
 package com.linecorp.armeria.internal.common.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -40,6 +46,7 @@ import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 class FixedStreamMessageTest {
@@ -60,7 +67,7 @@ class FixedStreamMessageTest {
 
             @Override
             public void onNext(Integer integer) {
-               received.getAndIncrement();
+                received.getAndIncrement();
             }
 
             @Override
@@ -120,7 +127,385 @@ class FixedStreamMessageTest {
         }
     }
 
-    private static final class FixedStreamMessageProvider implements ArgumentsProvider {
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenCollectAndAbort_startCollectFirst_eventLoopCollectFirst(
+            FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        // Execute collect() first on the event loop.
+        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, false);
+        final CompletableFuture<List<Integer>> collectionFuture = new CompletableFuture<>();
+        stream.collect(eventExecutor).handle((res, cause) -> {
+            if (cause != null) {
+                collectionFuture.completeExceptionally(cause);
+            } else {
+                collectionFuture.complete(res);
+            }
+            return null;
+        });
+
+        assertThat(eventExecutor.numPendingTasks()).isOne();
+        assertThat(stream.isComplete()).isFalse();
+
+        stream.abort();
+
+        // The race result:
+        // - collect() should win the race and return the list successfully.
+        // - abort() tries to clean up resources but nothing remains to clean.
+        assertThat(collectionFuture.join()).isInstanceOf(List.class);
+        assertThatCode(() -> {
+            stream.whenComplete().join();
+        }).doesNotThrowAnyException();
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenCollectAndAbort_startCollectFirst_eventLoopAbortFirst(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        // Execute abort() first on the event loop.
+        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, true);
+
+        final CompletableFuture<List<Integer>> collectionFuture = new CompletableFuture<>();
+        stream.collect(eventExecutor).handle((res, cause) -> {
+            if (cause != null) {
+                collectionFuture.completeExceptionally(cause);
+            } else {
+                collectionFuture.complete(res);
+            }
+            return null;
+        });
+
+        assertThat(eventExecutor.numPendingTasks()).isOne();
+        assertThat(stream.isComplete()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        stream.abort(abortCause);
+
+        // The race result:
+        // - collect() fails to execute and returns a future completed exceptionally with abortCause.
+        // - abort() cleans up the resources and completes whenComplete() exceptionally.
+        assertThatThrownBy(collectionFuture::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenSubscribeAndAbort_startSubscribeFirst_eventLoopSubscribeFirst(
+            FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        // Execute subscribe() first on the event loop.
+        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, false);
+
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscriptionRef.set(s);
+            }
+
+            @Override
+            public void onNext(Integer integer) {}
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {}
+        }, eventExecutor);
+
+        assertThat(eventExecutor.numPendingTasks()).isOne();
+        assertThat(stream.isComplete()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        stream.abort(abortCause);
+
+        // The race result:
+        // - subscribe() finishes successfully.
+        // - abort() cleans up the resources and propagate abortCause via onError().
+        await().untilAsserted(() -> {
+            assertThat(subscriptionRef).hasValue(stream);
+        });
+
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+        assertThat(causeRef).hasValue(abortCause);
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenSubscribeAndAbort_startSubscribeFirst_eventLoopAbortFirst(
+            FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        // Execute abort() first on the event loop.
+        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, true);
+
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                subscriptionRef.set(s);
+            }
+
+            @Override
+            public void onNext(Integer integer) {}
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {}
+        }, eventExecutor);
+
+        assertThat(eventExecutor.numPendingTasks()).isOne();
+        assertThat(stream.isComplete()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        stream.abort(abortCause);
+
+        // The race result:
+        // - subscribe() is aborted with NoopSubscription
+        // - abort() cleans the resources and completes whenCompletes() exceptionally with abortCause.
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+        assertThat(subscriptionRef).hasValue(NoopSubscription.get());
+        assertThat(causeRef).hasValue(abortCause);
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void raceBetweenCollectAndAbort_startAbortFirst(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        stream.abort(abortCause);
+        final CompletableFuture<List<Integer>> collectionFuture = stream.collect();
+
+        // The race result:
+        // - collect() fails with abortCause synchronously.
+        // - abort() cleans up the resources synchronously.
+        assertThat(collectionFuture).isCompletedExceptionally();
+        assertThatThrownBy(collectionFuture::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void abortOnSubscribe(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicBoolean completed = new AtomicBoolean();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                stream.abort(abortCause);
+            }
+
+            @Override
+            public void onNext(Integer integer) {}
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+        });
+
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+        assertThat(causeRef).hasValue(abortCause);
+        assertThat(completed).isFalse();
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void abortOnNext(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicBoolean completed = new AtomicBoolean();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+                stream.abort(abortCause);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+        });
+
+        if (stream instanceof OneElementFixedStreamMessage) {
+            // one element was published before the abortion.
+            assertThatCode(stream.whenComplete()::join)
+                    .doesNotThrowAnyException();
+            assertThat(causeRef).hasValue(null);
+            assertThat(completed).isTrue();
+        } else {
+            assertThatThrownBy(stream.whenComplete()::join)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCause(abortCause);
+            assertThat(causeRef).hasValue(abortCause);
+            assertThat(completed).isFalse();
+        }
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void abortOnComplete(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicBoolean completed = new AtomicBoolean();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                causeRef.set(t);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+                stream.abort(abortCause);
+            }
+        });
+
+        // abort() performs nothing when all elements are published.
+        assertThatCode(stream.whenComplete()::join)
+                .doesNotThrowAnyException();
+        assertThat(causeRef).hasValue(null);
+        assertThat(completed).isTrue();
+    }
+
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void abortOnError(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException onNextCause = new AnticipatedException();
+        final AnticipatedException abortCause = new AnticipatedException();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final AtomicBoolean completed = new AtomicBoolean();
+        final AtomicInteger errorCount = new AtomicInteger();
+        stream.subscribe(new Subscriber<Integer>() {
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(Integer integer) {
+                // make onError() get invoked.
+                throw onNextCause;
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                errorCount.getAndIncrement();
+                causeRef.set(t);
+                stream.abort(abortCause);
+            }
+
+            @Override
+            public void onComplete() {
+                completed.set(true);
+            }
+        });
+
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(onNextCause);
+        assertThat(causeRef).hasValue(onNextCause);
+        assertThat(completed).isFalse();
+        // Should invoke onError() exactly once.
+        assertThat(errorCount).hasValue(1);
+    }
+
+    private static class LatchedEventExecutor extends EventExecutorWrapper {
+        private final Deque<Runnable> pendingTasks = new ArrayDeque<>();
+        private int latchCount;
+        private final boolean reverseExecution;
+
+        LatchedEventExecutor(EventExecutor delegate, int latchCount, boolean reverseExecution) {
+            super(delegate);
+            this.latchCount = latchCount;
+            this.reverseExecution = reverseExecution;
+        }
+
+        @Override
+        public synchronized void execute(Runnable command) {
+            if (--latchCount >= 0) {
+                if (reverseExecution) {
+                    pendingTasks.addFirst(command);
+                } else {
+                    pendingTasks.addLast(command);
+                }
+                if (latchCount == 0) {
+                    for (Runnable task : pendingTasks) {
+                        super.execute(task);
+                    }
+                }
+            } else {
+                super.execute(command);
+            }
+        }
+
+        int numPendingTasks() {
+            return pendingTasks.size();
+        }
+    }
+
+    private static class FixedStreamMessageProvider implements ArgumentsProvider {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
@@ -136,7 +521,8 @@ class FixedStreamMessageTest {
                              StreamMessage.of(1, 2),       // TwoElementFixedStreamMessage
                              StreamMessage.of(1, 2, 3),    // ThreeElementFixedStreamMessage
                              StreamMessage.of(1, 2, 3, 4), // RegularFixedStreamMessage
-                             aggregatingStreamMessage)
+                             aggregatingStreamMessage
+                         )
                          .map(Arguments::of);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -167,7 +167,7 @@ class FixedStreamMessageTest {
         stream.abort(abortCause);
 
         // The race result:
-        // - collect() fails to execute and returns a future completed exceptionally with abortCause.
+        // - collect() returns a future which is exceptionally completed with abortCause.
         // - abort() cleans up the resources and completes whenComplete() exceptionally.
         assertThatThrownBy(collectionFuture::join)
                 .isInstanceOf(CompletionException.class)
@@ -215,7 +215,7 @@ class FixedStreamMessageTest {
 
         // The race result:
         // - subscribe() finishes successfully.
-        // - abort() cleans up the resources and propagate abortCause via onError().
+        // - abort() cleans up the resources and propagates abortCause via onError().
         await().untilAsserted(() -> {
             assertThat(subscriptionRef).hasValue(stream);
         });
@@ -262,7 +262,7 @@ class FixedStreamMessageTest {
         stream.abort(abortCause);
 
         // The race result:
-        // - subscribe() is aborted with NoopSubscription
+        // - subscribe() is aborted with NoopSubscription.
         // - abort() cleans the resources and completes whenCompletes() exceptionally with abortCause.
         assertThatThrownBy(stream.whenComplete()::join)
                 .isInstanceOf(CompletionException.class)
@@ -359,7 +359,7 @@ class FixedStreamMessageTest {
         });
 
         if (stream instanceof OneElementFixedStreamMessage) {
-            // one element was published before the abortion.
+            // One element was published before the abortion.
             assertThatCode(stream.whenComplete()::join)
                     .doesNotThrowAnyException();
             assertThat(causeRef).hasValue(null);
@@ -388,8 +388,7 @@ class FixedStreamMessageTest {
             }
 
             @Override
-            public void onNext(Integer integer) {
-            }
+            public void onNext(Integer integer) {}
 
             @Override
             public void onError(Throwable t) {
@@ -428,7 +427,7 @@ class FixedStreamMessageTest {
 
             @Override
             public void onNext(Integer integer) {
-                // make onError() get invoked.
+                // Make onError() get invoked.
                 throw onNextCause;
             }
 
@@ -504,8 +503,7 @@ class FixedStreamMessageTest {
                              StreamMessage.of(1, 2),       // TwoElementFixedStreamMessage
                              StreamMessage.of(1, 2, 3),    // ThreeElementFixedStreamMessage
                              StreamMessage.of(1, 2, 3, 4), // RegularFixedStreamMessage
-                             aggregatingStreamMessage
-                         )
+                             aggregatingStreamMessage)
                          .map(Arguments::of);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -167,15 +167,7 @@ class FixedStreamMessageTest {
         // Execute abort() first on the event loop.
         final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, true);
 
-        final CompletableFuture<List<Integer>> collectionFuture = new CompletableFuture<>();
-        stream.collect(eventExecutor).handle((res, cause) -> {
-            if (cause != null) {
-                collectionFuture.completeExceptionally(cause);
-            } else {
-                collectionFuture.complete(res);
-            }
-            return null;
-        });
+        final CompletableFuture<List<Integer>> collectionFuture = stream.collect(eventExecutor);
 
         assertThat(eventExecutor.numPendingTasks()).isOne();
         assertThat(stream.isComplete()).isFalse();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -134,17 +134,9 @@ class FixedStreamMessageTest {
         assumeThat(stream.isEmpty()).isFalse();
 
         // Execute collect() first on the event loop.
-        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, false);
-        final CompletableFuture<List<Integer>> collectionFuture = new CompletableFuture<>();
-        stream.collect(eventExecutor).handle((res, cause) -> {
-            if (cause != null) {
-                collectionFuture.completeExceptionally(cause);
-            } else {
-                collectionFuture.complete(res);
-            }
-            return null;
-        });
+        final TestEventExecutor eventExecutor = new TestEventExecutor(eventLoop.get(), 2, false);
 
+        final CompletableFuture<List<Integer>> collectionFuture = stream.collect(eventExecutor);
         assertThat(eventExecutor.numPendingTasks()).isOne();
         assertThat(stream.isComplete()).isFalse();
 
@@ -165,10 +157,9 @@ class FixedStreamMessageTest {
         assumeThat(stream.isEmpty()).isFalse();
 
         // Execute abort() first on the event loop.
-        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, true);
+        final TestEventExecutor eventExecutor = new TestEventExecutor(eventLoop.get(), 2, true);
 
         final CompletableFuture<List<Integer>> collectionFuture = stream.collect(eventExecutor);
-
         assertThat(eventExecutor.numPendingTasks()).isOne();
         assertThat(stream.isComplete()).isFalse();
 
@@ -194,7 +185,7 @@ class FixedStreamMessageTest {
         assumeThat(stream.isEmpty()).isFalse();
 
         // Execute subscribe() first on the event loop.
-        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, false);
+        final TestEventExecutor eventExecutor = new TestEventExecutor(eventLoop.get(), 2, false);
 
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -242,7 +233,7 @@ class FixedStreamMessageTest {
         assumeThat(stream.isEmpty()).isFalse();
 
         // Execute abort() first on the event loop.
-        final LatchedEventExecutor eventExecutor = new LatchedEventExecutor(eventLoop.get(), 2, true);
+        final TestEventExecutor eventExecutor = new TestEventExecutor(eventLoop.get(), 2, true);
 
         final AtomicReference<Throwable> causeRef = new AtomicReference<>();
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -463,12 +454,12 @@ class FixedStreamMessageTest {
         assertThat(errorCount).hasValue(1);
     }
 
-    private static class LatchedEventExecutor extends EventExecutorWrapper {
+    private static class TestEventExecutor extends EventExecutorWrapper {
         private final Deque<Runnable> pendingTasks = new ArrayDeque<>();
         private int latchCount;
         private final boolean reverseExecution;
 
-        LatchedEventExecutor(EventExecutor delegate, int latchCount, boolean reverseExecution) {
+        TestEventExecutor(EventExecutor delegate, int latchCount, boolean reverseExecution) {
             super(delegate);
             this.latchCount = latchCount;
             this.reverseExecution = reverseExecution;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -453,6 +453,20 @@ class FixedStreamMessageTest {
         assertThat(errorCount).hasValue(1);
     }
 
+    @ArgumentsSource(FixedStreamMessageProvider.class)
+    @ParameterizedTest
+    void doubleAbort(FixedStreamMessage<Integer> stream) {
+        assumeThat(stream.isEmpty()).isFalse();
+
+        final AnticipatedException abortCause = new AnticipatedException();
+        stream.abort(abortCause);
+        assertThatThrownBy(stream.whenComplete()::join)
+                .isInstanceOf(CompletionException.class)
+                .hasCause(abortCause);
+        // Should perform nothing
+        stream.abort();
+    }
+
     private static class TestEventExecutor extends EventExecutorWrapper {
         private final Deque<Runnable> pendingTasks = new ArrayDeque<>();
         private int latchCount;


### PR DESCRIPTION
A `NullPointerException` caused due to a race condition between `collect()` and `abort()` was fixed in #4652. Howerver, we got another reoprt from Slack community. https://line-armeria.slack.com/archives/C1NGPBUH2/p1675994120153789

```java
2023-02-09T02:08:55,526 [armeria-common-worker-epoll-3-3] WARN  com.linecorp.armeria.internal.common.stream.FixedStreamMessage - Subscriber.onError() should not raise an exception. subscriber: null
com.linecorp.armeria.common.util.CompositeException: 2 exceptions occurred.
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.onError0(FixedStreamMessage.java:247) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.onError(FixedStreamMessage.java:237) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort1(FixedStreamMessage.java:342) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort0(FixedStreamMessage.java:328) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort(FixedStreamMessage.java:308) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.stream.OneElementFixedStreamMessage.abort(OneElementFixedStreamMessage.java:112) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.AbstractServerCall.closeListener(AbstractServerCall.java:287) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.AbstractServerCall.closeListener(AbstractServerCall.java:264) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.AbstractServerCall.doClose(AbstractServerCall.java:239) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.AbstractServerCall.close(AbstractServerCall.java:222) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.AbstractServerCall.close(AbstractServerCall.java:217) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.grpc.FramedGrpcService.lambda$startCall$4(FramedGrpcService.java:318) ~[armeria-grpc-1.21.1-SNAPSHOT.jar:?]
    at java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934) ~[?:?]
    at java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911) ~[?:?]
    at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) ~[?:?]
    at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147) ~[?:?]
    at com.linecorp.armeria.common.util.UnmodifiableFuture.doComplete(UnmodifiableFuture.java:164) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.CancellationScheduler$CancellationFuture.doComplete(CancellationScheduler.java:521) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.CancellationScheduler.invokeTask(CancellationScheduler.java:477) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.CancellationScheduler.finishNow0(CancellationScheduler.java:322) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.common.CancellationScheduler.finishNow(CancellationScheduler.java:306) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.internal.server.DefaultServiceRequestContext.cancel(DefaultServiceRequestContext.java:327) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.StreamingDecodedHttpRequest.abortResponse(StreamingDecodedHttpRequest.java:181) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at com.linecorp.armeria.server.Http2RequestDecoder.onRstStreamRead(Http2RequestDecoder.java:356) ~[armeria-1.21.1-SNAPSHOT.jar:?]
    at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onRstStreamRead(Http2FrameListenerDecorator.java:59) ~[netty-codec-http2-4.1.86.Final.jar:4.1.86.Final]
    at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onRstStreamRead(DefaultHttp2ConnectionDecoder.java:442) ~[netty-codec-http2-4.1.86.Final.jar:4.1.86.Final]
    at io.netty.handler.codec.http2.Http2InboundFrameLogger$1.onRstStreamRead(Http2InboundFrameLogger.java:80) ~[netty-codec-http2-4.1.86.Final.jar:4.1.86.Final]
    at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readRstStreamFrame(DefaultHttp2FrameReader.java:509) ~[netty-codec-http2-4.1.86.Final.jar:4.1.86.Final]
    ...
Caused by: com.linecorp.armeria.common.util.CompositeException$ExceptionOverview: Multiple exceptions (2)
|-- java.lang.NullPointerException: Cannot invoke "org.reactivestreams.Subscriber.onError(java.lang.Throwable)" because "this.subscriber" is null
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.onError0(FixedStreamMessage.java:242)
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.onError(FixedStreamMessage.java:237)
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort1(FixedStreamMessage.java:342)
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort0(FixedStreamMessage.java:328)
    at com.linecorp.armeria.internal.common.stream.FixedStreamMessage.abort(FixedStreamMessage.java:308)
    at com.linecorp.armeria.internal.common.stream.OneElementFixedStreamMessage.abort(OneElementFixedStreamMessage.java:112)
    at com.linecorp.armeria.server.grpc.AbstractServerCall.closeListener(AbstractServerCall.java:287)
    at com.linecorp.armeria.server.grpc.AbstractServerCall.closeListener(AbstractServerCall.java:264)
    at com.linecorp.armeria.server.grpc.AbstractServerCall.doClose(AbstractServerCall.java:239)
    at com.linecorp.armeria.server.grpc.AbstractServerCall.close(AbstractServerCall.java:222)
    at com.linecorp.armeria.server.grpc.AbstractServerCall.close(AbstractServerCall.java:217)
    at com.linecorp.armeria.server.grpc.FramedGrpcService.lambda$startCall$4(FramedGrpcService.java:318)
    ...
```

Modifications:

- Check if a stream is aborted while `subscribe0()` or `collect()` is the pending queue of an event executor.
  - If it is aborted, abort the subscriber or the collection future.
- Check if a stream is subscribed while `abort1()` is in the pending queue of an event executor.
  - If it is subscribed, delegate the subscribe0() to signal abortCause via onError().
- Test possible race conditions by switching the execution order of in an event executor.

Result:

You no longer see a `NullPointerException` when a stream is aborted.