### PR TITLE
Fix `ThriftDocServicePlugin` maybe failed when thrift proto compile with fullcamel option

### DIFF
--- a/it/thrift-fullcamel/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/it/thrift-fullcamel/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/it/thrift-fullcamel/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/it/thrift-fullcamel/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.server.thrift;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.linecorp.armeria.internal.server.docs.DocServiceUtil.unifyFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.docs.MethodInfo;
+import com.linecorp.armeria.server.docs.ServiceInfo;
+import com.linecorp.armeria.server.docs.ServiceSpecification;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.service.test.thrift.main.SayHelloService;
+import com.linecorp.armeria.service.test.thrift.main.SayHelloService.AsyncIface;
+
+class ThriftDocServicePluginTest {
+    private static final String SAY_HELLO_NAME = SayHelloService.class.getName();
+    private static final ThriftDocServicePlugin GENERATOR = new ThriftDocServicePlugin();
+    private static final ThriftDescriptiveTypeInfoProvider DESCRIPTIVE_TYPE_INFO_PROVIDER =
+            new ThriftDescriptiveTypeInfoProvider();
+
+    @Test
+    void servicesTest() {
+        final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
+                                                           (plugin, service, method) -> false);
+        assertThat(services).containsKey(SAY_HELLO_NAME);
+        final ServiceInfo serviceInfo = services.get(SAY_HELLO_NAME);
+        final Map<String, MethodInfo> methods =
+                serviceInfo.methods().stream()
+                           .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+
+        assertThat(methods).containsOnlyKeys("say_hello", "SayHelloNow", "sayHelloWorld");
+    }
+
+    private static Map<String, ServiceInfo> services(DocServiceFilter include, DocServiceFilter exclude) {
+        final Server server =
+                Server.builder()
+                      .service("/",
+                               THttpService.of(mock(AsyncIface.class)))
+                      .build();
+
+        // Generate the specification with the ServiceConfigs.
+        final ServiceSpecification specification = GENERATOR.generateSpecification(
+                ImmutableSet.copyOf(server.serviceConfigs()),
+                unifyFilter(include, exclude), DESCRIPTIVE_TYPE_INFO_PROVIDER);
+
+        // Ensure the specification contains all services.
+        return specification.services()
+                            .stream()
+                            .collect(toImmutableMap(ServiceInfo::name, Function.identity()));
+    }
+}

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -200,9 +200,11 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
 
         // Need get the function name in thrift proto,
         // otherwise the argsClassName maybe wrong when use fullcamel compile option
