### PR TITLE
Allow `slf4j` `SimpleLogger` to block the eventloop when running the CI

### DIFF
--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/InternalTestingBlockHoundIntegration.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/InternalTestingBlockHoundIntegration.java
@@ -69,7 +69,7 @@ public final class InternalTestingBlockHoundIntegration implements BlockHoundInt
                                          "assertThatJson");
         builder.allowBlockingCallsInside("com.linecorp.armeria.testing.server.ServiceRequestContextCaptor$2",
                                          "serve");
-
+        builder.allowBlockingCallsInside("org.slf4j.impl.SimpleLogger", "write");
         builder.allowBlockingCallsInside(
                 "com.linecorp.armeria.internal.testing.InternalTestingBlockHoundIntegration",
                 "writeBlockingMethod");


### PR DESCRIPTION
Motivation:

```
java.base/java.io.PrintStream.implWriteln(PrintStream.java:848)
    at java.base/java.io.PrintStream.writeln(PrintStream.java:825)
    at java.base/java.io.PrintStream.println(PrintStream.java:1167)
    at org.slf4j.impl.SimpleLogger.write(SimpleLogger.java:341)
    at org.slf4j.impl.SimpleLogger.log(SimpleLogger.java:310)
    at org.slf4j.impl.SimpleLogger.formatAndLog(SimpleLogger.java:379)
    at org.slf4j.impl.SimpleLogger.warn(SimpleLogger.java:562)
    at com.linecorp.armeria.common.logging.LogLevel.log(LogLevel.java:155)
```

Since logging can occur not only at `LogLevel.log` but from other code points as well, I think it's fine to just ignore `SimpleLogger`.

Modifications:

- Add `SimpleLogger.write` to list of rules to ignore to our internal blockhound rule.

Result:

- More stable builds

Credit to @trustin for reporting this issue 🙇 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
