### PR TITLE
Add the release note for 1.16.2 and credit @rhodo in 1.22.0

### DIFF
--- a/site/src/pages/release-notes/1.16.2.mdx
+++ b/site/src/pages/release-notes/1.16.2.mdx
@@ -1,0 +1,17 @@
+---
+date: 2023-02-20
+---
+
+## 🛠️ Bug fixes
+
+- Client-side gRPC callback `ClientCall.Listener.onHeaders()` is now invoked correctly. #4583 #4608
+
+## 🙇 Thank you
+
+<ThankYou usernames={[
+  'ikhoon',
+  'jrhee17',
+  'Lincong',
+  'minwoox',
+  'rhodo'
+]} />

--- a/site/src/pages/release-notes/1.22.0.mdx
+++ b/site/src/pages/release-notes/1.22.0.mdx
@@ -128,6 +128,7 @@ date: 2023-02-09
   'kezhenxu94',
   'kojilin',
   'minwoox',
+  'rhodo',
   'sullis',
   'ta7uw',
   'tomatophobia',


### PR DESCRIPTION
- Added the release note for 1.16.2, the backport release for #4608 and #4583.
- Added @rhodo to the release note for 1.22.0 because he is the person who reported #4583 initially.