### PR TITLE
Introduce GrpcCallOptions

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcCallOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcCallOptions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.grpc.CallOptions;
+import io.netty.util.AttributeKey;
+
+/**
+ * Retrieves {@link CallOptions} from a given {@link RequestContext}. This might be useful while providing
+ * common middleware that needs to act on options configured at the gRPC client's call site.
+ * <p>
+ * Here is an example of how custom call options might be propagated between a gRPC stub and a decorator.
+ * </p>
+ * <pre>{@code
+ *     MyGrpcStub client = GrpcClients
+ *         .builder(grpcServerUri)
+ *         .decorator((delegate, ctx, req) -> {
+ *             CallOptions options = GrpcCallOptions.get(ctx);
+ *             MyOption myOption = options.getOption(myOptionKey);
+ *
+ *             // act on myOption if needed
+ *
+ *             return delegate.execute(ctx, req);
+ *         })
+ *         .build(MyGrpcStub.class)
+ *
+ *     client
+ *       .withOption(myOptionKey, myOptionValue)
+ *       .echo(...)
+ * }</pre>
+ */
+@UnstableApi
+public final class GrpcCallOptions {
+
+    private static final AttributeKey<CallOptions> GRPC_CALL_OPTIONS = AttributeKey.valueOf(
+            GrpcCallOptions.class, "GRPC_CALL_OPTIONS");
+
+    /**
+     * Returns {@link CallOptions} which was set to the specified {@link RequestContext} using
+     * {@link #set(RequestContext, CallOptions)}.
+     */
+    @Nullable
+    public static CallOptions get(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        return ctx.attr(GRPC_CALL_OPTIONS);
+    }
+
+    /**
+     * Sets the specified {@link CallOptions} to the {@link RequestContext}.
+     */
+    public static void set(RequestContext ctx, CallOptions options) {
+        requireNonNull(ctx, "ctx");
+        requireNonNull(options, "options");
+        ctx.setAttr(GRPC_CALL_OPTIONS, options);
+    }
+
+    private GrpcCallOptions() {}
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.grpc.GrpcCallOptions;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.SystemInfo;
@@ -134,6 +135,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
 
         final HttpRequestWriter req = HttpRequest.streaming(headersBuilder.build());
         final DefaultClientRequestContext ctx = newContext(HttpMethod.POST, req, method);
+
+        GrpcCallOptions.set(ctx, callOptions);
 
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT,

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -73,6 +73,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.grpc.GrpcCallOptions;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -135,6 +136,9 @@ class GrpcClientTest {
     private static final int MAX_MESSAGE_SIZE = 16 * 1024 * 1024;
 
     private static final Empty EMPTY = Empty.getDefaultInstance();
+
+    private static final CallOptions.Key<String> MY_CALL_OPTION_KEY =
+            CallOptions.Key.create("my-call-option");
 
     private static final AtomicReference<HttpHeaders> CLIENT_HEADERS_CAPTURE = new AtomicReference<>();
     private static final AtomicReference<HttpHeaders> SERVER_TRAILERS_CAPTURE = new AtomicReference<>();
@@ -302,6 +306,17 @@ class GrpcClientTest {
             asyncStub.emptyCall(EMPTY, StreamRecorder.create());
             final ClientRequestContext ctx = ctxCaptor.get();
             assertThat(ctx.path()).isEqualTo("/armeria.grpc.testing.TestService/EmptyCall");
+        }
+    }
+
+    @Test
+    void grpcCallOptions() {
+        try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
+            blockingStub
+                    .withOption(MY_CALL_OPTION_KEY, "foo")
+                    .emptyCall(EMPTY);
+            final ClientRequestContext ctx = ctxCaptor.get();
+            assertThat(GrpcCallOptions.get(ctx).getOption(MY_CALL_OPTION_KEY)).isEqualTo("foo");
         }
     }
 


### PR DESCRIPTION
Motivation:

While building the decorator-middleware for the gRPC clients, it can be useful to get access to the instance of the `CallOptions` used to send the client request. This PR introduces the new (experimental) API to fish `CallOptions` out of the `RequestContext` object. 

Modifications:

- Added new `GrpcCallOptions` API to save and retrieve gRPC's `CallOptions` to/from `RequestContext`
- ArmeriaChannel now saves the instance of `CallOptions` onto the context
- Added a test for the new functionality

Result:

- Closes #4776

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
