### PR TITLE
Automatically delete branch if `Update public suffix list` PR is merged

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,3 +7,10 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+  - name: Delete head branch after merge
+    conditions:
+      - author=github-actions[bot]
+      - title=Update public suffix list
+      - merged
+    actions:
+      delete_head_branch:


### PR DESCRIPTION
Motivation:

According to the documentation of [create-pull-request](https://github.com/marketplace/actions/create-pull-request#action-inputs), a branch has to be removed if `delete-branch` option is set to true.
https://github.com/line/armeria/blob/42129136e355542060967faaf10e243255343af5/.github/workflows/public-suffixes.yml#L48
I don't know why but it does not work as it is configured. 🤔

Mergify also provides an option that deletes the branch when a PR is merged. We can try the option as a workaround.
https://docs.mergify.com/actions/delete_head_branch/

Modifications:

- Add a new step that removes the head branch of a pull request.
  - This option is applied to the automatically generated PR.

Result:

Automatically delete `update-public-suffixes` after merging.

