### PR TITLE
Add AsyncClientInterceptor for gRPC clients

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptor.java
@@ -27,10 +27,32 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.MethodDescriptor;
 
+/**
+ * A {@link ClientInterceptor} that is able to asynchronously execute the interceptor without blocking the
+ * caller thread.
+ * For example:
+ * <pre>{@code
+ * class LongRunningTaskInterceptor implements AsyncClientInterceptor {
+ *
+ *    @Override
+ *    public <I, O> CompletableFuture<ClientCall<I, O>> asyncInterceptCall(MethodDescriptor<I, O> method,
+ *                                                                         CallOptions callOptions,
+ *                                                                         Channel next) {
+ *        return CompletableFuture.supplyAsync(() -> {
+ *            // long-running task
+ *            return next.newCall(method, callOptions);
+ *        });
+ *    }
+ * }
+ * }</pre>
+ */
 @UnstableApi
 @FunctionalInterface
 public interface AsyncClientInterceptor extends ClientInterceptor {
 
+    /**
+     * Asynchronously intercepts {@link ClientCall } dispatch by the {@code next} {@link Channel}.
+     */
     <I, O> CompletableFuture<ClientCall<I, O>> asyncInterceptCall(
             MethodDescriptor<I, O> method, CallOptions callOptions, Channel next);
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.internal.client.grpc.DeferredClientCall;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+
+@UnstableApi
+@FunctionalInterface
+public interface AsyncClientInterceptor extends ClientInterceptor {
+
+    <I, O> CompletableFuture<ClientCall<I, O>> asyncInterceptCall(
+            MethodDescriptor<I, O> method, CallOptions callOptions, Channel next);
+
+    @Override
+    default <I, O> ClientCall<I, O> interceptCall(
+            MethodDescriptor<I, O> method, CallOptions callOptions, Channel next) {
+        return new DeferredClientCall<I, O>(asyncInterceptCall(method, callOptions, next));
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -36,6 +36,7 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -448,6 +449,10 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     public void transportReportHeaders(Metadata metadata) {
         assert listener != null;
         listener.onHeaders(metadata);
+    }
+
+    ClientRequestContext ctx() {
+        return ctx;
     }
 
     private void prepareHeaders(Compressor compressor, Metadata metadata, long remainingNanos) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/DeferredClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/DeferredClientCall.java
@@ -19,53 +19,39 @@ package com.linecorp.armeria.internal.client.grpc;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.MoreExecutors;
-
-import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
-import io.grpc.Status;
 
 @UnstableApi
 public final class DeferredClientCall<I, O> extends ClientCall<I, O> {
-
-    private static final List<Runnable> NOOP_TASKS = ImmutableList.of();
 
     private List<Runnable> pendingTasks = new ArrayList<>();
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    private final Executor executor;
-
     @Nullable
-    private DeferredListner<O> deferredListner;
-
-    @Nullable
-    private volatile ArmeriaClientCall<I, O> delegate;
+    private volatile ClientCall<I, O> delegate;
 
     public DeferredClientCall(CompletableFuture<ClientCall<I, O>> clientFuture) {
-        executor = MoreExecutors.newSequentialExecutor(CommonPools.blockingTaskExecutor());
-        clientFuture.handleAsync((delegate, cause) -> {
+        clientFuture.handle((delegate, cause) -> {
             if (cause != null) {
                 // TODO
                 return null;
             }
             lock.lock();
             try {
-                this.delegate = (ArmeriaClientCall<I, O>) delegate;
+                this.delegate = delegate;
             } finally {
                 lock.unlock();
             }
             drainPendingTasks();
             return null;
-        }, executor);
+        });
     }
 
     @Override
@@ -75,8 +61,7 @@ public final class DeferredClientCall<I, O> extends ClientCall<I, O> {
             if (delegate != null) {
                 delegate.start(responseListener, headers);
             } else {
-                deferredListner = new DeferredListner<>(responseListener);
-                pendingTasks.add(() -> delegate.start(deferredListner, headers));
+                pendingTasks.add(() -> delegate.start(responseListener, headers));
             }
         } finally {
             lock.unlock();
@@ -141,106 +126,27 @@ public final class DeferredClientCall<I, O> extends ClientCall<I, O> {
 
     private void drainPendingTasks() {
         List<Runnable> runnables = new ArrayList<>();
-        DeferredListner<O> deferredListner;
         while (true) {
             lock.lock();
             try {
                 if (pendingTasks.isEmpty()) {
-                    pendingTasks = NOOP_TASKS;
-                    deferredListner = this.deferredListner;
                     break;
                 }
             } finally {
                 lock.unlock();
             }
-            final List<Runnable> tmp = runnables;
-            runnables = pendingTasks;
-            pendingTasks = tmp;
+            lock.lock();
+            try {
+                final List<Runnable> tmp = runnables;
+                runnables = pendingTasks;
+                pendingTasks = tmp;
+            } finally {
+                lock.unlock();
+            }
             for (Runnable runnable : runnables) {
                 runnable.run();
             }
             runnables.clear();
-        }
-        if (deferredListner != null) {
-            executor.execute(delegate.ctx().makeContextAware(deferredListner::drainPendingTasks));
-        }
-    }
-
-    class DeferredListner<O> extends Listener<O> {
-        private final Listener<O> listener;
-        private final ReentrantLock lock = new ReentrantLock();
-        private List<Runnable> pendingTasks = new ArrayList<>();
-        private volatile boolean passThrough;
-
-        DeferredListner(Listener<O> listener) {
-            this.listener = listener;
-        }
-
-        private void deferredOrExecute(Runnable runnable) {
-            lock.lock();
-            try {
-                if (!passThrough) {
-                    pendingTasks.add(runnable);
-                    return;
-                }
-            } finally {
-                lock.unlock();
-            }
-            runnable.run();
-        }
-
-        @Override
-        public void onHeaders(Metadata headers) {
-            if (passThrough) {
-                listener.onHeaders(headers);
-            } else {
-                deferredOrExecute(() -> listener.onHeaders(headers));
-            }
-        }
-
-        @Override
-        public void onMessage(O message) {
-            if (passThrough) {
-                listener.onMessage(message);
-            } else {
-                deferredOrExecute(() -> listener.onMessage(message));
-            }
-        }
-
-        @Override
-        public void onClose(Status status, Metadata trailers) {
-            deferredOrExecute(() -> listener.onClose(status, trailers));
-        }
-
-        @Override
-        public void onReady() {
-            if (passThrough) {
-                listener.onReady();
-            } else {
-                deferredOrExecute(listener::onReady);
-            }
-        }
-
-        void drainPendingTasks() {
-            List<Runnable> runnables = new ArrayList<>();
-            while (true) {
-                lock.lock();
-                try {
-                    if (pendingTasks.isEmpty()) {
-                        passThrough = true;
-                        break;
-                    }
-                    final List<Runnable> tmp = runnables;
-                    runnables = pendingTasks;
-                    pendingTasks = tmp;
-                    for (Runnable runnable : runnables) {
-                        runnable.run();
-                    }
-                    runnables.clear();
-                } finally {
-                    lock.unlock();
-                }
-            }
         }
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/DeferredClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/DeferredClientCall.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.grpc;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+
+@UnstableApi
+public final class DeferredClientCall<I, O> extends ClientCall<I, O> {
+
+    private static final List<Runnable> NOOP_TASKS = ImmutableList.of();
+
+    private List<Runnable> pendingTasks = new ArrayList<>();
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private final Executor executor;
+
+    @Nullable
+    private DeferredListner<O> deferredListner;
+
+    @Nullable
+    private volatile ArmeriaClientCall<I, O> delegate;
+
+    public DeferredClientCall(CompletableFuture<ClientCall<I, O>> clientFuture) {
+        executor = MoreExecutors.newSequentialExecutor(CommonPools.blockingTaskExecutor());
+        clientFuture.handleAsync((delegate, cause) -> {
+            if (cause != null) {
+                // TODO
+                return null;
+            }
+            lock.lock();
+            try {
+                this.delegate = (ArmeriaClientCall<I, O>) delegate;
+            } finally {
+                lock.unlock();
+            }
+            drainPendingTasks();
+            return null;
+        }, executor);
+    }
+
+    @Override
+    public void start(Listener<O> responseListener, Metadata headers) {
+        lock.lock();
+        try {
+            if (delegate != null) {
+                delegate.start(responseListener, headers);
+            } else {
+                deferredListner = new DeferredListner<>(responseListener);
+                pendingTasks.add(() -> delegate.start(deferredListner, headers));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void request(int numMessages) {
+        lock.lock();
+        try {
+            if (delegate != null) {
+                delegate.request(numMessages);
+            } else {
+                pendingTasks.add(() -> delegate.request(numMessages));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+        lock.lock();
+        try {
+            if (delegate != null) {
+                delegate.cancel(message, cause);
+            } else {
+                pendingTasks.add(() -> delegate.cancel(message, cause));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void halfClose() {
+        lock.lock();
+        try {
+            if (delegate != null) {
+                delegate.halfClose();
+            } else {
+                pendingTasks.add(this::halfClose);
+            }
+        }finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void sendMessage(I message) {
+        lock.lock();
+        try {
+            if (delegate != null) {
+                delegate.sendMessage(message);
+            } else {
+                pendingTasks.add(() -> delegate.sendMessage(message));
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void drainPendingTasks() {
+        List<Runnable> runnables = new ArrayList<>();
+        DeferredListner<O> deferredListner;
+        while (true) {
+            lock.lock();
+            try {
+                if (pendingTasks.isEmpty()) {
+                    pendingTasks = NOOP_TASKS;
+                    deferredListner = this.deferredListner;
+                    break;
+                }
+            } finally {
+                lock.unlock();
+            }
+            final List<Runnable> tmp = runnables;
+            runnables = pendingTasks;
+            pendingTasks = tmp;
+            for (Runnable runnable : runnables) {
+                runnable.run();
+            }
+            runnables.clear();
+        }
+        if (deferredListner != null) {
+            executor.execute(delegate.ctx().makeContextAware(deferredListner::drainPendingTasks));
+        }
+    }
+
+    class DeferredListner<O> extends Listener<O> {
+        private final Listener<O> listener;
+        private final ReentrantLock lock = new ReentrantLock();
+        private List<Runnable> pendingTasks = new ArrayList<>();
+        private volatile boolean passThrough;
+
+        DeferredListner(Listener<O> listener) {
+            this.listener = listener;
+        }
+
+        private void deferredOrExecute(Runnable runnable) {
+            lock.lock();
+            try {
+                if (!passThrough) {
+                    pendingTasks.add(runnable);
+                    return;
+                }
+            } finally {
+                lock.unlock();
+            }
+            runnable.run();
+        }
+
+        @Override
+        public void onHeaders(Metadata headers) {
+            if (passThrough) {
+                listener.onHeaders(headers);
+            } else {
+                deferredOrExecute(() -> listener.onHeaders(headers));
+            }
+        }
+
+        @Override
+        public void onMessage(O message) {
+            if (passThrough) {
+                listener.onMessage(message);
+            } else {
+                deferredOrExecute(() -> listener.onMessage(message));
+            }
+        }
+
+        @Override
+        public void onClose(Status status, Metadata trailers) {
+            deferredOrExecute(() -> listener.onClose(status, trailers));
+        }
+
+        @Override
+        public void onReady() {
+            if (passThrough) {
+                listener.onReady();
+            } else {
+                deferredOrExecute(listener::onReady);
+            }
+        }
+
+        void drainPendingTasks() {
+            List<Runnable> runnables = new ArrayList<>();
+            while (true) {
+                lock.lock();
+                try {
+                    if (pendingTasks.isEmpty()) {
+                        passThrough = true;
+                        break;
+                    }
+                    final List<Runnable> tmp = runnables;
+                    runnables = pendingTasks;
+                    pendingTasks = tmp;
+                    for (Runnable runnable : runnables) {
+                        runnable.run();
+                    }
+                    runnables.clear();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/AsyncClientInterceptorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
+import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceBlockingStub;
+import com.linecorp.armeria.grpc.testing.TestServiceGrpc.TestServiceImplBase;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.MethodDescriptor;
+import io.grpc.stub.StreamObserver;
+
+class AsyncClientInterceptorTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestService())
+                                  .build());
+        }
+    };
+
+    @Test
+    void interceptCall() {
+        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+                                                          .intercept(new LongRunningTaskInterceptor())
+                                                          .build(TestServiceBlockingStub.class);
+        client.unaryCall(SimpleRequest.getDefaultInstance());
+    }
+
+    private static final class LongRunningTaskInterceptor implements AsyncClientInterceptor {
+
+        @Override
+        public <I, O> CompletableFuture<ClientCall<I, O>> asyncInterceptCall(MethodDescriptor<I, O> method,
+                                                                             CallOptions callOptions,
+                                                                             Channel next) {
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                return next.newCall(method, callOptions);
+            });
+        }
+    }
+
+    private static final class TestService extends TestServiceImplBase {
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onNext(SimpleResponse.getDefaultInstance());
+            responseObserver.onCompleted();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Described in https://github.com/line/armeria/issues/4648

Modifications:

- Add `AsyncClientInterceptor` that returns `ClientCall` with `CompletableFuture`
- Add `DeferredClientCall` to execute pending tasks in order when the future returned by `AsyncClientInterceptor` completes.

Result:

- Closes #4648 
-