### PR TITLE
Prevent self reference in addSuppressed

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -145,18 +145,15 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
                     final Throwable firstCause = first.cause();
                     final Throwable secondCause = second.cause();
 
-                    Throwable combinedCause = null;
-                    if (firstCause != null) {
+                    final Throwable combinedCause;
+                    if (firstCause == null) {
+                        combinedCause = secondCause;
+                    } else {
+                        if (secondCause != null && secondCause != firstCause) {
+                            firstCause.addSuppressed(secondCause);
+                        }
                         combinedCause = firstCause;
                     }
-                    if (secondCause != null) {
-                        if (combinedCause == null) {
-                            combinedCause = secondCause;
-                        } else {
-                            combinedCause.addSuppressed(secondCause);
-                        }
-                    }
-
                     if (combinedCause != null) {
                         promise.setFailure(combinedCause);
                     } else {


### PR DESCRIPTION
Motivation:

Prevent an **IllegalArgumentException** from being thrown when the following conditions match
- `Http1VerboseWriteException` is sampled
- Both calls to `Http1ObjectEncoder.write` fail for the same reason (same `Throwable` instance)

Modifications:

- Fix Throwable combination code

Result:

- Closes #4749