### PR TITLE
Update the build requirements and the default JVM options

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ publishPasswordProperty=ossrhPassword
 publishSignatureRequired=true
 
 # Gradle options
-org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx1792m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Build requirements
 
-- [OpenJDK 11-19](https://adoptium.net/)
+- [OpenJDK 17](https://adoptium.net/)
   - Consider using a version manager for convenient installation of JDK, such as
     [asdf](https://asdf-vm.com/) and [jabba](https://github.com/shyiko/jabba).
 

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -2,7 +2,7 @@
 
 ## Build requirements
 
-- [OpenJDK 17](https://adoptium.net/)
+- OpenJDK 17 or its derivative, such as [Temurin](https://adoptium.net/)
   - Consider using a version manager for convenient installation of JDK, such as
     [asdf](https://asdf-vm.com/) and [jabba](https://github.com/shyiko/jabba).
 


### PR DESCRIPTION
Motivation:

- Our developer guide tells our contributors to use an old JDK that doesn't work for our build anymore.
- Some contributors reported they are getting `OOME` when trying to build with the default JVM settings. (Credit: @chris-ryan-square)

Modifications:

- Explicitly stated that we need JDK 17. Removed `-19` part to keep things simple and straightforward.
- Increased the default JVM heap size from 1536 (128 * 12) to 1792 (128 * 14) to reduce the chance of `OOME`.

Result:

Better experience to our fellow contributors.
