### PR TITLE
Added DefaultCpuHealthChecker

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultCpuHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultCpuHealthChecker.java
@@ -1,0 +1,74 @@
+package com.linecorp.armeria.server.healthcheck;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+public class DefaultCpuHealthChecker implements HealthChecker{
+
+    private static final List<String> OPERATING_SYSTEM_BEAN_CLASS_NAMES = Arrays.asList(
+            "com.ibm.lang.management.OperatingSystemMXBean", // J9
+            "com.sun.management.OperatingSystemMXBean" // HotSpot
+    );
+
+    private final OperatingSystemMXBean operatingSystemBean;
+
+    private final Class<?> operatingSystemBeanClass;
+
+    private final Method systemCpuUsage;
+
+    private final double targetCpuUsage;
+
+    public DefaultCpuHealthChecker(final double targetCpuUsage) {
+        this.targetCpuUsage = targetCpuUsage;
+        this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
+        this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
+        this.systemCpuUsage = detectMethod("getSystemCpuLoad");
+    }
+
+    @Override
+    public boolean isHealthy() {
+        double cpuUsage = invoke(systemCpuUsage);
+        return cpuUsage <= targetCpuUsage;
+    }
+
+    private double invoke(final Method method) {
+        try {
+            return (double) method.invoke(operatingSystemBean);
+        }
+        catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            return Double.NaN;
+        }
+    }
+
+    private Method detectMethod(final String name) {
+        requireNonNull(name);
+        if (operatingSystemBeanClass == null) {
+            return null;
+        }
+        try {
+            // ensure the Bean we have is actually an instance of the interface
+            requireNonNull(operatingSystemBeanClass.cast(operatingSystemBean));
+            return operatingSystemBeanClass.getMethod(name);
+        }
+        catch (ClassCastException | NoSuchMethodException | SecurityException e) {
+            return null;
+        }
+    }
+
+    private Class<?> getFirstClassFound(final List<String> classNames) {
+        for (String className : classNames) {
+            try {
+                return Class.forName(className);
+            }
+            catch (ClassNotFoundException ignore) {
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Motivation:

Resolves part of #1854

Some users may want to use CPU usage to determine if their instance is healthy.
From now on, Users can perform health checks in the following ways

```java
DefaultCpuHealthChecker cpuHealthChecker = new DefaultCpuHealthChecker(20.0);
cpuHealthChecker.isHealthy();
```

Modifications:

- Added DefaultCpuHealthChecker that checks cpu-usage by OperatingSystemMXBean

Result:

A User can health-check with system-cpu-usage

p.s.
Implemented this by referencing [ProcessorMetrics.java](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java) in the micrometer core.