### PR TITLE
Add ServiceRequestContextCaptor.isEmpty()

### DIFF
--- a/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
@@ -172,4 +172,11 @@ public final class ServiceRequestContextCaptor {
     public ServiceRequestContext poll(long timeout, TimeUnit unit) throws InterruptedException {
         return serviceContexts.poll(timeout, unit);
     }
+
+    /**
+     * Returns whether the {@link #size()} of this data is 0.
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
 }

--- a/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
@@ -174,9 +174,9 @@ public final class ServiceRequestContextCaptor {
     }
 
     /**
-     * Returns whether the {@link #size()} of this data is 0.
+     * Returns whether there is any captured {@link ServiceRequestContext}.
      */
     public boolean isEmpty() {
-        return size() == 0;
+        return serviceContexts.isEmpty();
     }
 }


### PR DESCRIPTION
Motivation:

ClientRequestContextCaptor has isEmpty() but ServiceRequestContextCaptor doesn't.

Modifications:

- Add ServiceRequestContextCaptor.isEmpty()

Result:

- Closes #4757 