### PR TITLE
Remove `spring.config.use-legacy-processing` in tests

### DIFF
--- a/examples/spring-boot-minimal-kotlin/src/test/resources/application-testbed.yml
+++ b/examples/spring-boot-minimal-kotlin/src/test/resources/application-testbed.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 # Disable the Web Server.
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-web-servers.html.
 spring.main.web-application-type: none

--- a/examples/spring-boot-minimal/src/test/resources/application-testbed.yml
+++ b/examples/spring-boot-minimal/src/test/resources/application-testbed.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 # Disable the Web Server.
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-web-servers.html.
 spring.main.web-application-type: none

--- a/examples/spring-boot-tomcat/src/main/resources/config/application.yml
+++ b/examples/spring-boot-tomcat/src/main/resources/config/application.yml
@@ -6,4 +6,4 @@ spring.config.activate.on-profile: local
 armeria:
   ports:
     - port: 8080
-      protocol: HTTP
+      protocols: HTTP

--- a/examples/spring-boot-tomcat/src/test/resources/application-testbed.yml
+++ b/examples/spring-boot-tomcat/src/test/resources/application-testbed.yml
@@ -1,12 +1,7 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 # Prevent the embedded Tomcat from opening a TCP/IP port.
 server.port: -1
 ---
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP

--- a/examples/spring-boot-webflux/src/main/resources/config/application.yml
+++ b/examples/spring-boot-webflux/src/main/resources/config/application.yml
@@ -12,4 +12,4 @@ armeria:
     - http
     - proxy
   - port: 8080    # Port 8080 will serve only HTTP.
-    protocol: http
+    protocols: http

--- a/examples/spring-boot-webflux/src/test/resources/application-testbed.yml
+++ b/examples/spring-boot-webflux/src/test/resources/application-testbed.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 # Use a random port to avoid a potential port conflict.
 server:
   port: 0

--- a/it/spring/boot3-mixed-tomcat10/src/main/resources/config/application.yml
+++ b/it/spring/boot3-mixed-tomcat10/src/main/resources/config/application.yml
@@ -1,4 +1,4 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP

--- a/it/spring/boot3-mixed/src/main/resources/config/application.yml
+++ b/it/spring/boot3-mixed/src/main/resources/config/application.yml
@@ -1,4 +1,4 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP

--- a/it/spring/boot3-tomcat10/src/main/resources/config/application.yml
+++ b/it/spring/boot3-tomcat10/src/main/resources/config/application.yml
@@ -1,7 +1,7 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
 server:
   error:
     include-message: always

--- a/it/spring/boot3-tomcat10/src/test/resources/application-healthGroupTest.yml
+++ b/it/spring/boot3-tomcat10/src/test/resources/application-healthGroupTest.yml
@@ -1,7 +1,7 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
 
 management:
   server:

--- a/site/src/pages/docs/advanced-dropwizard-integration.mdx
+++ b/site/src/pages/docs/advanced-dropwizard-integration.mdx
@@ -118,7 +118,6 @@ server:
       protocols:
         - HTTPS
         - PROXY
-          ports:
   compression:
     enabled: true
     mimeTypes:

--- a/site/src/pages/release-notes/0.83.0.mdx
+++ b/site/src/pages/release-notes/0.83.0.mdx
@@ -11,12 +11,12 @@ date: 2019-03-29
   armeria:
      ports:
        - port: 8080
-         protocol: HTTP
+         protocols: HTTP
        - ip: 127.0.0.1
          port: 8081
-         protocol:HTTP
+         protocols: HTTP
        - port: 8443
-         protocol: HTTPS
+         protocols: HTTPS
      ssl:
        key-alias: "host.name.com"
        key-store: "keystore.jks"

--- a/site/src/pages/release-notes/0.84.0.mdx
+++ b/site/src/pages/release-notes/0.84.0.mdx
@@ -123,7 +123,7 @@ date: 2019-04-23
   armeria:
     ports:
       - port: 8080
