### PR TITLE
Update public suffix list with pull requests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Automatically merge Public suffix list pull requests
+    conditions:
+      - author=github-actions[bot]
+      - title=Update public suffix list
+      - files=core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
+    actions:
+      merge:
+        method: squash

--- a/.github/workflows/public-suffixes.yml
+++ b/.github/workflows/public-suffixes.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build with Gradle
+      - name: Update public suffix list
         run: |
           ./gradlew --no-daemon --stacktrace :core:publicSuffixes
 
@@ -36,12 +36,16 @@ jobs:
           git-user-signingkey: true
           git-commit-gpgsign: true
 
-      - name: Push updated public suffix list
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v4
         with:
-          commit_options: '-S'
-          commit_message: Update public suffix list
-          file_pattern: core/src/main/resources/com/linecorp/armeria/public_suffixes.txt
-          commit_user_name: Meri Kim
-          commit_user_email: dl_armeria@linecorp.com
-          commit_author: Meri Kim <dl_armeria@linecorp.com>
+          # The title of the pull request.
+          title: Update public suffix list
+          commit-message: Update public suffix list
+          author: Meri Kim <dl_armeria@linecorp.com>
+          branch: update-public-suffixes
+          committer: Meri Kim <dl_armeria@linecorp.com>
+          delete-branch: true
+          label: miscellaneous
+          add-paths: |
+            core/src/main/resources/com/linecorp/armeria/public_suffixes.txt


### PR DESCRIPTION
Motivation:

`update-psl` fails to push changes to the master branch because the branch is protected after [Merge Queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) is enabled.

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error:
To https://github.com/line/armeria
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs to 'https://github.com/line/armeria'
Error: Invalid status code: 1
```

Modifications:

- Automatically create a pull request for new changes in `public_suffixes.txt`
- The created PR is also automatically merged by [Mergify](https://mergify.com).

Result:

New public suffixes are correctly updated to `public_suffixes.txt`.
