### PR TITLE
Fixed a bug where `StructInfo` is not linked in DocService when a protobuf is used both for gRPC and annotated

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceSpecificationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceSpecificationTest.java
@@ -1,0 +1,24 @@
+package com.linecorp.armeria.server.docs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class ServiceSpecificationTest {
+
+    @Test
+    void preferAliasedStructInfo() {
+        final StructInfo noAlias = new StructInfo("foo", ImmutableList.of());
+        final StructInfo aliased = noAlias.withAlias("bar");
+        ServiceSpecification specification =
+                new ServiceSpecification(ImmutableList.of(), ImmutableList.of(),
+                                         ImmutableList.of(noAlias, aliased), ImmutableList.of());
+        assertThat(specification.structs()).containsExactly(aliased);
+
+        specification = new ServiceSpecification(ImmutableList.of(), ImmutableList.of(),
+                                                 ImmutableList.of(aliased, noAlias), ImmutableList.of());
+        assertThat(specification.structs()).containsExactly(aliased);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/docs/ServiceSpecificationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/ServiceSpecificationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.server.docs;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/DuplicateStructInfoSpecificationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/DuplicateStructInfoSpecificationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.grpc.testing.Messages;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class DuplicateStructInfoSpecificationTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(18080);
+            sb.annotatedService(new SimpleAnnotatedService());
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(CommonPools.blockingTaskExecutor()))
+                                  .enableUnframedRequests(true)
+                                  .build());
+            sb.serviceUnder("/docs", new DocService());
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @Test
+    void shouldHaveAliasInSpecification() throws InterruptedException {
+        final BlockingWebClient client = server.blockingWebClient();
+        final JsonNode spec = client.prepare()
+                                    .get("/docs/specification.json").asJson(JsonNode.class)
+                                    .execute().content();
+        boolean found = false;
+        for (JsonNode struct : spec.get("structs")) {
+            if ("armeria.grpc.testing.SimpleRequest".equals(struct.get("name").asText())) {
+                found = true;
+                assertThat(struct.get("alias").asText())
+                        .isEqualTo("com.linecorp.armeria.grpc.testing.Messages$SimpleRequest");
+            }
+        }
+        assertThat(found)
+                .describedAs("Failed to find a StructInfo for 'armeria.grpc.testing.SimpleRequest'")
+                .isTrue();
+    }
+
+    private static class SimpleAnnotatedService {
+
+        @ConsumesJson
+        @ProducesJson
+        @Post("/echo")
+        public Messages.SimpleRequest echo(Messages.SimpleRequest request) {
+            return request;
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/DuplicateStructInfoSpecificationTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/DuplicateStructInfoSpecificationTest.java
@@ -42,7 +42,6 @@ class DuplicateStructInfoSpecificationTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.http(18080);
             sb.annotatedService(new SimpleAnnotatedService());
             sb.service(GrpcService.builder()
                                   .addService(new TestServiceImpl(CommonPools.blockingTaskExecutor()))


### PR DESCRIPTION
Motivation:

If a generated protobuf `Message` is used with both a gRPC service and an annotated service, `StructInfo.alias()` could be removed while merging `StructInfo`s. Because `ServiceSpecification.merge()` deduplicates `StructInfo`s that have the same name.

https://github.com/line/armeria/blob/6b7b1b0b638f3d780f5910a133daf24902af8d93/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecification.java#L151-L155

Background:

gRPC `DocService` creates `StructInfo` from protobuf's `Descriptor`. The generated `Message` class is unknown in the `Descriptor`. Only the message name defined in the `.proto` file can be extracted to `StructInfo`.

However, annotated services make `StructInfo` from `Message` generated by the protobuf compiler. The class name of `Message` is injected as an alias into the `Structinfo` created from the `Descriptor` so that `DocService` links the parameter class to the protobuf `Structinfo`.

https://github.com/line/armeria/blob/8652e5ea544a99790cab391274dde22370b96d35/docs-client/src/lib/specification.tsx#L117-L123

Modifications:

- If two `StructInfo`s have the same name, preserve the one with the alias.
- Miscellaneous) Fixed `JsonSchemaGenerator` so that `StructInfo` can also be found by an alias.

Result:

`DocService` now correctly makes the link to `StructInfo` even when a protobuf `Message` is used in both gRPC services and annotated services.
