### PR TITLE
Fix javadocs for `WeightedRoundRobinSelector`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -47,7 +47,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
      * <ul>
      *   <li>if endpoint weights are 1,1,1 (or 2,2,2), then select result is abc abc ...</li>
      *   <li>if endpoint weights are 1,2,3 (or 2,4,6), then select result is abcbcc(or abcabcbcbccc) ...</li>
-     *   <li>if endpoint weights are 3,5,7, then select result is abcabcabcbcbcbb abcabcabcbcbcbb ...</li>
+     *   <li>if endpoint weights are 3,5,7, then select result is abcabcabcbcbccc abcabcabcbcbccc ...</li>
      * </ul>
      */
     private static final class WeightedRoundRobinSelector extends AbstractEndpointSelector {


### PR DESCRIPTION
Motivation:

Typo in `WeightedRoundRobinSelector` javadoc 

Modifications:

Below javadoc should be modified. It seems that the weights are 3, 5, 7 but the javadoc indicates as if `b` has the highest weight. 

<as-is>
`if endpoint weights are 3,5,7, then select result is abcabcabcbcbcbb abcabcabcbcbcbb ...`

<to-be>
`if endpoint weights are 3,5,7, then select result is abcabcabcbcbccc abcabcabcbcbccc ...`

Result:

Fix typo 

