### PR TITLE
Added DefaultMemoryHealthChecker

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultMemoryHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/DefaultMemoryHealthChecker.java
@@ -1,0 +1,44 @@
+package com.linecorp.armeria.server.healthcheck;
+
+import java.lang.management.BufferPoolMXBean;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+import java.util.List;
+
+public class DefaultMemoryHealthChecker implements HealthChecker {
+
+    private final List<MemoryPoolMXBean> memoryPoolMXBeans;
+    private final double targetMemoryHeapUsage;
+    private final double targetMemoryNonHeapUsage;
+    private final double targetMemoryTotalUsage;
+
+    public DefaultMemoryHealthChecker(final double targetMemoryHeapUsage, final double targetMemoryNonHeapUsage, final double targetMemoryTotalUsage) {
+        this.targetMemoryHeapUsage = targetMemoryHeapUsage;
+        this.targetMemoryNonHeapUsage = targetMemoryNonHeapUsage;
+        this.targetMemoryTotalUsage = targetMemoryTotalUsage;
+        this.memoryPoolMXBeans = ManagementFactory.getMemoryPoolMXBeans();
+    }
+
+    @Override
+    public boolean isHealthy() {
+        final double heapMemoryUsage = getHeapMemoryUsage();
+        final double nonHeapMemoryUsage = getNonHeapMemoryUsage();
+        final double totalMemoryUsage = getTotalMemoryUsage();
+        return heapMemoryUsage <= targetMemoryHeapUsage &&
+               nonHeapMemoryUsage <= targetMemoryNonHeapUsage &&
+               totalMemoryUsage <= targetMemoryTotalUsage;
+    }
+
+    private double getHeapMemoryUsage() {
+        return this.memoryPoolMXBeans.stream().filter(e -> MemoryType.HEAP.equals(e.getType())).map(e -> e.getUsage().getUsed()).mapToDouble(e -> e).sum();
+    }
+
+    private double getNonHeapMemoryUsage() {
+        return ManagementFactory.getPlatformMXBean(BufferPoolMXBean.class).getMemoryUsed();
+    }
+
+    private double getTotalMemoryUsage() {
+        return Runtime.getRuntime().totalMemory();
+    }
+}


### PR DESCRIPTION
## Motivation:

Resolves part of #1854
Some users may want to use Memory usage to determine if their instance is healthy.

## Modifications:

- Added DefaultMemoryHealthChecker that checks memory-usage by as-shown.

| kind | how | implementation forked from... | 
| --- | --- | --- | 
| TOTAL | `Runtime.getRuntime().totalMemory()` | |
| NON-HEAP|  `ManagementFactory.getPlatformMXBean(BufferPoolMXBean.class).getMemoryUsed()` | https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java#L183-L193 | 
| HEAP | `ManagementFactory.getMemoryPoolMXBeans()` (filtered by its memory type heap) | |

## Result:

- Resolve part of #1854
- A User can perform health checks using system/application memory usage.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
