### PR TITLE
Handle overflow on `PathStreamMessage#range(offset, length)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PathStreamMessage.java
@@ -244,7 +244,7 @@ final class PathStreamMessage implements ByteStreamMessage {
             this.downstream = downstream;
             this.executor = executor;
             this.bufferSize = bufferSize;
-            end = offset + length;
+            end = LongMath.saturatedAdd(offset, length);
 
             this.notifyCancellation = notifyCancellation;
             this.withPooledObjects = withPooledObjects;

--- a/core/src/test/java/com/linecorp/armeria/common/stream/PathStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/PathStreamMessageTest.java
@@ -212,6 +212,97 @@ class PathStreamMessageTest {
         assertThat(result).isEqualTo("A1234567890\nB1234567890\nC1234567890\nD1234567890\nE1234567890\n");
     }
 
+    @Test
+    void skip0() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(0, Long.MAX_VALUE);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("A1234567890\nB1234567890\nC1234567890\nD1234567890\nE1234567890\n");
+    }
+
+    @Test
+    void skip0_take13() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(0, 13);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("A1234567890\nB");
+    }
+
+    @Test
+    void skip12() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(12, Long.MAX_VALUE);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("B1234567890\nC1234567890\nD1234567890\nE1234567890\n");
+    }
+
+    @Test
+    void skip12_take13() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(12, 13);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("B1234567890\nC");
+    }
+
+    @Test
+    void skipAll() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(999, Long.MAX_VALUE);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void skipMost() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(48, Long.MAX_VALUE);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("E1234567890\n");
+    }
+
+    @Test
+    void skip1() {
+        final Path path = Paths.get("src/test/resources/com/linecorp/armeria/common/stream/test.txt");
+        final ByteStreamMessage publisher = StreamMessage.builder(path).bufferSize(1).build()
+                                                         .range(1, Long.MAX_VALUE);
+        final StringAggregator stringAggregator = new StringAggregator();
+
+        publisher.subscribe(stringAggregator);
+        final String result = stringAggregator.future.join();
+
+        assertThat(result).isEqualTo("1234567890\nB1234567890\nC1234567890\nD1234567890\nE1234567890\n");
+    }
+
     private static class StringAggregator implements Subscriber<HttpData> {
         private final StringBuilder stringBuilder = new StringBuilder();
         private final CompletableFuture<String> future = new CompletableFuture<>();


### PR DESCRIPTION
**Related PR** https://github.com/line/armeria/pull/4058

### Motivation:

> https://github.com/line/armeria/blob/bc48105148d652e2e48e788c94bec007882c31dc/core/src/main/java/com/linecorp/armeria/common/stream/DefaultByteStreamMessage.java#L140
> 
> (Just curiotiy) Should we handle `overflow` here similar with `DefaultByteStreamMessage`?
> e.g offset(5) + lenth(Long.MAX_VALUE) = end(-xxx.., overflow) 
> 
> ```java
> assert position <= end; // if offset(5) + lenth(Long.MAX(), end is -xxx and this assertion failed
> if (position < end) { ... }
> ```
> on `L343`, we check `assert position <= end` so this assertion may failed on overflow case

- See https://github.com/line/armeria/pull/4058#discussion_r1118292165
- We should handle overflow on `PathStream.range(offset, length)` properly
  - PathStream.range(1, Long.MAX_VALUE) not works well due to overflow now


### Modifications:
- Handle overflow on `PathStreamMessage#range(offset, length)` and add test

### Result:
- Now `PathStream.range(offset > 0, Long.MAX_VALUE)` works well
