### PR TITLE
Fix buffer leak with HEAD requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -229,6 +229,7 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
      * {@link Channel#flush()} when each write unit is done.
      */
     final void writeData(HttpData data) {
+        data.touch(ctx);
         logBuilder.increaseRequestLength(data);
         write(data, data.isEndOfStream());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -147,6 +147,7 @@ abstract class AbstractHttpResponseHandler {
         }
 
         final HttpData content = res.content();
+        content.touch(reqCtx);
         // An aggregated response always has empty content if its status.isContentAlwaysEmpty() is true.
         assert !res.status().isContentAlwaysEmpty() || content.isEmpty();
         final boolean contentEmpty;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -210,6 +210,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                                    .addListener(writeHeadersFutureListener(true));
                 } else {
                     final HttpData data = (HttpData) o;
+                    data.touch(reqCtx);
                     final boolean wroteEmptyData = data.isEmpty();
                     logBuilder().increaseResponseLength(data);
                     if (endOfStream) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -115,6 +115,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
 
         if (failIfStreamOrSessionClosed()) {
             PooledObjects.close(o);
+            setDone(true);
             return;
         }
 
@@ -157,7 +158,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                         state = State.NEEDS_DATA_OR_TRAILERS;
                     }
                     if (endOfStream) {
-                        setDone(false);
+                        setDone(true);
                     }
                     final ServerConfig config = reqCtx.config().server().config();
                     merged = mergeResponseHeaders(headers, reqCtx.additionalResponseHeaders(),

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -50,7 +50,6 @@ class HeadMethodLeakTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.requestTimeoutMillis(0);
             sb.service("/{number}", new HttpService() {
 
                 @Override

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -90,8 +88,6 @@ class HeadMethodLeakTest {
         bufs = new LinkedBlockingDeque<>();
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(HeadMethodLeakTest.class);
-
     @EnumSource(ExchangeType.class)
     @ParameterizedTest
     void shouldReleaseDataWhenHeadMethodIsRequested(ExchangeType exchangeType) throws InterruptedException {
@@ -117,6 +113,5 @@ class HeadMethodLeakTest {
         for (ByteBuf buf : bufs) {
             assertThat(buf.refCnt()).isZero();
         }
-        logger.info("finished : {}", bufs);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpResponseWriter;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.buffer.ByteBuf;
+
+class HeadMethodLeakTest {
+
+    static Queue<ByteBuf> bufs;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.requestTimeoutMillis(0);
+            sb.service("/{number}", new HttpService() {
+
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    return ExchangeType.valueOf(
+                            QueryParams.fromQueryString(routingContext.query()).get("exchangeType"));
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    final int number = Integer.parseInt(ctx.pathParam("number"));
+                    final HttpObject[] objs = new HttpObject[number + 1];
+                    objs[0] = ResponseHeaders.of(HttpStatus.OK);
+                    for (int i = 0; i < number; i++) {
+                        final ByteBuf buf = ctx.alloc().buffer().writeBytes(new byte[] { 1, 2, 3, 4 });
+                        bufs.add(buf);
+                        objs[i + 1] = HttpData.wrap(buf);
+                    }
+                    if (number <= 5) {
+                        return HttpResponse.of(objs);
+                    } else {
+                        final HttpResponseWriter stream = HttpResponse.streaming();
+                        for (HttpObject obj : objs) {
+                            stream.write(obj);
+                        }
+                        stream.close();
+                        return stream;
+                    }
+                }
+            });
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        bufs = new LinkedBlockingDeque<>();
+    }
+
+    @EnumSource(ExchangeType.class)
+    @ParameterizedTest
+    void shouldReleaseDataWhenHeadMethodIsRequested(ExchangeType exchangeType) throws InterruptedException {
+        final BlockingWebClient client = server.blockingWebClient();
+        for (int i = 0; i < 10; i++) {
+            final AggregatedHttpResponse response = client.prepare()
+                                                          .method(HttpMethod.HEAD)
+                                                          .path("/{number}")
+                                                          .pathParam("number", i)
+                                                          .queryParam("exchangeType", exchangeType.name())
+                                                          .execute();
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+            assertThat(response.content().isEmpty()).isTrue();
+        }
+
+        // Make sure all bufs were released by HttpResponseSubscriber.
+        for (ByteBuf buf : bufs) {
+            assertThat(buf.refCnt()).isZero();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -116,7 +116,7 @@ class HeadMethodLeakTest {
         assertThat(response.content().isEmpty()).isTrue();
 
         final ServiceRequestContext sctx = server.requestContextCaptor().take();
-        // Waits for all responses to be cancelled.
+        // Waits for the server response to be cancelled.
         sctx.log().whenComplete().join();
         // Make sure all bufs were released by HttpResponseSubscriber.
         for (ByteBuf buf : bufs) {

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -44,7 +44,7 @@ import io.netty.buffer.ByteBuf;
 
 class HeadMethodLeakTest {
 
-    static Queue<ByteBuf> bufs;
+    private static Queue<ByteBuf> bufs;
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {


### PR DESCRIPTION
Motivation:

If a HEAD request is received, a server should discard the content of a response and return headers only. However, there was a [regression](https://github.com/line/armeria/pull/3956/files#diff-368938fb6a538f212fadf2ca09779cd5a6e05002c393454e7fc4b03361b588ccR153) in which pooled data is not released if the response body has more than two chunks. `setDone(false)` does not cancel the upstream. 
https://github.com/line/armeria/blob/a83388c18b31d400f36ff7346902b30f9c194ee7/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L152-L161 
We should instead use `setDone(true)` to release unconsumed data.

Modifications:

- Cancel an `HttpResponse`'s body if a HEAD method is received or data is published or a stream is closed.

Result:

Fixed a memory leak where a response to a HEAD request is not cleaned up properly.

