### PR TITLE
Fix a bug where RetryConfigMapping is evaluated multiple times per req

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -324,8 +324,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             response = executeWithFallback(unwrap(), derivedCtx,
                                            (context, cause) -> HttpResponse.ofFailure(cause));
         }
-
-        final RetryConfig<HttpResponse> config = mapping().get(ctx, duplicateReq);
+        final RetryConfig<HttpResponse> config = mappedRetryConfig(ctx);
         if (!ctx.exchangeType().isResponseStreaming() || config.requiresResponseTrailers()) {
             // XXX(ikhoon): Should we use `response.aggregateWithPooledObjects()`?
             response.aggregate().handle((aggregated, cause) -> {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -186,7 +186,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                                       (context, cause) -> RpcResponse.ofFailure(cause));
         }
 
-        final RetryConfig<RpcResponse> retryConfig = mapping().get(ctx, req);
+        final RetryConfig<RpcResponse> retryConfig = mappedRetryConfig(ctx);
         final RetryRuleWithContent<RpcResponse> retryRule =
                 retryConfig.needsContentInRule() ?
                 retryConfig.retryRuleWithContent() : retryConfig.fromRetryRule();


### PR DESCRIPTION
Motivation:

As described in #4753, user-configured `RetryConfigMapping` is evaluated multiple time per original/logical request. Twice for the original try, and an additional evaluation per each try. Not only this behavior could be surprising for users, it's also a performance penalty as most of the `RetryConfigMapping`s idempotent (don't change in between the retries).

Modifications:

- Only evaluate `RetryConfigMapping` once and store the result in `ClientReqeustContext`.

Result:

- Closes #4753 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
