### PR TITLE
Disable the tests that involve NIO.2 `WatchService` on old JRE

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
@@ -125,7 +125,7 @@ class FileWatcherRegistryTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11) // NIO.2 WatchService doesn't work reliably on older Java.
+    @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void runnableWithExceptionContinuesRun() throws Exception {
 
         final Path file = Files.createFile(folder.resolve("temp-file.properties"));

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroupTest.java
@@ -184,7 +184,7 @@ class PropertiesEndpointGroupTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11) // NIO.2 WatchService doesn't work reliably on older Java.
+    @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void propertiesFileUpdatesCorrectly() throws Exception {
         final Path file = folder.resolve("temp-file.properties");
 
@@ -224,7 +224,7 @@ class PropertiesEndpointGroupTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11) // NIO.2 WatchService doesn't work reliably on older Java.
+    @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void propertiesFileRestart() throws Exception {
         final Path file = folder.resolve("temp-file.properties");
 
@@ -255,7 +255,7 @@ class PropertiesEndpointGroupTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_11) // NIO.2 WatchService doesn't work reliably on older Java.
+    @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void endpointChangePropagatesToListeners() throws Exception {
         final Path file = folder.resolve("temp-file.properties");
 


### PR DESCRIPTION
Motivation:

At least on macOS 13.4 (and probably other OSes), `WatchService` seems not to notify the file changes quickly enough. As a result, we see the following tests fail:

- `FileWatcherRegistryTest.runnableWithExceptionContinuesRun`
- `PropertiesEndpointGroupTest.endpointChangePropagatesToListeners`
- `PropertiesEndpointGroupTest.propertiesFileRestart`
- `PropertiesEndpointGroupTest.propertiesFileUpdatesCorrectly`

Modifications:

- Migrated `FileWatcherRegistryTest` and `PropertiesEndpointGroupTest` from JUnit 4 to 5
- Added `@EnabledForJreRange` annotation on the problematic tests

Result:

- Build is more stable on the environment where `WatchService` is not very responsive.
- Fixes #3474 and #3075