### PR TITLE
Add documentation for timeout at the server side

### DIFF
--- a/site/src/pages/docs/server-timeouts.mdx
+++ b/site/src/pages/docs/server-timeouts.mdx
@@ -1,0 +1,210 @@
+# Overriding server timeouts
+
+You can override the default timeouts of a request.
+
+## Global Configuration
+
+Globally configuring the default timeout with system properties or a custom <type://FlagsProvider>.
+
+### Using JVM system properties
+
+You can override the default server timeouts by specifying the following JVM system properties if you do not prefer setting it programmatically.
+
+`-Dcom.linecorp.armeria.defaultRequestTimeoutMillis=<long>`
+
+The default value of this flag is 10000L and 0 disables the timeout.
+
+<Warning>
+
+  The JVM system properties have effect only when you did not specify them programmatically.
+  See <type://Flags> for the complete list of JVM system properties in Armeria.
+
+</Warning>
+
+### Using <type://FlagsProvider>
+
+You can override the global <type://Flags> by implementing your own <type://FlagsProvider> and loading it via Java SPI.
+
+```java
+package com.example.providers;
+
+// Add the following text file to your classpath or JAR file:
+//
+// $ cat META-INF/services/com.linecorp.armeria.common.FlagsProvider
+// com.example.providers.MyFlagsProvider
+//
+public class MyFlagsProvider implements FlagsProvider {
+  @Override
+  public int priority() {
+    // The provider with higher value will be evaluated first.
+    return 100;
+  }
+
+  @Override
+  public Long defaultRequestTimeoutMillis() {
+      return 1000L;
+  }
+}
+```
+
+## Using <type://ServerBuilder>
+```java
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import java.time.Duration;
+
+int requestTimeout = 5;
+
+ServerBuilder sb = Server.builder();
+Server server = sb.http(port)
+                  .annotatedService(new HelloService())
+                  .requestTimeout(Duration.ofSeconds(requestTimeout))
+                  .build();
+```
+
+## Using <type://VirtualHostBuilder>
+
+You can set the timeouts for each virtual host individually
+
+```java
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import java.time.Duration;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+
+int requestTimeout1 = 5;
+int requestTimeout2 = 10;
+int requestTimeout3 = 20;
+
+ServerBuilder sb = Server.builder();
+Server server = sb.http(port)
+                  .defaultVirtualHost()
+                  .service("/hello1", (ctx, req) -> HttpResponse.of(OK))
+                  .requestTimeout(Duration.ofSeconds(requestTimeout1))
+                  .and()
+                  .virtualHost("*.foo.com")
+                  .service("/hello2", (ctx, req) -> HttpResponse.of(OK))
+                  .requestTimeout(Duration.ofSeconds(requestTimeout2))
+                  .and()
+                  .withVirtualHost(builder -> {
+                      builder.hostnamePattern("*.bar.com")
+                              .service("/hello3", (ctx, req) -> HttpResponse.of(OK))
+                              .requestTimeout(Duration.ofSeconds(requestTimeout3));
+                  })
+                  .build();
+```
+
+## Using <type://ServiceBindingBuilder>
+
+You can set the timeouts for each route individually
+
+```java
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import java.time.Duration;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+
+int requestTimeout1 = 5;
+int requestTimeout2 = 10;
+
+ServerBuilder sb = Server.builder();
+Server server = sb.http(port)
+                  .route()
+                  .get("/hello1")
+                  .requestTimeout(Duration.ofSeconds(requestTimeout1))
+                  .build((ctx, req) -> HttpResponse.of(OK))
+                  .withRoute(builder -> {
+                      builder.get("/hello2")
+                             .requestTimeout(Duration.ofSeconds(requestTimeout2))
+                             .build((ctx, req) -> HttpResponse.of(OK));
+                  })
+                  .build();
+```
+
+## Using <type://ServiceRequestContext>
+
+You can use the context to set the timeouts for a request.
+
+```java
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+import java.time.Duration;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+
+int requestTimeout = 5;
+
+ServerBuilder sb = Server.builder();
+Server server = sb.http(port)
+                  .service("/hello", (ctx, req) -> {
+                      ctx.setRequestTimeout(Duration.ofSeconds(requestTimeout));
+                      return HttpResponse.of(OK);
+                  })
+                  .build();
+```
+
+Also, It is possible to use automatically injected context.
+
+```java
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+
+ServerBuilder sb = Server.builder();
+Server server = sb.http(port)
+                  .annotatedService(new HelloService())
+                  .build();
+```
+```java filename=HelloService.java
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+
+import java.time.Duration;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+
+public class HelloService {
+    @Get("/hello")
+    public HttpResponse getHello(ServiceRequestContext ctx) {
+        int requestTimeout = 5;
+        ctx.setRequestTimeout(Duration.ofSeconds(requestTimeout));
+        return HttpResponse.of(OK);
+    }
+}
+```
+
+## Using <type://@RequestTimeout> Annotation
+
+You can use the <type://@RequestTimeout> annotation for annotated services and gRPC services.
+
+```java filename=HelloService.java
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.decorator.RequestTimeout;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static com.linecorp.armeria.common.HttpStatus.OK;
+
+@RequestTimeout(value = 10, unit = TimeUnit.SECONDS)
+public class HelloService {
+
+    @Get("/hello")
+    @RequestTimeout(5000)
+    public HttpResponse getHello() {
+        return HttpResponse.of(OK);
+    }
+
+}
+```

