### PR TITLE
Fix `NullPointerException` in `FuseableStreamMessage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
@@ -67,7 +67,7 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                                   @Nullable MapperFunction<T, U> function,
                                   @Nullable Function<? super Throwable, ? extends Throwable> errorFunction) {
         requireNonNull(source, "source");
-        assert function != null && errorFunction == null || function == null && errorFunction != null
+        assert (function != null && errorFunction == null) || (function == null && errorFunction != null)
                 : "function and errorFunction should be mutually exclusive";
 
         source = peel(source);

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FuseableStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FuseableStreamMessageTest.java
@@ -241,6 +241,22 @@ class FuseableStreamMessageTest {
                     .verify();
     }
 
+    @Test
+    void mapErrorWithNoError() {
+        StreamMessage<Integer> fixed = StreamMessage.of(1, 2, 3, 4);
+        StreamMessage<Integer> mapped = fixed.mapError(IllegalStateException::new);
+        // Test subscribe()
+        StepVerifier.create(mapped)
+                    .expectNext(1, 2, 3, 4)
+                    .expectComplete()
+                    .verify();
+
+        fixed = StreamMessage.of(1, 2, 3, 4, 5);
+        mapped = fixed.mapError(IllegalStateException::new);
+        // Test collect()
+        assertThat(mapped.collect().join()).containsExactly(1, 2, 3, 4, 5);
+    }
+
     @CsvSource({ "true", "false" })
     @ParameterizedTest
     void mapWithPooledObjects_collect(boolean withPooledObjects) {


### PR DESCRIPTION
Related issue: #4852

Motivation:

`FuseableStreamMessage.collect()` throws a `NPE` when only `mapError()` is applied to a normal `StreamMessage`.
```java
StreamMessage.of(1, 2, 3, 4)
             .mapError(IllegalStateException::new)
             // Raises a NullPointerException
             .collect().join();
```

The `function` field in `FuseableStreamMessage` can be null if no `map()` is applied to `FuseableStreamMessage`.
https://github.com/line/armeria/blob/871d87297e4d051241589cb1ae95641cbc83f880/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java#L162

The problem only happens when `collect()` method is called. `subscribe()` method already takes the case into account.

Modifications:

- Use the original object as is if `function` is null.

Result:

- You no longer see `NullPointerException` when `.mapError()` is applied to `StreamMessage`
- Closes #4852