### PR TITLE
Add `StreamMessage.of(inputStream)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
@@ -25,11 +25,8 @@ import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.stream.InternalStreamMessageUtil;
 
-import io.netty.buffer.ByteBufAllocator;
-
 abstract class AbstractByteStreamMessageBuilder {
 
-    private ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
     private int bufferSize = InternalStreamMessageUtil.DEFAULT_FILE_BUFFER_SIZE;
 
     @Nullable
@@ -46,20 +43,6 @@ abstract class AbstractByteStreamMessageBuilder {
     AbstractByteStreamMessageBuilder executor(ExecutorService executor) {
         requireNonNull(executor, "executor");
         this.executor = executor;
-        return this;
-    }
-
-    final ByteBufAllocator alloc() {
-        return alloc;
-    }
-
-    /**
-     * Sets the specified {@link ByteBufAllocator}.
-     * If unspecified, {@link ByteBufAllocator#DEFAULT} is used by default.
-     */
-    AbstractByteStreamMessageBuilder alloc(ByteBufAllocator alloc) {
-        requireNonNull(alloc, "alloc");
-        this.alloc = alloc;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
@@ -28,8 +28,6 @@ import io.netty.buffer.ByteBufAllocator;
 
 abstract class AbstractByteStreamMessageBuilder {
 
-    // TODO(ikhoon) Add InputStreamStreamMessageBuilder as a subtype of this builder.
-
     private ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
     private int bufferSize = PathStreamMessage.DEFAULT_FILE_BUFFER_SIZE;
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
@@ -71,7 +71,7 @@ abstract class AbstractByteStreamMessageBuilder {
      * Sets the buffer size used to create a buffer used to read data from the source.
      * The newly created {@link StreamMessage} will emit {@link HttpData}s chunked to
      * size less than or equal to the buffer size.
-     * If unspecified, {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE} is used by default.
+     * If unspecified, {@code 8192} is used by default.
      *
      * @throws IllegalArgumentException if the {@code bufferSize} is non-positive.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
@@ -23,13 +23,14 @@ import java.util.concurrent.ExecutorService;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.stream.InternalStreamMessageUtil;
 
 import io.netty.buffer.ByteBufAllocator;
 
 abstract class AbstractByteStreamMessageBuilder {
 
     private ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
-    private int bufferSize = PathStreamMessage.DEFAULT_FILE_BUFFER_SIZE;
+    private int bufferSize = InternalStreamMessageUtil.DEFAULT_FILE_BUFFER_SIZE;
 
     @Nullable
     private ExecutorService executor;
@@ -70,7 +71,7 @@ abstract class AbstractByteStreamMessageBuilder {
      * Sets the buffer size used to create a buffer used to read data from the source.
      * The newly created {@link StreamMessage} will emit {@link HttpData}s chunked to
      * size less than or equal to the buffer size.
-     * If unspecified, {@value PathStreamMessage#DEFAULT_FILE_BUFFER_SIZE} is used by default.
+     * If unspecified, {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE} is used by default.
      *
      * @throws IllegalArgumentException if the {@code bufferSize} is non-positive.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AbstractByteStreamMessageBuilder.java
@@ -71,7 +71,7 @@ abstract class AbstractByteStreamMessageBuilder {
      * Sets the buffer size used to create a buffer used to read data from the source.
      * The newly created {@link StreamMessage} will emit {@link HttpData}s chunked to
      * size less than or equal to the buffer size.
-     * If unspecified, {@code 8192} is used by default.
+     * If unspecified, {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE} is used by default.
      *
      * @throws IllegalArgumentException if the {@code bufferSize} is non-positive.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -270,7 +270,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                     final long actualSkipped;
                     try {
                         actualSkipped = inputStream.skip(skip);
-                    } catch (IOException e) {
+                    } catch (Exception e) {
                         close(e);
                         return;
                     }
@@ -288,7 +288,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                 final byte[] readBytes = new byte[bufferSize];
                 try {
                     len = inputStream.read(readBytes);
-                } catch (IOException e) {
+                } catch (Exception e) {
                     close(e);
                     return;
                 }
@@ -310,8 +310,10 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                 return;
             }
 
+            if (requested != Long.MAX_VALUE) {
+                requested--;
+            }
             downstream.onNext(data);
-            requested--;
             readBytes();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -156,7 +156,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
         // To make sure to close the inputStreamSubscription when this is aborted.
         if (completionFuture.isCompletedExceptionally()) {
             completionFuture.exceptionally(cause -> {
-                inputStreamSubscription.close(cause);
+                inputStreamSubscription.close0(cause);
                 return null;
             });
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -116,6 +116,10 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
     @Override
     public void subscribe(Subscriber<? super HttpData> subscriber, EventExecutor executor,
                           SubscriptionOption... options) {
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        requireNonNull(options, "options");
+
         if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
             subscriber.onSubscribe(NoopSubscription.get());
             subscriber.onError(new IllegalStateException("Only single subscriber is allowed!"));

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -235,7 +235,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                 return;
             }
             if (offset >= end) {
-                close(null);
+                close0(null);
                 return;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -155,12 +155,9 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
 
         // To make sure to close the inputStreamSubscription when this is aborted.
         if (completionFuture.isCompletedExceptionally()) {
-            completionFuture.whenComplete((unused, cause) -> {
-                if (cause != null) {
-                    abort(cause);
-                } else {
-                    abort();
-                }
+            completionFuture.exceptionally(cause -> {
+                inputStreamSubscription.close(cause);
+                return null;
             });
         }
     }
@@ -344,10 +341,10 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
             }
             downstream = NoopSubscriber.get();
             completionFuture.completeExceptionally(cause);
-            maybeCloseInputStream();
+            closeInputStream();
         }
 
-        private void maybeCloseInputStream() {
+        private void closeInputStream() {
             try {
                 inputStream.close();
             } catch (IOException e) {
@@ -376,7 +373,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                 downstream.onError(cause);
                 completionFuture.completeExceptionally(cause);
             }
-            maybeCloseInputStream();
+            closeInputStream();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.linecorp.armeria.internal.common.stream.InternalStreamMessageUtil.containsNotifyCancellation;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.math.LongMath;
+import com.google.common.primitives.Ints;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
+import com.linecorp.armeria.internal.common.stream.NoopSubscription;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import io.netty.util.concurrent.EventExecutor;
+
+final class InputStreamStreamMessage implements ByteStreamMessage {
+
+    private static final Logger logger = LoggerFactory.getLogger(InputStreamStreamMessage.class);
+
+    private static final AtomicIntegerFieldUpdater<InputStreamStreamMessage> subscribedUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(InputStreamStreamMessage.class, "subscribed");
+
+    static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    private final InputStream inputStream;
+    @Nullable
+    private final ExecutorService blockingTaskExecutor;
+    private final int bufferSize;
+
+    private long offset;
+    private long length = Long.MAX_VALUE;
+
+    private volatile int subscribed;
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
+
+    @Nullable
+    private volatile InputStreamSubscription inputStreamSubscription;
+
+    InputStreamStreamMessage(InputStream inputStream, @Nullable ExecutorService blockingTaskExecutor,
+                             int bufferSize) {
+        requireNonNull(inputStream, "inputStream");
+        this.inputStream = inputStream;
+        this.blockingTaskExecutor = blockingTaskExecutor;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public ByteStreamMessage range(long offset, long length) {
+        checkArgument(offset >= 0, "offset: %s (expected: >= 0)", offset);
+        checkArgument(length > 0, "length: %s (expected: > 0)", length);
+        checkState(subscribed == 0, "cannot specify range(%s, %s) after this %s is subscribed",
+                   offset, length, InputStreamStreamMessage.class);
+        this.offset = offset;
+        this.length = length;
+        return this;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !completionFuture.isDone();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        if (isOpen()) {
+            return false;
+        }
+        final InputStreamSubscription inputStreamSubscription = this.inputStreamSubscription;
+        return inputStreamSubscription == null || inputStreamSubscription.position == 0;
+    }
+
+    @Override
+    public long demand() {
+        final InputStreamSubscription inputStreamSubscription = this.inputStreamSubscription;
+        if (inputStreamSubscription != null) {
+            return inputStreamSubscription.requested;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> whenComplete() {
+        return completionFuture;
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super HttpData> subscriber, EventExecutor executor,
+                          SubscriptionOption... options) {
+        if (!subscribedUpdater.compareAndSet(this, 0, 1)) {
+            subscriber.onSubscribe(NoopSubscription.get());
+            subscriber.onError(new IllegalStateException("Only single subscriber is allowed!"));
+            return;
+        }
+
+        if (executor.inEventLoop()) {
+            subscribe0(subscriber, executor, options);
+        } else {
+            executor.execute(() -> subscribe0(subscriber, executor, options));
+        }
+    }
+
+    private void subscribe0(Subscriber<? super HttpData> subscriber, EventExecutor executor,
+                            SubscriptionOption... options) {
+        final ExecutorService blockingTaskExecutor;
+        if (this.blockingTaskExecutor != null) {
+            blockingTaskExecutor = this.blockingTaskExecutor;
+        } else {
+            final ServiceRequestContext serviceRequestContext = ServiceRequestContext.currentOrNull();
+            if (serviceRequestContext != null) {
+                blockingTaskExecutor = serviceRequestContext.blockingTaskExecutor();
+            } else {
+                blockingTaskExecutor = CommonPools.blockingTaskExecutor();
+            }
+        }
+
+        final InputStreamSubscription inputStreamSubscription = new InputStreamSubscription(
+                subscriber, executor, blockingTaskExecutor, bufferSize, offset, length,
+                containsNotifyCancellation(options));
+        this.inputStreamSubscription = inputStreamSubscription;
+        subscriber.onSubscribe(inputStreamSubscription);
+    }
+
+    @Override
+    public void abort() {
+        abort(AbortedStreamException.get());
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        requireNonNull(cause, "cause");
+
+        final InputStreamSubscription inputStreamSubscription = this.inputStreamSubscription;
+        if (inputStreamSubscription != null) {
+            inputStreamSubscription.close(cause);
+        }
+        completionFuture.completeExceptionally(cause);
+    }
+
+    private final class InputStreamSubscription implements Subscription {
+
+        private Subscriber<? super HttpData> downstream;
+        private final EventExecutor executor;
+        private final ExecutorService blockingTaskExecutor;
+        private final int bufferSize;
+
+        private final long offset;
+        private final long end;
+        private volatile long position;
+
+        private final boolean notifyCancellation;
+
+        private boolean closed;
+        private volatile long requested;
+
+        private InputStreamSubscription(Subscriber<? super HttpData> downstream, EventExecutor executor,
+                                        ExecutorService blockingTaskExecutor, int bufferSize,
+                                        long offset, long length, boolean notifyCancellation) {
+            requireNonNull(downstream, "downstream");
+            requireNonNull(executor, "executor");
+            requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
+            this.downstream = downstream;
+            this.executor = executor;
+            this.blockingTaskExecutor = blockingTaskExecutor;
+            this.bufferSize = bufferSize;
+            this.offset = offset;
+            end = LongMath.saturatedAdd(offset, length);
+            this.notifyCancellation = notifyCancellation;
+        }
+
+        @Override
+        public void request(long n) {
+            if (n <= 0L) {
+                close(new IllegalArgumentException(
+                        "Rule §3.9 violated: non-positive subscription requests are forbidden."));
+                return;
+            }
+
+            if (closed) {
+                return;
+            }
+
+            if (executor.inEventLoop()) {
+                request0(n);
+            } else {
+                executor.execute(() -> request0(n));
+            }
+        }
+
+        private void request0(long n) {
+            final long oldRequested = requested;
+            if (oldRequested == Long.MAX_VALUE) {
+                return;
+            }
+            if (n == Long.MAX_VALUE) {
+                requested = Long.MAX_VALUE;
+            } else {
+                requested = LongMath.saturatedAdd(oldRequested, n);
+            }
+
+            if (oldRequested > 0) {
+                // InputStreamSubscription is reading input stream.
+                // New requests will be handled by 'publishDownstream(HttpData)'.
+                return;
+            }
+
+            readBytes();
+        }
+
+        private void readBytes() {
+            if (requested <= 0) {
+                return;
+            }
+
+            blockingTaskExecutor.execute(() -> {
+                if (position >= end) {
+                    close(null);
+                    return;
+                }
+
+                if (position < offset) {
+                    final long skip = offset - position;
+                    final long actualSkipped;
+                    try {
+                        actualSkipped = inputStream.skip(skip);
+                    } catch (IOException e) {
+                        close(e);
+                        return;
+                    }
+
+                    if (actualSkipped < skip) {
+                        close(null);
+                        return;
+                    }
+
+                    position += skip;
+                }
+
+                final int bufferSize = Math.min(this.bufferSize, Ints.saturatedCast(end - position));
+                final int len;
+                final byte[] readBytes = new byte[bufferSize];
+                try {
+                    len = inputStream.read(readBytes);
+                } catch (IOException e) {
+                    close(e);
+                    return;
+                }
+
+                if (len == -1) {
+                    close(null);
+                    return;
+                }
+
+                final HttpData data = HttpData.wrap(readBytes, 0, len);
+                position += len;
+
+                if (executor.inEventLoop()) {
+                    publishDownstream(data);
+                } else {
+                    executor.execute(() -> publishDownstream(data));
+                }
+            });
+        }
+
+        private void publishDownstream(HttpData data) {
+            if (closed) {
+                return;
+            }
+
+            downstream.onNext(data);
+            requested--;
+            readBytes();
+        }
+
+        @Override
+        public void cancel() {
+            if (executor.inEventLoop()) {
+                cancel0();
+            } else {
+                executor.execute(this::cancel0);
+            }
+        }
+
+        private void cancel0() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            final CancelledSubscriptionException cause = CancelledSubscriptionException.get();
+            if (notifyCancellation) {
+                downstream.onError(cause);
+            }
+            downstream = NoopSubscriber.get();
+            completionFuture.completeExceptionally(cause);
+            maybeCloseInputStream();
+        }
+
+        private void maybeCloseInputStream() {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                logger.warn("Unexpected exception while closing input stream {}.", inputStream, e);
+            }
+        }
+
+        private void close(@Nullable Throwable cause) {
+            if (executor.inEventLoop()) {
+                close0(cause);
+            } else {
+                executor.execute(() -> close0(cause));
+            }
+        }
+
+        private void close0(@Nullable Throwable cause) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            if (cause == null) {
+                downstream.onComplete();
+                completionFuture.complete(null);
+            } else {
+                downstream.onError(cause);
+                completionFuture.completeExceptionally(cause);
+            }
+            maybeCloseInputStream();
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -299,11 +299,7 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
                 final HttpData data = HttpData.wrap(readBytes, 0, len);
                 position += len;
 
-                if (executor.inEventLoop()) {
-                    publishDownstream(data);
-                } else {
-                    executor.execute(() -> publishDownstream(data));
-                }
+                executor.execute(() -> publishDownstream(data));
             });
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -51,8 +51,6 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
     private static final AtomicIntegerFieldUpdater<InputStreamStreamMessage> subscribedUpdater =
             AtomicIntegerFieldUpdater.newUpdater(InputStreamStreamMessage.class, "subscribed");
 
-    static final int DEFAULT_BUFFER_SIZE = 8192;
-
     private final InputStream inputStream;
     @Nullable
     private final ExecutorService blockingTaskExecutor;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java
@@ -76,9 +76,9 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
     @Override
     public ByteStreamMessage range(long offset, long length) {
         checkArgument(offset >= 0, "offset: %s (expected: >= 0)", offset);
-        checkArgument(length > 0, "length: %s (expected: > 0)", length);
-        checkState(subscribed == 0, "cannot specify range(%s, %s) after this %s is subscribed",
-                   offset, length, InputStreamStreamMessage.class);
+        checkArgument(length >= 0, "length: %s (expected: >= 0)", length);
+        checkState(subscribed == 0, "cannot specify range(%s, %s) once this stream is subscribed",
+                   offset, length);
         this.offset = offset;
         this.length = length;
         return this;
@@ -232,6 +232,10 @@ final class InputStreamStreamMessage implements ByteStreamMessage {
 
         private void request0(long n) {
             if (closed) {
+                return;
+            }
+            if (offset >= end) {
+                close(null);
                 return;
             }
 

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
@@ -20,11 +20,13 @@ import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 
 import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * A builder for creating a {@link ByteStreamMessage} that reads data from the {@link InputStream}
  * and publishes using {@link HttpData}.
  */
+@UnstableApi
 public final class InputStreamStreamMessageBuilder extends AbstractByteStreamMessageBuilder {
 
     private final InputStream inputStream;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.io.InputStream;
+import java.util.concurrent.ExecutorService;
+
+import com.linecorp.armeria.common.HttpData;
+
+/**
+ * A builder for creating a {@link ByteStreamMessage} that reads data from the {@link InputStream}
+ * and publishes using {@link HttpData}.
+ */
+public final class InputStreamStreamMessageBuilder extends AbstractByteStreamMessageBuilder {
+
+    private final InputStream inputStream;
+
+    InputStreamStreamMessageBuilder(InputStream inputStream) {
+        this.inputStream = inputStream;
+        bufferSize(InputStreamStreamMessage.DEFAULT_BUFFER_SIZE);
+    }
+
+    @Override
+    public ByteStreamMessage build() {
+        return new InputStreamStreamMessage(inputStream, executor(), bufferSize());
+    }
+
+    // Override the return type of the chaining methods in the superclass.
+
+    @Override
+    public InputStreamStreamMessageBuilder executor(ExecutorService executor) {
+        return (InputStreamStreamMessageBuilder) super.executor(executor);
+    }
+
+    @Override
+    public InputStreamStreamMessageBuilder bufferSize(int bufferSize) {
+        return (InputStreamStreamMessageBuilder) super.bufferSize(bufferSize);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageBuilder.java
@@ -31,7 +31,6 @@ public final class InputStreamStreamMessageBuilder extends AbstractByteStreamMes
 
     InputStreamStreamMessageBuilder(InputStream inputStream) {
         this.inputStream = inputStream;
-        bufferSize(InputStreamStreamMessage.DEFAULT_BUFFER_SIZE);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
@@ -60,8 +60,6 @@ final class PathStreamMessage implements ByteStreamMessage {
     private static final AtomicIntegerFieldUpdater<PathStreamMessage> subscribedUpdater =
             AtomicIntegerFieldUpdater.newUpdater(PathStreamMessage.class, "subscribed");
 
-    static final int DEFAULT_FILE_BUFFER_SIZE = 8192;
-
     private static final Set<StandardOpenOption> READ_OPERATION = ImmutableSet.of(StandardOpenOption.READ);
 
     private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common.stream;
 
+import static java.util.Objects.requireNonNull;
+
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
@@ -31,10 +33,15 @@ import io.netty.buffer.ByteBufAllocator;
 @UnstableApi
 public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBuilder {
 
+    private ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
     private final Path path;
 
     PathStreamMessageBuilder(Path path) {
         this.path = path;
+    }
+
+    ByteBufAllocator alloc() {
+        return alloc;
     }
 
     @Override
@@ -50,12 +57,17 @@ public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBui
     }
 
     @Override
-    public PathStreamMessageBuilder alloc(ByteBufAllocator alloc) {
-        return (PathStreamMessageBuilder) super.alloc(alloc);
-    }
-
-    @Override
     public PathStreamMessageBuilder bufferSize(int bufferSize) {
         return (PathStreamMessageBuilder) super.bufferSize(bufferSize);
+    }
+
+    /**
+     * Sets the specified {@link ByteBufAllocator}.
+     * If unspecified, {@link ByteBufAllocator#DEFAULT} is used by default.
+     */
+    public PathStreamMessageBuilder alloc(ByteBufAllocator alloc) {
+        requireNonNull(alloc, "alloc");
+        this.alloc = alloc;
+        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
@@ -44,6 +44,16 @@ public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBui
         return alloc;
     }
 
+    /**
+     * Sets the specified {@link ByteBufAllocator}.
+     * If unspecified, {@link ByteBufAllocator#DEFAULT} is used by default.
+     */
+    public PathStreamMessageBuilder alloc(ByteBufAllocator alloc) {
+        requireNonNull(alloc, "alloc");
+        this.alloc = alloc;
+        return this;
+    }
+
     @Override
     public ByteStreamMessage build() {
         return new PathStreamMessage(path, executor(), alloc(), bufferSize());
@@ -59,15 +69,5 @@ public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBui
     @Override
     public PathStreamMessageBuilder bufferSize(int bufferSize) {
         return (PathStreamMessageBuilder) super.bufferSize(bufferSize);
-    }
-
-    /**
-     * Sets the specified {@link ByteBufAllocator}.
-     * If unspecified, {@link ByteBufAllocator#DEFAULT} is used by default.
-     */
-    public PathStreamMessageBuilder alloc(ByteBufAllocator alloc) {
-        requireNonNull(alloc, "alloc");
-        this.alloc = alloc;
-        return this;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessageBuilder.java
@@ -40,10 +40,6 @@ public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBui
         this.path = path;
     }
 
-    ByteBufAllocator alloc() {
-        return alloc;
-    }
-
     /**
      * Sets the specified {@link ByteBufAllocator}.
      * If unspecified, {@link ByteBufAllocator#DEFAULT} is used by default.
@@ -56,7 +52,7 @@ public final class PathStreamMessageBuilder extends AbstractByteStreamMessageBui
 
     @Override
     public ByteStreamMessage build() {
-        return new PathStreamMessage(path, executor(), alloc(), bufferSize());
+        return new PathStreamMessage(path, executor(), alloc, bufferSize());
     }
 
     // Override the return type of the chaining methods in the superclass.

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -51,6 +51,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.stream.AbortedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.DecodedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.EmptyFixedStreamMessage;
+import com.linecorp.armeria.internal.common.stream.InternalStreamMessageUtil;
 import com.linecorp.armeria.internal.common.stream.OneElementFixedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.RecoverableStreamMessage;
 import com.linecorp.armeria.internal.common.stream.RegularFixedStreamMessage;
@@ -185,10 +186,10 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Creates a new {@link StreamMessage} that streams the specified {@link File}.
-     * The default buffer size({@value PathStreamMessage#DEFAULT_FILE_BUFFER_SIZE}) is used to
+     * The default buffer size({@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}) is used to
      * create a buffer used to read data from the {@link File}.
      * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
-     * size less than or equal to {@value PathStreamMessage#DEFAULT_FILE_BUFFER_SIZE}.
+     * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
     static ByteStreamMessage of(File file) {
         requireNonNull(file, "file");
@@ -197,10 +198,10 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Creates a new {@link StreamMessage} that streams the specified {@link Path}.
-     * The default buffer size({@value PathStreamMessage#DEFAULT_FILE_BUFFER_SIZE}) is used to
+     * The default buffer size({@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}) is used to
      * create a buffer used to read data from the {@link Path}.
      * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
-     * size less than or equal to {@value PathStreamMessage#DEFAULT_FILE_BUFFER_SIZE}.
+     * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
     static ByteStreamMessage of(Path path) {
         requireNonNull(path, "path");
@@ -283,10 +284,10 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Creates a new {@link StreamMessage} that streams the specified {@link InputStream}.
-     * The default buffer size({@value InputStreamStreamMessage#DEFAULT_BUFFER_SIZE}) is used to
+     * The default buffer size({@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}) is used to
      * create a buffer used to read data from the {@link InputStream}.
      * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
-     * size less than or equal to {@value InputStreamStreamMessage#DEFAULT_BUFFER_SIZE}.
+     * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
     static ByteStreamMessage of(InputStream inputStream) {
         requireNonNull(inputStream, "inputStream");

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -283,9 +283,9 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Creates a new {@link StreamMessage} that streams the specified {@link InputStream}.
+     * Creates a new {@link StreamMessage} that streams bytes from the specified {@link InputStream}.
      * The default buffer size({@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}) is used to
-     * create a buffer used to read data from the {@link InputStream}.
+     * create a buffer that is used to read data from the {@link InputStream}.
      * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
      * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -289,6 +289,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
      * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
+    @UnstableApi
     static ByteStreamMessage of(InputStream inputStream) {
         requireNonNull(inputStream, "inputStream");
         return builder(inputStream).build();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -290,6 +290,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
     @UnstableApi
+    @UnstableApi
     static ByteStreamMessage of(InputStream inputStream) {
         requireNonNull(inputStream, "inputStream");
         return builder(inputStream).build();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -282,6 +282,26 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
+     * Creates a new {@link StreamMessage} that streams the specified {@link InputStream}.
+     * The default buffer size({@value InputStreamStreamMessage#DEFAULT_BUFFER_SIZE}) is used to
+     * create a buffer used to read data from the {@link InputStream}.
+     * Therefore, the returned {@link StreamMessage} will emit {@link HttpData}s chunked to
+     * size less than or equal to {@value InputStreamStreamMessage#DEFAULT_BUFFER_SIZE}.
+     */
+    static ByteStreamMessage of(InputStream inputStream) {
+        requireNonNull(inputStream, "inputStream");
+        return builder(inputStream).build();
+    }
+
+    /**
+     * Returns a new {@link InputStreamStreamMessageBuilder} with the specified {@link InputStream}.
+     */
+    static InputStreamStreamMessageBuilder builder(InputStream inputStream) {
+        requireNonNull(inputStream, "inputStream");
+        return new InputStreamStreamMessageBuilder(inputStream);
+    }
+
+    /**
      * Creates a new {@link ByteStreamMessage} that publishes {@link HttpData}s from the specified
      * {@linkplain Consumer outputStreamConsumer}.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -290,7 +290,6 @@ public interface StreamMessage<T> extends Publisher<T> {
      * size less than or equal to {@value InternalStreamMessageUtil#DEFAULT_FILE_BUFFER_SIZE}.
      */
     @UnstableApi
-    @UnstableApi
     static ByteStreamMessage of(InputStream inputStream) {
         requireNonNull(inputStream, "inputStream");
         return builder(inputStream).build();
@@ -299,6 +298,7 @@ public interface StreamMessage<T> extends Publisher<T> {
     /**
      * Returns a new {@link InputStreamStreamMessageBuilder} with the specified {@link InputStream}.
      */
+    @UnstableApi
     static InputStreamStreamMessageBuilder builder(InputStream inputStream) {
         requireNonNull(inputStream, "inputStream");
         return new InputStreamStreamMessageBuilder(inputStream);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
@@ -22,6 +22,7 @@ import com.linecorp.armeria.common.stream.SubscriptionOption;
 
 public final class InternalStreamMessageUtil {
 
+    public static final int DEFAULT_FILE_BUFFER_SIZE = 8192;
     public static final SubscriptionOption[] EMPTY_OPTIONS = {};
     public static final SubscriptionOption[] POOLED_OBJECTS = { SubscriptionOption.WITH_POOLED_OBJECTS };
     public static final SubscriptionOption[] CANCELLATION_OPTION = { SubscriptionOption.NOTIFY_CANCELLATION };

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTckTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.math.LongMath;
+
+import com.linecorp.armeria.common.HttpData;
+
+public class InputStreamStreamMessageTckTest extends StreamMessageVerification<HttpData> {
+
+    @Override
+    public StreamMessage<HttpData> createPublisher(long elements) {
+        if (elements == 0) {
+            return completedPublisher();
+        }
+
+        return StreamMessage
+                .builder(inputStream(elements))
+                .bufferSize(1)
+                .build();
+    }
+
+    @Override
+    public StreamMessage<HttpData> createFailedPublisher() {
+        return abortedPublisher();
+    }
+
+    @Override
+    public StreamMessage<HttpData> createAbortedPublisher(long elements) {
+        if (elements == 0) {
+            return abortedPublisher();
+        }
+
+        final StreamMessage<HttpData> publisher = createPublisher(LongMath.saturatedAdd(elements, 1));
+        final AtomicLong produced = new AtomicLong();
+        return publisher
+                .peek(read -> {
+                    if (produced.getAndIncrement() >= elements) {
+                        publisher.abort();
+                    }
+                });
+    }
+
+    private static StreamMessage<HttpData> completedPublisher() {
+        final StreamMessage<HttpData> publisher = StreamMessage.of(inputStream(0));
+        // `InputStreamStreamMessage` doesn't check InputStream's availability so manually set complete.
+        publisher.whenComplete().complete(null);
+        return publisher;
+    }
+
+    private static StreamMessage<HttpData> abortedPublisher() {
+        final StreamMessage<HttpData> publisher = StreamMessage.of(inputStream(0));
+        publisher.abort();
+        return publisher;
+    }
+
+    private static InputStream inputStream(long elements) {
+        final AtomicLong index = new AtomicLong();
+        return new InputStream() {
+            @Override
+            public int read() throws IOException {
+                if (index.getAndIncrement() >= elements) {
+                    return -1;
+                }
+                return 1;
+            }
+        };
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -310,7 +310,7 @@ class InputStreamStreamMessageTest {
     }
 
     @Test
-    void skip0_tak3() {
+    void skip0_take3() {
         final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         final ByteStreamMessage byteStreamMessage = StreamMessage
                 .of(inputStream)

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.ByteArrayInputStream;
@@ -419,5 +420,17 @@ class InputStreamStreamMessageTest {
                     .verifyComplete();
         StepVerifier.create(byteStreamMessage)
                     .verifyError(IllegalStateException.class);
+    }
+
+    @Test
+    void abortedBeforeSubscribed() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        byteStreamMessage.abort();
+        await().untilAsserted(() -> assertThat(byteStreamMessage.isOpen()).isFalse());
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyError(AbortedStreamException.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import reactor.test.StepVerifier;
+
+class InputStreamStreamMessageTest {
+
+    @Test
+    void readIntegers() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void readIntegers_builder() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.builder(inputStream).build();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void readIntegers_bufferSize() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .expectNext(HttpData.wrap(new byte[] { 4, 5, 6 }))
+                    .expectNext(HttpData.wrap(new byte[] { 7, 8, 9 }))
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void readIntegers_bufferSize_request() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .thenRequest(2)
+                    .expectNext(HttpData.wrap(new byte[] { 4, 5, 6 }))
+                    .expectNext(HttpData.wrap(new byte[] { 7, 8, 9 }))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .thenRequest(1)
+                    .verifyComplete();
+    }
+
+    @Test
+    void readStrings() {
+        final InputStream inputStream = new ByteArrayInputStream("foobarbaz".getBytes());
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap("foobarbaz".getBytes()))
+                    .verifyComplete();
+    }
+
+    @Test
+    void readStrings_bufferSize() {
+        final InputStream inputStream = new ByteArrayInputStream("foobarbaz".getBytes());
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap("foo".getBytes()))
+                    .expectNext(HttpData.wrap("bar".getBytes()))
+                    .expectNext(HttpData.wrap("baz".getBytes()))
+                    .verifyComplete();
+    }
+
+    @Test
+    void readStrings_bufferSize_request() {
+        final InputStream inputStream = new ByteArrayInputStream("foobarbaz".getBytes());
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(HttpData.wrap("foo".getBytes()))
+                    .thenRequest(2)
+                    .expectNext(HttpData.wrap("bar".getBytes()))
+                    .expectNext(HttpData.wrap("baz".getBytes()))
+                    .thenRequest(1)
+                    .verifyComplete();
+    }
+
+    @Test
+    void blockingTaskExecutor() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .executor(CommonPools.blockingTaskExecutor())
+                .build();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .expectNext(HttpData.wrap(new byte[] { 4, 5, 6 }))
+                    .expectNext(HttpData.wrap(new byte[] { 7, 8, 9 }))
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void blockingTaskExecutor_withServiceRequestContext() {
+        final ServiceRequestContext sctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        try (SafeCloseable ignored = sctx.push()) {
+            StepVerifier.create(byteStreamMessage)
+                        .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                        .verifyComplete();
+        }
+    }
+
+    @Test
+    void nullBlockingTaskExecutor_withClientRequestContext() {
+        final ClientRequestContext cctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        try (SafeCloseable ignored = cctx.push()) {
+            StepVerifier.create(byteStreamMessage)
+                        .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                        .verifyComplete();
+        }
+    }
+
+    @Test
+    void blockingTaskExecutor_request_readingInputStream() {
+        final InputStream bytes = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final CountDownLatch wait = new CountDownLatch(3);
+        final InputStream inputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                try {
+                    wait.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return bytes.read();
+            }
+        };
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .executor(CommonPools.blockingTaskExecutor())
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectSubscription()
+                    .expectNoEvent(Duration.ofSeconds(1))
+                    .then(wait::countDown)
+                    .thenRequest(1)
+                    .expectNoEvent(Duration.ofSeconds(1))
+                    .then(wait::countDown)
+                    .thenRequest(1)
+                    .expectNoEvent(Duration.ofSeconds(1))
+                    .then(wait::countDown)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .expectNext(HttpData.wrap(new byte[] { 4, 5, 6 }))
+                    .expectNext(HttpData.wrap(new byte[] { 7, 8, 9 }))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .thenRequest(1)
+                    .verifyComplete();
+    }
+
+    @Test
+    void range_negativeOffset() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        assertThatThrownBy(() -> byteStreamMessage.range(-1, 10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("offset: -1 (expected: >= 0)");
+    }
+
+    @Test
+    void range_zeroLength() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        assertThatThrownBy(() -> byteStreamMessage.range(0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("length: 0 (expected: > 0)");
+    }
+
+    @Test
+    void skip0() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(0, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skip0_tak3() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(0, 3);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skip1() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(1, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skip1_take3() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(1, 3);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 2, 3, 4 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skipAll() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(10, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyComplete();
+    }
+
+    @Test
+    void skipMost() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .of(inputStream)
+                .range(9, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void skipBufferSize() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build()
+                .range(5, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 6, 7, 8 }))
+                    .expectNext(HttpData.wrap(new byte[] { 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void takeBufferSize() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build()
+                .range(2, Long.MAX_VALUE);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 3, 4, 5 }))
+                    .expectNext(HttpData.wrap(new byte[] { 6, 7, 8 }))
+                    .expectNext(HttpData.wrap(new byte[] { 9, 10 }))
+                    .verifyComplete();
+    }
+
+    @Test
+    void emptyInputStream() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyComplete();
+        assertThat(byteStreamMessage.isEmpty()).isTrue();
+        assertThat(byteStreamMessage.isOpen()).isFalse();
+    }
+
+    @Test
+    void closedInputStream() throws IOException {
+        final StreamMessage<String> streamMessage = StreamMessage.of("foo", "bar", "baz");
+        final InputStream inputStream = streamMessage.toInputStream(x -> HttpData.wrap(x.getBytes()));
+        assertDoesNotThrow(inputStream::close);
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        assertThatThrownBy(() -> byteStreamMessage.subscribe().join())
+                .hasCauseInstanceOf(IOException.class);
+        assertThat(byteStreamMessage.isEmpty()).isTrue();
+        assertThat(byteStreamMessage.isOpen()).isFalse();
+    }
+
+    @Test
+    void thrownInputStream() {
+        final InputStream bytes = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final InputStream inputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                final int read = bytes.read();
+                if (read >= 5) {
+                    throw new IOException();
+                }
+                return read;
+            }
+        };
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .executor(CommonPools.blockingTaskExecutor())
+                .build();
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .expectNext(HttpData.wrap(new byte[] { 4 }))
+                    .verifyError(IOException.class);
+        assertThat(byteStreamMessage.isEmpty()).isFalse();
+        assertThat(byteStreamMessage.isOpen()).isFalse();
+    }
+
+    @Test
+    void aborted() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .executor(CommonPools.blockingTaskExecutor())
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .then(byteStreamMessage::abort)
+                    .verifyError(AbortedStreamException.class);
+        assertThat(byteStreamMessage.isOpen()).isFalse();
+    }
+
+    @Test
+    void subscribedTwice() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
+
+        StepVerifier.create(byteStreamMessage)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }))
+                    .verifyComplete();
+        StepVerifier.create(byteStreamMessage)
+                    .verifyError(IllegalStateException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -270,13 +270,31 @@ class InputStreamStreamMessageTest {
     }
 
     @Test
-    void range_zeroLength() {
+    void range_negativeLength() {
         final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
         final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
 
-        assertThatThrownBy(() -> byteStreamMessage.range(0, 0))
+        assertThatThrownBy(() -> byteStreamMessage.range(0, -1))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("length: 0 (expected: > 0)");
+                .hasMessageContaining("length: -1 (expected: >= 0)");
+    }
+
+    @Test
+    void range_zeroLength_emptyStream() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream).range(0, 0);
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyComplete();
+    }
+
+    @Test
+    void range_positiveOffset_zeroLength_emptyStream() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream).range(5, 0);
+
+        StepVerifier.create(byteStreamMessage)
+                    .verifyComplete();
     }
 
     @Test
@@ -383,7 +401,7 @@ class InputStreamStreamMessageTest {
 
     @Test
     void emptyInputStream() {
-        final InputStream inputStream = new ByteArrayInputStream(new byte[] { });
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] {});
         final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
 
         StepVerifier.create(byteStreamMessage)

--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -97,6 +97,26 @@ class InputStreamStreamMessageTest {
     }
 
     @Test
+    void readIntegers_bufferSize_request1() {
+        final InputStream inputStream = new ByteArrayInputStream(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(HttpData.wrap(new byte[] { 1, 2, 3 }))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap(new byte[] { 4, 5, 6 }))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap(new byte[] { 7, 8, 9 }))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap(new byte[] { 10 }))
+                    .thenRequest(1)
+                    .verifyComplete();
+    }
+
+    @Test
     void readStrings() {
         final InputStream inputStream = new ByteArrayInputStream("foobarbaz".getBytes());
         final ByteStreamMessage byteStreamMessage = StreamMessage.of(inputStream);
@@ -133,6 +153,24 @@ class InputStreamStreamMessageTest {
                     .expectNext(HttpData.wrap("foo".getBytes()))
                     .thenRequest(2)
                     .expectNext(HttpData.wrap("bar".getBytes()))
+                    .expectNext(HttpData.wrap("baz".getBytes()))
+                    .thenRequest(1)
+                    .verifyComplete();
+    }
+
+    @Test
+    void readStrings_bufferSize_request1() {
+        final InputStream inputStream = new ByteArrayInputStream("foobarbaz".getBytes());
+        final ByteStreamMessage byteStreamMessage = StreamMessage
+                .builder(inputStream)
+                .bufferSize(3)
+                .build();
+
+        StepVerifier.create(byteStreamMessage, 1)
+                    .expectNext(HttpData.wrap("foo".getBytes()))
+                    .thenRequest(1)
+                    .expectNext(HttpData.wrap("bar".getBytes()))
+                    .thenRequest(1)
                     .expectNext(HttpData.wrap("baz".getBytes()))
                     .thenRequest(1)
                     .verifyComplete();


### PR DESCRIPTION
**Related Issue** #3937

### Motivation:
```java
static StreamMessage<HttpData> of(InputStream inputStream) {...}
```
- It would be nice if we provide a way to convert an InputStream to a StreamMessage<HttpData> that splits the binary by the bufferSize.


### Modifications:

- Add `StreamMessage.of(inputStream)`
- Add `InputStreamStreamMessage` and builder

### Result:
- You can now use `StreamMessage.of(inputStream)` to convert an `InputStream` to `StreamMessaeg<HttpData>` that splits the binary by the bufferSize
- Close https://github.com/line/armeria/issues/3937 issue
