### PR TITLE
Upgrade to Apache HttpClient 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ configure(projectsWithFlags('java')) {
         testRuntimeOnly libs.checkerframework // Required by guava-testlib
         testImplementation libs.assertj
         testImplementation libs.mockito
-        testImplementation libs.apache.httpclient
+        testImplementation libs.apache.httpclient5
         testImplementation libs.hamcrest
         testImplementation libs.hamcrest.library
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -15,6 +15,9 @@
  */
 package com.linecorp.armeria.internal.server.annotation;
 
+import static org.apache.hc.core5.http.HttpHeaders.ACCEPT;
+import static org.apache.hc.core5.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.hc.core5.http.HttpHeaders.IF_MATCH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -30,23 +33,24 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.HTTP;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Publisher;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.BlockingWebClient;
@@ -1091,8 +1095,8 @@ class AnnotatedServiceTest {
     @Test
     void testRequestHeaderInjection() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
-            HttpRequestBase request = get("/11/aHeader");
-            request.setHeader(org.apache.http.HttpHeaders.IF_MATCH, "737060cd8c284d8af7ad3082f209582d");
+            HttpUriRequestBase request = get("/11/aHeader");
+            request.setHeader(IF_MATCH, "737060cd8c284d8af7ad3082f209582d");
             testBody(hc, request, "matched");
 
             request = post("/11/customHeader1");
@@ -1240,46 +1244,45 @@ class AnnotatedServiceTest {
         NORMAL
     }
 
-    static void testBodyAndContentType(CloseableHttpClient hc, HttpRequestBase req,
-                                       String body, String contentType) throws IOException {
+    static void testBodyAndContentType(CloseableHttpClient hc, HttpUriRequestBase req,
+                                       String body, String contentType) throws IOException, ParseException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, body, null, contentType);
         }
     }
 
-    static void testBody(CloseableHttpClient hc, HttpRequestBase req,
-                         String body) throws IOException {
+    static void testBody(CloseableHttpClient hc, HttpUriRequestBase req,
+                         String body) throws IOException, ParseException {
         testBody(hc, req, body, null);
     }
 
-    static void testBody(CloseableHttpClient hc, HttpRequestBase req,
-                         String body, @Nullable Charset encoding) throws IOException {
+    static void testBody(CloseableHttpClient hc, HttpUriRequestBase req,
+                         String body, @Nullable Charset encoding) throws IOException, ParseException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, body, encoding, null);
         }
     }
 
-    static void testStatusCode(CloseableHttpClient hc, HttpRequestBase req,
-                               int statusCode) throws IOException {
+    static void testStatusCode(CloseableHttpClient hc, HttpUriRequestBase req,
+                               int statusCode) throws IOException, ParseException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, statusCode, null, null, null);
         }
     }
 
