### PR TITLE
Ensure `DnsResolver` is executed by `EventLoop`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupBuilder.java
@@ -71,14 +71,15 @@ public final class DnsAddressEndpointGroupBuilder extends DnsEndpointGroupBuilde
      * Returns a newly created {@link DnsAddressEndpointGroup}.
      */
     public DnsAddressEndpointGroup build() {
+        final EventLoop eventLoop = getOrAcquireEventLoop();
         final DefaultDnsResolver resolver = buildResolver(builder -> {
             if (resolvedAddressTypes != null) {
                 builder.resolvedAddressTypes(resolvedAddressTypes);
             }
-        });
+        }, eventLoop);
         return new DnsAddressEndpointGroup(selectionStrategy(), shouldAllowEmptyEndpoints(),
                                            selectionTimeoutMillis(), resolver,
-                                           eventLoop(), backoff(), minTtl(), maxTtl(),
+                                           eventLoop, backoff(), minTtl(), maxTtl(),
                                            resolvedAddressTypes, hostname(), port, dnsQueryListeners());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -67,11 +67,15 @@ abstract class DnsEndpointGroupBuilder
         return hostname;
     }
 
+    /**
+     * Returns the {@link EventLoop} set via {@link #eventLoop(EventLoop)} or acquires a random
+     * {@link EventLoop} from {@link CommonPools#workerGroup()}.
+     */
     final EventLoop eventLoop() {
         if (eventLoop != null) {
             return eventLoop;
         } else {
-            return CommonPools.workerGroup().next();
+            return eventLoop = CommonPools.workerGroup().next();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -71,11 +71,11 @@ abstract class DnsEndpointGroupBuilder
      * Returns the {@link EventLoop} set via {@link #eventLoop(EventLoop)} or acquires a random
      * {@link EventLoop} from {@link CommonPools#workerGroup()}.
      */
-    final EventLoop eventLoop() {
+    final EventLoop getOrAcquireEventLoop() {
         if (eventLoop != null) {
             return eventLoop;
         } else {
-            return eventLoop = CommonPools.workerGroup().next();
+            return CommonPools.workerGroup().next();
         }
     }
 
@@ -148,12 +148,11 @@ abstract class DnsEndpointGroupBuilder
         return dnsDynamicEndpointGroupBuilder.selectionTimeoutMillis();
     }
 
-    final DefaultDnsResolver buildResolver() {
-        return buildResolver(unused -> {});
+    final DefaultDnsResolver buildResolver(EventLoop eventLoop) {
+        return buildResolver(unused -> {}, eventLoop);
     }
 
-    final DefaultDnsResolver buildResolver(Consumer<DnsNameResolverBuilder> customizer) {
-        final EventLoop eventLoop = eventLoop();
+    final DefaultDnsResolver buildResolver(Consumer<DnsNameResolverBuilder> customizer, EventLoop eventLoop) {
         final DnsNameResolverBuilder resolverBuilder = new DnsNameResolverBuilder(eventLoop);
         customizer.accept(resolverBuilder);
         buildConfigurator(eventLoop.parent()).accept(resolverBuilder);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -43,9 +43,10 @@ public final class DnsServiceEndpointGroupBuilder extends DnsEndpointGroupBuilde
      * Returns a newly created {@link DnsServiceEndpointGroup}.
      */
     public DnsServiceEndpointGroup build() {
+        final EventLoop eventLoop = getOrAcquireEventLoop();
         return new DnsServiceEndpointGroup(selectionStrategy(), shouldAllowEmptyEndpoints(),
-                                           selectionTimeoutMillis(), buildResolver(),
-                                           eventLoop(), backoff(), minTtl(), maxTtl(),
+                                           selectionTimeoutMillis(), buildResolver(eventLoop),
+                                           eventLoop, backoff(), minTtl(), maxTtl(),
                                            hostname(), dnsQueryListeners());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsTextEndpointGroupBuilder.java
@@ -50,9 +50,10 @@ public final class DnsTextEndpointGroupBuilder extends DnsEndpointGroupBuilder {
      * Returns a newly created {@link DnsTextEndpointGroup}.
      */
     public DnsTextEndpointGroup build() {
+        final EventLoop eventLoop = getOrAcquireEventLoop();
         return new DnsTextEndpointGroup(selectionStrategy(), shouldAllowEmptyEndpoints(),
-                                        selectionTimeoutMillis(), buildResolver(),
-                                        eventLoop(), backoff(), minTtl(), maxTtl(),
+                                        selectionTimeoutMillis(), buildResolver(eventLoop),
+                                        eventLoop, backoff(), minTtl(), maxTtl(),
                                         hostname(), mapping, dnsQueryListeners());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolver.java
@@ -85,6 +85,7 @@ public final class DefaultDnsResolver implements SafeCloseable {
     }
 
     private CompletableFuture<List<DnsRecord>> resolveOne(DnsQuestionContext ctx, DnsQuestion question) {
+        assert executor.inEventLoop();
         final CompletableFuture<List<DnsRecord>> future = delegate.resolve(ctx, question);
         ctx.whenCancelled().handle((unused0, unused1) -> {
             if (!future.isDone()) {
@@ -104,6 +105,7 @@ public final class DefaultDnsResolver implements SafeCloseable {
     @VisibleForTesting
     CompletableFuture<List<DnsRecord>> resolveAll(DnsQuestionContext ctx, List<? extends DnsQuestion> questions,
                                                   String logPrefix) {
+        assert executor.inEventLoop();
         final CompletableFuture<List<DnsRecord>> future = new CompletableFuture<>();
         final Object[] results = new Object[questions.size()];
         for (int i = 0; i < questions.size(); i++) {

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -33,6 +33,7 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -344,9 +345,8 @@ class RefreshingAddressResolverTest {
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED);
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
                 final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
-                final Future<InetSocketAddress> future = eventLoop.submit(() -> {
-                    return resolver.resolve(InetSocketAddress.createUnresolved("foo.com", 36462));
-                }).get();
+                final Future<InetSocketAddress> future = resolver.resolve(
+                        InetSocketAddress.createUnresolved("foo.com", 36462));
                 assertHostAddress(future).isEqualTo("0:0:0:0:0:0:0:1");
             }
         }
@@ -397,7 +397,7 @@ class RefreshingAddressResolverTest {
     }
 
     @Test
-    void shouldRefreshWhenDnsCacheIsExpired() {
+    void shouldRefreshWhenDnsCacheIsExpired() throws ExecutionException, InterruptedException {
         try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
                 new DefaultDnsQuestion("foo.com.", A),
                 new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1"))))
@@ -419,12 +419,12 @@ class RefreshingAddressResolverTest {
             final Future<InetSocketAddress> foo0 = resolver.resolve(
                     InetSocketAddress.createUnresolved("foo.com", 36462));
             await().untilAsserted(() -> assertThat(foo0.isSuccess()).isTrue());
-            final InetSocketAddress fooAddress0 = foo0.getNow();
+            final InetSocketAddress fooAddress0 = foo0.get();
             final CacheEntry fooCache0 = cache.getIfPresent("foo.com");
 
             final Future<InetSocketAddress> foo1 = resolver.resolve(
                     InetSocketAddress.createUnresolved("foo.com", 36462));
-            final InetSocketAddress fooAddress1 = foo1.getNow();
+            final InetSocketAddress fooAddress1 = foo1.get();
             assertThat(fooAddress1).isEqualTo(fooAddress0);
             final CacheEntry fooCache1 = cache.getIfPresent("foo.com");
             assertThat(fooCache1.address()).isSameAs(fooCache0.address());
@@ -437,7 +437,7 @@ class RefreshingAddressResolverTest {
             final Future<InetSocketAddress> foo2 = resolver.resolve(
                     InetSocketAddress.createUnresolved("foo.com", 36462));
             await().untilAsserted(() -> assertThat(foo2.isSuccess()).isTrue());
-            final InetSocketAddress fooAddress2 = foo2.getNow();
+            final InetSocketAddress fooAddress2 = foo2.get();
             final CacheEntry fooCache2 = cache.getIfPresent("foo.com");
             // The address has been refreshed.
             assertThat(fooCache2.address()).isNotSameAs(fooCache1.address());
@@ -447,7 +447,7 @@ class RefreshingAddressResolverTest {
     }
 
     @Test
-    void shouldRefreshWhenSearchDnsCacheIsExpired() throws InterruptedException {
+    void shouldRefreshWhenSearchDnsCacheIsExpired() throws InterruptedException, ExecutionException {
         try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
                 new DefaultDnsQuestion("foo.com.", A),
                 new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1")),
@@ -487,12 +487,12 @@ class RefreshingAddressResolverTest {
                     InetSocketAddress.createUnresolved("foo.com", 36462));
             // Should resolve search domain IP
             assertIpAddress(foo0).isEqualTo("2.2.2.2");
-            final InetSocketAddress fooAddress0 = foo0.getNow();
+            final InetSocketAddress fooAddress0 = foo0.get();
 
             final CacheEntry fooCache0 = cache.getIfPresent("foo.com");
             final Future<InetSocketAddress> foo1 = resolver.resolve(
                     InetSocketAddress.createUnresolved("foo.com", 36462));
-            final InetSocketAddress fooAddress1 = foo1.getNow();
+            final InetSocketAddress fooAddress1 = foo1.get();
             assertThat(fooAddress1).isEqualTo(fooAddress0);
             final CacheEntry fooCache1 = cache.getIfPresent("foo.com");
             assertThat(fooCache1.address()).isSameAs(fooCache0.address());

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -344,8 +344,9 @@ class RefreshingAddressResolverTest {
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_PREFERRED);
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
                 final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
-                final Future<InetSocketAddress> future = resolver.resolve(
-                        InetSocketAddress.createUnresolved("foo.com", 36462));
+                final Future<InetSocketAddress> future = eventLoop.submit(() -> {
+                    return resolver.resolve(InetSocketAddress.createUnresolved("foo.com", 36462));
+                }).get();
                 assertHostAddress(future).isEqualTo("0:0:0:0:0:0:0:1");
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilderTest.java
@@ -48,9 +48,9 @@ class DnsEndpointGroupBuilderTest {
 
     @Test
     void eventLoop() {
-        assertThat(builder().eventLoop()).isNotNull();
+        assertThat(builder().getOrAcquireEventLoop()).isNotNull();
         final EventLoop loop = new NioEventLoopGroup().next();
-        assertThat(builder().eventLoop(loop).eventLoop()).isSameAs(loop);
+        assertThat(builder().eventLoop(loop).getOrAcquireEventLoop()).isSameAs(loop);
         assertThatThrownBy(() -> builder().eventLoop(new DefaultEventLoop()))
                 .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("unsupported");
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolverTest.java
@@ -167,7 +167,7 @@ class DefaultDnsResolverTest {
             }
 
             final CompletableFuture<List<DnsRecord>> result =
-                    resolver.resolveAll(ctx, questions, "");
+                    eventLoop.submit(() -> resolver.resolveAll(ctx, questions, "")).get();
 
             final List<DnsRecord> records = result.join();
 
@@ -182,8 +182,7 @@ class DefaultDnsResolverTest {
             assertThat(records.size()).isOne();
             final ByteArrayDnsRecord dnsRecord = (ByteArrayDnsRecord) records.get(0);
             assertThat(dnsRecord.type()).isEqualTo(DnsRecordType.A);
-            final ByteArrayDnsRecord dnsRawRecord = dnsRecord;
-            assertThat(NetUtil.bytesToIpAddress(dnsRawRecord.content())).isEqualTo("1.2.3.4");
+            assertThat(NetUtil.bytesToIpAddress(dnsRecord.content())).isEqualTo("1.2.3.4");
 
             resolver.close();
         }


### PR DESCRIPTION
Motivation:

Implementing #4695, I assumed that a DNS resolver is executed by an event loop.
- `DnsEndpointGroup` schedules DNS queries using an event loop.
https://github.com/line/armeria/blob/10583eb0f34e0de9ef38654d808b1ce3db7eb0c2/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java#L115
- `RefreshingAddressResolver.doResolve(...)` is invoked by the event loop that is set to `DnsResolverGroupBuilder`.
https://github.com/line/armeria/blob/39efeb240b95c8969c81e94eca8ed07f1f4026df/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java#L107

However, both assumptions were wrong.
- `DnsEndpointGroup` and `DefaultDnsResolver` can have different event loops if no event loops are specified. Because `DnsEndpointGroupBuilder.eventLoop()` returns a random event loop which is called twice if no executor is configured.
https://github.com/line/armeria/blob/97a17cb1e6671a8b73a61b45b3e460784adcf214/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java#L74
- `RefreshingAddressResolver.doResolve(...)` is directly called by the caller thread without switching to an event loop.

This bug may affect the following failure during CI builds.
```
DefaultDnsResolverTest > resolveLessPreferredQuestionFirst(ResolvedAddressTypes) > com.linecorp.armeria.internal.client.dns.DefaultDnsResolverTest.resolveLessPreferredQuestionFirst(ResolvedAddressTypes)[1] FAILED
    java.util.concurrent.CompletionException: com.linecorp.armeria.client.DnsTimeoutException: [] [DefaultDnsQuestion(foo.com. IN A), DefaultDnsQuestion(foo.com. IN AAAA)] is timed out after 5000 milliseconds.
        at java.base/java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:412)
        at java.base/java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2044)
        at com.linecorp.armeria.internal.client.dns.DefaultDnsResolverTest.resolveLessPreferredQuestionFirst(DefaultDnsResolverTest.java:172)

        Caused by:
        com.linecorp.armeria.client.DnsTimeoutException: [] [DefaultDnsQuestion(foo.com. IN A), DefaultDnsQuestion(foo.com. IN AAAA)] is timed out after 5000 milliseconds.
```

I am not 100% sure that the exact cause of the problem but the problem has gone after executing the test DNS queries on an event loop.

Modifications:

- Use the event loop bound to the DNS resolver to execute DNS queries.

Result:

Make sure to execute `DnsResolver` in a single thread environment.