### PR TITLE
Fix flaky `HeadMethodLeakTest`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpMessageAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpMessageAggregator.java
@@ -218,9 +218,7 @@ public final class HttpMessageAggregator {
             for (int i = start; i < end; i++) {
                 try (HttpData data = (HttpData) objects.get(i)) {
                     final ByteBuf buf = data.byteBuf();
-                    if (data.isEmpty()) {
-                        data.close();
-                    } else {
+                    if (!data.isEmpty()) {
                         merged.writeBytes(buf, buf.readerIndex(), data.length());
                     }
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -23,9 +23,6 @@ import static com.linecorp.armeria.internal.common.HttpHeadersUtil.mergeTrailers
 
 import java.util.concurrent.CompletableFuture;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpData;
@@ -131,8 +128,6 @@ abstract class AbstractHttpResponseHandler {
         return responseEncoder.isWritable(req.id(), req.streamId());
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractHttpResponseHandler.class);
-
     /**
      * Writes the {@link AggregatedHttpResponse} to the {@link Channel}.
      * Note that the caller has to flush the written data when needed.
@@ -151,10 +146,8 @@ abstract class AbstractHttpResponseHandler {
             disconnectWhenFinished();
         }
 
-        logger.info("4. id: {}, response: {}", reqCtx.id().text(), res);
         final HttpData content = res.content();
         content.touch(reqCtx);
-        logger.info("5. id: {}, response: {}, refCnt: {}", reqCtx.id().text(), res, content.byteBuf().refCnt());
         // An aggregated response always has empty content if its status.isContentAlwaysEmpty() is true.
         assert !res.status().isContentAlwaysEmpty() || content.isEmpty();
         final boolean contentEmpty;
@@ -166,12 +159,6 @@ abstract class AbstractHttpResponseHandler {
             content.close();
         } else {
             contentEmpty = false;
-        }
-        try {
-            logger.info("6. id: {}, response: {}, refCnt: {}, contentEmpty: {}", reqCtx.id().text(), res,
-                        content.byteBuf().refCnt(), contentEmpty);
-        } catch (Exception ex) {
-            logger.warn("id: {}, {}", reqCtx.id().text(), ex.getMessage());
         }
 
         final HttpHeaders trailers = mergeTrailers(res.trailers(), reqCtx.additionalResponseTrailers());

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -151,10 +151,10 @@ abstract class AbstractHttpResponseHandler {
             disconnectWhenFinished();
         }
 
-        logger.info("4. response: {}", res);
+        logger.info("4. id: {}, response: {}", reqCtx.id().text(), res);
         final HttpData content = res.content();
         content.touch(reqCtx);
-        logger.info("5. response: {}, refCnt: {}", res, content.byteBuf().refCnt());
+        logger.info("5. id: {}, response: {}, refCnt: {}", reqCtx.id().text(), res, content.byteBuf().refCnt());
         // An aggregated response always has empty content if its status.isContentAlwaysEmpty() is true.
         assert !res.status().isContentAlwaysEmpty() || content.isEmpty();
         final boolean contentEmpty;
@@ -168,10 +168,10 @@ abstract class AbstractHttpResponseHandler {
             contentEmpty = false;
         }
         try {
-            logger.info("6. response: {}, refCnt: {}, contentEmpty: {}", res, content.byteBuf().refCnt(),
-                        contentEmpty);
+            logger.info("6. id: {}, response: {}, refCnt: {}, contentEmpty: {}", reqCtx.id().text(), res,
+                        content.byteBuf().refCnt(), contentEmpty);
         } catch (Exception ex) {
-            logger.warn(ex.getMessage(), ex);
+            logger.warn("id: {}, {}", reqCtx.id().text(), ex.getMessage());
         }
 
         final HttpHeaders trailers = mergeTrailers(res.trailers(), reqCtx.additionalResponseTrailers());

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -64,7 +64,6 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
     }
 
     private void apply0(@Nullable AggregatedHttpResponse response, @Nullable Throwable cause) {
-        logger.info("1. id: {}, response: {}, cause: {}", reqCtx.id().text(), response, cause);
         clearTimeout();
         if (cause != null) {
             cause = Exceptions.peel(cause);
@@ -73,13 +72,11 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         }
 
         assert response != null;
-        logger.info("2. id: {}, response: {}", reqCtx.id().text(), response);
         if (failIfStreamOrSessionClosed()) {
             response.content().close();
             return;
         }
 
-        logger.info("3. id: {}, response: {}", reqCtx.id().text(), response);
         logBuilder().startResponse();
         write(response, null);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -64,7 +64,7 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
     }
 
     private void apply0(@Nullable AggregatedHttpResponse response, @Nullable Throwable cause) {
-        logger.info("1. response: {}, cause: {}", response, cause);
+        logger.info("1. id: {}, response: {}, cause: {}", reqCtx.id().text(), response, cause);
         clearTimeout();
         if (cause != null) {
             cause = Exceptions.peel(cause);
@@ -73,13 +73,13 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         }
 
         assert response != null;
-        logger.info("2. response: {}", response);
+        logger.info("2. id: {}, response: {}", reqCtx.id().text(), response);
         if (failIfStreamOrSessionClosed()) {
             response.content().close();
             return;
         }
 
-        logger.info("3. response: {}", response);
+        logger.info("3. id: {}, response: {}", reqCtx.id().text(), response);
         logBuilder().startResponse();
         write(response, null);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -33,7 +33,6 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
-import com.linecorp.armeria.unsafe.PooledObjects;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -65,6 +64,7 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
     }
 
     private void apply0(@Nullable AggregatedHttpResponse response, @Nullable Throwable cause) {
+        logger.info("1. response: {}, cause: {}", response, cause);
         clearTimeout();
         if (cause != null) {
             cause = Exceptions.peel(cause);
@@ -73,11 +73,13 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
         }
 
         assert response != null;
+        logger.info("2. response: {}", response);
         if (failIfStreamOrSessionClosed()) {
-            PooledObjects.close(response.content());
+            response.content().close();
             return;
         }
 
+        logger.info("3. response: {}", response);
         logBuilder().startResponse();
         write(response, null);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -127,9 +127,12 @@ class HeadMethodLeakTest {
         // Waits for the server response to be cancelled.
         sctx.log().whenComplete().join();
         // Make sure all bufs were released by HttpResponseSubscriber.
+        logger.info("id: {}, bufs: {}", sctx.id().text(), bufs);
         for (ByteBuf buf : bufs) {
-            logger.info("buf: {}, refCnt: {}", buf, buf.refCnt());
-            assertThat(buf.refCnt()).isZero();
+            logger.info("id: {}, bufs: {}, buf: {}, refCnt: {}", sctx.id().text(), bufs, buf, buf.refCnt());
+            assertThat(buf.refCnt())
+                    .describedAs("id: %s, buf: %s, refCnt: %s", sctx.id().text(), buf, buf.refCnt())
+                    .isZero();
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HeadMethodLeakTest.java
@@ -52,6 +52,7 @@ import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 class HeadMethodLeakTest {
 
@@ -79,7 +80,7 @@ class HeadMethodLeakTest {
                     final HttpObject[] objs = new HttpObject[number + 1];
                     objs[0] = ResponseHeaders.of(HttpStatus.OK);
                     for (int i = 0; i < number; i++) {
-                        final ByteBuf buf = ctx.alloc().buffer().writeBytes(new byte[] { 1, 2, 3, 4 });
+                        final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] { 1, 2, 3, 4 });
                         bufs.add(buf);
                         objs[i + 1] = HttpData.wrap(buf);
                     }


### PR DESCRIPTION
Motivation:

A pooled `ByteBuf` instance is reused so we can't tell its `refCnt` is 0 forever after the `ByteBuf` is freed.
https://github.com/netty/netty/blob/44b7e5b12d8dff3d07dfb773680120cc20f7e203/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java#L38
When I logged `refCount` of `ByteBuf`s in `HeadMethodLeakTest`, they became 1 from 0 during assertions.

Modifications:

- Use Unpooled allocator instead

Result:

Clean up flaky tests 
