### PR TITLE
Build the changesets in GitHub merge queue before merging

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -7,6 +7,7 @@ on:
       # The release versions will be verified by 'publish-release.yml'
       - armeria-*
   pull_request:
+  merge_group:
 
 concurrency:
   # Cancel the previous builds in the same PR.


### PR DESCRIPTION
Motivation:

We recently enabled GitHub merge queue to make sure the PR being merged doesn't introduce any unexpected build failure.

However, it seems like we have explicitly tell GitHub to run builds, on top of just enabling merge queue.

Modifications:

- Add `merge_group:` event listener to `actions_build.yml` so that GitHub triggers the build for the changesets in the merge queue before merging anything.

Result:

- Build stability