### PR TITLE
Fix the micrometer version in release notes for 1.22.0

### DIFF
--- a/site/src/pages/release-notes/1.22.0.mdx
+++ b/site/src/pages/release-notes/1.22.0.mdx
@@ -99,7 +99,7 @@ date: 2023-02-09
 - java-jwt 4.2.1 → 4.2.2
 - Kafka client 3.3.1 → 3.4.0
 - Kotlin 1.7.22 → 1.8.10
-- Micrometer 4.10.0 → 4.11.0
+- Micrometer 1.10.2 → 1.10.3
 - Netty 4.1.86.Final → 4.1.87.Final
 - io_uring 0.0.16.Final → 0.0.17.Final
 - Protobuf 3.21.1 → 3.21.7


### PR DESCRIPTION
Motivation:



Modifications:

- Fix the micrometer version in the release notes for 1.22.0 to the correct version

Result:

- A more accurate description of upgraded dependencies