-        String thriftFunctionName = methodName;
+        final String thriftFunctionName;
         if (entry.thriftServiceEntry != null) {
             thriftFunctionName = entry.thriftServiceEntry.functionName(methodName);
+        } else {
+            thriftFunctionName = methodName;
         }
         final String argsClassName = serviceName + '$' + thriftFunctionName + "_args";
         final Class<? extends TBase<?, ?>> argsClass;

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -190,22 +190,21 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
     @Nullable
     private MethodInfo newMethodInfo(Method method, Entry entry,
                                      DocServiceFilter filter) {
-        final String methodName = method.getName();
+        // Get the function name in thrift IDL
+        final String thriftFunctionName;
+        if (entry.thriftServiceEntry != null) {
+            thriftFunctionName = entry.thriftServiceEntry.functionName(method.getName());
+        } else {
+            thriftFunctionName = method.getName();
+        }
+
         final Class<?> serviceClass = method.getDeclaringClass().getDeclaringClass();
         final String serviceName = serviceClass.getName();
-        if (!filter.test(name(), serviceName, methodName)) {
+        if (!filter.test(name(), serviceName, thriftFunctionName)) {
             return null;
         }
         final ClassLoader classLoader = serviceClass.getClassLoader();
 
-        // Need get the function name in thrift proto,
-        // otherwise the argsClassName maybe wrong when use fullcamel compile option
-        final String thriftFunctionName;
-        if (entry.thriftServiceEntry != null) {
-            thriftFunctionName = entry.thriftServiceEntry.functionName(methodName);
-        } else {
-            thriftFunctionName = methodName;
-        }
         final String argsClassName = serviceName + '$' + thriftFunctionName + "_args";
         final Class<? extends TBase<?, ?>> argsClass;
         try {
@@ -317,17 +316,17 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
     }
 
     @VisibleForTesting
-    public static final class EntryBuilder {
+    static final class EntryBuilder {
         private final Class<?> serviceType;
         private final List<EndpointInfo> endpointInfos = new ArrayList<>();
         @Nullable
         private ThriftServiceEntry thriftServiceEntry;
 
-        public EntryBuilder(Class<?> serviceType) {
+        EntryBuilder(Class<?> serviceType) {
             this(serviceType, null);
         }
 
-        public EntryBuilder(Class<?> serviceType, @Nullable ThriftServiceEntry thriftServiceEntry) {
+        EntryBuilder(Class<?> serviceType, @Nullable ThriftServiceEntry thriftServiceEntry) {
             this.serviceType = requireNonNull(serviceType, "serviceType");
             this.thriftServiceEntry = thriftServiceEntry;
         }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -336,7 +336,7 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
             return this;
         }
 
-        public Entry build() {
+        Entry build() {
             return new Entry(serviceType, endpointInfos, thriftServiceEntry);
         }
     }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -320,7 +320,7 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
         private final Class<?> serviceType;
         private final List<EndpointInfo> endpointInfos = new ArrayList<>();
         @Nullable
-        private ThriftServiceEntry thriftServiceEntry;
+        private final ThriftServiceEntry thriftServiceEntry;
 
         EntryBuilder(Class<?> serviceType) {
             this(serviceType, null);

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -302,7 +302,7 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
     }
 
     @VisibleForTesting
-    public static final class Entry {
+    static final class Entry {
         final Class<?> serviceType;
         final List<EndpointInfo> endpointInfos;
         @Nullable

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -195,6 +195,7 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
         if (entry.thriftServiceEntry != null) {
             thriftFunctionName = entry.thriftServiceEntry.functionName(method.getName());
         } else {
+            // entry.thriftServiceEntry can be null for tests
             thriftFunctionName = method.getName();
         }
 

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePlugin.java
@@ -331,7 +331,7 @@ public final class ThriftDocServicePlugin implements DocServicePlugin {
             this.thriftServiceEntry = thriftServiceEntry;
         }
 
-        public EntryBuilder endpoint(EndpointInfo endpointInfo) {
+        EntryBuilder endpoint(EndpointInfo endpointInfo) {
             endpointInfos.add(requireNonNull(endpointInfo, "endpointInfo"));
             return this;
         }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
@@ -75,8 +75,7 @@ public final class ThriftServiceEntry {
     }
 
     /**
-     * Returns the associated thrift method name in `.thrift` from Thrift function.
-     * @return the associated thrift method name in `.thrift` function.
+     * Returns the associated thrift method name in the Thrift IDL.
      */
     public String functionName(String method) {
         final ThriftFunction function = metadata.function(method);

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
@@ -19,12 +19,10 @@ package com.linecorp.armeria.server.thrift;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.thrift.ThriftFunction;
 import com.linecorp.armeria.internal.common.thrift.ThriftServiceMetadata;
 
@@ -77,15 +75,13 @@ public final class ThriftServiceEntry {
     }
 
     /**
-     * Returns the associated thrift method name in proto from Thrift function.
-     *
-     * @return the associated thrift method name in proto, or {@code null} if there's no such function.
+     * Returns the associated thrift method name in `.thrift` from Thrift function.
+     * @return the associated thrift method name in `.thrift` function.
      */
-    @Nullable
     public String functionName(String method) {
-        return Optional.ofNullable(metadata.function(method))
-                       .map(ThriftFunction::name)
-                       .orElse(null);
+        final ThriftFunction function = metadata.function(method);
+        requireNonNull(function);
+        return function.name();
     }
 
     @Override

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
@@ -19,10 +19,13 @@ package com.linecorp.armeria.server.thrift;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.thrift.ThriftFunction;
 import com.linecorp.armeria.internal.common.thrift.ThriftServiceMetadata;
 
 /**
@@ -71,6 +74,18 @@ public final class ThriftServiceEntry {
      */
     public Set<Class<?>> interfaces() {
         return metadata.interfaces();
+    }
+
+    /**
+     * Returns the associated thrift method name in proto from Thrift function.
+     *
+     * @return the associated thrift method name in proto, or {@code null} if there's no such function.
+     */
+    @Nullable
+    public String functionName(String method) {
+        return Optional.ofNullable(metadata.function(method))
+                       .map(ThriftFunction::name)
+                       .orElse(null);
     }
 
     @Override

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/ThriftServiceEntry.java
@@ -79,7 +79,8 @@ public final class ThriftServiceEntry {
      */
     public String functionName(String method) {
         final ThriftFunction function = metadata.function(method);
-        requireNonNull(function);
+        requireNonNull(function, "metadata.function(method) returned null. metadata: " + metadata +
+                                 ", method: " + method);
         return function.name();
     }
 

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -28,11 +28,12 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.Entry;
+import com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.EntryBuilder;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
@@ -214,14 +215,18 @@ class ThriftDocServicePluginTest {
 
     @Test
     void testNewServiceInfo() {
+        final EntryBuilder builder = new EntryBuilder(FooService.class);
+        builder.endpoint(EndpointInfo.builder("*", "/foo")
+                                     .fragment("a")
+                                     .defaultFormat(ThriftSerializationFormats.BINARY)
+                                     .build());
+        builder.endpoint(EndpointInfo.builder("*", "/debug/foo")
+                                     .fragment("b")
+                                     .defaultFormat(ThriftSerializationFormats.TEXT)
+                                     .build());
+        final Entry entry = builder.build();
         final ServiceInfo service = generator.newServiceInfo(
-                FooService.class,
-                ImmutableList.of(EndpointInfo.builder("*", "/foo")
-                                             .fragment("a").defaultFormat(ThriftSerializationFormats.BINARY)
-                                             .build(),
-                                 EndpointInfo.builder("*", "/debug/foo")
-                                             .fragment("b").defaultFormat(ThriftSerializationFormats.TEXT)
-                                             .build()),
+                entry,
                 (pluginName, serviceName, methodName) -> true);
 
         final Map<String, MethodInfo> methods =
@@ -296,11 +301,13 @@ class ThriftDocServicePluginTest {
 
     @Test
     void typeDefService() {
+        final EntryBuilder builder = new EntryBuilder(TypeDefService.class);
+        builder.endpoint(EndpointInfo.builder("*", "/typeDef")
+                                     .defaultFormat(ThriftSerializationFormats.BINARY)
+                                     .build());
+        final Entry entry = builder.build();
         final ServiceInfo service = generator.newServiceInfo(
-                TypeDefService.class,
-                ImmutableList.of(EndpointInfo.builder("*", "/typeDef")
-                                             .defaultFormat(ThriftSerializationFormats.BINARY)
-                                             .build()),
+                entry,
                 (pluginName, serviceName, methodName) -> true);
 
         final Map<String, MethodInfo> methods =

--- a/thrift/thrift0.17/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
+++ b/thrift/thrift0.17/src/test/java/com/linecorp/armeria/internal/server/thrift/ThriftDocServicePluginTest.java
@@ -28,11 +28,12 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
+import com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.Entry;
+import com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.EntryBuilder;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.docs.DocServiceFilter;
@@ -222,14 +223,16 @@ class ThriftDocServicePluginTest {
 
     @Test
     void testNewServiceInfo() {
+        final EntryBuilder builder = new EntryBuilder(FooService.class);
+        builder.endpoint(EndpointInfo.builder("*", "/foo")
+                                     .fragment("a").defaultFormat(ThriftSerializationFormats.BINARY)
+                                     .build());
+        builder.endpoint(EndpointInfo.builder("*", "/debug/foo")
+                                     .fragment("b").defaultFormat(ThriftSerializationFormats.TEXT)
+                                     .build());
+        final Entry entry = builder.build();
         final ServiceInfo service = GENERATOR.newServiceInfo(
-                FooService.class,
-                ImmutableList.of(EndpointInfo.builder("*", "/foo")
-                                             .fragment("a").defaultFormat(ThriftSerializationFormats.BINARY)
-                                             .build(),
-                                 EndpointInfo.builder("*", "/debug/foo")
-                                             .fragment("b").defaultFormat(ThriftSerializationFormats.TEXT)
-                                             .build()),
+                entry,
                 (pluginName, serviceName, methodName) -> true);
 
         final Map<String, MethodInfo> methods =
@@ -304,11 +307,13 @@ class ThriftDocServicePluginTest {
 
     @Test
     void typeDefService() {
+        final EntryBuilder builder = new EntryBuilder(TypeDefService.class);
+        builder.endpoint(EndpointInfo.builder("*", "/typeDef")
+                                     .defaultFormat(ThriftSerializationFormats.BINARY)
+                                     .build());
+        final Entry entry = builder.build();
         final ServiceInfo service = GENERATOR.newServiceInfo(
-                TypeDefService.class,
-                ImmutableList.of(EndpointInfo.builder("*", "/typeDef")
-                                             .defaultFormat(ThriftSerializationFormats.BINARY)
-                                             .build()),
+                entry,
                 (pluginName, serviceName, methodName) -> true);
 
         final Map<String, MethodInfo> methods =


### PR DESCRIPTION
Motivation:

Fix the problem that ThriftDocServicePlugin maybe failed when thrift proto compile with fullcamel option.

For example, thrift proto like this
```
service GreetService {
    string greet_hi(1: string name);
}
```
when use `java:fullcamel` in thrift compile, the doc service will failed to start, with exception like this
```
Caused by: java.lang.IllegalStateException: failed to find a class: hello.GreetService$greetHi_args
	at com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.newMethodInfo(ThriftDocServicePlugin.java:210) ~[armeria-thrift0.9-1.23.1.jar:?]
	at com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.lambda$newServiceInfo$4(ThriftDocServicePlugin.java:181) ~[armeria-thrift0.9-1.23.1.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193) ~[?:1.8.0_291]
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948) ~[?:1.8.0_291]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_291]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_291]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708) ~[?:1.8.0_291]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_291]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499) ~[?:1.8.0_291]
	at com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.newServiceInfo(ThriftDocServicePlugin.java:183) ~[armeria-thrift0.9-1.23.1.jar:?]
```

Modifications:

- Add a method functionName in `ThriftServiceEntry` to get the proto method by `ThriftFunction`
- Add `ThriftServiceEntry` to `com.linecorp.armeria.internal.server.thrift.ThriftDocServicePlugin.Entry` as a member
- Add extra process to get the `ThriftFunction`'s name for argsClassName in `ThriftDocServicePlugin#newMethodInfo`
- Assure the `MethodInfo.name` always use the right `thriftFunctionName`, otherwise the example requests will not work.

Result:

- thrift proto service method name like "say_hi" with fullcamel option will generate right thrift docs service for debug and view.
- thrift proto service method name like "say_hi" with fullcamel option could process the example request right.