--- a/site/src/pages/docs/server-timeouts.mdx
+++ b/site/src/pages/docs/server-timeouts.mdx
@@ -1,10 +1,10 @@
 # Overriding server timeouts
 
-You can override the default timeouts of a request.
+There are several ways to override the default timeouts at server-side.
 
 ## Global Configuration
 
-Globally configuring the default timeout with system properties or a custom <type://FlagsProvider>.
+You may globally configure the default timeout with system properties or a custom <type://FlagsProvider>.
 
 ### Using JVM system properties
 
@@ -12,7 +12,7 @@ You can override the default server timeouts by specifying the following JVM sys
 
 `-Dcom.linecorp.armeria.defaultRequestTimeoutMillis=<long>`
 
-The default value of this flag is 10000L and 0 disables the timeout.
+Represents the amount of time from receiving a request to sending the corresponding response completely. Default: `10000`.
 
 <Warning>
 
@@ -23,7 +23,7 @@ The default value of this flag is 10000L and 0 disables the timeout.
 
 ### Using <type://FlagsProvider>
 
-You can override the global <type://Flags> by implementing your own <type://FlagsProvider> and loading it via Java SPI.
+You can override the request timeout specified by JVM system properties by implementing your own <type://FlagsProvider> and loading it via Java SPI.
 
 ```java
 package com.example.providers;
@@ -54,18 +54,16 @@ import com.linecorp.armeria.server.ServerBuilder;
 
 import java.time.Duration;
 
-int requestTimeout = 5;
-
 ServerBuilder sb = Server.builder();
 Server server = sb.http(port)
                   .annotatedService(new HelloService())
-                  .requestTimeout(Duration.ofSeconds(requestTimeout))
+                  .requestTimeout(Duration.ofSeconds(5))
                   .build();
 ```
 
 ## Using <type://VirtualHostBuilder>
 