-        protocol: HTTP
+        protocols: HTTP
     compression:
       enabled: true
       mime-types: text/*, application/json

--- a/spring/boot2-autoconfigure/src/test/resources/config/application-deprecatedIpTest.yml
+++ b/spring/boot2-autoconfigure/src/test/resources/config/application-deprecatedIpTest.yml
@@ -2,7 +2,7 @@ armeria:
   ports:
     - ip: 127.0.0.1
       port: 0
-      protocol: HTTP
+      protocols: HTTP
     - ip: 0.0.0.0
       port: 0
-      protocol: HTTP
+      protocols: HTTP

--- a/spring/boot2-autoconfigure/src/test/resources/config/application-localhostAddressTest.yml
+++ b/spring/boot2-autoconfigure/src/test/resources/config/application-localhostAddressTest.yml
@@ -2,4 +2,4 @@ armeria:
   ports:
     - address: localhost
       port: 0
-      protocol: HTTP
+      protocols: HTTP

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-actuatorTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-actuatorTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-allInternalServices.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-allInternalServices.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-autoConfTest.yml
@@ -1,13 +1,13 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 127.0.0.1
       port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 0.0.0.0
       port: 0
-      protocol: HTTP
+      protocols: HTTP
 
 management:
   endpoints:

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathSamePortTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathSamePortTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathWithoutPortTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-basePathWithoutPortTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-defaultInternalServices.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-defaultInternalServices.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-internalServiceTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-internalServiceTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-managedMetricPath.yml
@@ -1,13 +1,13 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 127.0.0.1
       port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 0.0.0.0
       port: 0
-      protocol: HTTP
+      protocols: HTTP
   metrics-path: ''
 
 management:

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-managementLocalhostTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-managementLocalhostTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-secureTest.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-secureTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-actuator-autoconfigure/src/test/resources/application-ssl.yml
+++ b/spring/boot3-actuator-autoconfigure/src/test/resources/application-ssl.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 armeria:
   ports:
     - port: 0

--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -49,12 +49,12 @@ import io.netty.channel.EventLoopGroup;
  * armeria:
  *   ports:
  *     - port: 8080
- *       protocol: HTTP
+ *       protocols: HTTP
  *     - address: 127.0.0.1
  *       port: 8081
- *       protocol:HTTP
+ *       protocols: HTTP
  *     - port: 8443
- *       protocol: HTTPS
+ *       protocols: HTTPS
  *   ssl:
  *     key-alias: "host.name.com"
  *     key-store: "keystore.jks"

--- a/spring/boot3-autoconfigure/src/test/resources/config/application-autoConfTest.yml
+++ b/spring/boot3-autoconfigure/src/test/resources/config/application-autoConfTest.yml
@@ -12,11 +12,11 @@ management:
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 127.0.0.1
       port: 0
-      protocol: HTTP
+      protocols: HTTP
     - address: 0.0.0.0
       port: 0
-      protocol: HTTP
+      protocols: HTTP
   enable-auto-injection: true

--- a/spring/boot3-autoconfigure/src/test/resources/config/application-compressionTest.yml
+++ b/spring/boot3-autoconfigure/src/test/resources/config/application-compressionTest.yml
@@ -1,7 +1,7 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
   compression:
     enabled: true
     mime-types: text/*, application/json

--- a/spring/boot3-autoconfigure/src/test/resources/config/application-internalServiceTest.yml
+++ b/spring/boot3-autoconfigure/src/test/resources/config/application-internalServiceTest.yml
@@ -1,8 +1,3 @@
-# Use-legacy-processing to use this application-testbed.yml file instead of application.yml
-spring:
-  config:
-    use-legacy-processing: true
-
 # Should not bind internal services to the management.server.port
 # if ArmeriaSpringActuatorAutoConfiguration was not configured.
 management.server.port: 0

--- a/spring/boot3-autoconfigure/src/test/resources/config/application-sslTest.yml
+++ b/spring/boot3-autoconfigure/src/test/resources/config/application-sslTest.yml
@@ -1,9 +1,9 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
     - port: 0
-      protocol: HTTPS
+      protocols: HTTPS
   ssl:
     enabled: true # Use self-signed certificate because no key-store configuration is specified.
   # Make sure that port-based virtual host settings are compatible with Server Name Indication.

--- a/spring/boot3-webflux-autoconfigure/src/test/resources/config/application-test_actuator.yml
+++ b/spring/boot3-webflux-autoconfigure/src/test/resources/config/application-test_actuator.yml
@@ -1,7 +1,7 @@
 armeria:
   ports:
     - port: 0
-      protocol: HTTP
+      protocols: HTTP
 
 management:
   endpoints:


### PR DESCRIPTION
Motivation:
When we upgrade to Spring Boot 2.4, we used `spring.config.use-legacy-processing` property because main application.yml overrides the yaml files in the test. However, it was a bug and was fixed.
https://github.com/spring-projects/spring-boot/issues/24719 Therefore, we don't have to use `spring.config.use-legacy-processing` anymore.

Modifications:
- Remove `spring.config.use-legacy-processing` property

Result:
- Close #4899