### PR TITLE
Provide a way to customize GraphQL ExecutionId

### DIFF
--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -30,7 +30,8 @@ import graphql.execution.ExecutionIdProvider;
 @FunctionalInterface
 public interface ExecutionIdGenerator {
     /**
-     * Returns the default {@link ExecutionIdGenerator} which uses the ID of the {@link ServiceRequestContext} as the execution ID.
+     * Returns the default {@link ExecutionIdGenerator} which uses the ID of the {@link ServiceRequestContext}
+     * as the execution ID.
      */
     static ExecutionIdGenerator of() {
         return (ctx, query, operationName) -> ExecutionId.from(ctx.id().text());
@@ -42,7 +43,8 @@ public interface ExecutionIdGenerator {
     ExecutionId generate(ServiceRequestContext ctx, String query, String operationName);
 
     /**
-     * Returns an {@link ExecutionIdProvider} that uses this {@link ExecutionIdGenerator} to generate execution IDs.
+     * Returns an {@link ExecutionIdProvider} that uses this {@link ExecutionIdGenerator} to generate
+     * execution IDs.
      */
     default ExecutionIdProvider asExecutionProvider() {
         return (query, operationName, context) -> {

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -34,13 +34,13 @@ public interface ExecutionIdGenerator {
      * as the execution ID.
      */
     static ExecutionIdGenerator of() {
-        return (ctx, query, operationName) -> ExecutionId.from(ctx.id().text());
+        return (requestContext, query, operationName, graphqlContext) -> ExecutionId.from(requestContext.id().text());
     }
 
     /**
      * Generates an execution ID based on the provided context, query, and operation name.
      */
-    ExecutionId generate(ServiceRequestContext ctx, String query, String operationName);
+    ExecutionId generate(ServiceRequestContext requestContext, String query, String operationName, GraphQLContext graphqlContext);
 
     /**
      * Returns an {@link ExecutionIdProvider} that uses this {@link ExecutionIdGenerator} to generate
@@ -48,8 +48,9 @@ public interface ExecutionIdGenerator {
      */
     default ExecutionIdProvider asExecutionProvider() {
         return (query, operationName, context) -> {
-            final ServiceRequestContext ctx = GraphqlServiceContexts.get((GraphQLContext) context);
-            return generate(ctx, query, operationName);
+            final GraphQLContext graphqlContext = (GraphQLContext) context;
+            final ServiceRequestContext requestContext = GraphqlServiceContexts.get(graphqlContext);
+            return generate(requestContext, query, operationName, graphqlContext);
         };
     }
 }

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -34,13 +34,15 @@ public interface ExecutionIdGenerator {
      * as the execution ID.
      */
     static ExecutionIdGenerator of() {
-        return (requestContext, query, operationName, graphqlContext) -> ExecutionId.from(requestContext.id().text());
+        return (requestContext, query, operationName, graphqlContext) -> ExecutionId.from(
+                requestContext.id().text());
     }
 
     /**
      * Generates an execution ID based on the provided context, query, and operation name.
      */
-    ExecutionId generate(ServiceRequestContext requestContext, String query, String operationName, GraphQLContext graphqlContext);
+    ExecutionId generate(ServiceRequestContext requestContext, String query, String operationName,
+                         GraphQLContext graphqlContext);
 
     /**
      * Returns an {@link ExecutionIdProvider} that uses this {@link ExecutionIdGenerator} to generate

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -30,8 +30,7 @@ import graphql.execution.ExecutionIdProvider;
 @FunctionalInterface
 public interface ExecutionIdGenerator {
     /**
-     * Returns the default {@link ExecutionIdGenerator} which uses the ID of the {@link ServiceRequestContext}
-     * as the execution ID.
+     * Returns the default {@link ExecutionIdGenerator} which uses {@link ServiceRequestContext#id()}
      */
     static ExecutionIdGenerator of() {
         return (requestContext, query, operationName, graphqlContext) -> ExecutionId.from(
@@ -39,7 +38,7 @@ public interface ExecutionIdGenerator {
     }
 
     /**
-     * Generates an execution ID based on the provided context, query, and operation name.
+     * Generates an execution ID based on the provided context, query, operation name, and graphql context.
      */
     ExecutionId generate(ServiceRequestContext requestContext, String query, String operationName,
                          GraphQLContext graphqlContext);

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -29,7 +29,8 @@ import graphql.execution.ExecutionIdProvider;
 @FunctionalInterface
 public interface ExecutionIdGenerator {
     /**
-     * Returns the default {@link ExecutionIdGenerator} which uses {@link ServiceRequestContext#id()}
+     * Returns the default {@link ExecutionIdGenerator} that uses {@link ServiceRequestContext#id()}
+     * as the execution ID.
      */
     static ExecutionIdGenerator of() {
         return (requestContext, query, operationName, graphqlContext) -> ExecutionId.from(

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -23,8 +23,7 @@ import graphql.execution.ExecutionId;
 import graphql.execution.ExecutionIdProvider;
 
 /**
- * An interface for generating unique execution ID in the Armeria GraphQL integration.
- * Implementations of this interface provide a mechanism to generate execution ID for GraphQL requests.
+ * Generates a unique execution ID of each GraphQL request.
  */
 @UnstableApi
 @FunctionalInterface

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionIdGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.graphql;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import graphql.GraphQLContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionIdProvider;
+
+/**
+ * An interface for generating unique execution ID in the Armeria GraphQL integration.
+ * Implementations of this interface provide a mechanism to generate execution ID for GraphQL requests.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface ExecutionIdGenerator {
+    /**
+     * Returns the default {@link ExecutionIdGenerator} which uses the ID of the {@link ServiceRequestContext} as the execution ID.
+     */
+    static ExecutionIdGenerator of() {
+        return (ctx, query, operationName) -> ExecutionId.from(ctx.id().text());
+    }
+
+    /**
+     * Generates an execution ID based on the provided context, query, and operation name.
+     */
+    ExecutionId generate(ServiceRequestContext ctx, String query, String operationName);
+
+    /**
+     * Returns an {@link ExecutionIdProvider} that uses this {@link ExecutionIdGenerator} to generate execution IDs.
+     */
+    default ExecutionIdProvider asExecutionProvider() {
+        return (query, operationName, context) -> {
+            final ServiceRequestContext ctx = GraphqlServiceContexts.get((GraphQLContext) context);
+            return generate(ctx, query, operationName);
+        };
+    }
+}

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
@@ -82,6 +82,8 @@ public final class GraphqlServiceBuilder {
     @Nullable
     private GraphqlErrorHandler errorHandler;
 
+    private ExecutionIdGenerator executionIdGenerator = ExecutionIdGenerator.of();
+
     GraphqlServiceBuilder() {}
 
     /**
@@ -243,11 +245,21 @@ public final class GraphqlServiceBuilder {
     }
 
     /**
+     * Sets the {@link ExecutionIdGenerator}.
+     * If not specified, {@link ExecutionIdGenerator#of()} is used by default.
+     */
+    public GraphqlServiceBuilder executionIdGenerator(ExecutionIdGenerator executionIdGenerator) {
+        this.executionIdGenerator = requireNonNull(executionIdGenerator, "executionIdGenerator");
+        return this;
+    }
+
+    /**
      * Creates a {@link GraphqlService}.
      */
     public GraphqlService build() {
         final GraphQLSchema schema = buildSchema();
-        GraphQL.Builder builder = GraphQL.newGraphQL(schema);
+        GraphQL.Builder builder = GraphQL.newGraphQL(schema)
+                                         .executionIdProvider(executionIdGenerator.asExecutionProvider());
         final List<Instrumentation> instrumentations = this.instrumentations.build();
         if (!instrumentations.isEmpty()) {
             builder = builder.instrumentation(new ChainedInstrumentation(instrumentations));

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.graphql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import graphql.ExecutionResult;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.ExecutionContext;
+import graphql.execution.ExecutionId;
+import graphql.execution.ExecutionStrategyParameters;
+import graphql.schema.DataFetcher;
+
+class ExecutionIdGeneratorTest {
+
+    static CaptureIdStrategy idStrategy = new CaptureIdStrategy();
+
+    static class CaptureIdStrategy extends AsyncExecutionStrategy {
+        @Nullable
+        ExecutionId executionId;
+
+        @Override
+        public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext,
+                                                          ExecutionStrategyParameters parameters) {
+            executionId = executionContext.getExecutionId();
+            return super.execute(executionContext, parameters);
+        }
+    }
+
+    static class ConcatExecutionIdGenerator implements ExecutionIdGenerator {
+        @Override
+        public ExecutionId generate(ServiceRequestContext ctx, String query, String operationName) {
+            return ExecutionId.from(ctx + query + operationName);
+        }
+    }
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final File graphqlSchemaFile =
+                    new File(getClass().getResource("/test.graphqls").toURI());
+            final GraphqlService service =
+                    GraphqlService.builder()
+                                  .configureGraphql(builder -> builder.queryExecutionStrategy(idStrategy))
+                                  .schemaFile(graphqlSchemaFile)
+                                  .runtimeWiring(c -> {
+                                      final DataFetcher<String> bar = dataFetcher("bar");
+                                      c.type("Query",
+                                             typeWiring -> typeWiring.dataFetcher("foo", bar));
+                                  })
+                                  .build();
+            final GraphqlService customizedExecutionIdService =
+                    GraphqlService.builder()
+                                  .executionIdGenerator(new ConcatExecutionIdGenerator())
+                                  .configureGraphql(builder -> builder.queryExecutionStrategy(idStrategy))
+                                  .schemaFile(graphqlSchemaFile)
+                                  .runtimeWiring(c -> {
+                                      final DataFetcher<String> bar = dataFetcher("bar");
+                                      c.type("Query",
+                                             typeWiring -> typeWiring.dataFetcher("foo", bar));
+                                  })
+                                  .build();
+            sb.service("/graphql", service)
+              .service("/graphql-customized-execution-id", customizedExecutionIdService);
+        }
+    };
+
+    static DataFetcher<String> dataFetcher(String value) {
+        return environment -> {
+            final ServiceRequestContext ctx = GraphqlServiceContexts.get(environment);
+            assertThat(ctx.eventLoop().inEventLoop()).isTrue();
+            // Make sure that a ServiceRequestContext is available
+            assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+            return value;
+        };
+    }
+
+    @Test
+    void defaultExecutionIdGenerator() throws InterruptedException {
+        BlockingWebClient.of(server.httpUri()).get("/graphql?query={foo}");
+
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        assertThat(idStrategy.executionId).isEqualTo(ExecutionId.from(ctx.id().text()));
+    }
+
+    @Test
+    void concatenateExecutionIdGenerator() throws InterruptedException {
+        final String operationName = "Foo";
+        final String query = "query " + operationName + " {foo}";
+        final String content = "{\n" +
+                               "  \"operationName\": \"" + operationName + "\",\n" +
+                               "  \"query\": \"" + query + "\"\n" +
+                               "}\n";
+        final HttpRequest request = HttpRequest.builder().post("/graphql-customized-execution-id")
+                                               .content(MediaType.GRAPHQL_RESPONSE_JSON, content)
+                                               .build();
+        BlockingWebClient.of(server.httpUri()).execute(request);
+
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        assertThat(idStrategy.executionId).isEqualTo(ExecutionId.from(ctx + query + operationName));
+    }
+}

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
@@ -65,7 +65,7 @@ class ExecutionIdGeneratorTest {
         @Override
         public ExecutionId generate(ServiceRequestContext requestContext, String query, String operationName,
                                     GraphQLContext graphqlContext) {
-                return ExecutionId.from(requestContext + query + operationName + graphqlContext);
+            return ExecutionId.from(requestContext + query + operationName + graphqlContext);
         }
     }
 
@@ -138,6 +138,7 @@ class ExecutionIdGeneratorTest {
 
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(response.contentUtf8()).node("data.foo").isEqualTo("bar");
-        assertThat(idStrategy.executionId).isEqualTo(ExecutionId.from(ctx + query + operationName + capturedGraphQLContext));
+        assertThat(idStrategy.executionId).isEqualTo(
+                ExecutionId.from(ctx + query + operationName + capturedGraphQLContext));
     }
 }

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/ExecutionIdGeneratorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -50,7 +51,7 @@ class ExecutionIdGeneratorTest {
 
     static class CaptureIdStrategy extends AsyncExecutionStrategy {
         @Nullable
-        ExecutionId executionId;
+        volatile ExecutionId executionId;
 
         @Override
         public CompletableFuture<ExecutionResult> execute(ExecutionContext executionContext,
@@ -109,6 +110,11 @@ class ExecutionIdGeneratorTest {
             assertThat(ServiceRequestContext.current()).isSameAs(ctx);
             return value;
         };
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        idStrategy.executionId = null;
     }
 
     @Test


### PR DESCRIPTION
Motivation:

- Currently, if an `ExecutionId` is not explicitly set for a query in GraphQL-Java, a default `ExecutionId` is generated using `UUID.randomUUID()`. However, this default approach has drawbacks. To address these limitations, this PR introduces the ability for users to customize the generation of `ExecutionId`.

Modifications:

- Introduce an `ExecutionIdGenerator` to enable customization of the execution ID generation mechanism using the `ServiceRequestContext`, query, and operation name.
    - The `of()` method in the `ExecutionIdGenerator` interface provides a default implementation that automatically assigns the execution ID as the ID of the `ServiceRequestContext`, allowing for convenient generation of execution IDs.
- The method `executionIdGenerator()`, is introduced in the `GraphqlServiceBuilder`, which enables users to inject a customized `ExecutionIdGenerator` instance into the builder.

Result:

- Closes #4867.
- Users can customize the mechanism of generation of `ExecutionId`.
- The default mechanism uses ID of the `ServiceRequestContext` as the `ExecutionID`.