-You can set the timeouts for each virtual host individually
+You can set the timeouts for each virtual host.
 
 ```java
 import com.linecorp.armeria.common.HttpResponse;
@@ -76,31 +74,27 @@ import java.time.Duration;
 
 import static com.linecorp.armeria.common.HttpStatus.OK;
 
-int requestTimeout1 = 5;
-int requestTimeout2 = 10;
-int requestTimeout3 = 20;
-
 ServerBuilder sb = Server.builder();
 Server server = sb.http(port)
                   .defaultVirtualHost()
                   .service("/hello1", (ctx, req) -> HttpResponse.of(OK))
-                  .requestTimeout(Duration.ofSeconds(requestTimeout1))
+                  .requestTimeout(Duration.ofSeconds(5))
                   .and()
                   .virtualHost("*.foo.com")
                   .service("/hello2", (ctx, req) -> HttpResponse.of(OK))
-                  .requestTimeout(Duration.ofSeconds(requestTimeout2))
+                  .requestTimeout(Duration.ofSeconds(10))
                   .and()
                   .withVirtualHost(builder -> {
                       builder.hostnamePattern("*.bar.com")
                               .service("/hello3", (ctx, req) -> HttpResponse.of(OK))
-                              .requestTimeout(Duration.ofSeconds(requestTimeout3));
+                              .requestTimeout(Duration.ofSeconds(15));
                   })
                   .build();
 ```
 
 ## Using <type://ServiceBindingBuilder>
 
-You can set the timeouts for each route individually
+You can set the timeouts for each route.
 
 ```java
 import com.linecorp.armeria.common.HttpResponse;
@@ -111,18 +105,15 @@ import java.time.Duration;
 
 import static com.linecorp.armeria.common.HttpStatus.OK;
 
-int requestTimeout1 = 5;
-int requestTimeout2 = 10;
-
 ServerBuilder sb = Server.builder();
 Server server = sb.http(port)
                   .route()
                   .get("/hello1")
-                  .requestTimeout(Duration.ofSeconds(requestTimeout1))
+                  .requestTimeout(Duration.ofSeconds(5))
                   .build((ctx, req) -> HttpResponse.of(OK))
                   .withRoute(builder -> {
                       builder.get("/hello2")
-                             .requestTimeout(Duration.ofSeconds(requestTimeout2))
+                             .requestTimeout(Duration.ofSeconds(10))
                              .build((ctx, req) -> HttpResponse.of(OK));
                   })
                   .build();
@@ -141,45 +132,13 @@ import java.time.Duration;
 
 import static com.linecorp.armeria.common.HttpStatus.OK;
 
-int requestTimeout = 5;
-
 ServerBuilder sb = Server.builder();
 Server server = sb.http(port)
                   .service("/hello", (ctx, req) -> {
-                      ctx.setRequestTimeout(Duration.ofSeconds(requestTimeout));
+                      ctx.setRequestTimeout(Duration.ofSeconds(5));
                       return HttpResponse.of(OK);
                   })
                   .build();
-```
-
-Also, It is possible to use automatically injected context.
-
-```java
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
-
-ServerBuilder sb = Server.builder();
-Server server = sb.http(port)
-                  .annotatedService(new HelloService())
-                  .build();
-```
-```java filename=HelloService.java
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.annotation.Get;
-
-import java.time.Duration;
-
-import static com.linecorp.armeria.common.HttpStatus.OK;
-
-public class HelloService {
-    @Get("/hello")
-    public HttpResponse getHello(ServiceRequestContext ctx) {
-        int requestTimeout = 5;
-        ctx.setRequestTimeout(Duration.ofSeconds(requestTimeout));
-        return HttpResponse.of(OK);
-    }
-}
 ```
 
 ## Using <type://@RequestTimeout> Annotation

--- a/site/src/pages/docs/server-timeouts.mdx
+++ b/site/src/pages/docs/server-timeouts.mdx
@@ -1,4 +1,4 @@
-# Overriding server timeouts
+# Configuring server timeouts
 
 There are several ways to override the default timeouts at server-side.
 
