### PR TITLE
Allow serving an HTTP/1 request with absolute URI.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -46,6 +46,10 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -98,6 +102,8 @@ import io.netty.util.internal.StringUtil;
 public final class ArmeriaHttpUtil {
 
     // Forked from Netty 4.1.34 at 4921f62c8ab8205fd222439dcd1811760b05daf1
+
+    private static final Logger logger = LoggerFactory.getLogger(ArmeriaHttpUtil.class);
 
     /**
      * The default case-insensitive {@link AsciiString} hasher and comparator for HTTP/2 headers.
@@ -246,6 +252,8 @@ public final class ArmeriaHttpUtil {
             Flags.headerValueCacheSpec() != null ? buildCache(Flags.headerValueCacheSpec()) : null;
     private static final Set<AsciiString> CACHED_HEADERS = Flags.cachedHeaders().stream().map(AsciiString::of)
                                                                 .collect(toImmutableSet());
+
+    private static boolean warnedIllegalAbsoluteUriTransformer = false;
 
     private static LoadingCache<AsciiString, String> buildCache(String spec) {
         return Caffeine.from(spec).build(AsciiString::toString);
@@ -605,15 +613,12 @@ public final class ArmeriaHttpUtil {
      * </ul>
      * {@link ExtensionHeaderNames#PATH} is ignored and instead extracted from the {@code Request-Line}.
      */
-    public static RequestHeaders toArmeria(ChannelHandlerContext ctx, HttpRequest in,
-                                           ServerConfig cfg, String scheme) throws URISyntaxException {
+    public static RequestHeaders toArmeria(
+            ChannelHandlerContext ctx, HttpRequest in,
+            ServerConfig cfg, String scheme,
+            Function<? super String, String> absoluteUriTransformer) throws URISyntaxException {
 
-        final String path = in.uri();
-        if (path.charAt(0) != '/' && !"*".equals(path)) {
-            // We support only origin form and asterisk form.
-            throw new URISyntaxException(path, "neither origin form nor asterisk form");
-        }
-
+        final String path = maybeTransformAbsoluteUri(in.uri(), absoluteUriTransformer);
         final io.netty.handler.codec.http.HttpHeaders inHeaders = in.headers();
         final RequestHeadersBuilder out = RequestHeaders.builder();
         out.sizeHint(inHeaders.size());
@@ -632,6 +637,60 @@ public final class ArmeriaHttpUtil {
             out.add(HttpHeaderNames.HOST, defaultHostname + ':' + port);
         }
         return out.build();
+    }
+
+    private static String maybeTransformAbsoluteUri(
+            String path, Function<? super String, String> absoluteUriTransformer) throws URISyntaxException {
+
+        if (isValidHttp2Path(path)) {
+            return path;
+        }
+
+        if (!isAbsoluteUri(path)) {
+            throw newInvalidPathException(path);
+        }
+
+        final String newPath;
+        try {
+            newPath = absoluteUriTransformer.apply(path);
+        } catch (Exception e) {
+            warnExceptionThrowingAbsoluteUriTransformer(e);
+            throw newInvalidPathException(path);
+        }
+
+        if (newPath == null) {
+            warnNullReturningAbsoluteUriTransformer();
+            throw newInvalidPathException(path);
+        }
+
+        if (path.equals(newPath) || !isValidHttp2Path(newPath)) {
+            throw newInvalidPathException(path);
+        }
+
+        return newPath;
+    }
+
+    private static void warnExceptionThrowingAbsoluteUriTransformer(Exception e) {
+        if (!warnedIllegalAbsoluteUriTransformer) {
+            warnedIllegalAbsoluteUriTransformer = true;
+            logger.warn("absoluteUriTransformer.apply() raised an exception; returning 400 Bad Request", e);
+        }
+    }
+
+    private static void warnNullReturningAbsoluteUriTransformer() {
+        if (!warnedIllegalAbsoluteUriTransformer) {
+            warnedIllegalAbsoluteUriTransformer = true;
+            logger.warn("absoluteUriTransformer.apply() returned null; returning 400 Bad Request");
+        }
+    }
+
+    private static URISyntaxException newInvalidPathException(String path) {
+        return new URISyntaxException(path, "neither origin form nor asterisk form");
+    }
+
+    private static boolean isValidHttp2Path(String path) {
+        // We support only origin form and asterisk form.
+        return path.charAt(0) == '/' || "*".equals(path);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -732,7 +732,7 @@ public final class ArmeriaHttpUtil {
             throw newInvalidPathException(path);
         }
 
-        if (path.equals(newPath) || !isValidHttp2Path(newPath)) {
+        if (!isValidHttp2Path(newPath)) {
             throw newInvalidPathException(path);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server;
 import static com.linecorp.armeria.server.ServiceRouteUtil.newRoutingContext;
 
 import java.net.URISyntaxException;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,7 +177,8 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
 
                     // Convert the Netty HttpHeaders into Armeria RequestHeaders.
                     final RequestHeaders headers =
-                            ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg, scheme.toString());
+                            ArmeriaHttpUtil.toArmeria(ctx, nettyReq, cfg, scheme.toString(),
+                                                      cfg.absoluteUriTransformer());
 
                     // Do not accept a CONNECT request.
                     if (headers.method() == HttpMethod.CONNECT) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import static com.linecorp.armeria.server.ServiceRouteUtil.newRoutingContext;
 
 import java.net.URISyntaxException;
-import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1804,12 +1804,12 @@ public final class ServerBuilder implements TlsSetters {
      * such an HTTP/1 request, because Armeria always assumes that request path is an absolute path and
      * return a {@code 400 Bad Request} response otherwise. For example:
      * <pre>{@code
-     * builder.absoluteUriTransformer(absoluteUri ->
+     * builder.absoluteUriTransformer(absoluteUri -> {
      *   // https://foo.com/bar -> /bar
      *   return absoluteUri.replaceFirst("^https://\\.foo\\.com/", "/");
      *   // or..
      *   // return "/proxy?uri=" + URLEncoder.encode(absoluteUri);
-     * );
+     * });
      * }</pre>
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -211,6 +211,7 @@ public final class ServerBuilder implements TlsSetters {
     private Http1HeaderNaming http1HeaderNaming = Http1HeaderNaming.ofDefault();
     @Nullable
     private DependencyInjector dependencyInjector;
+    private Function<? super String, String> absoluteUriTransformer = Function.identity();
     private final List<ShutdownSupport> shutdownSupports = new ArrayList<>();
 
     ServerBuilder() {
@@ -1798,6 +1799,26 @@ public final class ServerBuilder implements TlsSetters {
     }
 
     /**
+     * Sets the {@link Function} that transforms the absolute URI in an HTTP/1 request line
+     * into an absolute path. Use this property when you have to handle a client that sends
+     * such an HTTP/1 request, because Armeria always assumes that request path is an absolute path and
+     * return a {@code 400 Bad Request} response otherwise. For example:
+     * <pre>{@code
+     * builder.absoluteUriTransformer(absoluteUri ->
+     *   // https://foo.com/bar -> /bar
+     *   return absoluteUri.replaceFirst("^https://\\.foo\\.com/", "/");
+     *   // or..
+     *   // return "/proxy?uri=" + URLEncoder.encode(absoluteUri);
+     * );
+     * }</pre>
+     */
+    @UnstableApi
+    public ServerBuilder absoluteUriTransformer(Function<? super String, String> absoluteUriTransformer) {
+        this.absoluteUriTransformer = requireNonNull(absoluteUriTransformer, "absoluteUriTransformer");
+        return this;
+    }
+
+    /**
      * Sets the {@link Http1HeaderNaming} which converts a lower-cased HTTP/2 header name into
      * another HTTP/1 header name. This is useful when communicating with a legacy system that only supports
      * case sensitive HTTP/1 headers.
@@ -1939,7 +1960,8 @@ public final class ServerBuilder implements TlsSetters {
                 meterRegistry, proxyProtocolMaxTlvSize, channelOptions, newChildChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, requestIdGenerator, errorHandler, sslContexts,
-                http1HeaderNaming, dependencyInjector, ImmutableList.copyOf(shutdownSupports));
+                http1HeaderNaming, dependencyInjector, absoluteUriTransformer,
+                ImmutableList.copyOf(shutdownSupports));
     }
 
     /**
@@ -2034,6 +2056,6 @@ public final class ServerBuilder implements TlsSetters {
                 proxyProtocolMaxTlvSize, gracefulShutdownQuietPeriod, gracefulShutdownTimeout, null,
                 meterRegistry, channelOptions, childChannelOptions,
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
-                enableServerHeader, enableDateHeader, dependencyInjector);
+                enableServerHeader, enableDateHeader, dependencyInjector, absoluteUriTransformer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
@@ -295,4 +296,11 @@ public interface ServerConfig {
      * Returns the {@link DependencyInjector} that injects dependencies in annotations.
      */
     DependencyInjector dependencyInjector();
+
+    /**
+     * Returns the {@link Function} that transforms the absolute URI in an HTTP/1 request line
+     * into an absolute path.
+     */
+    @UnstableApi
+    Function<String, String> absoluteUriTransformer();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -285,6 +285,11 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
+    public Function<String, String> absoluteUriTransformer() {
+        return delegate.absoluteUriTransformer();
+    }
+
+    @Override
     public String toString() {
         return delegate.toString();
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -275,14 +276,9 @@ class ArmeriaHttpUtilTest {
         final HttpRequest originReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello", headers);
 
-        final InetSocketAddress socketAddress = new InetSocketAddress(36462);
-        final Channel channel = mock(Channel.class);
-        when(channel.localAddress()).thenReturn(socketAddress);
+        final ChannelHandlerContext ctx = mockChannelHandlerContext();
 
-        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        when(ctx.channel()).thenReturn(channel);
-
-        RequestHeaders armeriaHeaders = toArmeria(ctx, originReq, serverConfig(), "http");
+        RequestHeaders armeriaHeaders = toArmeria(ctx, originReq, serverConfig(), "http", Function.identity());
         assertThat(armeriaHeaders.get(HttpHeaderNames.HOST)).isEqualTo("bar");
         assertThat(armeriaHeaders.authority()).isEqualTo("bar");
         assertThat(armeriaHeaders.scheme()).isEqualTo("http");
@@ -290,7 +286,7 @@ class ArmeriaHttpUtilTest {
 
         // Remove Host header.
         headers.remove(HttpHeaderNames.HOST);
-        armeriaHeaders = toArmeria(ctx, originReq, serverConfig(), "https");
+        armeriaHeaders = toArmeria(ctx, originReq, serverConfig(), "https", Function.identity());
         assertThat(armeriaHeaders.get(HttpHeaderNames.HOST)).isEqualTo("foo:36462"); // The default hostname.
         assertThat(armeriaHeaders.authority()).isEqualTo("foo:36462");
         assertThat(armeriaHeaders.scheme()).isEqualTo("https");
@@ -298,39 +294,83 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void pathValidation() throws Exception {
-        final InetSocketAddress socketAddress = new InetSocketAddress(36462);
-        final Channel channel = mock(Channel.class);
-        when(channel.localAddress()).thenReturn(socketAddress);
+    void absoluteUriTransformation() throws URISyntaxException {
+        final String requestUri = "https://foo.com/bar";
+        final ChannelHandlerContext ctx = mockChannelHandlerContext();
 
-        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        when(ctx.channel()).thenReturn(channel);
+        // Should fail with an invalid path.
+        assertThatThrownBy(() -> toArmeria(
+                ctx, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "../.."),
+                serverConfig(), "http", Function.identity()))
+                .isInstanceOf(URISyntaxException.class)
+                .hasMessageContaining("neither origin form nor asterisk form")
+                .hasMessageContaining("../..");
+
+        // Should fail without any transformation.
+        final HttpRequest originReq = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, requestUri, new DefaultHttpHeaders());
+        assertThatThrownBy(() -> toArmeria(ctx, originReq, serverConfig(), "http", Function.identity()))
+                .isInstanceOf(URISyntaxException.class)
+                .hasMessageContaining("neither origin form nor asterisk form")
+                .hasMessageContaining(requestUri);
+
+        // Should pass with correct transformation.
+        RequestHeaders armeriaHeaders = toArmeria(
+                ctx, originReq, serverConfig(), "http", absoluteUri -> {
+                    assertThat(absoluteUri).isEqualTo(requestUri);
+                    return "/alice";
+                });
+
+        assertThat(armeriaHeaders.path()).isEqualTo("/alice");
+
+        // Should pass even with a non-HTTP absolute URI.
+        final String requestUri2 = "ftp://bar.com/qux";
+        final HttpRequest originReq2 = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, requestUri2, new DefaultHttpHeaders());
+        armeriaHeaders = toArmeria(
+                ctx, originReq2, serverConfig(), "http", absoluteUri -> {
+                    assertThat(absoluteUri).isEqualTo(requestUri2);
+                    return "/bob";
+                });
+
+        assertThat(armeriaHeaders.path()).isEqualTo("/bob");
+
+        // Should fail when transformed path is not a valid HTTP/2 path yet.
+        assertThatThrownBy(() -> toArmeria(ctx, originReq, serverConfig(), "http", absoluteUri -> "../.."))
+                .isInstanceOf(URISyntaxException.class)
+                .hasMessageContaining("neither origin form nor asterisk form")
+                .hasMessageContaining(requestUri);
+    }
+
+    @Test
+    void pathValidation() throws Exception {
+        final ChannelHandlerContext ctx = mockChannelHandlerContext();
 
         // Should not be overly strict, e.g. allow `"` in the path.
         final HttpRequest doubleQuoteReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/\"?\"",
                                        new DefaultHttpHeaders());
-        RequestHeaders armeriaHeaders = toArmeria(ctx, doubleQuoteReq, serverConfig(), "http");
+        RequestHeaders armeriaHeaders = toArmeria(ctx, doubleQuoteReq, serverConfig(), "http", null);
         assertThat(armeriaHeaders.path()).isEqualTo("/\"?\"");
 
         // Should accept an asterisk request.
         final HttpRequest asteriskReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "*", new DefaultHttpHeaders());
-        armeriaHeaders = toArmeria(ctx, asteriskReq, serverConfig(), "http");
+        armeriaHeaders = toArmeria(ctx, asteriskReq, serverConfig(), "http", null);
         assertThat(armeriaHeaders.path()).isEqualTo("*");
 
         // Should reject an absolute URI.
         final HttpRequest absoluteUriReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
                                        "http://example.com/hello", new DefaultHttpHeaders());
-        assertThatThrownBy(() -> toArmeria(ctx, absoluteUriReq, serverConfig(), "http"))
+        assertThatThrownBy(() -> toArmeria(ctx, absoluteUriReq, serverConfig(), "http", null))
                 .isInstanceOf(URISyntaxException.class)
                 .hasMessageContaining("neither origin form nor asterisk form");
 
         // Should not accept a path that starts with an asterisk.
         final HttpRequest badAsteriskReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "*/", new DefaultHttpHeaders());
-        assertThatThrownBy(() -> toArmeria(ctx, badAsteriskReq, serverConfig(), "http"))
+        assertThatThrownBy(() -> toArmeria(ctx, badAsteriskReq, serverConfig(), "http", null))
                 .isInstanceOf(URISyntaxException.class)
                 .hasMessageContaining("neither origin form nor asterisk form");
     }
@@ -558,12 +598,7 @@ class ArmeriaHttpUtilTest {
     void toArmeriaRequestHeaders() {
         final Http2Headers in = new ArmeriaHttp2Headers().set("a", "b");
 
-        final InetSocketAddress socketAddress = new InetSocketAddress(36462);
-        final Channel channel = mock(Channel.class);
-        when(channel.localAddress()).thenReturn(socketAddress);
-
-        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        when(ctx.channel()).thenReturn(channel);
+        final ChannelHandlerContext ctx = mockChannelHandlerContext();
 
         in.set(HttpHeaderNames.METHOD, "GET")
           .set(HttpHeaderNames.PATH, "/");
@@ -617,5 +652,15 @@ class ArmeriaHttpUtilTest {
                                     .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                                     .build();
         return server.config();
+    }
+
+    private static ChannelHandlerContext mockChannelHandlerContext() {
+        final InetSocketAddress socketAddress = new InetSocketAddress(36462);
+        final Channel channel = mock(Channel.class);
+        when(channel.localAddress()).thenReturn(socketAddress);
+
+        final ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        return ctx;
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/AbsoluteRequestUriTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbsoluteRequestUriTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.Socket;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class AbsoluteRequestUriTest {
+
+    private static final HttpService service = (ctx, req) -> {
+        return HttpResponse.of(firstNonNull(ctx.queryParam("uri"), "<null>"));
+    };
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.absoluteUriTransformer(absoluteUri -> {
+                try {
+                    return "/proxy?uri=" + URLEncoder.encode(absoluteUri, "ISO-8859-1");
+                } catch (UnsupportedEncodingException e) {
+                    return Exceptions.throwUnsafely(e);
+                }
+            });
+
+            sb.service("/proxy", service);
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension serverWithExceptionThrowingTransformer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.absoluteUriTransformer(absoluteUri -> {
+                throw new RuntimeException("oops!");
+            });
+
+            sb.service("/proxy", service);
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension serverWithNullReturningTransformer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.absoluteUriTransformer(absoluteUri -> null);
+            sb.service("/proxy", service);
+        }
+    };
+
+    @Test
+    void absoluteUriTransformation() throws Exception {
+        assertThat(sendRequest(server))
+                .startsWith("HTTP/1.1 200 OK\r\n")
+                .endsWith("\r\nhttps://foo.com/bar");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("badServers")
+    void illegalAbsoluteUriTransformer(String serverName, ServerExtension server) throws Exception {
+        assertThat(sendRequest(server))
+                .startsWith("HTTP/1.1 400 Bad Request\r\n");
+    }
+
+    static List<Object[]> badServers() {
+        return ImmutableList.of(
+                new Object[] { "exceptionThrowing", serverWithExceptionThrowingTransformer },
+                new Object[] { "nullReturning", serverWithNullReturningTransformer });
+    }
+
+    private static String sendRequest(ServerExtension server) throws IOException {
+        try (Socket s = new Socket()) {
+            s.connect(server.httpSocketAddress());
+            s.getOutputStream().write(
+                    ("GET https://foo.com/bar HTTP/1.1\r\n" +
+                     "Host: localhost\r\n" +
+                     "Connection: close\r\n" +
+                     "\r\n").getBytes(StandardCharsets.US_ASCII));
+            return new String(ByteStreams.toByteArray(s.getInputStream()),
+                              StandardCharsets.US_ASCII);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

HTTP/1 allows a client to send a request whose request path is actually an absolute URI:

    GET https://foo.com/bar HTTP/1.1
    Host: proxy.com

However, Armeria does not accept such a request and returns a 400 Bad Request response.

Unfortunately, we can't allow such absolute URIs as they are because:

- Armeria's HTTP message model is based on HTTP/2, which doesn't allow an absolute path in `:path` pseudo header.
- Existing Armeria applications also assume that a request path is always an absolute path in Armeria.

Modifications:

- Added a new configuration property named `absoluteUriTransformer` that allows a user to transform the absolute URI in an HTTP/1 request into an absolute path. e.g.
  ```java
  builder.absoluteUriTransformer(absoluteUri -> {
    // https://foo.com/bar -> /bar
    return absoluteUri.replaceFirst("^https://\\.foo\\.com/", "/");
    // or..
    // return "/proxy?uri=" + URLEncoder.encode(absoluteUri);
  });
  ```
- Modified `Http1RequestDecoder` and `ArmeriaHttpUtil` so they apply the `absoluteUriTransformer` function when convering a Netty HTTP/1 request into Armeria HTTP/2 headers.

Result:

- A user can now handle an HTTP/1 request with an absolute URI using Armeria.
- Closes #4681