### PR TITLE
Backport #4494, #4508 and #4524 to 1.16

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseCompleteException;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
@@ -318,7 +319,7 @@ abstract class HttpResponseDecoder {
             cancelTimeoutOrLog(cause, cancel);
             if (ctx != null) {
                 if (cause == null) {
-                    ctx.request().abort();
+                    ctx.request().abort(ResponseCompleteException.get());
                 } else {
                     ctx.request().abort(cause);
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -147,9 +147,14 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
             return unwrap().execute(ctx, req);
         }
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
-        final ContentPreviewer requestContentPreviewer =
-                contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
+        if (!req.isEmpty()) {
+            final ContentPreviewer requestContentPreviewer =
+                    contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
+            req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
+        } else {
+            // Set empty String.
+            ctx.logBuilder().requestContentPreview("");
+        }
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().execute(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseCompleteException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseCompleteException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * A special {@link CancellationException} that aborts an {@link HttpRequest} after the corresponding
+ * {@link HttpResponse} is completed.
+ */
+@UnstableApi
+public final class ResponseCompleteException extends CancellationException {
+
+    private static final long serialVersionUID = 6090278381004263949L;
+
+    private static final ResponseCompleteException INSTANCE = new ResponseCompleteException();
+
+    /**
+     * Returns the singleton {@link ResponseCompleteException}.
+     */
+    public static ResponseCompleteException get() {
+        return INSTANCE;
+    }
+
+    private ResponseCompleteException() {
+        super(null, null, false, false);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseCompleteException;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
@@ -1049,7 +1050,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         if (requestCause instanceof HttpStatusException || requestCause instanceof HttpResponseException) {
             // Log the requestCause only when an Http{Status,Response}Exception was created with a cause.
             this.requestCause = requestCause.getCause();
-        } else {
+        } else if (!(requestCause instanceof ResponseCompleteException)) {
             this.requestCause = requestCause;
         }
         updateFlags(flags);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancelledSubscriptionException.java
@@ -40,6 +40,13 @@ public final class CancelledSubscriptionException extends RuntimeException {
                new CancelledSubscriptionException() : INSTANCE;
     }
 
+    /**
+     * Creates a new exception with the specified {@code message}.
+     */
+    public CancelledSubscriptionException(String message) {
+        super(message);
+    }
+
     private CancelledSubscriptionException() {}
 
     private CancelledSubscriptionException(@SuppressWarnings("unused") boolean dummy) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/UnmodifiableFuture.java
@@ -17,8 +17,11 @@ package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -41,6 +44,7 @@ public class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
     private static final UnmodifiableFuture<?> NIL;
     private static final UnmodifiableFuture<Boolean> TRUE;
     private static final UnmodifiableFuture<Boolean> FALSE;
+    private static final UnmodifiableFuture<List> IMMUTABLE_LIST;
 
     static {
         NIL = new UnmodifiableFuture<>();
@@ -49,6 +53,8 @@ public class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
         TRUE.doComplete(Boolean.TRUE);
         FALSE = new UnmodifiableFuture<>();
         FALSE.doComplete(Boolean.FALSE);
+        IMMUTABLE_LIST = new UnmodifiableFuture<>();
+        IMMUTABLE_LIST.doComplete(ImmutableList.of());
     }
 
     /**
@@ -70,6 +76,12 @@ public class UnmodifiableFuture<T> extends EventLoopCheckingFuture<T> {
         if (value == Boolean.FALSE) {
             @SuppressWarnings("unchecked")
             final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) FALSE;
+            return cast;
+        }
+
+        if (value == ImmutableList.of()) {
+            @SuppressWarnings("unchecked")
+            final UnmodifiableFuture<U> cast = (UnmodifiableFuture<U>) IMMUTABLE_LIST;
             return cast;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -417,7 +417,7 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
 
     @Override
     public final boolean isClosed() {
-        return closed;
+        return closed || !channel().isActive();
     }
 
     private static final class PendingWrites extends ArrayDeque<Entry<HttpObject, ChannelPromise>> {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
@@ -126,6 +126,6 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
 
     @Override
     public boolean isClosed() {
-        return closed;
+        return closed || !channel().isActive();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
@@ -148,11 +148,6 @@ public final class RequestMetricSupport {
     private static void updateMetrics(
             RequestContext ctx, RequestLog log, RequestMetrics metrics,
             SuccessFunction successFunction) {
-        if (log.requestCause() != null) {
-            metrics.failure().increment();
-            return;
-        }
-
         metrics.requestDuration().record(log.requestDurationNanos(), TimeUnit.NANOSECONDS);
         metrics.requestLength().record(log.requestLength());
         metrics.responseDuration().record(log.responseDurationNanos(), TimeUnit.NANOSECONDS);

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -16,27 +16,35 @@
 
 package com.linecorp.armeria.server;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.reactivestreams.Subscriber;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.HttpObject;
-import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
+import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.common.stream.NoopSubscription;
 
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.EventExecutor;
 
 final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
 
-    private final HttpRequest delegate;
+    private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
+
     private final EventLoop eventLoop;
     private final int id;
     private final int streamId;
+    private final RequestHeaders headers;
     private final boolean keepAlive;
     private final RoutingContext routingContext;
     @Nullable
@@ -51,10 +59,10 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     EmptyContentDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
                                    boolean keepAlive, RoutingContext routingContext,
                                    @Nullable Routed<ServiceConfig> routed) {
-        delegate = HttpRequest.of(headers);
         this.eventLoop = eventLoop;
         this.id = id;
         this.streamId = streamId;
+        this.headers = headers;
         this.keepAlive = keepAlive;
         this.routingContext = routingContext;
         this.routed = routed;
@@ -92,33 +100,40 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
 
     @Override
     public boolean isOpen() {
-        return delegate.isOpen();
+        return false;
     }
 
     @Override
     public boolean isEmpty() {
-        return delegate.isEmpty();
+        return true;
     }
 
     @Override
     public long demand() {
-        return delegate.demand();
+        return 0;
     }
 
     @Override
     public CompletableFuture<Void> whenComplete() {
-        return delegate.whenComplete();
-    }
-
-    @Override
-    public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor) {
-        delegate.subscribe(subscriber, executor);
+        return completionFuture;
     }
 
     @Override
     public void subscribe(Subscriber<? super HttpObject> subscriber, EventExecutor executor,
                           SubscriptionOption... options) {
-        delegate.subscribe(subscriber, executor, options);
+        requireNonNull(subscriber, "subscriber");
+        requireNonNull(executor, "executor");
+        if (executor.inEventLoop()) {
+            subscribe0(subscriber);
+        } else {
+            executor.execute(() -> subscribe0(subscriber));
+        }
+    }
+
+    private void subscribe0(Subscriber<? super HttpObject> subscriber) {
+        subscriber.onSubscribe(NoopSubscription.get());
+        subscriber.onComplete();
+        completionFuture.complete(null);
     }
 
     @Override
@@ -128,22 +143,23 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
 
     @Override
     public void abort() {
-        delegate.abort();
+        completionFuture.complete(null);
     }
 
     @Override
     public void abort(Throwable cause) {
-        delegate.abort(cause);
+        completionFuture.complete(null);
     }
 
     @Override
     public CompletableFuture<List<HttpObject>> collect(EventExecutor executor, SubscriptionOption... options) {
-        return delegate.collect(executor, options);
+        completionFuture.complete(null);
+        return UnmodifiableFuture.completedFuture(ImmutableList.of());
     }
 
     @Override
     public RequestHeaders headers() {
-        return delegate.headers();
+        return headers;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.internal.common.HttpHeadersUtil.mergeResponse
 import static com.linecorp.armeria.internal.common.HttpHeadersUtil.mergeTrailers;
 
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CompletableFuture;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -37,6 +38,7 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
@@ -62,7 +64,6 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
     @Nullable
     private Subscription subscription;
     private State state = State.NEEDS_HEADERS;
-    private boolean isComplete;
 
     private boolean isSubscriptionCompleted;
 
@@ -75,8 +76,9 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
     private WriteDataFutureListener cachedWriteDataListener;
 
     HttpResponseSubscriber(ChannelHandlerContext ctx, ServerHttpObjectEncoder responseEncoder,
-                           DefaultServiceRequestContext reqCtx, DecodedHttpRequest req) {
-        super(ctx, responseEncoder, reqCtx, req);
+                           DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
+                           CompletableFuture<Void> completionFuture) {
+        super(ctx, responseEncoder, reqCtx, req, completionFuture);
     }
 
     @Override
@@ -137,7 +139,8 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                 } else {
                     if (responseEncoder.isResponseHeadersSent(req.id(), req.streamId())) {
                         // The response is sent by the HttpRequestDecoder so we just cancel the stream message.
-                        isComplete = true;
+                        tryComplete(new CancelledSubscriptionException(
+                                "An HTTP response was sent already. ctx: " + reqCtx));
                         setDone(true);
                         return;
                     }
@@ -288,7 +291,8 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
         final State oldState = setDone(false);
         if (oldState == State.NEEDS_HEADERS) {
             logger.warn("{} Published nothing (or only informational responses): {}", ctx.channel(), service());
-            responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR);
+            responseEncoder.writeReset(req.id(), req.streamId(), Http2Error.INTERNAL_ERROR)
+                           .addListener(future -> tryComplete(null));
             ctx.flush();
             return;
         }
@@ -310,19 +314,11 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
 
     @Override
     void fail(Throwable cause) {
-        if (tryComplete()) {
+        if (tryComplete(cause)) {
             setDone(true);
             endLogRequestAndResponse(cause);
             maybeWriteAccessLog();
         }
-    }
-
-    private boolean tryComplete() {
-        if (isComplete) {
-            return false;
-        }
-        isComplete = true;
-        return true;
     }
 
     private void failAndRespond(Throwable cause, AggregatedHttpResponse res, Http2Error error, boolean cancel) {
@@ -360,7 +356,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
                         maybeLogFirstResponseBytesTransferred();
                     }
                     // Write an access log always with a cause. Respect the first specified cause.
-                    if (tryComplete()) {
+                    if (tryComplete(cause)) {
                         endLogRequestAndResponse(cause);
                         maybeWriteAccessLog();
                     }
@@ -445,7 +441,7 @@ final class HttpResponseSubscriber extends AbstractHttpResponseHandler implement
             maybeLogFirstResponseBytesTransferred();
 
             if (endOfStream) {
-                if (tryComplete()) {
+                if (tryComplete(null)) {
                     final Throwable capturedException = CapturedServiceException.get(reqCtx);
                     if (capturedException != null) {
                         endLogRequestAndResponse(capturedException);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -170,6 +170,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private final IdentityHashMap<DecodedHttpRequest, HttpResponse> unfinishedRequests;
     private boolean isReading;
+    private boolean isCleaning;
     private boolean handledLastRequest;
 
     HttpServerHandler(ServerConfig config,
@@ -233,6 +234,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private void cleanup() {
         if (!unfinishedRequests.isEmpty()) {
+            isCleaning = true;
             final ClosedSessionException cause = ClosedSessionException.get();
             unfinishedRequests.forEach((req, res) -> {
                 // An HTTP2 request is cancelled by Http2RequestDecoder.onRstStreamRead()
@@ -240,6 +242,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 // Mark the request stream as closed due to disconnection.
                 req.abortResponse(cause, cancel);
             });
+            unfinishedRequests.clear();
         }
     }
 
@@ -416,6 +419,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             final CompletableFuture<Void> resWriteFuture = new CompletableFuture<>();
             resWriteFuture.handle((ret, cause) -> {
                 try {
+                    assert eventLoop.inEventLoop();
                     if (cause == null || !req.isOpen()) {
                         req.abort(ResponseCompleteException.get());
                     } else {
@@ -425,7 +429,13 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     if (!isTransientService) {
                         gracefulShutdownSupport.dec();
                     }
-                    unfinishedRequests.remove(req);
+
+                    // This callback could be called by `req.abortResponse(cause, cancel)` in `cleanup()`.
+                    // As `unfinishedRequests` is being iterated, `unfinishedRequests` should not be removed.
+                    if (!isCleaning) {
+                        unfinishedRequests.remove(req);
+                    }
+
                     if (unfinishedRequests.isEmpty() && handledLastRequest) {
                         ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(CLOSE);
                     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.IdentityHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -46,6 +47,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ProtocolViolationException;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.ResponseCompleteException;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -199,6 +201,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (responseEncoder != null) {
+            // Immediately close responseEncoder so that a late response is completed with
+            // a ClosedSessionException.
+            responseEncoder.close();
+        }
+
         // Give the unfinished streaming responses a chance to close themselves before we abort them,
         // so that successful responses are not aborted due to a race condition like the following:
         //
@@ -224,10 +232,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private void cleanup() {
-        if (responseEncoder != null) {
-            responseEncoder.close();
-        }
-
         if (!unfinishedRequests.isEmpty()) {
             final ClosedSessionException cause = ClosedSessionException.get();
             unfinishedRequests.forEach((req, res) -> {
@@ -357,9 +361,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             } catch (Throwable cause) {
                 // No need to consume further since the response is ready.
                 if (cause instanceof HttpResponseException || cause instanceof HttpStatusException) {
-                    req.close();
+                    req.abort(ResponseCompleteException.get());
                 } else {
-                    req.close(cause);
+                    req.abort(cause);
                 }
                 serviceResponse = HttpResponse.ofFailure(cause);
             }
@@ -407,10 +411,13 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 return null;
             });
 
-            res.whenComplete().handleAsync((ret, cause) -> {
+            // A future which is completed when the all response objects are written to channel and
+            // the returned promises are done.
+            final CompletableFuture<Void> resWriteFuture = new CompletableFuture<>();
+            resWriteFuture.handle((ret, cause) -> {
                 try {
-                    if (cause == null) {
-                        req.abort();
+                    if (cause == null || !req.isOpen()) {
+                        req.abort(ResponseCompleteException.get());
                     } else {
                         req.abort(cause);
                     }
@@ -426,7 +433,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     logger.warn("Unexpected exception:", t);
                 }
                 return null;
-            }, eventLoop);
+            });
 
             // Set the response to the request in order to be able to immediately abort the response
             // when the peer cancels the stream.
@@ -435,11 +442,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             assert responseEncoder != null;
             if (service.exchangeType(headers, routed.route()).isResponseStreaming()) {
                 final HttpResponseSubscriber resSubscriber =
-                        new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req);
+                        new HttpResponseSubscriber(ctx, responseEncoder, reqCtx, req, resWriteFuture);
                 res.subscribe(resSubscriber, eventLoop, SubscriptionOption.WITH_POOLED_OBJECTS);
             } else {
                 final AggregatedHttpResponseHandler resHandler =
-                        new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req);
+                        new AggregatedHttpResponseHandler(ctx, responseEncoder, reqCtx, req, resWriteFuture);
                 res.aggregateWithPooledObjects(eventLoop, ctx.alloc()).handle(resHandler);
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -147,9 +147,14 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
             return unwrap().serve(ctx, req);
         }
         ctx.setAttr(SETTING_CONTENT_PREVIEW, true);
-        final ContentPreviewer requestContentPreviewer =
-                contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
-        req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
+        if (!req.isEmpty()) {
+            final ContentPreviewer requestContentPreviewer =
+                    contentPreviewerFactory.requestContentPreviewer(ctx, req.headers());
+            req = setUpRequestContentPreviewer(ctx, req, requestContentPreviewer, requestPreviewSanitizer);
+        } else {
+            // Set empty String.
+            ctx.logBuilder().requestContentPreview("");
+        }
 
         ctx.logBuilder().defer(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
         final HttpResponse res = unwrap().serve(ctx, req);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseDecoderTest.java
@@ -40,9 +40,9 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseCompleteException;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
-import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -114,9 +114,10 @@ class HttpResponseDecoderTest {
         final HttpRequestWriter request = HttpRequest.streaming(RequestHeaders.of(HttpMethod.POST, "/"));
         final AggregatedHttpResponse res = client.execute(request).aggregate().join();
         assertThat(res.contentUtf8()).isEqualTo("Hello, Armeria!");
-        // The stream is aborted in HttpResponseDecoder.close(...) after the client receives the response.
+        // The stream is aborted with ResponseCompleteException
+        // in HttpResponseDecoder.close(...) after the client receives the response.
         request.whenComplete().handle((unused, cause) -> {
-            assertThat(cause).isExactlyInstanceOf(AbortedStreamException.class);
+            assertThat(cause).isExactlyInstanceOf(ResponseCompleteException.class);
             return null;
         }).join();
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
@@ -53,11 +53,9 @@ class StreamMessageCollectingTest {
         assertThat(stream1.collect().join()).isEqualTo(ImmutableList.of());
 
         final StreamMessage<Object> stream2 = StreamMessage.of();
-        final Throwable cause = new IllegalStateException("oops");
-        stream2.abort(cause);
-        assertThatThrownBy(() -> stream2.collect().join())
-                .isInstanceOf(CompletionException.class)
-                .hasCause(cause);
+        stream2.abort();
+        // An empty stream isn't aborted.
+        assertThat(stream1.collect().join()).isEqualTo(ImmutableList.of());
 
         final DefaultStreamMessage<Object> stream3 = new DefaultStreamMessage<>();
         stream3.close();
@@ -69,6 +67,7 @@ class StreamMessageCollectingTest {
         assertThat(collectingFuture.join()).isEqualTo(ImmutableList.of());
 
         final DefaultStreamMessage<Object> stream5 = new DefaultStreamMessage<>();
+        final Throwable cause = new IllegalStateException("oops");
         stream5.abort(cause);
         assertThatThrownBy(() -> stream5.collect().join())
                 .isInstanceOf(CompletionException.class)

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -214,9 +214,9 @@ class RequestMetricSupportTest {
                                "service=none}", 1.0)
                 .containsEntry("foo.timeouts#count{cause=ResponseTimeoutException," +
                                "http.status=0,method=POST,service=none}", 0.0)
-                .containsEntry("foo.response.duration#count{http.status=0,method=POST,service=none}", 0.0)
-                .containsEntry("foo.response.length#count{http.status=0,method=POST,service=none}", 0.0)
-                .containsEntry("foo.total.duration#count{http.status=0,method=POST,service=none}", 0.0);
+                .containsEntry("foo.response.duration#count{http.status=0,method=POST,service=none}", 1.0)
+                .containsEntry("foo.response.length#count{http.status=0,method=POST,service=none}", 1.0)
+                .containsEntry("foo.total.duration#count{http.status=0,method=POST,service=none}", 1.0);
     }
 
     private static ClientRequestContext setupClientRequestCtx(MeterRegistry registry) {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/HttpRequestNotSubscribedTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/HttpRequestNotSubscribedTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HttpRequestNotSubscribedTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService(new Object() {
+
+                @Get("/foo")
+                public HttpResponse foo() {
+                    // Request is not subscribed, so it's aborted in the HttpServerHandler.
+                    return HttpResponse.of("OK");
+                }
+            });
+        }
+    };
+
+    @Test
+    void nullRequestCause() throws InterruptedException {
+        assertThat(server.blockingWebClient().get("/foo").status()).isSameAs(HttpStatus.OK);
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        assertThat(ctx.log().ensureComplete().requestCause()).isNull();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1KeepAliveTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.time.Duration;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.util.AsciiString;
+
+class Http1KeepAliveTest {
+
+    private static final AsciiString EXCHANGE_TYPE = HttpHeaderNames.of("X-Exchange-Type");
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(LoggingService.newDecorator());
+
+            sb.service("/", new HttpService() {
+                @Override
+                public ExchangeType exchangeType(RequestHeaders headers, Route route) {
+                    return ExchangeType.valueOf(headers.get(EXCHANGE_TYPE, "UNARY"));
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    // Wrap `delayedResponse` with an `HttpResponseException` so that
+                    // the HttpResponseException completes first and `delayedResponse` is written later.
+                    final HttpResponse delayedResponse =
+                            HttpResponse.delayed(HttpResponse.of("A late response"),
+                                                 Duration.ofSeconds(1));
+                    throw HttpResponseException.of(delayedResponse);
+                }
+            });
+        }
+    };
+
+    @EnumSource(ExchangeType.class)
+    @ParameterizedTest
+    void noKeepAlive(ExchangeType exchangeType) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", server.httpPort())) {
+            socket.setSoTimeout(10000);
+            final PrintWriter writer = new PrintWriter(socket.getOutputStream());
+            writer.print("GET / HTTP/1.1\r\n");
+            writer.print(EXCHANGE_TYPE + ": " + exchangeType.name() + "\r\n");
+            writer.print("Connection: close\r\n\r\n");
+            writer.flush();
+
+            final BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            assertThat(in.readLine()).isEqualTo("HTTP/1.1 200 OK");
+
+            String line;
+            while ((line = in.readLine()) != null) {
+                if (line.isEmpty() || line.contains(":")) {
+                    // Skip headers.
+                    continue;
+                }
+                assertThat(line).isEqualTo("A late response");
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/UnfinishedRequestTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class UnfinishedRequestTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.idleTimeoutMillis(0);
+            sb.requestTimeoutMillis(0);
+
+            final AtomicInteger requestCounter = new AtomicInteger();
+            sb.service("/", (ctx, req) -> {
+                if (requestCounter.incrementAndGet() == 2) {
+                    ctx.initiateConnectionShutdown(0);
+                }
+                return HttpResponse.delayed(HttpResponse.of(200), Duration.ofMinutes(1));
+            });
+        }
+    };
+
+    @Test
+    void shouldCompleteUnfinishedRequestWhenConnectionIsClosed() throws Exception {
+        final WebClient client = server.webClient(cb -> cb.responseTimeoutMillis(0));
+        client.get("/").aggregate();
+        client.get("/").aggregate();
+
+        final ServiceRequestContext ctx1 = server.requestContextCaptor().take();
+        final ServiceRequestContext ctx2 = server.requestContextCaptor().take();
+        // Make sure that `HttpServerHandler.cleanup()` aborts all unfinished requests successfully.
+        ctx1.log().whenComplete().join();
+        ctx2.log().whenComplete().join();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingFailureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingFailureTest.java
@@ -88,9 +88,9 @@ class ContentPreviewingFailureTest {
                 assertThat(log.responseCause()).isNull();
                 break;
             case "/http-status-exception-with-cause":
-                assertThat(log.requestCause())
-                        .isInstanceOf(RuntimeException.class)
-                        .hasMessage("with-status");
+                // The cause of HttpStatusException and HttpResponseException are only propagated to
+                // `log.responseCause()`.
+                assertThat(log.requestCause()).isNull();
                 assertThat(log.responseCause())
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("with-status");

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -133,14 +133,14 @@ class ContentPreviewingServiceTest {
 
             sb.service("/deferred", httpService);
             sb.decorator("/deferred", ContentPreviewingService.newDecorator(100));
-            sb.decorator("/deferred", ((delegate, ctx, req) -> HttpResponse.from(
+            sb.decorator("/deferred", (delegate, ctx, req) -> HttpResponse.from(
                     completedFuture(null).handleAsync((ignored, cause) -> {
                         try {
                             return delegate.serve(ctx, req);
                         } catch (Exception e) {
                             return Exceptions.throwUnsafely(e);
                         }
-                    }, ctx.eventLoop()))));
+                    }, ctx.eventLoop())));
 
             sb.decoratorUnder("/", (delegate, ctx, req) -> {
                 contextCaptor.set(ctx);


### PR DESCRIPTION
Motivation:

A customer wants #4508 to be backported to 1.16.x because they require
more time to upgrade to a newer Armeria version.

Modifications:

- Backported #4508
- Backported #4494 because #4508 depends on it
- Backported #4524 that fixes a regression introduced in #4508

Result:

The customer buys some time until they upgrade Armeria.