### PR TITLE
#Issue4362 Provide a way to generate RequestId from Request information

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -250,7 +250,7 @@ final class DefaultServerConfig implements ServerConfig {
         @SuppressWarnings("unchecked")
         final Function<RoutingContext, RequestId> castRequestIdGenerator =
                 (Function<RoutingContext, RequestId>) requireNonNull(requestIdGenerator, "requestIdGenerator");
-        this.requestIdGenerator = requireNonNull(castRequestIdGenerator);
+        this.requestIdGenerator = castRequestIdGenerator;
         this.errorHandler = requireNonNull(errorHandler, "errorHandler");
         this.sslContexts = sslContexts;
         this.http1HeaderNaming = requireNonNull(http1HeaderNaming, "http1HeaderNaming");

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
 
@@ -107,7 +106,7 @@ final class DefaultServerConfig implements ServerConfig {
     private final Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper;
     private final boolean enableServerHeader;
     private final boolean enableDateHeader;
-    private final Supplier<RequestId> requestIdGenerator;
+    private final Function<RoutingContext, RequestId> requestIdGenerator;
     private final ServerErrorHandler errorHandler;
     private final Http1HeaderNaming http1HeaderNaming;
     private final DependencyInjector dependencyInjector;
@@ -138,7 +137,7 @@ final class DefaultServerConfig implements ServerConfig {
             Predicate<? super InetAddress> clientAddressFilter,
             Function<? super ProxiedAddresses, ? extends InetSocketAddress> clientAddressMapper,
             boolean enableServerHeader, boolean enableDateHeader,
-            Supplier<? extends RequestId> requestIdGenerator,
+            Function<? super RoutingContext, ? extends RequestId> requestIdGenerator,
             ServerErrorHandler errorHandler,
             @Nullable Mapping<String, SslContext> sslContexts,
             Http1HeaderNaming http1HeaderNaming,
@@ -249,9 +248,9 @@ final class DefaultServerConfig implements ServerConfig {
         this.enableDateHeader = enableDateHeader;
 
         @SuppressWarnings("unchecked")
-        final Supplier<RequestId> castRequestIdGenerator =
-                (Supplier<RequestId>) requireNonNull(requestIdGenerator, "requestIdGenerator");
-        this.requestIdGenerator = castRequestIdGenerator;
+        final Function<RoutingContext, RequestId> castRequestIdGenerator =
+                (Function<RoutingContext, RequestId>) requireNonNull(requestIdGenerator, "requestIdGenerator");
+        this.requestIdGenerator = requireNonNull(castRequestIdGenerator);
         this.errorHandler = requireNonNull(errorHandler, "errorHandler");
         this.sslContexts = sslContexts;
         this.http1HeaderNaming = requireNonNull(http1HeaderNaming, "http1HeaderNaming");
@@ -615,7 +614,7 @@ final class DefaultServerConfig implements ServerConfig {
     }
 
     @Override
-    public Supplier<RequestId> requestIdGenerator() {
+    public Function<RoutingContext, RequestId> requestIdGenerator() {
         return requestIdGenerator;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -352,7 +352,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(
                 serviceCfg, channel, config.meterRegistry(), protocol,
-                nextRequestId(), routingCtx, routingResult, req.exchangeType(),
+                nextRequestId(routingCtx), routingCtx, routingResult, req.exchangeType(),
                 req, sslSession, proxiedAddresses, clientAddress,
                 req.requestStartTimeNanos(), req.requestStartTimeMicros());
 
@@ -641,17 +641,17 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         return new DefaultServiceRequestContext(
                 serviceConfig,
                 channel, NoopMeterRegistry.get(), protocol(),
-                nextRequestId(), routingCtx, routingResult, req.exchangeType(),
+                nextRequestId(routingCtx), routingCtx, routingResult, req.exchangeType(),
                 req, sslSession, proxiedAddresses, clientAddress,
                 System.nanoTime(), SystemInfo.currentTimeMicros());
     }
 
-    private RequestId nextRequestId() {
-        final RequestId id = config.requestIdGenerator().get();
+    private RequestId nextRequestId(RoutingContext routingCtx) {
+        final RequestId id = config.requestIdGenerator().apply(routingCtx);
         if (id == null) {
             if (!warnedNullRequestId) {
                 warnedNullRequestId = true;
-                logger.warn("requestIdGenerator.get() returned null; using RequestId.random()");
+                logger.warn("requestIdGenerator.apply(routingCtx) returned null; using RequestId.random()");
             }
             return RequestId.random();
         } else {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -207,7 +207,8 @@ public final class ServerBuilder implements TlsSetters {
             ProxiedAddresses::sourceAddress;
     private boolean enableServerHeader = true;
     private boolean enableDateHeader = true;
-    private Supplier<? extends RequestId> requestIdGenerator = RequestId::random;
+    private Function<? super RoutingContext, ? extends RequestId> requestIdGenerator =
+            routingContext -> RequestId.random();
     private Http1HeaderNaming http1HeaderNaming = Http1HeaderNaming.ofDefault();
     @Nullable
     private DependencyInjector dependencyInjector;
@@ -1708,12 +1709,26 @@ public final class ServerBuilder implements TlsSetters {
     }
 
     /**
-     * Sets the {@link Supplier} which generates a {@link RequestId}.
+     * Sets the {@link Function} from {@link Supplier} which generates a {@link RequestId}.
      * By default, a {@link RequestId} is generated from a random 64-bit integer.
      *
      * @see RequestContext#id()
      */
     public ServerBuilder requestIdGenerator(Supplier<? extends RequestId> requestIdGenerator) {
+        final Supplier<? extends RequestId> requestIdSupplier = requireNonNull(requestIdGenerator);
+        this.requestIdGenerator = routingContext -> requestIdSupplier.get();
+        return this;
+    }
+
+    /**
+     * Sets the {@link Function} which generates a {@link RequestId}.
+     * Add logic to generate {@link RequestId} from {@link RoutingContext}.
+     * By default, a {@link RequestId} is generated from a random 64-bit integer.
+     *
+     * @see RequestContext#id()
+     */
+    public ServerBuilder requestIdGenerator(
+            Function<? super RoutingContext, ? extends RequestId> requestIdGenerator) {
         this.requestIdGenerator = requireNonNull(requestIdGenerator, "requestIdGenerator");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -276,7 +276,7 @@ public interface ServerConfig {
     /**
      * Returns the {@link Supplier} that generates a {@link RequestId} for each {@link Request}.
      */
-    Supplier<RequestId> requestIdGenerator();
+    Function<? super RoutingContext, RequestId> requestIdGenerator();
 
     /**
      * Returns the {@link ServerErrorHandler} that provides the error responses in case of unexpected

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -276,7 +276,7 @@ public interface ServerConfig {
     /**
      * Returns the {@link Supplier} that generates a {@link RequestId} for each {@link Request}.
      */
-    Function<? super RoutingContext, RequestId> requestIdGenerator();
+    Function<RoutingContext, RequestId> requestIdGenerator();
 
     /**
      * Returns the {@link ServerErrorHandler} that provides the error responses in case of unexpected

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.common.Http1HeaderNaming;
@@ -265,7 +264,7 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
-    public Supplier<RequestId> requestIdGenerator() {
+    public Function<RoutingContext, RequestId> requestIdGenerator() {
         return delegate.requestIdGenerator();
     }
 


### PR DESCRIPTION
Motivation:

* I would like to add logic that can generate requestId through request information as well as random generation.

Modifications:

1. ServerBuilder.java

* default requestIdGenerator is changed
* `private final Supplier<RequestId> requestIdGenerator;` to`Function<RoutingContext, RequestId> requestIdGenerator;`

2. ServerConfig.java
3. DefaultServerConfig.java
4. UpdatableServerConfig.java

* The type of requestIdGenerator for these classes has also changed. to Function type from Supplier type

5. HttpServerHandler.java
   
* HttpServerHandler's nextRequestId() modified to nextRequestId(routingCtx)

Result:
* Closes #4362 