@@ -41,8 +41,8 @@ Server server = sb.http(port)
                   .and()
                   .withVirtualHost(builder -> {
                       builder.hostnamePattern("*.bar.com")
-                              .service("/hello3", (ctx, req) -> HttpResponse.of(OK))
-                              .requestTimeout(Duration.ofSeconds(15));
+                             .service("/hello3", (ctx, req) -> HttpResponse.of(OK))
+                             .requestTimeout(Duration.ofSeconds(15));
                   })
                   .build();
 ```

--- a/site/src/pages/docs/server-timeouts.mdx
+++ b/site/src/pages/docs/server-timeouts.mdx
@@ -2,51 +2,6 @@
 
 There are several ways to override the default timeouts at server-side.
 
-## Global Configuration
-
-You may globally configure the default timeout with system properties or a custom <type://FlagsProvider>.
-
-### Using JVM system properties
-
-You can override the default server timeouts by specifying the following JVM system properties if you do not prefer setting it programmatically.
-
-`-Dcom.linecorp.armeria.defaultRequestTimeoutMillis=<long>`
-
-Represents the amount of time from receiving a request to sending the corresponding response completely. Default: `10000`.
-
-<Warning>
-
-  The JVM system properties have effect only when you did not specify them programmatically.
-  See <type://Flags> for the complete list of JVM system properties in Armeria.
-
-</Warning>
-
-### Using <type://FlagsProvider>
-
-You can override the request timeout specified by JVM system properties by implementing your own <type://FlagsProvider> and loading it via Java SPI.
-
-```java
-package com.example.providers;
-
-// Add the following text file to your classpath or JAR file:
-//
-// $ cat META-INF/services/com.linecorp.armeria.common.FlagsProvider
-// com.example.providers.MyFlagsProvider
-//
-public class MyFlagsProvider implements FlagsProvider {
-  @Override
-  public int priority() {
-    // The provider with higher value will be evaluated first.
-    return 100;
-  }
-
-  @Override
-  public Long defaultRequestTimeoutMillis() {
-      return 1000L;
-  }
-}
-```
-
 ## Using <type://ServerBuilder>
 ```java
 import com.linecorp.armeria.server.Server;
@@ -167,3 +122,49 @@ public class HelloService {
 
 }
 ```
+
+## Global Configuration
+
+You may globally configure the default timeout with system properties or a custom <type://FlagsProvider>.
+
+### Using <type://FlagsProvider>
+
+You can override the request timeout specified by JVM system properties by implementing your own <type://FlagsProvider> and loading it via Java SPI.
+
+```java
+package com.example.providers;
+
+// Add the following text file to your classpath or JAR file:
+//
+// $ cat META-INF/services/com.linecorp.armeria.common.FlagsProvider
+// com.example.providers.MyFlagsProvider
+//
+public class MyFlagsProvider implements FlagsProvider {
+  @Override
+  public int priority() {
+    // The provider with higher value will be evaluated first.
+    return 100;
+  }
+
+  @Override
+  public Long defaultRequestTimeoutMillis() {
+      return 1000L;
+  }
+}
+```
+
+### Using JVM system properties
+
+You can override the default server timeouts by specifying the following JVM system properties if you do not prefer setting it programmatically.
+
+`-Dcom.linecorp.armeria.defaultRequestTimeoutMillis=<long>`
+
+Represents the amount of time from receiving a request to sending the corresponding response completely. Default: `10000`.
+
+<Warning>
+
+  The JVM system properties have effect only when you did not specify them programmatically.
+  See <type://Flags> for the complete list of JVM system properties in Armeria.
+
+</Warning>
+

--- a/site/src/pages/docs/toc.json
+++ b/site/src/pages/docs/toc.json
@@ -23,7 +23,8 @@
     "server-cors",
     "server-sse",
     "server-service-registration",
-    "server-multipart"
+    "server-multipart",
+    "server-timeouts"
   ],
   "Client": [
     "client-http",


### PR DESCRIPTION
Motivation:

- Related issue: #4595
- Documentation exists for [configuring timeouts on the client-side](https://armeria.dev/docs/client-timeouts) of an application, but there is no documentation available for configuring timeouts on the server-side.

Modifications:

- Create a documentation of several ways to override request timeouts on a server.

Result:

- Closes #4595
