### PR TITLE
Increase the JVM heap for Gradle to avoid OOME

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ gradle.buildFinished({ result ->
 allprojects {
     // Add common JVM options such as max memory and leak detection.
     tasks.withType(JavaForkOptions) {
-        maxHeapSize = '512m'
+        maxHeapSize = '768m'
 
         if (rootProject.ext.testJavaVersion >= 9) {
             jvmArgs '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ publishPasswordProperty=ossrhPassword
 publishSignatureRequired=true
 
 # Gradle options
-org.gradle.jvmargs=-Xmx1792m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 


### PR DESCRIPTION
Our build still fails when running with JDK 8 even after increasing the max heap size. Increase again, this time to 2GiB. Java compiler's max heap size also has been increased to 768MiB.