### PR TITLE
Add `UncaughtExceptionsLogger` to log uncaught service exceptions. 

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -116,6 +116,7 @@ public final class DefaultServiceRequestContext
 
     @Nullable
     private String strVal;
+    private Boolean shouldLogUncaughtException;
 
     /**
      * Creates a new instance.
@@ -188,6 +189,8 @@ public final class DefaultServiceRequestContext
         maxRequestLength = cfg.maxRequestLength();
         this.additionalResponseHeaders = additionalResponseHeaders;
         this.additionalResponseTrailers = additionalResponseTrailers;
+
+        shouldLogUncaughtException = true;
     }
 
     @Nullable
@@ -437,6 +440,16 @@ public final class DefaultServiceRequestContext
     @Override
     public ProxiedAddresses proxiedAddresses() {
         return proxiedAddresses;
+    }
+
+    @Override
+    public boolean shouldLogUncaughtExceptions() {
+        return shouldLogUncaughtException;
+    }
+
+    @Override
+    public void setShouldLogUncaughtExceptions(boolean value) {
+        shouldLogUncaughtException = value;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -70,6 +70,7 @@ import com.linecorp.armeria.server.annotation.HttpResult;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.ServiceName;
+import com.linecorp.armeria.server.logging.UncaughtExceptionsLogger;
 
 /**
  * An {@link HttpService} which is defined by a {@link Path} or HTTP method annotations.
@@ -531,6 +532,9 @@ public final class AnnotatedService implements HttpService {
                 final HttpResponse response = unwrap().serve(ctx, req);
                 return response.recover(cause -> {
                     try (SafeCloseable ignored = ctx.push()) {
+                        if (ctx.shouldLogUncaughtExceptions()) {
+                            UncaughtExceptionsLogger.handleUncaughtExceptions(cause);
+                        }
                         return exceptionHandler.handleException(ctx, req, cause);
                     }
                 });

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -112,6 +112,8 @@ final class DefaultServerConfig implements ServerConfig {
     private final Http1HeaderNaming http1HeaderNaming;
     private final DependencyInjector dependencyInjector;
     private final List<ShutdownSupport> shutdownSupports;
+    private final boolean logUncaughtExceptions;
+    private final long logUncaughtExceptionsIntervalInSeconds;
 
     @Nullable
     private final Mapping<String, SslContext> sslContexts;
@@ -143,7 +145,9 @@ final class DefaultServerConfig implements ServerConfig {
             @Nullable Mapping<String, SslContext> sslContexts,
             Http1HeaderNaming http1HeaderNaming,
             DependencyInjector dependencyInjector,
-            List<ShutdownSupport> shutdownSupports) {
+            List<ShutdownSupport> shutdownSupports,
+            boolean logUncaughtExceptions,
+            long logUncaughtExceptionsIntervalInSeconds) {
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
         requireNonNull(virtualHosts, "virtualHosts");
@@ -257,6 +261,8 @@ final class DefaultServerConfig implements ServerConfig {
         this.http1HeaderNaming = requireNonNull(http1HeaderNaming, "http1HeaderNaming");
         this.dependencyInjector = requireNonNull(dependencyInjector, "dependencyInjector");
         this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
+        this.logUncaughtExceptions = logUncaughtExceptions;
+        this.logUncaughtExceptionsIntervalInSeconds = logUncaughtExceptionsIntervalInSeconds;
     }
 
     private static Int2ObjectMap<Mapping<String, VirtualHost>> buildDomainAndPortMapping(
@@ -640,6 +646,16 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public DependencyInjector dependencyInjector() {
         return dependencyInjector;
+    }
+
+    @Override
+    public boolean logUncaughtExceptions() {
+        return logUncaughtExceptions;
+    }
+
+    @Override
+    public long logUncaughtExceptionsIntervalInSeconds() {
+        return logUncaughtExceptionsIntervalInSeconds;
     }
 
     List<ShutdownSupport> shutdownSupports() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -295,4 +295,14 @@ public interface ServerConfig {
      * Returns the {@link DependencyInjector} that injects dependencies in annotations.
      */
     DependencyInjector dependencyInjector();
+
+    /**
+     * Returns whether the server should log uncaught exceptions.
+     */
+    boolean logUncaughtExceptions();
+
+    /**
+     * Returns the interval between logging uncaught exceptions.
+     */
+    long logUncaughtExceptionsIntervalInSeconds();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -54,6 +54,8 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
+import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.server.logging.LoggingService;
 
 /**
  * Provides information about an invocation and related utilities. Every request being handled has its own
@@ -579,6 +581,18 @@ public interface ServiceRequestContext extends RequestContext {
      * Returns the proxied addresses of the current {@link Request}.
      */
     ProxiedAddresses proxiedAddresses();
