### PR TITLE
Return 400 Bad request when `absoluteUriTransformer` returns an empty…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -727,7 +727,7 @@ public final class ArmeriaHttpUtil {
             throw newInvalidPathException(path);
         }
 
-        if (newPath == null) {
+        if (newPath == null || newPath.isEmpty()) {
             warnNullReturningAbsoluteUriTransformer();
             throw newInvalidPathException(path);
         }

--- a/core/src/test/java/com/linecorp/armeria/server/AbsoluteRequestUriTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbsoluteRequestUriTest.java
@@ -80,6 +80,15 @@ class AbsoluteRequestUriTest {
         }
     };
 
+    @RegisterExtension
+    static final ServerExtension serverWithEmptyStringReturningTransformer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.absoluteUriTransformer(absoluteUri -> "");
+            sb.service("/proxy", service);
+        }
+    };
+
     @Test
     void absoluteUriTransformation() throws Exception {
         assertThat(sendRequest(server))
@@ -97,7 +106,8 @@ class AbsoluteRequestUriTest {
     static List<Object[]> badServers() {
         return ImmutableList.of(
                 new Object[] { "exceptionThrowing", serverWithExceptionThrowingTransformer },
-                new Object[] { "nullReturning", serverWithNullReturningTransformer });
+                new Object[] { "nullReturning", serverWithNullReturningTransformer },
+                new Object[] { "emptyStringReturning", serverWithEmptyStringReturningTransformer });
     }
 
     private static String sendRequest(ServerExtension server) throws IOException {


### PR DESCRIPTION
… path

Motivation:

https://github.com/line/armeria/pull/4726 is merged before https://github.com/line/armeria/pull/4726#discussion_r1127995230 is addressed.

Modifications:

- Reject a request if a transformed path is empty.

Result:

An empty path is rejected with 400 Bad Request

