### PR TITLE
Add `StreamMessageWriter` and `StreamMessage.streaming()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractStreamMessageWriter.java
@@ -26,8 +26,8 @@ import org.reactivestreams.Subscription;
 import com.linecorp.armeria.internal.common.stream.AbortingSubscriber;
 import com.linecorp.armeria.internal.common.stream.StreamMessageUtil;
 
-abstract class AbstractStreamMessageAndWriter<T> extends CancellableStreamMessage<T>
-        implements StreamMessageAndWriter<T> {
+abstract class AbstractStreamMessageWriter<T> extends CancellableStreamMessage<T>
+        implements StreamMessageWriter<T> {
 
     enum State {
         /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ByteStreamMessageOutputStream.java
@@ -33,7 +33,7 @@ import io.netty.util.concurrent.EventExecutor;
 
 final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
-    private final StreamMessageAndWriter<HttpData> outputStreamWriter = new DefaultStreamMessage<>();
+    private final StreamMessageWriter<HttpData> outputStreamWriter = new DefaultStreamMessage<>();
     private final ByteStreamMessage delegate = ByteStreamMessage.of(outputStreamWriter);
 
     private final Consumer<? super OutputStream> outputStreamConsumer;
@@ -94,12 +94,12 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
     private static final class OutputStreamSubscriber implements Subscriber<HttpData> {
 
         private final Subscriber<? super HttpData> downstream;
-        private final StreamMessageAndWriter<HttpData> outputStreamWriter;
+        private final StreamMessageWriter<HttpData> outputStreamWriter;
         private final Consumer<? super OutputStream> outputStreamConsumer;
         private final Executor blockingTaskExecutor;
 
         OutputStreamSubscriber(Subscriber<? super HttpData> downstream,
-                               StreamMessageAndWriter<HttpData> outputStreamWriter,
+                               StreamMessageWriter<HttpData> outputStreamWriter,
                                Consumer<? super OutputStream> outputStreamConsumer,
                                Executor blockingTaskExecutor) {
             requireNonNull(downstream, "downstream");
@@ -145,9 +145,9 @@ final class ByteStreamMessageOutputStream implements ByteStreamMessage {
 
     private static final class StreamWriterOutputStream extends OutputStream {
 
-        private final StreamMessageAndWriter<HttpData> streamWriter;
+        private final StreamMessageWriter<HttpData> streamWriter;
 
-        StreamWriterOutputStream(StreamMessageAndWriter<HttpData> streamWriter) {
+        StreamWriterOutputStream(StreamMessageWriter<HttpData> streamWriter) {
             this.streamWriter = streamWriter;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -68,7 +68,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  * @param <T> the type of element signaled
  */
 @UnstableApi
-public class DefaultStreamMessage<T> extends AbstractStreamMessageAndWriter<T> {
+public class DefaultStreamMessage<T> extends AbstractStreamMessageWriter<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultStreamMessage.class);
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -395,6 +395,14 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
+     * Creates a new {@link StreamMessageWriter} that produces the objects to be published
+     * by {@link StreamMessage}.
+     */
+    static <T> StreamMessageWriter<T> streaming() {
+        return new DefaultStreamMessage<>();
+    }
+
+    /**
      * Returns {@code true} if this stream is not closed yet. Note that a stream may not be
      * {@linkplain #whenComplete() complete} even if it's closed; a stream is complete when it's fully
      * consumed by a {@link Subscriber}.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -398,6 +398,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Creates a new {@link StreamMessageWriter} that publishes the objects written via
      * {@link StreamWriter#write(Object)}.
      */
+    @UnstableApi
     static <T> StreamMessageWriter<T> streaming() {
         return new DefaultStreamMessage<>();
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -395,8 +395,8 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Creates a new {@link StreamMessageWriter} that produces the objects to be published
-     * by {@link StreamMessage}.
+     * Creates a new {@link StreamMessageWriter} that publishes the objects written via
+     * {@link StreamWriter#write(Object)}.
      */
     static <T> StreamMessageWriter<T> streaming() {
         return new DefaultStreamMessage<>();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
@@ -17,8 +17,8 @@
 package com.linecorp.armeria.common.stream;
 
 /**
- * A type which is both a {@link StreamMessage} and a {@link StreamWriter}. This type is mainly used by tests
- * which need to exercise both functionality.
+ * A type which is both a {@link StreamMessage} and a {@link StreamWriter}.
+ * {@link StreamMessageWriter} publishes the objects written via {@link StreamWriter#write(Object)}.
  */
 public interface StreamMessageWriter<T> extends StreamMessage<T>, StreamWriter<T> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
@@ -20,5 +20,5 @@ package com.linecorp.armeria.common.stream;
  * A type which is both a {@link StreamMessage} and a {@link StreamWriter}. This type is mainly used by tests
  * which need to exercise both functionality.
  */
-interface StreamMessageAndWriter<T> extends StreamMessage<T>, StreamWriter<T> {
+public interface StreamMessageWriter<T> extends StreamMessage<T>, StreamWriter<T> {
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageWriter.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.armeria.common.stream;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
 /**
  * A type which is both a {@link StreamMessage} and a {@link StreamWriter}.
  * {@link StreamMessageWriter} publishes the objects written via {@link StreamWriter#write(Object)}.
  */
+@UnstableApi
 public interface StreamMessageWriter<T> extends StreamMessage<T>, StreamWriter<T> {
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -57,7 +57,7 @@ class DefaultStreamMessageTest {
         final BlockingQueue<String> queue = new LinkedTransferQueue<>();
         // Repeat to increase the chance of reproduction.
         for (int i = 0; i < 8192; i++) {
-            final StreamMessageAndWriter<Integer> stream = new DefaultStreamMessage<>();
+            final StreamMessageWriter<Integer> stream = new DefaultStreamMessage<>();
             eventLoop.get().execute(stream::close);
             stream.subscribe(new Subscriber<Object>() {
                 @Override
@@ -89,7 +89,7 @@ class DefaultStreamMessageTest {
 
     @Test
     void releaseWhenWritingToClosedStream_HttpData() {
-        final StreamMessageAndWriter<HttpData> stream = new DefaultStreamMessage<>();
+        final StreamMessageWriter<HttpData> stream = new DefaultStreamMessage<>();
         final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().writeByte(0).retain();
         stream.close();
 
@@ -102,7 +102,7 @@ class DefaultStreamMessageTest {
 
     @Test
     void releaseWhenWritingToClosedStream_HttpData_Supplier() {
-        final StreamMessageAndWriter<HttpData> stream = new DefaultStreamMessage<>();
+        final StreamMessageWriter<HttpData> stream = new DefaultStreamMessage<>();
         final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().writeByte(0).retain();
         stream.close();
 
@@ -116,7 +116,7 @@ class DefaultStreamMessageTest {
 
     @Test
     void abortedStreamCallOnCompleteIfNoData() throws InterruptedException {
-        final StreamMessageAndWriter<Object> stream = new DefaultStreamMessage<>();
+        final StreamMessageWriter<Object> stream = new DefaultStreamMessage<>();
         stream.close();
 
         final AtomicBoolean onCompleteCalled = new AtomicBoolean();
@@ -144,7 +144,7 @@ class DefaultStreamMessageTest {
 
     @Test
     void abortedStreamCallOnErrorAfterCloseIsCalled() throws InterruptedException {
-        final StreamMessageAndWriter<HttpData> stream = new DefaultStreamMessage<>();
+        final StreamMessageWriter<HttpData> stream = new DefaultStreamMessage<>();
         final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
         stream.write(HttpData.wrap(buf).withEndOfStream());
         stream.close();
@@ -175,7 +175,7 @@ class DefaultStreamMessageTest {
 
     @Test
     void requestWithNegativeValue() {
-        final StreamMessageAndWriter<HttpData> stream = new DefaultStreamMessage<>();
+        final StreamMessageWriter<HttpData> stream = new DefaultStreamMessage<>();
         final ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer().writeByte(0);
         stream.write(HttpData.wrap(buf).withEndOfStream());
 


### PR DESCRIPTION
**Related Issue** #4253 

### Motivation:
https://github.com/line/armeria/blob/0016f868b15cae6d8568004f3288ed86621a7b93/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageAndWriter.java#L23

- As there is no public API for a streaming writer, we directly instantiate DefaultStreamMessage.

```java
StreamWriter writer = new DefaultStreamMessage(); // directly using DefaultStreamMessage constructor
writer.write(...);
writer.close();
```
- #4186  will provide a way to write a StreamMessage using OutputStream
- But to convert a StreamMessage to OutputStream, users should use directly `DefaultStreamMessage` as well
- That might be not what we want. `DefaultStreamMessage` is `@UnstableApi` and a part of implementations, so we have to hide the implementation detail

### Modifications:

- Rename `StreaMessageAndWrtier` interface to `STreamMessageWriter` and make it public
- Add `StreamMessage.streaming()` to create `StreamMessageWriter` instance instead of using `new DefaultStreamMessage()` directly 

### Result:
- You can now use `StreamMessage.streaming()` to create `StreamMessageWrtier` instance instead of using `new DefaultStreamMessage()` directly 
- After this PR is merged, I'll replace `new DefaultStreamMessage() -> StreamMessage.streaming()`. then we can close #4253 issue
