### PR TITLE
Upgrade Gradle to 8.1.1

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -215,7 +215,9 @@ jobs:
 
       - name: Run flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check -PnoLint -PflakyTests=true
+          ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check -PnoLint -PflakyTests=true \
+          -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
+          -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}
 
       - name: Summarize the failed tests
         if: failure()

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -217,6 +217,7 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check -PnoLint -PflakyTests=true \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
+          -PtestJavaVersion=${{ env.BUILD_JDK_VERSION }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}
 
       - name: Summarize the failed tests

--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation project(':testing-internal')
 }
 
+tasks.sourcesJar.dependsOn(tasks.compileJmhThrift)
+
 jmh {
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     jmhVersion = libs.versions.jmh.core.get()

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
     tasks.withType(JavaForkOptions) {
         maxHeapSize = '768m'
 
-        if (rootProject.ext.testJavaVersion >= 9) {
+        if (project.ext.testJavaVersion >= 9) {
             jvmArgs '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED'
         }
 
@@ -74,7 +74,7 @@ allprojects {
         // `-Pjava.security.manager` was added in Java 17 and the default value was changed to `disallow` in Java 18.
         // - https://openjdk.org/jeps/411
         // - https://bugs.openjdk.org/browse/JDK-8270380
-        if (rootProject.ext.testJavaVersion >= 17) {
+        if (project.ext.testJavaVersion >= 17) {
             systemProperty "java.security.manager", "allow"
         }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -173,45 +173,63 @@ if (!rootProject.hasProperty('noWeb')) {
 // Run HttpServerStreamingTest separately with memory constraint.
 tasks.test.exclude '**/HttpServerStreamingTest**'
 tasks.shadedTest.exclude '**/HttpServerStreamingTest**'
-task testStreaming(type: Test,
-                   group: 'Verification',
-                   description: 'Runs the streaming tests.',
-                   dependsOn: tasks.shadedTestClasses) {
-    // Use small heap for streaming tests to quickly ensure we can stream the content larger than heap.
-    maxHeapSize = '64m'
+testing {
+    suites {
+        testStreaming(JvmTestSuite) {
 
-    include '**/HttpServerStreamingTest**'
-    testClassesDirs = tasks.shadedTest.testClassesDirs
-    classpath = testClassesDirs
+            group = 'Verification'
+            description = 'Runs the streaming tests.'
 
-    // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
-    doFirst {
-        classpath += project.files(configurations.shadedTestRuntime.resolve())
-    }
-}
-tasks.shadedTest.finalizedBy tasks.testStreaming
-tasks.check.dependsOn tasks.testStreaming
+            targets {
+                all {
+                    testTask.configure {
+                        dependsOn(tasks.shadedTestClasses)
+                        // Use small heap for streaming tests to quickly ensure we can stream the content larger than heap.
+                        maxHeapSize = '64m'
 
-if (rootProject.findProperty('FLAKY_TESTS') != 'true') {
-    // Run the test cases based on reactive-streams-tck only with non-flaky mode
-    task testNg(type: Test,
-            group: 'Verification',
-            description: 'Runs the TestNG unit tests.',
-            dependsOn: tasks.shadedTestClasses) {
-        useTestNG()
-        include '/com/linecorp/armeria/common/**'
+                        include '**/HttpServerStreamingTest**'
+                        testClassesDirs = tasks.shadedTest.testClassesDirs
+                        classpath = testClassesDirs
 
-        scanForTestClasses = false
-        testClassesDirs = tasks.shadedTest.testClassesDirs
-        classpath = testClassesDirs
-
-        // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
-        doFirst {
-            classpath += project.files(configurations.shadedTestRuntime.resolve())
+                        // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
+                        doFirst {
+                            classpath += project.files(configurations.shadedTestRuntime.resolve())
+                        }
+                    }
+                }
+            }
         }
     }
-    tasks.shadedTest.finalizedBy tasks.testNg
-    tasks.check.dependsOn tasks.testNg
+}
+tasks.shadedTest.finalizedBy testing.suites.testStreaming
+tasks.check.dependsOn testing.suites.testStreaming
+
+// Run the test cases based on reactive-streams-tck only with non-flaky mode
+if (rootProject.findProperty('FLAKY_TESTS') != 'true') {
+    testing {
+        suites {
+            testNg(JvmTestSuite) {
+                useTestNG()
+
+                targets {
+                    all {
+                        testTask.configure {
+                            include '/com/linecorp/armeria/**/common/**'
+                            dependsOn tasks.shadedTestClasses
+                            scanForTestClasses = false
+                            testClassesDirs = tasks.shadedTest.testClassesDirs
+                            classpath = testClassesDirs
+                            doFirst {
+                                classpath += project.files(configurations.shadedTestRuntime.resolve())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    tasks.shadedTest.finalizedBy testing.suites.testNg
+    tasks.check.dependsOn testing.suites.testNg
 }
 
 if (tasks.findByName('trimShadedJar')) {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,7 +42,7 @@ mrJarVersions.each { version->
         classpath = sourceSets."java${version}Test".runtimeClasspath
 
         enabled = Integer.parseInt(JavaVersion.current().getMajorVersion()) >= version &&
-                rootProject.ext.testJavaVersion >= version
+                project.ext.testJavaVersion >= version
     }
 
     configurations."java${version}Implementation".extendsFrom configurations.implementation

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -205,7 +205,7 @@ tasks.shadedTest.finalizedBy testing.suites.testStreaming
 tasks.check.dependsOn testing.suites.testStreaming
 
 // Run the test cases based on reactive-streams-tck only with non-flaky mode
-if (rootProject.findProperty('FLAKY_TESTS') != 'true') {
+if (rootProject.findProperty('flakyTests') != 'true') {
     testing {
         suites {
             testNg(JvmTestSuite) {

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -150,10 +150,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
      */
     @Test
     public void required_subscribeOnAbortedStreamMustFail() throws Throwable {
-        final StreamMessage<T> pub = createAbortedPublisher(1);
-        if (pub == null) {
-            notVerified();
-        }
+        final StreamMessage<T> pub = createAbortedPublisher(0);
         assumeAbortedPublisherAvailable(pub);
         assertThatThrownBy(() -> pub.whenComplete().join())
                 .isInstanceOf(CompletionException.class)
@@ -234,7 +231,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
                 .hasCauseInstanceOf(AbortedStreamException.class);
     }
 
-    private void assumeAbortedPublisherAvailable(@Nullable Publisher<T> pub) {
+    protected void assumeAbortedPublisherAvailable(@Nullable Publisher<T> pub) {
         if (pub == null) {
             throw new SkipException("Skipping because no aborted StreamMessage provided.");
         }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageVerification.java
@@ -150,7 +150,7 @@ public abstract class StreamMessageVerification<T> extends PublisherVerification
      */
     @Test
     public void required_subscribeOnAbortedStreamMustFail() throws Throwable {
-        final StreamMessage<T> pub = createAbortedPublisher(0);
+        final StreamMessage<T> pub = createAbortedPublisher(1);
         if (pub == null) {
             notVerified();
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageVerification.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageVerification.java
@@ -16,10 +16,19 @@
 
 package com.linecorp.armeria.internal.common.stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.LongStream;
 
+import org.reactivestreams.Subscription;
+import org.reactivestreams.tck.TestEnvironment.Latch;
+import org.reactivestreams.tck.TestEnvironment.TestSubscriber;
 import org.testng.annotations.Test;
 
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessageVerification;
 
@@ -57,5 +66,49 @@ public class FixedStreamMessageVerification extends StreamMessageVerification<Lo
         // Publishes Integer.MAX_VALUE values, which is not feasible with a FixedStreamMessage where the values
         // are all pre-allocated.
         notVerified();
+    }
+
+    /**
+     * Modified from {@link #optional_spec104_mustSignalOnErrorWhenFails()}.
+     */
+    @Test
+    public void required_subscribeOnAbortedStreamMustFail() throws Throwable {
+        // EmptyFixedStreamMessage performs nothing on abortion.
+        final StreamMessage<Long> pub = createAbortedPublisher(1);
+        if (pub == null || pub instanceof EmptyFixedStreamMessage) {
+            notVerified();
+        }
+        assumeAbortedPublisherAvailable(pub);
+        assertThatThrownBy(() -> pub.whenComplete().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(AbortedStreamException.class);
+        assertThat(pub.isOpen()).isFalse();
+
+        final AtomicReference<Throwable> capturedCause = new AtomicReference<>();
+        final Latch onErrorLatch = new Latch(env());
+        final Latch onSubscribeLatch = new Latch(env());
+        pub.subscribe(new TestSubscriber<Long>(env()) {
+            @Override
+            public void onSubscribe(Subscription subs) {
+                onSubscribeLatch.assertOpen("Only one onSubscribe call expected");
+                onSubscribeLatch.close();
+            }
+
+            @Override
+            public void onError(Throwable cause) {
+                onSubscribeLatch.assertClosed("onSubscribe should be called prior to onError always");
+                onErrorLatch.assertOpen(String.format(
+                        "Error-state Publisher %s called `onError` twice on new Subscriber", pub));
+                capturedCause.set(cause);
+                onErrorLatch.close();
+            }
+        });
+
+        onSubscribeLatch.expectClose("Should have received onSubscribe");
+        onErrorLatch.expectClose(String.format(
+                "Error-state Publisher %s did not call `onError` on new Subscriber", pub));
+
+        env().verifyNoAsyncErrors();
+        assertThat(capturedCause.get()).isInstanceOf(AbortedStreamException.class);
     }
 }

--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts
 	branch = main
-	commit = a706e2826247c958aed17a1d7ec1168bb1a9c7e1
-	parent = 506e1b3c1236579d7344e3f10f3de13f811af5b1
+	commit = c20bc5b416c7fe19475dd1a2ca658d9177d23f35
+	parent = d48d5fa5c0e30f34deac6df1ada7e41b58ae444c
 	method = merge
 	cmdver = 0.4.5

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -15,8 +15,6 @@ buildscript {
     }
 }
 
-def managedDependencyOverrides = [] as Set
-
 allprojects { p ->
     ext {
         // Add managedVersions() for backward compatibility with dependencies.yml
@@ -178,19 +176,8 @@ configure(projectsWithFlags('java')) {
         dependencies {
             configurations.configureEach { configuration ->
                 // Add to resolvable configurations
-                if (configuration.canBeResolved && !configuration.canBeConsumed) {
-                    add(configuration.name, platform(dependencyManagementProject))
-                }
-
-                // Find version overrides in dependency declaration configurations
                 if (!configuration.canBeResolved && !configuration.canBeConsumed) {
-                    configuration.dependencies.configureEach { dep ->
-                        if (dep instanceof org.gradle.api.artifacts.ExternalDependency) {
-                            if (dep.version != null) {
-                                managedDependencyOverrides.add(String.valueOf("${dep.module}:${dep.version}"))
-                            }
-                        }
-                    }
+                    add(configuration.name, platform(dependencyManagementProject))
                 }
             }
         }

--- a/gradle/scripts/lib/common-git.gradle
+++ b/gradle/scripts/lib/common-git.gradle
@@ -101,12 +101,17 @@ private static String executeCommand(...command) {
     def stdout = new StringWriter()
     def stderr = new StringWriter()
     proc.waitForProcessOutput(stdout, stderr)
+    def outMsg = stdout.toString().trim()
 
     if (proc.exitValue() != 0) {
+        var errMsg = stderr.toString().trim()
+        if (errMsg.isEmpty()) {
+            errMsg = outMsg
+        }
         throw new IOException(
                 "'${command}' exited with a non-zero exit code: ${proc.exitValue()}:" +
-                        "${System.lineSeparator()}${stderr.toString().trim()}")
+                        "${System.lineSeparator()}$errMsg")
     }
 
-    return stdout.toString().trim()
+    return outMsg
 }

--- a/gradle/scripts/lib/java-alpn.gradle
+++ b/gradle/scripts/lib/java-alpn.gradle
@@ -24,6 +24,11 @@ configure(projectsWithFlags('java')) {
                 fileName.replaceFirst("-[0-9]+\\.[0-9]+\\.[0-9]+(?:\\.[^.]+)?\\.jar", ".jar")
             }
         }
+        tasks.compileJava.dependsOn(tasks.copyAlpnAgent)
+        tasks.processResources.dependsOn(tasks.copyAlpnAgent)
+        tasks.sourcesJar.dependsOn(tasks.copyAlpnAgent)
+        tasks.javadoc.dependsOn(tasks.copyAlpnAgent)
+        project.ext.getLintTask().dependsOn(tasks.copyAlpnAgent)
 
         tasks.withType(JavaForkOptions) {
             dependsOn tasks.copyAlpnAgent

--- a/gradle/scripts/lib/java-alpn.gradle
+++ b/gradle/scripts/lib/java-alpn.gradle
@@ -1,9 +1,9 @@
-// JDK 9 or above does not require Jetty ALPN agent at all.
-if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && rootProject.ext.testJavaVersion != 8) {
-    return
-}
-
 configure(projectsWithFlags('java')) {
+    // JDK 9 or above does not require Jetty ALPN agent at all.
+    if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && project.ext.testJavaVersion != 8) {
+        return
+    }
+
     // Use Jetty ALPN agent if dependencyManagement mentions it.
     if (managedVersions.containsKey('org.mortbay.jetty.alpn:jetty-alpn-agent')) {
         configurations {

--- a/gradle/scripts/lib/java-coverage.gradle
+++ b/gradle/scripts/lib/java-coverage.gradle
@@ -49,11 +49,11 @@ configure(rootProject) {
     task jacocoTestReport(type: JacocoReport) {
         def reportTask = delegate
         reports {
-            csv.enabled = false
-            xml.enabled = true
-            xml.destination = file("${rootProject.buildDir}/report/jacoco/jacocoTestReport.xml")
-            html.enabled = true
-            html.destination = file("${rootProject.buildDir}/report/jacoco/html")
+            csv.required = false
+            xml.required = true
+            xml.outputLocation.set(file("${rootProject.buildDir}/report/jacoco/jacocoTestReport.xml"))
+            html.required = true
+            html.outputLocation.set(file("${rootProject.buildDir}/report/jacoco/html"))
         }
 
         jacocoClasspath = configurations.jacocoAnt

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -129,6 +129,14 @@ configure(projectsWithFlags('java')) {
                     // declaring an explicit or implicit dependency.
                     sourcesJarTask.dependsOn(task)
                 }
+
+                def copyAlpnAgentTask= tasks.findByName('copyAlpnAgent')
+                if (copyAlpnAgentTask) {
+                    // A workaround for ':generateProto' uses this output of task ':copyAlpnAgent' without
+                    // declaring an explicit or implicit dependency.
+                    task.dependsOn(copyAlpnAgentTask)
+                }
+
                 project.ext.getGenerateSourcesTask().dependsOn(task)
             }
         }

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -112,6 +112,13 @@ configure(projectsWithFlags('java')) {
                 compileTask.dependsOn(task)
             }
 
+            def copyAlpnAgentTask= tasks.findByName('copyAlpnAgent')
+            if (copyAlpnAgentTask) {
+                // A workaround for ':generateProto' uses this output of task ':copyAlpnAgent' without
+                // declaring an explicit or implicit dependency.
+                task.dependsOn(copyAlpnAgentTask)
+            }
+
             project.ext.getGenerateSourcesTask().dependsOn(task)
         }
     }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -152,6 +152,7 @@ configure(relocatedProjects) {
             printconfiguration file("${project.buildDir}/proguard.cfg")
         }
 
+        tasks.shadedClasses.dependsOn tasks.trimShadedJar
         tasks.assemble.dependsOn tasks.trimShadedJar
 
         // Add the trimmed JAR to archives.

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -284,7 +284,7 @@ private void configureShadowTask(Project project, ShadowJar task, boolean isMain
 
 /**
  * Finds the dependencies of {@code project} recursively and adds the found dependencies to
- * the configuration named as {@code 'shadedTestRuntime'}.
+ * the configuration named as {@code 'shadedTestImplementation'}.
  */
 private Configuration configureShadedTestImplementConfiguration(
         Project project, Project recursedProject = project,

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -198,9 +198,21 @@ configure(relocatedProjects) {
     tasks.check.dependsOn tasks.shadedTest
 
     // Configurations shouldn't be created in afterEvaluate so create it eagerly here before configuring it.
-    it.configurations.create("shadedTestRuntime") {
+
+    // In Gradle 8, dependencies can't be declared in a resolvable (canBeResolved=true) configuration. As a
+    // workaround two configurations are created to separate the declaration and resolving roles.
+    // - Directly declares dependencies to `shadedTestImplementation`.
+    // - Indirectly resolves the dependencies of `shadedTestImplementation` by creating a new configuration
+    //   and extends `shadedTestImplementation`.
+    // https://discuss.gradle.org/t/problem-with-compileclasspath-after-gradle-8-update/44940
+    project.configurations.create("shadedTestImplementation") {
+        canBeResolved = false
+        canBeConsumed = false
+    }
+    project.configurations.create("shadedTestRuntime") {
         canBeResolved = true
         canBeConsumed = false
+        extendsFrom(project.configurations.shadedTestImplementation)
     }
 
     // Update the classpath of the 'shadedTest' task after all shaded projects are evaluated
@@ -208,7 +220,7 @@ configure(relocatedProjects) {
     project.afterEvaluate {
         if (numConfiguredRelocatedProjects.incrementAndGet() == relocatedProjects.size()) {
             relocatedProjects.each { p ->
-                configureShadedTestRuntimeConfiguration(p)
+                configureShadedTestImplementConfiguration(p)
             }
             relocatedProjects.each { p ->
                 def testTask = p.tasks.shadedTest
@@ -273,23 +285,23 @@ private void configureShadowTask(Project project, ShadowJar task, boolean isMain
  * Finds the dependencies of {@code project} recursively and adds the found dependencies to
  * the configuration named as {@code 'shadedTestRuntime'}.
  */
-private Configuration configureShadedTestRuntimeConfiguration(
+private Configuration configureShadedTestImplementConfiguration(
         Project project, Project recursedProject = project,
         Set<ExcludeRule> excludeRules = new HashSet<>(),
         Set<Project> visitedProjects = new HashSet<>()) {
 
-    def shadedTestRuntime = project.configurations.getByName('shadedTestRuntime')
+    def shadedTestImplementation = project.configurations.getByName('shadedTestImplementation')
 
     if (visitedProjects.contains(recursedProject)) {
-        return shadedTestRuntime
+        return shadedTestImplementation
     } else {
         visitedProjects.add(recursedProject);
     }
 
     if (recursedProject.tasks.findByName('trimShadedJar')) {
-        project.dependencies.add(shadedTestRuntime.name, files(recursedProject.tasks.trimShadedJar.outJarFiles))
+        project.dependencies.add(shadedTestImplementation.name, files(recursedProject.tasks.trimShadedJar.outJarFiles))
     } else if (recursedProject.tasks.findByName('shadedJar')) {
-        project.dependencies.add(shadedTestRuntime.name, files(recursedProject.tasks.shadedJar.archivePath))
+        project.dependencies.add(shadedTestImplementation.name, files(recursedProject.tasks.shadedJar.archivePath))
     }
 
     def shadedDependencyNames = project.ext.relocations.collect { it['name'] }
@@ -323,17 +335,17 @@ private Configuration configureShadedTestRuntimeConfiguration(
                 }
                 // Do not use `project.dependencies.add(name, dep)` that discards the classifier of
                 // a dependency. See https://github.com/gradle/gradle/issues/23096
-                project.configurations.getByName(shadedTestRuntime.name).dependencies.add(dep)
+                project.configurations.getByName(shadedTestImplementation.name).dependencies.add(dep)
             }
         }
     }
 
     // Recurse into the project dependencies.
     projectDependencies.each { ProjectDependency dep ->
-        configureShadedTestRuntimeConfiguration(
+        configureShadedTestImplementConfiguration(
                 project, dep.dependencyProject,
                 excludeRules + dep.excludeRules, visitedProjects)
     }
 
-    return shadedTestRuntime
+    return shadedTestImplementation
 }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -2,27 +2,15 @@ import java.util.regex.Pattern
 
 def buildJdkVersion = Integer.parseInt(JavaVersion.current().getMajorVersion())
 if (rootProject.hasProperty('buildJdkVersion')) {
-    def jdkVersion = Integer.parseInt(rootProject.findProperty('buildJdkVersion'))
+    def jdkVersion = Integer.parseInt(String.valueOf(rootProject.findProperty('buildJdkVersion')))
     if (buildJdkVersion != jdkVersion) {
         buildJdkVersion = jdkVersion
         logger.quiet("Overriding JDK for build with ${buildJdkVersion}")
     }
 }
 
-logger.info("Using JDK ${buildJdkVersion} to build ${project.name}")
+logger.info("Using JDK ${buildJdkVersion} for build")
 rootProject.ext.set("buildJdkVersion", buildJdkVersion)
-
-def testJavaVersion = buildJdkVersion
-if (rootProject.hasProperty('testJavaVersion')) {
-    def testVersion = Integer.parseInt(rootProject.findProperty('testJavaVersion'))
-    if (buildJdkVersion != testVersion) {
-        testJavaVersion = testVersion
-        logger.quiet("Overriding JRE for tests with ${testJavaVersion}")
-    }
-}
-
-logger.info("Using JRE ${testJavaVersion} to test ${project.name}")
-rootProject.ext.set("testJavaVersion", testJavaVersion)
 
 // Enable checkstyle if the rule file exists.
 def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
@@ -75,8 +63,20 @@ configure(projectsWithFlags('java')) {
     def targetJavaVersion = extractTargetJavaVersion(project)
     if (targetJavaVersion != null && targetJavaVersion < 8) {
         throw new IllegalArgumentException("The minimum target Java version ${version} specified " +
-                "for '${project.name}' cannot be smaller than 8")
+                "for '${project.path}' cannot be smaller than 8")
     }
+
+    def testJavaVersion = targetJavaVersion
+    if (project.hasProperty('testJavaVersion')) {
+        def testVersion = Integer.parseInt(String.valueOf(project.findProperty('testJavaVersion')))
+        if (testJavaVersion != testVersion) {
+            testJavaVersion = testVersion
+            logger.quiet("Overriding JRE for testing ${project.path} with ${testJavaVersion}")
+        }
+    }
+
+    logger.info("Using JRE ${testJavaVersion} to test ${project.path}")
+    project.ext.set("testJavaVersion", testJavaVersion)
 
     java {
         toolchain {
@@ -126,7 +126,7 @@ configure(projectsWithFlags('java')) {
         sourceCompatibility = targetJavaVersionStr ?: project.findProperty('javaSourceCompatibility') ?: '1.8'
         // the default targetJavaVersion is 'javaTargetCompatibility'
         targetCompatibility = targetJavaVersionStr ?: project.findProperty('javaTargetCompatibility') ?: '1.8'
-        if (buildJdkVersion >= 9) {
+        if (rootProject.ext.buildJdkVersion >= 9) {
             // Supported since java 9 https://openjdk.org/jeps/247
             options.release.set(Integer.valueOf(JavaVersion.toVersion(targetCompatibility).majorVersion))
         }
@@ -160,15 +160,15 @@ configure(projectsWithFlags('java')) {
                             }
 
                             // Use a different JRE for testing if necessary.
-                            if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {
+                            if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
                                 javaLauncher = javaToolchains.launcherFor {
-                                    languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
+                                    languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
                                 }
                             }
 
                             // disable tests for projects which target a higher java version
-                            if (rootProject.ext.testJavaVersion < targetJavaVersion) {
-                                project.logger.lifecycle("Skipping tests for ${project.name} since the " +
+                            if (project.ext.testJavaVersion < targetJavaVersion) {
+                                project.logger.lifecycle("Skipping tests for ${project.path} since the " +
                                         "testJavaVersion(${testJavaVersion}) is smaller than the " +
                                         "targetJavaVersion(${targetJavaVersion})")
                                 enabled = false

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -66,6 +66,17 @@ configure(projectsWithFlags('java')) {
                 "for '${project.path}' cannot be smaller than 8")
     }
 
+    def targetJavaVersionStr = null
+    if (targetJavaVersion != null) {
+        targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
+    }
+    def javaSourceCompatibility = targetJavaVersionStr ?: project.findProperty('javaSourceCompatibility') ?: '1.8'
+    def javaTargetCompatibility = targetJavaVersionStr ?: project.findProperty('javaTargetCompatibility') ?: '1.8'
+
+    // The default targetJavaVersion is 'javaTargetCompatibility'
+    targetJavaVersion = Integer.valueOf(JavaVersion.toVersion(javaTargetCompatibility).majorVersion)
+    project.ext.set('targetJavaVersion', targetJavaVersion)
+
     def testJavaVersion = targetJavaVersion
     if (project.hasProperty('testJavaVersion')) {
         def testVersion = Integer.parseInt(String.valueOf(project.findProperty('testJavaVersion')))
@@ -73,6 +84,10 @@ configure(projectsWithFlags('java')) {
             testJavaVersion = testVersion
             logger.quiet("Overriding JRE for testing ${project.path} with ${testJavaVersion}")
         }
+    }
+
+    if (targetJavaVersion != null) {
+        targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
     }
 
     logger.info("Using JRE ${testJavaVersion} to test ${project.path}")
@@ -119,16 +134,11 @@ configure(projectsWithFlags('java')) {
 
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
-        def targetJavaVersionStr = null
-        if (targetJavaVersion != null) {
-            targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
-        }
-        sourceCompatibility = targetJavaVersionStr ?: project.findProperty('javaSourceCompatibility') ?: '1.8'
-        // the default targetJavaVersion is 'javaTargetCompatibility'
-        targetCompatibility = targetJavaVersionStr ?: project.findProperty('javaTargetCompatibility') ?: '1.8'
+        sourceCompatibility = javaSourceCompatibility
+        targetCompatibility = javaTargetCompatibility
         if (rootProject.ext.buildJdkVersion >= 9) {
             // Supported since java 9 https://openjdk.org/jeps/247
-            options.release.set(Integer.valueOf(JavaVersion.toVersion(targetCompatibility).majorVersion))
+            options.release.set(targetJavaVersion)
         }
         options.encoding = 'UTF-8'
         options.warnings = false
@@ -167,10 +177,10 @@ configure(projectsWithFlags('java')) {
                             }
 
                             // disable tests for projects which target a higher java version
-                            if (project.ext.testJavaVersion < targetJavaVersion) {
+                            if (project.ext.testJavaVersion < project.ext.targetJavaVersion) {
                                 project.logger.lifecycle("Skipping tests for ${project.path} since the " +
-                                        "testJavaVersion(${testJavaVersion}) is smaller than the " +
-                                        "targetJavaVersion(${targetJavaVersion})")
+                                        "testJavaVersion(${project.ext.testJavaVersion}) is smaller than the " +
+                                        "targetJavaVersion(${project.ext.targetJavaVersion})")
                                 enabled = false
                             }
                         }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -158,11 +158,11 @@ configure(projectsWithFlags('java')) {
 
                             def flakyTests = rootProject.findProperty('flakyTests')
                             if (flakyTests == 'true') {
-                                options {
+                                useJUnitPlatform {
                                     includeTags 'FLAKY_TESTS'
                                 }
                             } else if (flakyTests == 'false') {
-                                options {
+                                useJUnitPlatform {
                                     excludeTags 'FLAKY_TESTS'
                                 }
                             } else if (flakyTests != null) {

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -59,6 +59,7 @@ configure(projectsWithFlags('java')) {
     apply plugin: 'java-library'
     apply plugin: 'eclipse'
     apply plugin: 'idea'
+    apply plugin: 'jvm-test-suite'
 
     archivesBaseName = project.ext.artifactId
 
@@ -134,40 +135,48 @@ configure(projectsWithFlags('java')) {
         options.compilerArgs += '-parameters'
     }
 
-    // Enable full exception logging for test failures.
-    tasks.withType(Test).configureEach {
-        testLogging.exceptionFormat = 'full'
+    testing {
+        suites {
+            test {
+                // Use JUnit platform.
+                useJUnitJupiter()
 
-        // Use JUnit platform.
-        def flakyTests = rootProject.findProperty('flakyTests')
-        if (flakyTests == 'true') {
-            useJUnitPlatform {
-                includeTags 'FLAKY_TESTS'
-            }
-        } else if (flakyTests == 'false') {
-            useJUnitPlatform {
-                excludeTags 'FLAKY_TESTS'
-            }
-        } else {
-            if (flakyTests != null) {
-                throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
-            }
-            useJUnitPlatform()
-        }
+                targets {
+                    all {
+                        testTask.configure {
+                             testLogging.exceptionFormat = 'full'
 
-        // Use a different JRE for testing if necessary.
-        if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {
-            javaLauncher = javaToolchains.launcherFor {
-                languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
-            }
-        }
+                            def flakyTests = rootProject.findProperty('flakyTests')
+                            if (flakyTests == 'true') {
+                                options {
+                                    includeTags 'FLAKY_TESTS'
+                                }
+                            } else if (flakyTests == 'false') {
+                                options {
+                                    excludeTags 'FLAKY_TESTS'
+                                }
+                            } else if (flakyTests != null) {
+                                throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
+                            }
 
-        // disable tests for projects which target a higher java version
-        if (rootProject.ext.testJavaVersion < targetJavaVersion) {
-            project.logger.lifecycle("Skipping tests for ${project.name} since the " +
-                    "testJavaVersion(${testJavaVersion}) is smaller than the " +
-                    "targetJavaVersion(${targetJavaVersion})")
-            it.enabled = false
+                            // Use a different JRE for testing if necessary.
+                            if (rootProject.ext.buildJdkVersion != rootProject.ext.testJavaVersion) {
+                                javaLauncher = javaToolchains.launcherFor {
+                                    languageVersion = JavaLanguageVersion.of(rootProject.ext.testJavaVersion)
+                                }
+                            }
+
+                            // disable tests for projects which target a higher java version
+                            if (rootProject.ext.testJavaVersion < targetJavaVersion) {
+                                project.logger.lifecycle("Skipping tests for ${project.name} since the " +
+                                        "testJavaVersion(${testJavaVersion}) is smaller than the " +
+                                        "targetJavaVersion(${targetJavaVersion})")
+                                enabled = false
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/gradle/scripts/lib/kotlin.gradle
+++ b/gradle/scripts/lib/kotlin.gradle
@@ -46,9 +46,19 @@ configure(projectsWithFlags('kotlin')) {
             ['Main', 'Test', 'Jmh'].each { name ->
                 // A workaround for 'runKtlintCheckOverMainSourceSet' uses this output of task ':generateProto'
                 // without declaring an explicit or implicit dependency.
+                def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
                 def ktlintTask = tasks.findByName("runKtlintCheckOver${name}SourceSet")
                 if (ktlintTask != null) {
                     ktlintTask.dependsOn(project.ext.getGenerateSourcesTask())
+                    if (copyAlpnAgentTask != null) {
+                        ktlintTask.dependsOn(copyAlpnAgentTask)
+                    }
+                }
+                def ktlintScriptTask = tasks.findByName("runKtlintCheckOverKotlinScripts")
+                if (ktlintScriptTask != null) {
+                    if (copyAlpnAgentTask != null) {
+                        ktlintScriptTask.dependsOn(copyAlpnAgentTask)
+                    }
                 }
 
                 // A workaround for 'compileJmhKotlin' uses this output of task 'compileJmhThrift' without

--- a/gradle/scripts/lib/kotlin.gradle
+++ b/gradle/scripts/lib/kotlin.gradle
@@ -36,9 +36,23 @@ configure(projectsWithFlags('kotlin')) {
         }
 
         afterEvaluate {
-            // A workaround for 'runKtlintCheckOverMainSourceSet' uses this output of task ':generateProto' without
-            // declaring an explicit or implicit dependency.
-            tasks.runKtlintCheckOverMainSourceSet.dependsOn(project.ext.getGenerateSourcesTask())
+
+            // `tasks.withType(KtLintCheckTask)` does not work here.
+            ['Main', 'Test', 'Jmh'].each { name ->
+                // A workaround for 'runKtlintCheckOverMainSourceSet' uses this output of task ':generateProto'
+                // without declaring an explicit or implicit dependency.
+                def ktlintTask = tasks.findByName("runKtlintCheckOver${name}SourceSet")
+                if (ktlintTask != null) {
+                    ktlintTask.dependsOn(project.ext.getGenerateSourcesTask())
+                }
+
+                // A workaround for 'compileJmhKotlin' uses this output of task 'compileJmhThrift' without
+                // declaring an explicit or implicit dependency.
+                def compileTask = tasks.findByName("compile${name}Kotlin")
+                if (compileTask != null) {
+                    compileTask.dependsOn(project.ext.getGenerateSourcesTask())
+                }
+            }
             project.ext.getLintTask().dependsOn(tasks.ktlintCheck)
         }
     }

--- a/gradle/scripts/lib/kotlin.gradle
+++ b/gradle/scripts/lib/kotlin.gradle
@@ -16,6 +16,11 @@ configure(projectsWithFlags('kotlin')) {
         }.each { task ->
             task.kotlinOptions.jvmTarget = target
             task.kotlinOptions.freeCompilerArgs = compilerArgs
+
+            def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
+            if (copyAlpnAgentTask != null) {
+                task.dependsOn(copyAlpnAgentTask)
+            }
         }
     }
 

--- a/gradle/scripts/lib/scala.gradle
+++ b/gradle/scripts/lib/scala.gradle
@@ -33,6 +33,7 @@ configure(scala212 + scala213 + scala3) {
         // Run `scalafmt` to automatically format scala code from source sets
         // https://github.com/alenkacz/gradle-scalafmt#tasks
         project.ext.getLintTask().dependsOn tasks.checkScalafmt
+        tasks.checkScalafmt.dependsOn tasks.processResources
     }
 
     if (project.hasFlags('publish')) {

--- a/gradle/scripts/lib/scala.gradle
+++ b/gradle/scripts/lib/scala.gradle
@@ -16,14 +16,22 @@ configure(scala212 + scala213 + scala3) {
         }
     }
 
-    tasks.withType(Test) {
-        useJUnitPlatform {
-            // A workaround for 'java.lang.InternalError: Malformed class name'
-            // when testing scalapb module with Java 8. This bug was fixed in Java 9.
-            // - https://github.com/gradle/gradle/issues/8432
-            // - https://bugs.openjdk.java.net/browse/JDK-8057919
-            if (rootProject.ext.testJavaVersion == 8) {
-                exclude("**/*\$*\$*.class")
+    testing {
+        suites {
+            test {
+                targets {
+                    all {
+                        testTask.configure {
+                            // A workaround for 'java.lang.InternalError: Malformed class name'
+                            // when testing scalapb module with Java 8. This bug was fixed in Java 9.
+                            // - https://github.com/gradle/gradle/issues/8432
+                            // - https://bugs.openjdk.java.net/browse/JDK-8057919
+                            if (rootProject.ext.testJavaVersion == 8) {
+                                exclude("**/*\$*\$*.class")
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/gradle/scripts/lib/scala.gradle
+++ b/gradle/scripts/lib/scala.gradle
@@ -26,7 +26,7 @@ configure(scala212 + scala213 + scala3) {
                             // when testing scalapb module with Java 8. This bug was fixed in Java 9.
                             // - https://github.com/gradle/gradle/issues/8432
                             // - https://bugs.openjdk.java.net/browse/JDK-8057919
-                            if (rootProject.ext.testJavaVersion == 8) {
+                            if (project.ext.testJavaVersion == 8) {
                                 exclude("**/*\$*\$*.class")
                             }
                         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/micrometer1.3/build.gradle
+++ b/it/micrometer1.3/build.gradle
@@ -15,6 +15,7 @@ tasks.compileTestJava.source "${rootProject.projectDir}/core/src/test/java/com/l
 
 task copyThriftFiles(type: Copy) {
     dependsOn project(':thrift0.17').tasks.compileTestThrift
+    dependsOn project(':thrift0.17').tasks.generateTestSources
 
     from "${rootProject.projectDir}/thrift/thrift0.17/gen-src/test/java"
     into "${project.ext.genSrcDir}/test/java"

--- a/it/thrift0.9.1/build.gradle
+++ b/it/thrift0.9.1/build.gradle
@@ -44,7 +44,8 @@ task generateSources(type: Copy) {
     into "${project.ext.genSrcDir}/test"
 }
 
-tasks.compileTestJava.dependsOn(generateSources)
+tasks.compileTestJava.dependsOn(tasks.generateSources)
+tasks.generateSources.dependsOn(tasks.processTestResources)
 
 // Disable checkstyle because it's checked by ':thrift0.13'
 tasks.withType(Checkstyle) {

--- a/junit4/build.gradle
+++ b/junit4/build.gradle
@@ -16,3 +16,4 @@ task copyJunitSources(type: Copy) {
 
 tasks.compileJava.dependsOn(generateSources)
 tasks.compileJava.dependsOn(copyJunitSources)
+tasks.sourcesJar.dependsOn(copyJunitSources)

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,11 +16,16 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
-val testNg by tasks.registering(Test::class) {
-    group = "Verification"
-    description = "Runs the TestNG unit tests"
-    useTestNG()
+testing {
+    suites {
+        val testNg by registering(JvmTestSuite::class) {
+            useTestNG()
+
+            group = "Verification"
+            description = "Runs the TestNG unit tests"
+        }
+    }
 }
 
-tasks.shadedTest { finalizedBy(testNg) }
-tasks.check { dependsOn(testNg) }
+tasks.shadedTest { finalizedBy(testing.suites.named("testNg")) }
+tasks.check { dependsOn(testing.suites.named("testNg")) }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -18,6 +18,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 
 testing {
     suites {
+        @Suppress("UNUSED_VARIABLE")
         val testNg by registering(JvmTestSuite::class) {
             useTestNG()
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,13 @@
+plugins {
+    // This plugin should be applied in settings.gradle, not build.gradle.
+    // https://github.com/gradle/foojay-toolchains/issues/15
+    //
+    // If Gradle can’t find a locally available toolchain that matches the requirements of the build, it can
+    // automatically download one based on the foojay Disco API.
+    // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
+    id("org.gradle.toolchains.foojay-resolver") version "0.5.0"
+}
+
 rootProject.name = 'armeria'
 
 apply from: "${rootDir}/gradle/scripts/settings-flags.gradle"

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,15 @@ plugins {
     // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
     id("org.gradle.toolchains.foojay-resolver") version "0.5.0"
 }
+toolchainManagement {
+    jvm {
+        javaRepositories {
+            repository("foojay") {
+                resolverClass = org.gradle.toolchains.foojay.FoojayToolchainResolver
+            }
+        }
+    }
+}
 
 rootProject.name = 'armeria'
 

--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -21,6 +21,7 @@ def boot3Actuator = "boot3-actuator-autoconfigure"
 def boot3ActuatorProjectDir = "${rootProject.projectDir}/spring/$boot3Actuator"
 tasks.compileJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileJava)
 tasks.compileTestJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileTestJava)
+tasks.sourcesJar.dependsOn(project(":spring:$boot3Actuator").tasks.sourcesJar)
 
 tasks.compileJava.source "${boot3ActuatorProjectDir}/src/main/java",
         "${boot3ActuatorProjectDir}/gen-src/main/java"

--- a/spring/boot2-autoconfigure/build.gradle
+++ b/spring/boot2-autoconfigure/build.gradle
@@ -45,7 +45,7 @@ tasks.withType(Checkstyle) {
 }
 
 // allows illegal access by cglib
-if (rootProject.ext.testJavaVersion >= 16) {
+if (project.ext.testJavaVersion >= 16) {
     tasks.withType(Test) {
         jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     }

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -68,3 +68,5 @@ task generateSources(type: Copy) {
 }
 
 tasks.compileJava.dependsOn(tasks.generateSources)
+tasks.processResources.dependsOn(tasks.generateSources)
+tasks.processTestResources.dependsOn(tasks.generateSources)

--- a/spring/boot3-actuator-autoconfigure/build.gradle
+++ b/spring/boot3-actuator-autoconfigure/build.gradle
@@ -41,4 +41,5 @@ task generateSources(type: Copy) {
     include '**/Ssl.java'
 }
 
-tasks.compileJava.dependsOn(generateSources)
+tasks.compileJava.dependsOn(tasks.generateSources)
+tasks.processTestResources.dependsOn(tasks.generateSources)

--- a/spring/boot3-autoconfigure/build.gradle
+++ b/spring/boot3-autoconfigure/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 // allows illegal access by cglib
-if (rootProject.ext.testJavaVersion >= 16) {
+if (project.ext.testJavaVersion >= 16) {
     tasks.withType(Test) {
         jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     }

--- a/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsConfigurationTest.java
+++ b/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsConfigurationTest.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.spring.ArmeriaSettingsConfigurationTest.TestConfigur
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "settings" })
 @DirtiesContext
-class ArmeriaSettingsConfigurationTest {
+public class ArmeriaSettingsConfigurationTest {
 
     @SpringBootApplication
     static class TestConfiguration {}


### PR DESCRIPTION
Motivation:

[Gradle 8](https://docs.gradle.org/8.0/release-notes.html) has been released.

Modifications:

- In Gradle 8, dependencies can't be declared in a resolvable configuration (`canBeResolved=true`). `gradle-scripts` used resolvable configurations such as `compileClasspath`, `runtimeClasspath` to inject platform dependencies. https://github.com/line/armeria/blob/20969832640bcc0fa66edc68c531891ab35cea25/gradle/scripts/lib/common-dependencies.gradle#L180-L183
  ```
  * Where: Script '.../gradle/scripts/lib/common-dependencies.gradle'

  * What went wrong: A problem occurred configuring project ':foobar'.
  > Dependencies can not be declared against the `compileClasspath` configuration.
  ```

  `platform` dependencies should be added to non resolvable and non
  configurations. There is no workaround to set dependencies to
  resolvable configurations. So I changed `common-dependencies.gradle`
  to set platform dependencies to the non resolvable and non
  configurations. 

  As a workaround `shadedTestImplementation` is newly added to declare
  dependencies while configuring `shadedTest` task. The original `shadedTestRuntime`
  extends `shadedTestImplementation` and is only used to resolve its dependencies.

  Related discussion: https://discuss.gradle.org/t/problem-with-compileclasspath-after-gradle-8-update/44940

- Gradle 8 also disallows implicit dependencies between two tasks. The solution was quite simple. I added an explicit dependency for the implicit dependency with `.dependsOn(...)` whenever encountering the error.

Result:

You can now use Gradle 8 with `gradle-scripts`.

