### PR TITLE
Provide a way to customize the netty pipeline for server-side

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -44,6 +45,7 @@ import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.Mapping;
@@ -97,6 +99,7 @@ final class DefaultServerConfig implements ServerConfig {
 
     private final Map<ChannelOption<?>, ?> channelOptions;
     private final Map<ChannelOption<?>, ?> childChannelOptions;
+    private final Consumer<? super ChannelPipeline> childChannelPipelineCustomizer;
 
     private final List<ClientAddressSource> clientAddressSources;
     private final Predicate<? super InetAddress> clientAddressTrustedProxyFilter;
@@ -131,6 +134,7 @@ final class DefaultServerConfig implements ServerConfig {
             MeterRegistry meterRegistry, int proxyProtocolMaxTlvSize,
             Map<ChannelOption<?>, Object> channelOptions,
             Map<ChannelOption<?>, Object> childChannelOptions,
+            Consumer<? super ChannelPipeline> childChannelPipelineCustomizer,
             List<ClientAddressSource> clientAddressSources,
             Predicate<? super InetAddress> clientAddressTrustedProxyFilter,
             Predicate<? super InetAddress> clientAddressFilter,
@@ -185,6 +189,8 @@ final class DefaultServerConfig implements ServerConfig {
                 new Object2ObjectArrayMap<>(requireNonNull(channelOptions, "channelOptions")));
         this.childChannelOptions = Collections.unmodifiableMap(
                 new Object2ObjectArrayMap<>(requireNonNull(childChannelOptions, "childChannelOptions")));
+        this.childChannelPipelineCustomizer =
+                requireNonNull(childChannelPipelineCustomizer, "childChannelPipelineCustomizer");
         this.clientAddressSources = ImmutableList.copyOf(
                 requireNonNull(clientAddressSources, "clientAddressSources"));
         this.clientAddressTrustedProxyFilter =
@@ -477,6 +483,11 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public Map<ChannelOption<?>, ?> childChannelOptions() {
         return childChannelOptions;
+    }
+
+    @Override
+    public Consumer<? super ChannelPipeline> childChannelPipelineCustomizer() {
+        return childChannelPipelineCustomizer;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -155,6 +155,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         p.addLast(new FlushConsolidationHandler());
         p.addLast(ReadSuppressingHandler.INSTANCE);
         configurePipeline(p, port.protocols(), null);
+        config.childChannelPipelineCustomizer().accept(p);
     }
 
     private void configurePipeline(ChannelPipeline p, Set<SessionProtocol> protocols,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -34,6 +35,7 @@ import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 
 /**
@@ -125,6 +127,12 @@ public interface ServerConfig {
      * Returns the {@link ChannelOption}s and their values of sockets accepted by {@link Server}.
      */
     Map<ChannelOption<?>, ?> childChannelOptions();
+
+    /**
+     * Returns the {@link Consumer} that customizes the Netty {@link ChannelPipeline}.
+     */
+    @UnstableApi
+    Consumer<? super ChannelPipeline> childChannelPipelineCustomizer();
 
     /**
      * Returns the maximum allowed number of open connections.

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -35,6 +36,7 @@ import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.Mapping;
@@ -136,6 +138,11 @@ final class UpdatableServerConfig implements ServerConfig {
     @Override
     public Map<ChannelOption<?>, ?> childChannelOptions() {
         return delegate.childChannelOptions();
+    }
+
+    @Override
+    public Consumer<? super ChannelPipeline> childChannelPipelineCustomizer() {
+        return delegate.childChannelPipelineCustomizer();
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/ServerChildChannelPipelineCustomizerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerChildChannelPipelineCustomizerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.net.ssl.SSLEngine;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testng.util.Strings;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ResponseTimeoutException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.traffic.ChannelTrafficShapingHandler;
+
+class ServerChildChannelPipelineCustomizerTest {
+
+    @RegisterExtension
+    @Order(0)
+    static final SelfSignedCertificateExtension ssc = new SelfSignedCertificateExtension();
+
+    @RegisterExtension
+    @Order(1)
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final SslContext sslCtx = SslContextBuilder
+                    .forServer(ssc.privateKey(), ssc.certificate())
+                    .startTls(true)
+                    .build();
+
+            sb.http(0);
+            sb.tlsSelfSigned();
+
+            sb.childChannelPipelineCustomizer(
+                    pipeline -> {
+                        final SSLEngine engine = sslCtx.newEngine(pipeline.channel().alloc());
+                        engine.setUseClientMode(false);
+                        pipeline.addFirst(new SslHandler(engine));
+                    });
+            sb.childChannelPipelineCustomizer(
+                    pipeline -> pipeline.addFirst(new ChannelTrafficShapingHandler(1024, 0)));
+
+            sb.service("/SslHandler", (ctx, req) -> HttpResponse.of(200));
+            sb.service("/TrafficShapingHandler", new AbstractHttpService() {
+                @Override
+                protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.of(
+                            ResponseHeaders.of(HttpStatus.OK, "header1", Strings.repeat("a", 2048)));
+                }
+            });
+        }
+    };
+
+    @Test
+    void testSessionProtocolNegotiationException() {
+        final ClientFactory clientFactory = ClientFactory.insecure();
+
+        final AggregatedHttpResponse response = WebClient
+                .builder(SessionProtocol.H1, server.httpEndpoint())
+                .factory(clientFactory)
+                .build()
+                .blocking()
+                .execute(RequestHeaders.of(HttpMethod.GET, "/SslHandler"), "content");
+        assertThat(response.status().code()).isEqualTo(200);
+    }
+
+    @Test
+    void testResponseTimeout() {
+        final RequestHeaders requestHeaders = RequestHeaders.of(HttpMethod.GET, "/TrafficShapingHandler");
+        final ClientFactory clientFactory = ClientFactory.insecure();
+
+        // using h1 or h1c since http2 compresses headers
+        assertThatThrownBy(() -> WebClient.builder(SessionProtocol.H1, server.httpEndpoint())
+                                          .responseTimeoutMillis(1000)
+                                          .factory(clientFactory)
+                                          .build()
+                                          .blocking()
+                                          .execute(requestHeaders, "content"))
+                .isInstanceOf(ResponseTimeoutException.class);
+    }
+}


### PR DESCRIPTION
This PR is same with #4734 

Motivation:

Described in #4710 

Modifications:

- Add `channelPipelineCustomizer` method to `ServerBuilder` in order to provide a way to customize pipeline behavior for server side. (#4260 PR has already provided a way for client side)
- Accept a consumer on `ChannelPipeline` which is specifed by `channelPipelineCustomizer` method on `ServerBuilder` in `HttpServerPipelineConfigurator`.
- Add `ResponseTimeoutTest`

Result:

- Closes #4710 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
