### PR TITLE
fix typo in javadoc

### DIFF
--- a/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/server/ServiceRequestContextCaptor.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 
 /**
- * Captures the {@code ServiceRequestContext}s.
+ * Captures the {@code ServiceRequestContext}.
  *
  * <p>Example:
  * <pre>{@code


### PR DESCRIPTION
Motivation:
- Fix  annotation in `ServiceRequestContextCaptor`

Modifications:
- Update annotation

Result:
- No impact except for correcting the annotation
