### PR TITLE
Add newly-added method from logback 1.3 to support compatibility

### DIFF
--- a/logback/src/main/java/com/linecorp/armeria/common/logback/LoggingEventWrapper.java
+++ b/logback/src/main/java/com/linecorp/armeria/common/logback/LoggingEventWrapper.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.common.logback;
 
+import java.time.Instant;
 import java.util.Map;
 
 import org.slf4j.Marker;
@@ -90,6 +91,12 @@ final class LoggingEventWrapper extends LoggingEvent {
     @Override
     public long getTimeStamp() {
         return event.getTimeStamp();
+    }
+
+    // To keep compatibility with logback 1.4.x
+    // @Override
+    public Instant getInstant() {
+        return Instant.ofEpochMilli(event.getTimeStamp());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Improve compatibility with logback 1.3.x.

`armeria-logback` has compatibility with logback 1.3.x and logstash-logback-encoder 5.3:

* logback 1.3.x introduces the `ILoggingEvent#getInstant()` method which returns null by default.
* logstash-logback-encoder 5.3 uses `ILoggingEvent#getInstant()` in case of using logback 1.3.x or higher
* As a result, logging system is broken when uses logback 1.3.x and logstash-logback-encoder 5.3.

This change enables us to migrate Spring Boot 3 smoothly.

I also submitted the PR to logback https://github.com/qos-ch/logback/pull/652 
But, I am not sure that the PR will be accepted.

Modifications:

- Add method `LoggingEventWrapper#getInstant()` that implements `ILoggingEvent#getInstatnt()`
  - It doesn't have `@Override` because armeria depends on logback 1.2.x

Result:

- Closes  #4855 


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->

Appendix:

I also checked that this change doesn't break the ABI.

- https://github.com/wreulicke/logback-abi-test
