### PR TITLE
Preseve `%3F` (?) character in a request path

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -57,7 +57,7 @@ public final class DefaultRequestTarget implements RequestTarget {
      * other implementations in the ecosystem, e.g. HTTP/JSON to gRPC transcoding. See
      * <a href="https://github.com/googleapis/googleapis/blob/02710fa0ea5312d79d7fb986c9c9823fb41049a9/google/api/http.proto#L257-L258">http.proto</a>.
      */
-    private static final BitSet PATH_MUST_PRESERVE_ENCODING = toBitSet("/");
+    private static final BitSet PATH_MUST_PRESERVE_ENCODING = toBitSet("/?");
 
     /**
      * The lookup table for the characters that whose percent encoding must be preserved

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
@@ -359,6 +359,13 @@ class DefaultRequestTargetTest {
     }
 
     @Test
+    void shouldReserveQuestionMark() {
+        // '%3F' must not be decoded into '?'.
+        assertAccepted(forServer("/abc%3F.json?a=%3F"), "/abc%3F.json", "a=%3F");
+        assertAccepted(forClient("/abc%3F.json?a=%3F"), "/abc%3F.json", "a=%3F");
+    }
+
+    @Test
     void serverShouldNormalizePoundSign() {
         // '#' must be encoded into '%23'.
         assertAccepted(forServer("/#?a=b#1"), "/%23", "a=b%231");

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ReservedCharsIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ReservedCharsIntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ReservedCharsIntegrationTest {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.serviceUnder("/", (ctx, req) -> {
+                return HttpResponse.ofJson(
+                        ImmutableMap.of("path", ctx.path(), "query", firstNonNull(ctx.query(), "")));
+            });
+        }
+    };
+
+    @Test
+    void shouldPreserveReservedCharsInPath() {
+        final Map<String, String> response =
+                server.blockingWebClient().prepare()
+                      // %2F = '/', %3F = '?'
+                      .get("/%2F%3F/foo?bar=1")
+                      .asJson(new TypeReference<Map<String, String>>() {})
+                      .execute()
+                      .content();
+        assertThat(response.get("path")).isEqualTo("/%2F%3F/foo");
+        assertThat(response.get("query")).isEqualTo("bar=1");
+    }
+}


### PR DESCRIPTION
Motivation:

`?` is not in the preserved encoding character set. As a result, if `%3F` or `%3f` is included in a request path, it is converted into `?`.
https://github.com/line/armeria/blob/0df139a41cac430b3805f2774ac6d0c8ca4b4a68/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java#L60-L60
`/foo/x%3Fy.json`, for example, is decoded into `/foo/x?y.json`. When a server parses the request path, `/foo/x` will be the path component, and `y.json` will be the query component. Although they wanted to send a path ending with `.json`.

Modifications:

- Add `?` to `PATH_MUST_PRESERVE_ENCODING` so that `RequestTarget` does not decode `%3F` in a path into `?`

Result:

You can now correctly send percent-encoded `?` in a request path.
