### PR TITLE
Fix `#` character encoding in URIs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -57,7 +57,7 @@ public final class PathAndQuery {
     /**
      * The lookup table for the characters that whose percent encoding must be preserved
      * when used in a query string because whether they are percent-encoded or not affects
-     * their semantics. For example, 'A%3dB=1' should NOT be encoded into 'A=B=1' because
+     * their semantics. For example, 'A%3dB=1' should NOT be normalized into 'A=B=1' because
      * 'A=B=1` means 'A' is 'B=1' but 'A%3dB=1' means 'A=B' is '1'.
      */
     private static final BitSet MUST_PRESERVE_ENCODING_IN_QUERY = new BitSet();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/PathAndQuery.java
@@ -55,9 +55,12 @@ public final class PathAndQuery {
     private static final BitSet ALLOWED_QUERY_CHARS = new BitSet();
 
     /**
-     * The lookup table for the reserved characters that require percent-encoding.
+     * The lookup table for the characters that whose percent encoding must be preserved
+     * when used in a query string because whether they are percent-encoded or not affects
+     * their semantics. For example, 'A%3dB=1' should NOT be encoded into 'A=B=1' because
+     * 'A=B=1` means 'A' is 'B=1' but 'A%3dB=1' means 'A=B' is '1'.
      */
-    private static final BitSet RESERVED_CHARS = new BitSet();
+    private static final BitSet MUST_PRESERVE_ENCODING_IN_QUERY = new BitSet();
 
     /**
      * The table that converts a byte into a percent-encoded chars, e.g. 'A' -> "%41".
@@ -65,21 +68,21 @@ public final class PathAndQuery {
     private static final char[][] TO_PERCENT_ENCODED_CHARS = new char[256][];
 
     static {
-        final String allowedPathChars =
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#@!$&'()*+,;=";
+        final String commonAllowedChars =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?@!$&'()*,;=";
+        final String allowedPathChars = commonAllowedChars + '+';
         for (int i = 0; i < allowedPathChars.length(); i++) {
             ALLOWED_PATH_CHARS.set(allowedPathChars.charAt(i));
         }
 
-        final String allowedQueryChars =
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*,;=";
+        final String allowedQueryChars = commonAllowedChars + "[]";
         for (int i = 0; i < allowedQueryChars.length(); i++) {
             ALLOWED_QUERY_CHARS.set(allowedQueryChars.charAt(i));
         }
 
-        final String reservedChars = ":/?#[]@!$&'()*+,;=";
-        for (int i = 0; i < reservedChars.length(); i++) {
-            RESERVED_CHARS.set(reservedChars.charAt(i));
+        final String mustPreserveEncodingInQuery = ":/?[]@!$&'()*+,;=";
+        for (int i = 0; i < mustPreserveEncodingInQuery.length(); i++) {
+            MUST_PRESERVE_ENCODING_IN_QUERY.set(mustPreserveEncodingInQuery.charAt(i));
         }
 
         for (int i = 0; i < TO_PERCENT_ENCODED_CHARS.length; i++) {
@@ -308,7 +311,7 @@ public final class PathAndQuery {
                     }
                 } else {
                     // If query:
-                    if (RESERVED_CHARS.get(decoded)) {
+                    if (MUST_PRESERVE_ENCODING_IN_QUERY.get(decoded)) {
                         buf.ensure(1);
                         buf.addEncoded((byte) decoded);
                         wasSlash = false;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -28,6 +28,7 @@ import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
+import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.annotation.Nullable;
 
@@ -463,15 +464,16 @@ class PathAndQueryTest {
 
     @Test
     void sharp() {
+        // '#' must be encoded into '%23'.
         final PathAndQuery res = parse("/#?a=b#1");
         assertThat(res).isNotNull();
-        assertThat(res.path()).isEqualTo("/#");
-        assertThat(res.query()).isEqualTo("a=b#1");
+        assertThat(res.path()).isEqualTo("/%23");
+        assertThat(res.query()).isEqualTo("a=b%231");
 
-        // '%23' in a query string should never be decoded into '#'.
+        // '%23' should never be decoded into '#'.
         final PathAndQuery res2 = parse("/%23?a=b%231");
         assertThat(res2).isNotNull();
-        assertThat(res2.path()).isEqualTo("/#");
+        assertThat(res2.path()).isEqualTo("/%23");
         assertThat(res2.query()).isEqualTo("a=b%231");
     }
 
@@ -479,14 +481,14 @@ class PathAndQueryTest {
     void allReservedCharacters() {
         final PathAndQuery res = parse("/#/:@!$&'()*+,;=?a=/#/:[]@!$&'()*+,;=");
         assertThat(res).isNotNull();
-        assertThat(res.path()).isEqualTo("/#/:@!$&'()*+,;=");
-        assertThat(res.query()).isEqualTo("a=/#/:[]@!$&'()*+,;=");
+        assertThat(res.path()).isEqualTo("/%23/:@!$&'()*+,;=");
+        assertThat(res.query()).isEqualTo("a=/%23/:[]@!$&'()*+,;=");
 
         final PathAndQuery res2 =
                 parse("/%23%2F%3A%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
                       "?a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
         assertThat(res2).isNotNull();
-        assertThat(res2.path()).isEqualTo("/#%2F:@!$&'()*+,;=?");
+        assertThat(res2.path()).isEqualTo("/%23%2F:@!$&'()*+,;=?");
         assertThat(res2.query()).isEqualTo("a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
     }
 
@@ -547,13 +549,13 @@ class PathAndQueryTest {
 
     @Test
     void assertSquareBracketsInPath() {
-        final PathAndQuery res = parse("/#/:@[]!$&'()*+,;=");
+        final PathAndQuery res = parse("/@/:[]!$&'()*+,;=");
         assertThat(res).isNotNull();
-        assertThat(res.path()).isEqualTo("/#/:@%5B%5D!$&'()*+,;=");
+        assertThat(res.path()).isEqualTo("/@/:%5B%5D!$&'()*+,;=");
 
         final PathAndQuery res2 =
-                parse("/%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
+                parse("/%40%2F%3A%5B%5D%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
         assertThat(res2).isNotNull();
-        assertThat(res2.path()).isEqualTo("/#%2F:%5B%5D@!$&'()*+,;=?");
+        assertThat(res2.path()).isEqualTo("/@%2F:%5B%5D!$&'()*+,;=?");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/PathAndQueryTest.java
@@ -28,7 +28,6 @@ import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
-import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.annotation.Nullable;
 


### PR DESCRIPTION
Motivation:

When a path or query string contains a `#` character, Armeria normalizes it into `#` regardless whether its percent-encoded or not. For example, the following two paths are normalized into `/#.json`, which is not desirable:

- `/#.json`
- `/%23.json`

Modifications:

- Made `PathAndQuery` always percent-encode `#`.
- Renamed the poorly named `RESERVER_CHARS`.

Result:

- Fixes #4751
- `#` character is now always percent-encoded in both path and query string.