### PR TITLE
Fix onPingAck comment

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -49,7 +49,7 @@ public interface KeepAliveHandler {
     void onPing();
 
     /**
-     * Invoked when a <a href="https://www.rfc-editor.org/rfc/rfc9113.html#name-ping">PING ACK</a> is received.
+     * Invoked when a <a href="https://datatracker.ietf.org/doc/html/rfc9113#name-ping">PING ACK</a> is received.
      * Note that this method is only valid for an HTTP/2 connection.
      */
     void onPingAck(long data);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandler.java
@@ -49,7 +49,7 @@ public interface KeepAliveHandler {
     void onPing();
 
     /**
-     * Invoked when a <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.7">PING ACK</a> is received.
+     * Invoked when a <a href="https://www.rfc-editor.org/rfc/rfc9113.html#name-ping">PING ACK</a> is received.
      * Note that this method is only valid for an HTTP/2 connection.
      */
     void onPingAck(long data);


### PR DESCRIPTION
Motivation:

Provide a more recent version of the RFC document that describes the same thing

Modifications:

Fix KeepAliveHandler#onPingAck comment

Result:

Closes #4665 