+
+    /**
+     * Returns whether uncaught exceptions thrown by {@link AnnotatedService} should be logged.
+     * When {@link LoggingService} handles exceptions, this is set to false.
+     */
+    boolean shouldLogUncaughtExceptions();
+
+    /**
+     * Sets whether to log uncaught exceptions.
+     * @param value whether to log uncaught exceptions
+     */
+    void setShouldLogUncaughtExceptions(boolean value);
 
     /**
      * Initiates graceful connection shutdown with a given drain duration in microseconds and returns

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -233,6 +233,16 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public boolean shouldLogUncaughtExceptions() {
+        return unwrap().shouldLogUncaughtExceptions();
+    }
+
+    @Override
+    public void setShouldLogUncaughtExceptions(boolean value) {
+        unwrap().setShouldLogUncaughtExceptions(value);
+    }
+
+    @Override
     public CompletableFuture<Void> initiateConnectionShutdown(long drainDurationMicros) {
         return unwrap().initiateConnectionShutdown(drainDurationMicros);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -285,6 +285,16 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
+    public boolean logUncaughtExceptions() {
+        return delegate.logUncaughtExceptions();
+    }
+
+    @Override
+    public long logUncaughtExceptionsIntervalInSeconds() {
+        return delegate.logUncaughtExceptionsIntervalInSeconds();
+    }
+
+    @Override
     public String toString() {
         return delegate.toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -145,6 +145,8 @@ public final class LoggingService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        // exceptions are caught by provided LoggingService, so we can set logUncaughtExceptions to false
+        ctx.setShouldLogUncaughtExceptions(false);
         ctx.log().whenComplete().thenAccept(requestLog -> {
             if (sampler.isSampled(requestLog)) {
                 log(logger, ctx, requestLog, requestLogger, responseLogger);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/UncaughtExceptionsLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/UncaughtExceptionsLogger.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.logging;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
@@ -47,6 +49,7 @@ public final class UncaughtExceptionsLogger {
      * @param interval interval between logging in seconds.
      */
     public static void schedule(EventLoopGroup workerGroup, long interval) {
+        requireNonNull(workerGroup, "workerGroup");
         if (!initialized) {
             UncaughtExceptionsLogger.initialize(interval);
         }
@@ -85,6 +88,7 @@ public final class UncaughtExceptionsLogger {
         if (!initialized) {
             throw new IllegalStateException("UncaughtExceptionLogger is not initialized.");
         }
+        requireNonNull(throwable, "throwable");
         counter.increment();
         lastThrownException = throwable;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/UncaughtExceptionsLogger.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/UncaughtExceptionsLogger.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.channel.EventLoopGroup;
+
+/**
+ * Log uncaught exceptions. Uncaught exceptions are exceptions thrown by services
+ * which have not been decorated with {@link LoggingService}.
+ */
+public final class UncaughtExceptionsLogger {
+    private static final Logger logger = LoggerFactory.getLogger(UncaughtExceptionsLogger.class);
+    private static boolean initialized;
+    @Nullable private static ScheduledFuture<?> reportUncaughtExceptionsSchedule;
+    @Nullable private static LongAdder counter;
+    private static long logUncaughtExceptionsIntervalInSeconds = 60;
+    @Nullable private static Throwable lastThrownException;
+
+    private UncaughtExceptionsLogger() {}
+
+    /**
+     * Schedules uncaught exceptions logging.
+     * @param workerGroup eventLoopGroup on which logging will be scheduled.
+     * @param interval interval between logging in seconds.
+     */
+    public static void schedule(EventLoopGroup workerGroup, long interval) {
+        if (!initialized) {
+            UncaughtExceptionsLogger.initialize(interval);
+        }
+        reportUncaughtExceptionsSchedule = workerGroup.scheduleAtFixedRate(
+                UncaughtExceptionsLogger::logUncaughtExceptions,
+                interval,
+                interval,
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Unschedule uncaught exceptions logging.
+     * @throws IllegalStateException if no schedule exists.
+     */
+    public static void unSchedule() {
+        if (reportUncaughtExceptionsSchedule == null) {
+            throw new IllegalStateException("UncaughtExceptionsLogger is not scheduled.");
+        }
+        reportUncaughtExceptionsSchedule.cancel(true);
+    }
+
+    private static void initialize(long seconds) {
+        if (initialized) {
+            return;
+        }
+        counter = new LongAdder();
+        logUncaughtExceptionsIntervalInSeconds = seconds;
+        initialized = true;
+    }
+
+    /**
+     * Increments number of uncaught exceptions and stores last thrown exception.
+     * @param throwable uncaught exception.
+     */
+    public static void handleUncaughtExceptions(Throwable throwable) {
+        if (!initialized) {
+            throw new IllegalStateException("UncaughtExceptionLogger is not initialized.");
+        }
+        counter.increment();
+        lastThrownException = throwable;
+    }
+
+    private static void logUncaughtExceptions() {
+        logger.warn("Observed {} uncaught exceptions in last {} seconds. " +
+                    "If you don't see error logs please use LoggingService decorator.",
+                    counter.sum(), logUncaughtExceptionsIntervalInSeconds);
+        if (lastThrownException == null) {
+            return;
+        }
+        logger.warn("Last exception occurred with following message: {}", lastThrownException.getMessage());
+
+        counter.reset();
+        lastThrownException = null;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -641,4 +641,27 @@ class ServerBuilderTest {
                 .containsExactly(entry(TCP_USER_TIMEOUT, userDefinedValue),
                                  entry(SO_LINGER, lingerMillis));
     }
+
+    @Test
+    void testServerLogUncaughtExceptions() {
+        final Server server1 = Server.builder()
+                               .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                               .build();
+        assertThat(server1.config().logUncaughtExceptions()).isTrue();
+        assertThat(server1.config().logUncaughtExceptionsIntervalInSeconds()).isEqualTo(60);
+
+        final Server server2 = Server.builder()
+                               .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                               .logUncaughtExceptions(true)
+                               .logUncaughtExceptionsInterval(120)
+                               .build();
+        assertThat(server2.config().logUncaughtExceptions()).isTrue();
+        assertThat(server2.config().logUncaughtExceptionsIntervalInSeconds()).isEqualTo(120);
+
+        final Server server3 = Server.builder()
+                               .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                               .logUncaughtExceptions(false)
+                               .build();
+        assertThat(server3.config().logUncaughtExceptions()).isFalse();
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -195,6 +195,12 @@ class ServiceRequestContextTest {
         assertThat(ctx.queryParams("Not exist")).isEmpty();
     }
 
+    @Test
+    void defaultServiceRequestContextShouldLogUncaughtExceptions() {
+        final ServiceRequestContext sctx = serviceRequestContext();
+        assertThat(sctx.shouldLogUncaughtExceptions()).isTrue();
+    }
+
     private static void assertUnwrapAllCurrentCtx(@Nullable RequestContext ctx) {
         final RequestContext current = RequestContext.currentOrNull();
         if (current == null) {


### PR DESCRIPTION
Motivation:

If `LoggingService` is not added to services, exceptions thrown by those services are not caught. This default behavior might be confusing to users because even though exceptions are thrown, users can't check the exceptions. 
The purpose of this feature is to provide users with logging uncaught exceptions by default.

Modifications:

- `ServerConfig`
  - `logUncaughtExceptions` is added to allow users select whether to log uncaught exceptions(`true` by default) 
  - `logUncaughtExceptionsIntervalInSeconds` is added to allow users set the time interval between logging uncaught excptions 
- `ServiceRequestContext`
  - `shouldLogUncaughtException` is added to determine whether to log uncaught exceptions(`true` by default) 
  - `LoggingService` sets `shouldLogUncaughtException` to `false` before serving the request. 
- Armeria server will schedule the logging of uncaught exceptions by default and unschedule it when being stopped. 
- `UncaughtExceptionsLogger` is added which tracks the number of uncaught exceptions and the last thrown exception. 

Result:

- [Closes #<4324>](https://github.com/line/armeria/issues/4324). (If this resolves the issue.)
- User will be able to check the number of uncaught exceptions and last thrown exception periodically by default. 

<b>Example</b>
```
[armeria-common-worker-nio-2-1] WARN com.linecorp.armeria.server.logging.UncaughtExceptionsLogger - Observed 15 uncaught exceptions in last 60 seconds. If you don't see error logs please use LoggingService decorator.
[armeria-common-worker-nio-2-1] WARN com.linecorp.armeria.server.logging.UncaughtExceptionsLogger - Last exception occurred with following message: null
```
- User can change default settings by using `ServerBuilder` 
```
final ServerBuilder sb = Server.builder();
sb.http(port);
sb.logUncaughtExceptions(false); 
sb.logUncaughtExceptionsInterval(120); 
```

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