-    static void testForm(CloseableHttpClient hc, HttpPost req) throws IOException {
+    static void testForm(CloseableHttpClient hc, HttpPost req) throws IOException, ParseException {
         try (CloseableHttpResponse res = hc.execute(req)) {
             checkResult(res, 200, EntityUtils.toString(req.getEntity()), null, null);
         }
     }
 
-    static void checkResult(org.apache.http.HttpResponse res,
+    static void checkResult(CloseableHttpResponse res,
                             int statusCode,
                             @Nullable String body,
                             @Nullable Charset encoding,
-                            @Nullable String contentType) throws IOException {
+                            @Nullable String contentType) throws IOException, ParseException {
         final HttpStatus status = HttpStatus.valueOf(statusCode);
-        assertThat(res.getStatusLine().toString()).isEqualTo(
-                "HTTP/1.1 " + status);
+        assertThat(res.getCode()).isEqualTo(status);
         if (body != null) {
             if (encoding != null) {
                 assertThat(EntityUtils.toString(res.getEntity(), encoding))
@@ -1289,7 +1292,7 @@ class AnnotatedServiceTest {
             }
         }
 
-        final org.apache.http.Header header = res.getFirstHeader(org.apache.http.HttpHeaders.CONTENT_TYPE);
+        final org.apache.hc.core5.http.Header header = res.getFirstHeader(CONTENT_TYPE);
         if (contentType != null) {
             assertThat(MediaType.parse(header.getValue())).isEqualTo(MediaType.parse(contentType));
         } else if (statusCode >= 400) {
@@ -1299,23 +1302,23 @@ class AnnotatedServiceTest {
         }
     }
 
-    static HttpRequestBase get(String path) {
+    static HttpUriRequestBase get(String path) {
         return request(HttpMethod.GET, path, null, null);
     }
 
-    static HttpRequestBase get(String path, @Nullable String accept) {
+    static HttpUriRequestBase get(String path, @Nullable String accept) {
         return request(HttpMethod.GET, path, null, accept);
     }
 
-    static HttpRequestBase post(String path) {
+    static HttpUriRequestBase post(String path) {
         return request(HttpMethod.POST, path, null, null);
     }
 
-    static HttpRequestBase post(String path, @Nullable String contentType) {
+    static HttpUriRequestBase post(String path, @Nullable String contentType) {
         return request(HttpMethod.POST, path, contentType, null);
     }
 
-    static HttpRequestBase post(String path, @Nullable String contentType, @Nullable String accept) {
+    static HttpUriRequestBase post(String path, @Nullable String contentType, @Nullable String accept) {
         return request(HttpMethod.POST, path, contentType, accept);
     }
 
@@ -1331,19 +1334,19 @@ class AnnotatedServiceTest {
             params.add(new BasicNameValuePair(kv[i], kv[i + 1]));
         }
         // HTTP.DEF_CONTENT_CHARSET = ISO-8859-1
-        final Charset encoding = charset == null ? HTTP.DEF_CONTENT_CHARSET : charset;
+        final Charset encoding = charset == null ? Charsets.ISO_8859_1 : charset;
         final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, encoding);
         req.setEntity(entity);
         return req;
     }
 
-    static HttpRequestBase request(HttpMethod method, String path, @Nullable String contentType) {
+    static HttpUriRequestBase request(HttpMethod method, String path, @Nullable String contentType) {
         return request(method, path, contentType, null);
     }
 
-    static HttpRequestBase request(HttpMethod method, String path,
-                                   @Nullable String contentType, @Nullable String accept) {
-        final HttpRequestBase req;
+    static HttpUriRequestBase request(HttpMethod method, String path,
+                                      @Nullable String contentType, @Nullable String accept) {
+        final HttpUriRequestBase req;
         switch (method) {
             case GET:
                 req = new HttpGet(server.httpUri().resolve(path));
@@ -1355,10 +1358,10 @@ class AnnotatedServiceTest {
                 throw new Error("Unexpected method: " + method);
         }
         if (contentType != null) {
-            req.setHeader(org.apache.http.HttpHeaders.CONTENT_TYPE, contentType);
+            req.setHeader(CONTENT_TYPE, contentType);
         }
         if (accept != null) {
-            req.setHeader(org.apache.http.HttpHeaders.ACCEPT, accept);
+            req.setHeader(ACCEPT, accept);
         }
         return req;
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -1281,8 +1281,7 @@ class AnnotatedServiceTest {
                             @Nullable String body,
                             @Nullable Charset encoding,
                             @Nullable String contentType) throws IOException, ParseException {
-        final HttpStatus status = HttpStatus.valueOf(statusCode);
-        assertThat(res.getCode()).isEqualTo(status);
+        assertThat(res.getCode()).isEqualTo(statusCode);
         if (body != null) {
             if (encoding != null) {
                 assertThat(EntityUtils.toString(res.getEntity(), encoding))

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServiceTest.java
@@ -27,8 +27,8 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -41,12 +41,12 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.logging.LoggingService;
-import com.linecorp.armeria.testing.junit4.server.ServerRule;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
-public class HttpServiceTest {
+class HttpServiceTest {
 
-    @ClassRule
-    public static final ServerRule rule = new ServerRule() {
+    @RegisterExtension
+    static final ServerExtension rule = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service(
@@ -160,7 +160,7 @@ public class HttpServiceTest {
     }
 
     @Test
-    public void contentLengthIsNotSetWhenTrailerExists() {
+    void contentLengthIsNotSetWhenTrailerExists() {
         final WebClient client = WebClient.of(rule.httpUri());
         AggregatedHttpResponse res = client.get("/trailersWithoutData").aggregate().join();
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH)).isNull();

--- a/core/src/test/java/com/linecorp/armeria/server/InitiateConnectionShutdownTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/InitiateConnectionShutdownTest.java
@@ -34,12 +34,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.Header;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -259,7 +259,7 @@ class InitiateConnectionShutdownTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             final HttpUriRequest req = new HttpGet(goAwayServer.httpUri() + path);
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.containsHeader("Connection")).isTrue();
                 assertThat(res.getHeaders("Connection"))
                         .extracting(Header::getValue).containsExactly("close");
@@ -285,7 +285,7 @@ class InitiateConnectionShutdownTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             final HttpUriRequest req = new HttpGet(goAwayServerNoopKeepAliveHandler.httpUri() + path);
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.containsHeader("Connection")).isTrue();
                 assertThat(res.getHeaders("Connection"))
                         .extracting(Header::getValue).containsExactly("close");

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -45,12 +45,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -245,13 +246,13 @@ class ServerTest {
         assertThat(numBossThreads).isEqualTo(oldNumBossThreads);
     }
 
-    private static void testInvocation0(String path) throws IOException {
+    private static void testInvocation0(String path) throws IOException, ParseException {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             final HttpPost req = new HttpPost(server.httpUri().resolve(path));
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("Hello, world!");
             }
         }
@@ -264,8 +265,7 @@ class ServerTest {
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()))
-                        .isNotEqualTo(HttpStatusClass.SUCCESS);
+                assertThat(HttpStatusClass.valueOf(res.getCode())).isNotEqualTo(HttpStatusClass.SUCCESS);
             }
         }
     }
@@ -277,8 +277,7 @@ class ServerTest {
             req.setEntity(new StringEntity("Hello, world!", StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertThat(HttpStatusClass.valueOf(res.getStatusLine().getStatusCode()))
-                        .isEqualTo(HttpStatusClass.SUCCESS);
+                assertThat(HttpStatusClass.valueOf(res.getCode())).isEqualTo(HttpStatusClass.SUCCESS);
             }
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -137,6 +137,7 @@ class SniServerTest {
         final HttpClientConnectionManager cm =
                 PoolingHttpClientConnectionManagerBuilder.create()
                                                          .setSSLSocketFactory(sslSocketFactory)
+                                                         .setDnsResolver(dnsResolver)
                                                          .build();
         return HttpClients.custom()
                           .setConnectionManager(cm)

--- a/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/SniServerTest.java
@@ -22,14 +22,18 @@ import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.conn.InMemoryDnsResolver;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.InMemoryDnsResolver;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -89,19 +93,18 @@ class SniServerTest {
     void testSniMatch() throws Exception {
         try (CloseableHttpClient hc = newHttpClient()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet("https://a.com:" + server.httpsPort()))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo(
-                        "HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo(
                         "a.com: CN=a.com");
             }
 
             try (CloseableHttpResponse res = hc.execute(new HttpGet("https://b.com:" + server.httpsPort()))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("b.com: CN=b.com");
             }
 
             try (CloseableHttpResponse res = hc.execute(new HttpGet("https://c.com:" + server.httpsPort()))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("c.com: CN=c.com");
             }
         }
@@ -112,12 +115,12 @@ class SniServerTest {
         try (CloseableHttpClient hc = newHttpClient()) {
             try (CloseableHttpResponse res = hc.execute(
                     new HttpGet("https://mismatch.com:" + server.httpsPort()))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("c.com: CN=c.com");
             }
 
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server.httpsUri()))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(EntityUtils.toString(res.getEntity())).isEqualTo("c.com: CN=c.com");
             }
         }
@@ -126,11 +129,17 @@ class SniServerTest {
     CloseableHttpClient newHttpClient() throws Exception {
         final SSLContext sslCtx =
                 new SSLContextBuilder().loadTrustMaterial(null, (chain, authType) -> true).build();
-
+        final SSLConnectionSocketFactory sslSocketFactory =
+                SSLConnectionSocketFactoryBuilder.create()
+                                                 .setSslContext(sslCtx)
+                                                 .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                                                 .build();
+        final HttpClientConnectionManager cm =
+                PoolingHttpClientConnectionManagerBuilder.create()
+                                                         .setSSLSocketFactory(sslSocketFactory)
+                                                         .build();
         return HttpClients.custom()
-                          .setDnsResolver(dnsResolver)
-                          .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                          .setSSLContext(sslCtx)
+                          .setConnectionManager(cm)
                           .build();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -32,13 +32,13 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -300,21 +300,21 @@ class FileServiceTest {
             // Ensure auto-redirect without query works as expected.
             HttpUriRequest req = new HttpGet(baseUri + "/fs/auto_index");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 307 Temporary Redirect");
+                assertStatusLine(res, 307);
                 assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/");
             }
 
             // Ensure auto-redirect with query works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index?foobar=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 307 Temporary Redirect");
+                assertStatusLine(res, 307);
                 assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/?foobar=1");
             }
 
             // Ensure directory listing works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertStatusLine(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/")
@@ -329,7 +329,7 @@ class FileServiceTest {
             // Ensure directory listing on an empty directory works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index/empty_child_dir/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertStatusLine(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/empty_child_dir/")
@@ -341,7 +341,7 @@ class FileServiceTest {
             // even with query parameters.
             req = new HttpGet(baseUri + "/fs/auto_index/empty_child_dir/?foo=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertStatusLine(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/empty_child_dir/")
@@ -352,7 +352,7 @@ class FileServiceTest {
             // Ensure custom index.html takes precedence over auto-generated directory listing.
             req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertStatusLine(res, 200);
                 assertThat(contentString(res)).isEqualTo("custom_index_file");
             }
 
@@ -360,7 +360,7 @@ class FileServiceTest {
             // even with query parameters.
             req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/?foo=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, "HTTP/1.1 200 OK");
+                assertStatusLine(res, 200);
                 assertThat(contentString(res)).isEqualTo("custom_index_file");
             }
         }
@@ -659,7 +659,7 @@ class FileServiceTest {
                                     @Nullable String expectedContentType,
                                     Consumer<String> contentAssertions) throws Exception {
 
-        assertStatusLine(res, "HTTP/1.1 200 OK");
+        assertStatusLine(res, 200);
 
         // Ensure that the 'Date' header exists and is well-formed.
         final String date = headerOrNull(res, HttpHeaders.DATE);
@@ -731,7 +731,7 @@ class FileServiceTest {
 
         try (CloseableHttpResponse res = hc.execute(req5)) {
             // Should not receive '304 Not Modified' because the etag did not match.
-            assertStatusLine(res, "HTTP/1.1 200 OK");
+            assertStatusLine(res, 200);
 
             // Read the content fully so that Apache HC does not close the connection prematurely.
             ByteStreams.exhaust(res.getEntity().getContent());
@@ -741,7 +741,7 @@ class FileServiceTest {
     private static void assert304NotModified(
             CloseableHttpResponse res, String expectedEtag, String expectedLastModified) {
 
-        assertStatusLine(res, "HTTP/1.1 304 Not Modified");
+        assertStatusLine(res, 304);
 
         // Ensure that the 'ETag' header did not change.
         assertThat(headerOrNull(res, HttpHeaders.ETAG)).isEqualTo(expectedEtag);
@@ -757,13 +757,13 @@ class FileServiceTest {
     }
 
     private static void assert404NotFound(CloseableHttpResponse res) {
-        assertStatusLine(res, "HTTP/1.1 404 Not Found");
+        assertStatusLine(res, 404);
         // Ensure that the 'Last-Modified' header does not exist.
         assertThat(res.getFirstHeader(HttpHeaders.LAST_MODIFIED)).isNull();
     }
 
-    private static void assertStatusLine(CloseableHttpResponse res, String expectedStatusLine) {
-        assertThat(res.getStatusLine().toString()).isEqualTo(expectedStatusLine);
+    private static void assertStatusLine(CloseableHttpResponse res, int expectedStatus) {
+        assertThat(res.getCode()).isEqualTo(expectedStatus);
     }
 
     private static String header(CloseableHttpResponse res, String name) {

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -300,21 +300,21 @@ class FileServiceTest {
             // Ensure auto-redirect without query works as expected.
             HttpUriRequest req = new HttpGet(baseUri + "/fs/auto_index");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 307);
+                assertStatusCode(res, 307);
                 assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/");
             }
 
             // Ensure auto-redirect with query works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index?foobar=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 307);
+                assertStatusCode(res, 307);
                 assertThat(header(res, "location")).isEqualTo(basePath + "/fs/auto_index/?foobar=1");
             }
 
             // Ensure directory listing works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 200);
+                assertStatusCode(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/")
@@ -329,7 +329,7 @@ class FileServiceTest {
             // Ensure directory listing on an empty directory works as expected.
             req = new HttpGet(baseUri + "/fs/auto_index/empty_child_dir/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 200);
+                assertStatusCode(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/empty_child_dir/")
@@ -341,7 +341,7 @@ class FileServiceTest {
             // even with query parameters.
             req = new HttpGet(baseUri + "/fs/auto_index/empty_child_dir/?foo=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 200);
+                assertStatusCode(res, 200);
                 final String content = contentString(res);
                 assertThat(content)
                         .contains("Directory listing: " + basePath + "/fs/auto_index/empty_child_dir/")
@@ -352,7 +352,7 @@ class FileServiceTest {
             // Ensure custom index.html takes precedence over auto-generated directory listing.
             req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 200);
+                assertStatusCode(res, 200);
                 assertThat(contentString(res)).isEqualTo("custom_index_file");
             }
 
@@ -360,7 +360,7 @@ class FileServiceTest {
             // even with query parameters.
             req = new HttpGet(baseUri + "/fs/auto_index/child_dir_with_custom_index/?foo=1");
             try (CloseableHttpResponse res = hc.execute(req)) {
-                assertStatusLine(res, 200);
+                assertStatusCode(res, 200);
                 assertThat(contentString(res)).isEqualTo("custom_index_file");
             }
         }
@@ -659,7 +659,7 @@ class FileServiceTest {
                                     @Nullable String expectedContentType,
                                     Consumer<String> contentAssertions) throws Exception {
 
-        assertStatusLine(res, 200);
+        assertStatusCode(res, 200);
 
         // Ensure that the 'Date' header exists and is well-formed.
         final String date = headerOrNull(res, HttpHeaders.DATE);
@@ -731,7 +731,7 @@ class FileServiceTest {
 
         try (CloseableHttpResponse res = hc.execute(req5)) {
             // Should not receive '304 Not Modified' because the etag did not match.
-            assertStatusLine(res, 200);
+            assertStatusCode(res, 200);
 
             // Read the content fully so that Apache HC does not close the connection prematurely.
             ByteStreams.exhaust(res.getEntity().getContent());
@@ -741,7 +741,7 @@ class FileServiceTest {
     private static void assert304NotModified(
             CloseableHttpResponse res, String expectedEtag, String expectedLastModified) {
 
-        assertStatusLine(res, 304);
+        assertStatusCode(res, 304);
 
         // Ensure that the 'ETag' header did not change.
         assertThat(headerOrNull(res, HttpHeaders.ETAG)).isEqualTo(expectedEtag);
@@ -757,12 +757,12 @@ class FileServiceTest {
     }
 
     private static void assert404NotFound(CloseableHttpResponse res) {
-        assertStatusLine(res, 404);
+        assertStatusCode(res, 404);
         // Ensure that the 'Last-Modified' header does not exist.
         assertThat(res.getFirstHeader(HttpHeaders.LAST_MODIFIED)).isNull();
     }
 
-    private static void assertStatusLine(CloseableHttpResponse res, int expectedStatus) {
+    private static void assertStatusCode(CloseableHttpResponse res, int expectedStatus) {
         assertThat(res.getCode()).isEqualTo(expectedStatus);
     }
 

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -159,6 +159,8 @@ module = "org.apache.httpcomponents.client5:httpclient5"
 version.ref = "apache-httpclient"
 exclusions = "commons-logging:commons-logging"
 
+# needed to test thrift apis
+# https://github.com/apache/thrift/blob/master/lib/java/gradle.properties#L28
 [libraries.apache-httpclient4]
 module = "org.apache.httpcomponents:httpclient"
 version.ref = "apache-httpclient4"

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -2,7 +2,7 @@
 akka = "2.6.20"
 akka-http-cors = "1.0.0"
 akka-grpc-runtime = "1.0.3"
-apache-httpclient = "5.2.1"
+apache-httpclient5 = "5.2.1"
 apache-httpclient4 = "4.5.14"
 assertj = "3.24.2"
 awaitility = "4.2.0"
@@ -154,9 +154,9 @@ version.ref = "akka"
 module = "com.typesafe.akka:akka-stream_2.13"
 version.ref = "akka"
 
-[libraries.apache-httpclient]
+[libraries.apache-httpclient5]
 module = "org.apache.httpcomponents.client5:httpclient5"
-version.ref = "apache-httpclient"
+version.ref = "apache-httpclient5"
 exclusions = "commons-logging:commons-logging"
 
 # needed to test thrift apis

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -2,7 +2,8 @@
 akka = "2.6.20"
 akka-http-cors = "1.0.0"
 akka-grpc-runtime = "1.0.3"
-apache-httpclient = "4.5.14"
+apache-httpclient = "5.2.1"
+apache-httpclient4 = "4.5.14"
 assertj = "3.24.2"
 awaitility = "4.2.0"
 bouncycastle = "1.70"
@@ -154,8 +155,13 @@ module = "com.typesafe.akka:akka-stream_2.13"
 version.ref = "akka"
 
 [libraries.apache-httpclient]
-module = "org.apache.httpcomponents:httpclient"
+module = "org.apache.httpcomponents.client5:httpclient5"
 version.ref = "apache-httpclient"
+exclusions = "commons-logging:commons-logging"
+
+[libraries.apache-httpclient4]
+module = "org.apache.httpcomponents:httpclient"
+version.ref = "apache-httpclient4"
 exclusions = "commons-logging:commons-logging"
 
 [libraries.assertj]

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 
     api libs.json.unit
     api libs.json.unit.fluent
-    api libs.apache.httpclient
+    api libs.apache.httpclient5
     api libs.assertj
     api libs.junit5.jupiter.params
     api libs.mockito.junit.jupiter

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/webapp/WebAppContainerTest.java
@@ -33,15 +33,15 @@ import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLSession;
 
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -140,7 +140,7 @@ public abstract class WebAppContainerTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(
                     server().httpUri() + "/jsp/" + URLEncoder.encode("日本語", "UTF-8") + "/index.jsp"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -163,7 +163,7 @@ public abstract class WebAppContainerTest {
             try (CloseableHttpResponse res = hc.execute(
                     new HttpGet(server().httpUri() + "/jsp/query_string.jsp?foo=%31&bar=%32"))) {
 
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -198,7 +198,7 @@ public abstract class WebAppContainerTest {
                     Collections.singletonList(new BasicNameValuePair("bar", "4")), StandardCharsets.UTF_8));
 
             try (CloseableHttpResponse res = hc.execute(post)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -234,7 +234,7 @@ public abstract class WebAppContainerTest {
             post.setEntity(new StringEntity("test"));
 
             try (CloseableHttpResponse res = hc.execute(post)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -254,7 +254,7 @@ public abstract class WebAppContainerTest {
             final HttpPost post = new HttpPost(server().httpUri() + "/jsp/echo_post.jsp");
 
             try (CloseableHttpResponse res = hc.execute(post)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -274,7 +274,7 @@ public abstract class WebAppContainerTest {
             try (CloseableHttpResponse res = hc.execute(
                     new HttpGet(server().httpUri() + "/jsp/addrs_and_ports.jsp"))) {
 
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -301,7 +301,7 @@ public abstract class WebAppContainerTest {
             final HttpGet request = new HttpGet(server().httpUri() + "/jsp/addrs_and_ports.jsp");
             request.setHeader("Host", "localhost:1111");
             try (CloseableHttpResponse res = hc.execute(request)) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/html");
                 final String actualContent = CR_OR_LF.matcher(EntityUtils.toString(res.getEntity()))
@@ -335,7 +335,7 @@ public abstract class WebAppContainerTest {
     protected void testLarge(String path, boolean requiresContentLength) throws IOException {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server().httpUri().resolve(path)))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("text/plain");
 

--- a/thrift/thrift0.12/build.gradle
+++ b/thrift/thrift0.12/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     }
     testImplementation libs.thrift012
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.13/build.gradle
+++ b/thrift/thrift0.13/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
     testImplementation libs.apache.httpclient4
 
     // Jetty, for testing TServlet interoperability.

--- a/thrift/thrift0.13/build.gradle
+++ b/thrift/thrift0.13/build.gradle
@@ -4,6 +4,8 @@ dependencies {
 
     api libs.javax.annotation
 
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.14/build.gradle
+++ b/thrift/thrift0.14/build.gradle
@@ -5,6 +5,9 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.15/build.gradle
+++ b/thrift/thrift0.15/build.gradle
@@ -5,6 +5,9 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.16/build.gradle
+++ b/thrift/thrift0.16/build.gradle
@@ -6,6 +6,9 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.17/build.gradle
+++ b/thrift/thrift0.17/build.gradle
@@ -6,6 +6,9 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/thrift/thrift0.9/build.gradle
+++ b/thrift/thrift0.9/build.gradle
@@ -12,6 +12,9 @@ dependencies {
 
     api libs.javax.annotation
 
+    // thrift api depends on httpclient4
+    testImplementation libs.apache.httpclient4
+
     // Jetty, for testing TServlet interoperability.
     testImplementation libs.jetty94.webapp
     testImplementation libs.jetty94.http2.server

--- a/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/ManagedTomcatServiceTest.java
+++ b/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/ManagedTomcatServiceTest.java
@@ -22,11 +22,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.catalina.Service;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -93,7 +93,7 @@ class ManagedTomcatServiceTest extends WebAppContainerTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(
                     new HttpGet(server.httpUri() + "/jar/io/netty/util/concurrent/Future.class"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("application/java");
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())
@@ -108,7 +108,7 @@ class ManagedTomcatServiceTest extends WebAppContainerTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(
                     server.httpUri() + "/jar_altroot/Future.class"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_TYPE.toString()).getValue())
                         .startsWith("application/java");
                 assertThat(res.getFirstHeader(HttpHeaderNames.CONTENT_LENGTH.toString()).getValue())

--- a/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/UnmanagedTomcatServiceTest.java
+++ b/tomcat9/src/test/java/com/linecorp/armeria/server/tomcat/UnmanagedTomcatServiceTest.java
@@ -28,10 +28,10 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.startup.Tomcat;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -96,8 +96,7 @@ class UnmanagedTomcatServiceTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server.httpUri() + "/empty/"))) {
                 // as connector is not configured, TomcatServiceInvocationHandler will throw.
-                assertThat(res.getStatusLine().toString()).isEqualTo(
-                        "HTTP/1.1 503 Service Unavailable");
+                assertThat(res.getCode()).isEqualTo(503);
             }
         }
     }
@@ -109,8 +108,7 @@ class UnmanagedTomcatServiceTest {
                 // When no webapp is configured, Tomcat sends:
                 // - 400 Bad Request response for 9.0.10+
                 // - 404 Not Found for other versions
-                final String statusLine = res.getStatusLine().toString();
-                assertThat(statusLine).matches("^HTTP/1\\.1 (400 Bad Request|404 Not Found)$");
+                assertThat(res.getCode()).isIn(400, 404);
             }
         }
     }
@@ -119,7 +117,7 @@ class UnmanagedTomcatServiceTest {
     void ok() throws Exception {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server.httpUri() + "/some-webapp/"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
             }
         }
     }
@@ -129,7 +127,7 @@ class UnmanagedTomcatServiceTest {
         try (CloseableHttpClient hc = HttpClients.createMinimal()) {
             try (CloseableHttpResponse res = hc.execute(new HttpGet(
                     server.httpUri() + "/some-webapp-nohostname/"))) {
-                assertThat(res.getStatusLine().toString()).isEqualTo("HTTP/1.1 200 OK");
+                assertThat(res.getCode()).isEqualTo(200);
             }
         }
     }


### PR DESCRIPTION
Motivation:

Apache HttpClient works a little differently from armeria's client and is useful for internal testing.
For example, square brackets are not encoded by default.

I would like to use HttpClient's HTTP/2 functionality which is available starting from version 5 for use in the following PR.
https://github.com/line/armeria/pull/4721

Note that thrift client has a direct dependency on HttpClient4, and thus the dependency remains for thrift modules

Modifications:

- Migrate to HttpClient 5
- Use HttpClient 4 for thrift modules

Result:

- Most internal usages are migrated to Apache HttpClient 5

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
