### PR TITLE
Contain which file doesn't exist in the response

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -197,7 +197,15 @@ public abstract class AbstractHttpFile implements HttpFile {
         requireNonNull(alloc, "alloc");
 
         return readAttributes(fileReadExecutor)
-                .thenApply(attrs -> read(fileReadExecutor, alloc, attrs))
+                .thenApply(attrs -> {
+                    final HttpResponse res = read(fileReadExecutor, alloc, attrs);
+                    if (res != null) {
+                        return res;
+                    }
+
+                    // read() returned null above.
+                    return HttpResponse.of(HttpStatus.NOT_FOUND);
+                })
                 .exceptionally(cause -> HttpResponse.ofFailure(Exceptions.peel(cause)));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -74,9 +74,6 @@ public final class FileService extends AbstractHttpService {
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',');
 
-    private static final UnmodifiableFuture<HttpFile> NON_EXISTENT_FILE_FUTURE =
-            UnmodifiableFuture.completedFuture(HttpFile.nonExistent());
-
     /**
      * Returns a new {@link FileService} for the specified {@code rootDir} in an O/S file system.
      */
@@ -238,12 +235,12 @@ public final class FileService extends AbstractHttpService {
                     // Auto-generate directory listing if enabled.
                     final Executor readExecutor = ctx.blockingTaskExecutor();
                     if (!config.autoIndex()) {
-                        return NON_EXISTENT_FILE_FUTURE;
+                        return UnmodifiableFuture.completedFuture(HttpFile.nonExistent(decodedMappedPath));
                     }
 
                     return config.vfs().canList(readExecutor, decodedMappedPath).thenCompose(canList -> {
                         if (!canList) {
-                            return NON_EXISTENT_FILE_FUTURE;
+                            return UnmodifiableFuture.completedFuture(HttpFile.nonExistent(decodedMappedPath));
                         }
 
                         return config.vfs().list(readExecutor, decodedMappedPath).thenApply(listing -> {
@@ -284,7 +281,7 @@ public final class FileService extends AbstractHttpService {
                             return HttpFile.ofRedirect(locationBuilder.toString());
                         }
                     } else {
-                        return HttpFile.nonExistent();
+                        return HttpFile.nonExistent(decodedMappedPath);
                     }
                 });
             }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -125,11 +125,19 @@ public interface HttpFile {
     }
 
     /**
+     * Returns an {@link HttpFile} which represents a non-existent file.
+     * Contains additional {@code location} information.
+     */
+    static HttpFile nonExistent(String location) {
+        return new NonExistentHttpFile(location, false);
+    }
+
+    /**
      * Returns an {@link HttpFile} redirected to the specified {@code location}.
      */
     static HttpFile ofRedirect(String location) {
         requireNonNull(location, "location");
-        return new NonExistentHttpFile(location);
+        return new NonExistentHttpFile(location, true);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -63,7 +63,7 @@ final class NonExistentHttpFile implements HttpFile {
     @Override
     public HttpService asService() {
         return (ctx, req) -> {
-            final HttpMethod method = ctx.method();
+            final HttpMethod method = req.method();
             if (method != HttpMethod.GET && method != HttpMethod.HEAD) {
                 return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
             }
@@ -77,7 +77,7 @@ final class NonExistentHttpFile implements HttpFile {
                     String.format("No file are available for the location. location is %s ", location));
             }
 
-            return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
         };
     }
 


### PR DESCRIPTION
Motivation:

1. When we were looking for a file, it was hard to guess why we couldn't find it. I think it would be much easier to raise the issue if the response contained information that allowed me to make a guess. This could be fixed by adding a `decodedMappedPath`.
2. When `AbstractHttpFile#read(...)` returns `null`, it should return an `HttpResponse`. When it returns `null`, returning a `404` response can solve the problem.

Modifications:

- Add location if file does not exist in the specified path
- Modify situations where read is null to return a response

Result:

- Closes [Contain which file doesn't exist in the response #4797](https://github.com/line/armeria/issues/4797)
- If the file service is bound, but fails, we can see a hint about the path that failed.
- `AbstractHttpFile#read(...)` no longer returns null.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
