### PR TITLE
Add implicit request mapping to @Head when the service is mapped to @Get

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -68,7 +68,7 @@ final class FallbackService implements HttpService {
         // Handle the case where '/path' (or '/path?query') doesn't exist
         // but '/path/' (or '/path/?query') exists.
         final String newPath = oldPath + '/';
-        if (!ctx.config().virtualHost().findServiceConfig(routingCtx.overridePath(newPath)).isPresent()) {
+        if (!ctx.config().virtualHost().findServiceConfig(routingCtx.withPath(newPath)).isPresent()) {
             // No need to send a redirect response because '/path/' (or '/path/?query') does not exist.
             throw cause;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RegexPathMappingWithPrefix.java
@@ -66,7 +66,7 @@ final class RegexPathMappingWithPrefix extends AbstractPathMapping {
             return null;
         }
 
-        return mapping.apply(routingCtx.overridePath(path.substring(pathPrefix.length() - 1)));
+        return mapping.apply(routingCtx.withPath(path.substring(pathPrefix.length() - 1)));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -49,6 +49,19 @@ public interface RoutingContext {
     HttpMethod method();
 
     /**
+     * Returns a wrapped {@link RoutingContext} which holds the specified {@link HttpMethod}.
+     */
+    default RoutingContext overrideMethod(HttpMethod method) {
+        requireNonNull(method, "method");
+        return new RoutingContextWrapper(this) {
+            @Override
+            public HttpMethod method() {
+                return method;
+            }
+        };
+    }
+
+    /**
      * Returns the absolute path retrieved from the request,
      * as defined in <a href="https://datatracker.ietf.org/doc/rfc3986/">RFC3986</a>.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -140,17 +140,11 @@ public interface RoutingContext {
      * Returns a wrapped {@link RoutingContext} which holds the specified {@code path}.
      * It is usually used to find an {@link HttpService} with a prefix-stripped path.
      *
-     * @deprecated Use {@link #withPath} instead.
+     * @deprecated Use {@link #withPath}.
      */
     @Deprecated
     default RoutingContext overridePath(String path) {
-        requireNonNull(path, "path");
-        return new RoutingContextWrapper(this) {
-            @Override
-            public String path() {
-                return path;
-            }
-        };
+        return withPath(path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -119,6 +119,23 @@ public interface RoutingContext {
      * Returns a wrapped {@link RoutingContext} which holds the specified {@code path}.
      * It is usually used to find an {@link HttpService} with a prefix-stripped path.
      */
+    default RoutingContext withPath(String path) {
+        requireNonNull(path, "path");
+        return new RoutingContextWrapper(this) {
+            @Override
+            public String path() {
+                return path;
+            }
+        };
+    }
+
+    /**
+     * Returns a wrapped {@link RoutingContext} which holds the specified {@code path}.
+     * It is usually used to find an {@link HttpService} with a prefix-stripped path.
+     *
+     * @deprecated Use {@link #withPath} instead.
+     */
+    @Deprecated
     default RoutingContext overridePath(String path) {
         requireNonNull(path, "path");
         return new RoutingContextWrapper(this) {

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -51,8 +51,12 @@ public interface RoutingContext {
     /**
      * Returns a wrapped {@link RoutingContext} which holds the specified {@link HttpMethod}.
      */
+    @UnstableApi
     default RoutingContext withMethod(HttpMethod method) {
         requireNonNull(method, "method");
+        if (method == method()) {
+            return this;
+        }
         return new RoutingContextWrapper(this) {
             @Override
             public HttpMethod method() {
@@ -121,6 +125,9 @@ public interface RoutingContext {
      */
     default RoutingContext withPath(String path) {
         requireNonNull(path, "path");
+        if (path.equals(path())) {
+            return this;
+        }
         return new RoutingContextWrapper(this) {
             @Override
             public String path() {

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -51,7 +51,7 @@ public interface RoutingContext {
     /**
      * Returns a wrapped {@link RoutingContext} which holds the specified {@link HttpMethod}.
      */
-    default RoutingContext overrideMethod(HttpMethod method) {
+    default RoutingContext withMethod(HttpMethod method) {
         requireNonNull(method, "method");
         return new RoutingContextWrapper(this) {
             @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -95,8 +95,8 @@ class RoutingContextWrapper implements RoutingContext {
     }
 
     @Override
-    public RoutingContext overridePath(String path) {
-        return delegate.overridePath(path);
+    public RoutingContext withPath(String path) {
+        return delegate.withPath(path);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -28,8 +28,11 @@ class RoutingContextWrapper implements RoutingContext {
 
     private final RoutingContext delegate;
 
+    private final int hashcode;
+
     RoutingContextWrapper(RoutingContext delegate) {
         this.delegate = delegate;
+        hashcode = DefaultRoutingContext.hashCode(this);
     }
 
     @Override
@@ -131,7 +134,7 @@ class RoutingContextWrapper implements RoutingContext {
 
     @Override
     public int hashCode() {
-        return DefaultRoutingContext.hashCode(this);
+        return hashcode;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -397,7 +397,7 @@ public final class VirtualHost {
                 return routed;
             case NOT_MATCHED:
                 if (routingCtx.method() == HttpMethod.HEAD) {
-                    return findServiceConfig(routingCtx.withMethod(HttpMethod.GET));
+                    return findServiceConfig(routingCtx.withMethod(HttpMethod.GET), useFallbackService);
                 }
 
                 if (!useFallbackService) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import com.google.common.base.Ascii;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
@@ -395,6 +396,10 @@ public final class VirtualHost {
                 maybeSetRoutingResult(routingCtx, routed);
                 return routed;
             case NOT_MATCHED:
+                if (routingCtx.method() == HttpMethod.HEAD) {
+                    return findServiceConfig(routingCtx.overrideMethod(HttpMethod.GET));
+                }
+
                 if (!useFallbackService) {
                     maybeSetRoutingResult(routingCtx, routed);
                     return routed;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -397,7 +397,7 @@ public final class VirtualHost {
                 return routed;
             case NOT_MATCHED:
                 if (routingCtx.method() == HttpMethod.HEAD) {
-                    return findServiceConfig(routingCtx.overrideMethod(HttpMethod.GET));
+                    return findServiceConfig(routingCtx.withMethod(HttpMethod.GET));
                 }
 
                 if (!useFallbackService) {

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-public class VirtualHostTest {
+public class AnnotatedServiceImplicitHeadTest {
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -51,7 +51,7 @@ public class VirtualHostTest {
     }
 
     @Test
-    void getAnnotationMatchesDeleteMethod() {
+    void getAnnotationDoesNotMatchDeleteMethod() {
         final BlockingWebClient webClient = server.blockingWebClient();
         final AggregatedHttpResponse res = webClient.delete("/test");
         assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-public class AnnotatedServiceImplicitHeadTest {
+class AnnotatedServiceImplicitHeadTest {
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AnnotatedServiceImplicitHeadTest.java
@@ -56,4 +56,11 @@ public class AnnotatedServiceImplicitHeadTest {
         final AggregatedHttpResponse res = webClient.delete("/test");
         assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
     }
+
+    @Test
+    void testHeadMethodWithNonExistencePath() {
+        final BlockingWebClient webClient = server.blockingWebClient();
+        final AggregatedHttpResponse res = webClient.head("/invalid");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/CachingRoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CachingRoutingContextTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.linecorp.armeria.server.RoutingContextTest.virtualHost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ class CachingRoutingContextTest {
 
     @Test
     void disableMatchingQueryParamsByCachingRoutingContext() {
+        final VirtualHost virtualHost = virtualHost();
         final Route route = Route.builder()
                                  .exact("/test")
                                  .methods(HttpMethod.GET)
@@ -42,6 +44,7 @@ class CachingRoutingContextTest {
         when(context.method()).thenReturn(HttpMethod.GET);
         when(context.params()).thenReturn(QueryParams.of("foo", "qux"));
         when(context.requiresMatchingParamsPredicates()).thenReturn(true);
+        when(context.virtualHost()).thenReturn(virtualHost);
 
         assertThat(route.apply(context, false).isPresent()).isFalse(); // Because of the query parameters.
 
@@ -51,6 +54,7 @@ class CachingRoutingContextTest {
 
     @Test
     void disableMatchingHeadersByCachingRoutingContext() {
+        final VirtualHost virtualHost = virtualHost();
         final Route route = Route.builder()
                                  .exact("/test")
                                  .methods(HttpMethod.GET)
@@ -62,6 +66,7 @@ class CachingRoutingContextTest {
         when(context.method()).thenReturn(HttpMethod.GET);
         when(context.headers()).thenReturn(RequestHeaders.of(HttpMethod.GET, "/test", "foo", "qux"));
         when(context.requiresMatchingHeadersPredicates()).thenReturn(true);
+        when(context.virtualHost()).thenReturn(virtualHost);
 
         assertThat(route.apply(context, false).isPresent()).isFalse(); // Because of HTTP headers.
 

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
@@ -110,8 +110,8 @@ class RoutingContextTest {
                                                             MediaType.XML_UTF_8 + "; q=0.8"),
                                           "/hello", null, null, RoutingStatus.OK);
         final RoutingContext ctx3 = ctx1.withMethod(HttpMethod.POST);
-        assertThat(ctx1).isNotEqualTo(ctx3);
-        assertThat(ctx2).isEqualTo(ctx3);
+        assertThat(ctx1.hashCode()).isNotEqualTo(ctx3.hashCode());
+        assertThat(ctx2.hashCode()).isEqualTo(ctx3.hashCode());
     }
 
     static RoutingContext create(String path) {

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
@@ -90,6 +90,30 @@ class RoutingContextTest {
         assertThat(ctx1).isEqualTo(ctx2);
     }
 
+    @Test
+    void hashcodeRecalculateWhenMethodChange() {
+        final VirtualHost virtualHost = virtualHost();
+        final RoutingContext ctx1 =
+                new DefaultRoutingContext(virtualHost, "example.com",
+                                          RequestHeaders.of(HttpMethod.GET, "/hello",
+                                                            HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                            HttpHeaderNames.ACCEPT,
+                                                            MediaType.JSON_UTF_8 + ", " +
+                                                            MediaType.XML_UTF_8 + "; q=0.8"),
+                                          "/hello", null, null, RoutingStatus.OK);
+        final RoutingContext ctx2 =
+                new DefaultRoutingContext(virtualHost, "example.com",
+                                          RequestHeaders.of(HttpMethod.POST, "/hello",
+                                                            HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8,
+                                                            HttpHeaderNames.ACCEPT,
+                                                            MediaType.JSON_UTF_8 + ", " +
+                                                            MediaType.XML_UTF_8 + "; q=0.8"),
+                                          "/hello", null, null, RoutingStatus.OK);
+        final RoutingContext ctx3 = ctx1.withMethod(HttpMethod.POST);
+        assertThat(ctx1).isNotEqualTo(ctx3);
+        assertThat(ctx2).isEqualTo(ctx3);
+    }
+
     static RoutingContext create(String path) {
         return create(path, null);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class VirtualHostTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService(new Object() {
+                @Get("/test")
+                public HttpResponse hello() {
+                    return HttpResponse.of("Hello");
+                }
+            });
+        }
+    };
+
+    @Test
+    void getAnnotationMatchesHeadMethod() {
+        final WebClient webClient = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = webClient.head("/test").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void getAnnotationMatchesDeleteMethod() {
+        final WebClient webClient = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = webClient.delete("/test").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -45,15 +45,15 @@ public class VirtualHostTest {
 
     @Test
     void getAnnotationMatchesHeadMethod() {
-        final WebClient webClient = WebClient.of(server.httpUri());
-        final AggregatedHttpResponse res = webClient.head("/test").aggregate().join();
+        final BlockingWebClient webClient = server.blockingWebClient();
+        final AggregatedHttpResponse res = webClient.head("/test");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     void getAnnotationMatchesDeleteMethod() {
-        final WebClient webClient = WebClient.of(server.httpUri());
-        final AggregatedHttpResponse res = webClient.delete("/test").aggregate().join();
+        final BlockingWebClient webClient = server.blockingWebClient();
+        final AggregatedHttpResponse res = webClient.delete("/test");
         assertThat(res.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
     }
 }


### PR DESCRIPTION
Motivation:

To resolve #4038 

> Many server frameworks(e.g. [Spring](https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#mvc-ann-requestmapping-head-options), express) create an implicit request mapping to HEAD when there's a request handler for GET.
> 
> The feature can be useful as client sometimes just want to check the existence of resources without receiving the whole body and almost always the handlers for @Get and @Head should be the same.
> 
> Currently, armeria needs 3 annotations to do the same thing.
> 
> ```
> @Get
> @Head
> @Path("/some-file")
> public HttpResponse someFile(ServiceRequestContext ctx) {
>     // ...
>     return client.execute(RequestHeaders.of(ctx.method(), "/some-object-storage-path"));
> }
> ```

Modifications:

- Implement `overrideMethod` in `RoutingContext` for wrapping RoutingContext that holds new HttpMethod.
- Add new logic in `findServiceConfig` of `VitualHost`. When routingResultType is `NOT_MATCHED` & `HttpMethod is Head`, retry router.find() with GET.

Result:

- Closes #4038
- request mapping to HEAD when there's a request handler for GET.
- Get request handler also support request mapping to HEAD, just for using @Get.