### PR TITLE
Fix a bug where `shadedTest` tests only Junit 4 suites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     alias libs.plugins.kotlin apply false
     alias libs.plugins.ktlint apply false
     alias libs.plugins.errorprone apply false
+    id 'jvm-test-suite'
 }
 
 allprojects {
@@ -71,7 +72,8 @@ allprojects {
         jvmArgs '-XX:+HeapDumpOnOutOfMemoryError'
         jvmArgs "-XX:HeapDumpPath=${rootProject.buildDir}"
 
-        // `-Pjava.security.manager` was added in Java 17 and the default value was changed to `disallow` in Java 18.
+        // `-Djava.security.manager` was added in Java 17 and the default value was changed to
+        // `disallow` in Java 18.
         // - https://openjdk.org/jeps/411
         // - https://bugs.openjdk.org/browse/JDK-8270380
         if (project.ext.testJavaVersion >= 17) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
     alias libs.plugins.kotlin apply false
     alias libs.plugins.ktlint apply false
     alias libs.plugins.errorprone apply false
-    id 'jvm-test-suite'
 }
 
 allprojects {

--- a/consul/build.gradle
+++ b/consul/build.gradle
@@ -2,7 +2,7 @@ import static org.gradle.internal.os.OperatingSystem.current
 
 import com.pszymczyk.consul.BinariesManager
 
-def consulVersion = '1.11.3'
+def consulVersion = '1.15.3'
 def consulBinaryDownloadDir = new File(gradle.gradleUserHomeDir, "caches/embedded-consul/${consulVersion}")
 
 buildscript {

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -64,7 +64,7 @@ public abstract class ConsulTestBase {
 
     private static final String ENV_CONSUL_VERSION = "CONSUL_VERSION";
     private static final String ENV_CONSUL_BINARY_DOWNLOAD_DIR = "CONSUL_BINARY_DOWNLOAD_DIR";
-    private static final String FALLBACK_CONSUL_VERSION = "1.9.3";
+    private static final String FALLBACK_CONSUL_VERSION = "1.15.3";
 
     protected static final String CONSUL_TOKEN = UUID.randomUUID().toString();
     protected static final String serviceName = "testService";

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,8 +41,10 @@ mrJarVersions.each { version->
         testClassesDirs = sourceSets."java${version}Test".output.classesDirs
         classpath = sourceSets."java${version}Test".runtimeClasspath
 
+        project.ext.configureCommonTestSettings(it)
+
         enabled = Integer.parseInt(JavaVersion.current().getMajorVersion()) >= version &&
-                project.ext.testJavaVersion >= version
+                  project.ext.testJavaVersion >= version
     }
 
     configurations."java${version}Implementation".extendsFrom configurations.implementation
@@ -173,29 +175,27 @@ if (!rootProject.hasProperty('noWeb')) {
 // Run HttpServerStreamingTest separately with memory constraint.
 tasks.test.exclude '**/HttpServerStreamingTest**'
 tasks.shadedTest.exclude '**/HttpServerStreamingTest**'
-testing {
-    suites {
-        testStreaming(JvmTestSuite) {
+testing.suites {
+    testStreaming(JvmTestSuite) {
 
-            targets {
-                all {
-                    testTask.configure {
-                        group = 'Verification'
-                        description = 'Runs the streaming tests.'
+        targets.configureEach {
+            testTask.configure {
+                group = 'Verification'
+                description = 'Runs the streaming tests.'
 
-                        dependsOn(tasks.shadedTestClasses)
-                        // Use small heap for streaming tests to quickly ensure we can stream the content larger than heap.
-                        maxHeapSize = '64m'
+                project.ext.configureCommonTestSettings(it)
 
-                        include '**/HttpServerStreamingTest**'
-                        testClassesDirs = tasks.shadedTest.testClassesDirs
-                        classpath = testClassesDirs
+                dependsOn(tasks.shadedTestClasses)
+                // Use small heap for streaming tests to quickly ensure we can stream the content larger than heap.
+                maxHeapSize = '64m'
 
-                        // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
-                        doFirst {
-                            classpath += project.files(configurations.shadedJarTestRuntime.resolve())
-                        }
-                    }
+                include '**/HttpServerStreamingTest**'
+                testClassesDirs = tasks.shadedTest.testClassesDirs
+                classpath = testClassesDirs
+
+                // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
+                doFirst {
+                    classpath += project.files(configurations.shadedJarTestRuntime.resolve())
                 }
             }
         }
@@ -206,23 +206,21 @@ tasks.check.dependsOn testing.suites.testStreaming
 
 // Run the test cases based on reactive-streams-tck only with non-flaky mode
 if (rootProject.findProperty('flakyTests') != 'true') {
-    testing {
-        suites {
-            testNg(JvmTestSuite) {
-                useTestNG()
+    testing.suites {
+        testNg(JvmTestSuite) {
+            useTestNG()
 
-                targets {
-                    all {
-                        testTask.configure {
-                            include '/com/linecorp/armeria/**/common/**'
-                            dependsOn tasks.shadedTestClasses
-                            scanForTestClasses = false
-                            testClassesDirs = tasks.shadedTest.testClassesDirs
-                            classpath = testClassesDirs
-                            doFirst {
-                                classpath += project.files(configurations.shadedJarTestRuntime.resolve())
-                            }
-                        }
+            targets.configureEach {
+                testTask.configure {
+
+                    project.ext.configureCommonTestSettings(it)
+                    include '/com/linecorp/armeria/**/common/**'
+                    dependsOn tasks.shadedTestClasses
+                    scanForTestClasses = false
+                    testClassesDirs = tasks.shadedTest.testClassesDirs
+                    classpath = testClassesDirs
+                    doFirst {
+                        classpath += project.files(configurations.shadedJarTestRuntime.resolve())
                     }
                 }
             }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -193,7 +193,7 @@ testing {
 
                         // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
                         doFirst {
-                            classpath += project.files(configurations.shadedTestRuntime.resolve())
+                            classpath += project.files(configurations.shadedJarTestRuntime.resolve())
                         }
                     }
                 }
@@ -220,7 +220,7 @@ if (rootProject.findProperty('flakyTests') != 'true') {
                             testClassesDirs = tasks.shadedTest.testClassesDirs
                             classpath = testClassesDirs
                             doFirst {
-                                classpath += project.files(configurations.shadedTestRuntime.resolve())
+                                classpath += project.files(configurations.shadedJarTestRuntime.resolve())
                             }
                         }
                     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1286,9 +1286,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             }
 
             if (rpcResponse.cause() != null && responseCause == null) {
-                // Don't use 'responseCause(Throwable)' to set responseCause because if the HTTP response was
-                // ended successfully the RequestLogProperty.RESPONSE_CAUSE flag becomes available with a null
-                // value.
+                // Don't use 'responseCause(Throwable)' to set 'RpcResponse.cause()'.
+                // 'responseCause(Throwable)' performs nothing if the HTTP response was ended successfully.
                 responseCause = rpcResponse.cause();
                 updateFlags(RequestLogProperty.RESPONSE_CAUSE);
             }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -352,7 +352,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             lock.lock();
             try {
                 pendingFutures.add(newFuture);
-                satisfiedFutures = removeSatisfiedFutures(pendingFutures, flags);
+                satisfiedFutures = removeSatisfiedFutures(pendingFutures);
             } finally {
                 lock.unlock();
             }
@@ -398,7 +398,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
                 final RequestLogFuture[] satisfiedFutures;
                 lock.lock();
                 try {
-                    satisfiedFutures = removeSatisfiedFutures(pendingFutures, newFlags);
+                    satisfiedFutures = removeSatisfiedFutures(pendingFutures);
                 } finally {
                     lock.unlock();
                 }
@@ -421,8 +421,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Nullable
-    private static RequestLogFuture[] removeSatisfiedFutures(List<RequestLogFuture> pendingFutures,
-                                                             int flags) {
+    private RequestLogFuture[] removeSatisfiedFutures(List<RequestLogFuture> pendingFutures) {
         if (pendingFutures.isEmpty()) {
             return null;
         }
@@ -435,6 +434,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         do {
             final RequestLogFuture e = i.next();
             final int interestedFlags = e.interestedFlags;
+            // 'flags' should be read inside 'lock' when completing 'pendingFutures' to ensure visibility.
             if ((flags & interestedFlags) == interestedFlags) {
                 i.remove();
                 if (satisfied == null) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1284,9 +1284,13 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             if (!rpcResponse.isDone()) {
                 throw new IllegalArgumentException("responseContent must be complete: " + responseContent);
             }
-            final Throwable cause = rpcResponse.cause();
-            if (cause != null) {
-                responseCause(cause);
+
+            if (rpcResponse.cause() != null && responseCause == null) {
+                // Don't use 'responseCause(Throwable)' to set responseCause because if the HTTP response was
+                // ended successfully the RequestLogProperty.RESPONSE_CAUSE flag becomes available with a null
+                // value.
+                responseCause = rpcResponse.cause();
+                updateFlags(RequestLogProperty.RESPONSE_CAUSE);
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -321,9 +321,9 @@ class HttpClientIntegrationTest {
 
             sb.service("glob:/oneparam/**", (ctx, req) -> {
                 // The client was able to send a request with an escaped path param. Armeria servers always
-                // decode the path so ctx.path == '/oneparam/foo' here (without query string).
-                if ("/oneparam/foo?bar".equals(req.headers().path()) &&
-                    "/oneparam/foo".equals(ctx.path())) {
+                // decode the path so ctx.path == '/oneparam/foo%3Fbar' here.
+                if ("/oneparam/foo%3Fbar".equals(req.headers().path()) &&
+                    "/oneparam/foo%3Fbar".equals(ctx.path())) {
                     return HttpResponse.of("routed");
                 }
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
@@ -88,12 +88,11 @@ class FileWatcherRegistryTest {
         PropertiesEndpointGroup.resetRegistry();
     }
 
-
     @Test
     void emptyGroupStopsBackgroundThread() throws Exception {
 
-        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
-        final Path file2 = Files.createFile(folder.newFile().resolve("temp-file2.properties"));
+        final Path file = folder.newFile("temp-file.properties");
+        final Path file2 = folder.newFile("temp-file2.properties");
 
         try (FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry()) {
             final FileWatchRegisterKey key1 = fileWatcherRegistry.register(file, () -> {});
@@ -114,7 +113,7 @@ class FileWatcherRegistryTest {
     @Test
     void closeEndpointGroupStopsRegistry() throws Exception {
 
-        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
+        final Path file = folder.newFile("temp-file.properties");
 
         final FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry();
         fileWatcherRegistry.register(file, () -> {});
@@ -130,7 +129,7 @@ class FileWatcherRegistryTest {
     @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void runnableWithExceptionContinuesRun() throws Exception {
 
-        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
+        final Path file = folder.newFile("temp-file.properties");
         final FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry();
 
         final AtomicInteger val = new AtomicInteger(0);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
@@ -163,6 +163,7 @@ class FileWatcherRegistryTest {
         assertThat(fileWatcherRegistry.isRunning()).isFalse();
 
         fileWatcherRegistry.close();
+        Files.delete(file);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
@@ -28,7 +28,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.FileSystem;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/FileWatcherRegistryTest.java
@@ -42,11 +42,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.endpoint.FileWatcherRegistry.FileWatchRegisterKey;
+import com.linecorp.armeria.internal.testing.TemporaryFolderExtension;
 
 class FileWatcherRegistryTest {
+
+    @RegisterExtension
+    static TemporaryFolderExtension folder = new TemporaryFolderExtension();
 
     @BeforeAll
     static void before() {
@@ -58,7 +62,7 @@ class FileWatcherRegistryTest {
         Awaitility.setDefaultTimeout(10, TimeUnit.SECONDS);
     }
 
-    // Not sure if there is a better way to test multi-filesystem other than mocking..
+    // Not sure if there is a better way to test multi-filesystem other than mocking.
     private static Path createMockedPath() throws Exception {
         final Path path = mock(Path.class);
         final FileSystem fileSystem = mock(FileSystem.class);
@@ -84,14 +88,12 @@ class FileWatcherRegistryTest {
         PropertiesEndpointGroup.resetRegistry();
     }
 
-    @TempDir
-    Path folder;
 
     @Test
     void emptyGroupStopsBackgroundThread() throws Exception {
 
-        final Path file = Files.createFile(folder.resolve("temp-file.properties"));
-        final Path file2 = Files.createFile(folder.resolve("temp-file2.properties"));
+        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
+        final Path file2 = Files.createFile(folder.newFile().resolve("temp-file2.properties"));
 
         try (FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry()) {
             final FileWatchRegisterKey key1 = fileWatcherRegistry.register(file, () -> {});
@@ -112,7 +114,7 @@ class FileWatcherRegistryTest {
     @Test
     void closeEndpointGroupStopsRegistry() throws Exception {
 
-        final Path file = Files.createFile(folder.resolve("temp-file.properties"));
+        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
 
         final FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry();
         fileWatcherRegistry.register(file, () -> {});
@@ -128,7 +130,7 @@ class FileWatcherRegistryTest {
     @EnabledForJreRange(min = JRE.JAVA_17) // NIO.2 WatchService doesn't work reliably on older Java.
     void runnableWithExceptionContinuesRun() throws Exception {
 
-        final Path file = Files.createFile(folder.resolve("temp-file.properties"));
+        final Path file = Files.createFile(folder.newFile().resolve("temp-file.properties"));
         final FileWatcherRegistry fileWatcherRegistry = new FileWatcherRegistry();
 
         final AtomicInteger val = new AtomicInteger(0);
@@ -163,7 +165,6 @@ class FileWatcherRegistryTest {
         assertThat(fileWatcherRegistry.isRunning()).isFalse();
 
         fileWatcherRegistry.close();
-        Files.delete(file);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
@@ -391,7 +391,7 @@ class DefaultRequestTargetTest {
                        "a=/%23/:[]@!$&'()*+,;=");
         assertAccepted(forServer("/%23%2F%3A%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
                                  "?a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F"),
-                       "/%23%2F:@!$&'()*+,;=?",
+                       "/%23%2F:@!$&'()*+,;=%3F",
                        "a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F");
     }
 
@@ -404,9 +404,9 @@ class DefaultRequestTargetTest {
         assertAccepted(forClient("/%23%2F%3A%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
                                  "?a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F" +
                                  "#%23%2F%3A%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F"),
-                       "/%23%2F:@!$&'()*+,;=?",
+                       "/%23%2F:@!$&'()*+,;=%3F",
                        "a=%23%2F%3A%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F",
-                       "%23%2F:@!$&'()*+,;=?");
+                       "%23%2F:@!$&'()*+,;=%3F");
     }
 
     @ParameterizedTest
@@ -420,7 +420,7 @@ class DefaultRequestTargetTest {
     void shouldHandleSquareBracketsInPath(Mode mode) {
         assertAccepted(parse(mode, "/@/:[]!$&'()*+,;="), "/@/:%5B%5D!$&'()*+,;=");
         assertAccepted(parse(mode, "/%40%2F%3A%5B%5D%21%24%26%27%28%29%2A%2B%2C%3B%3D%3F"),
-                       "/@%2F:%5B%5D!$&'()*+,;=?");
+                       "/@%2F:%5B%5D!$&'()*+,;=%3F");
     }
 
     @ParameterizedTest

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -64,7 +64,7 @@ configure(relocatedProjects) {
         archiveBaseName.set("test-${tasks.jar.archiveBaseName.get()}-shaded")
     }
 
-    task shadedTestClasses(
+    task copyShadedTestClasses(
             type: Copy,
             group: 'Build',
             description: 'Extracts the shaded test JAR.',
@@ -166,9 +166,9 @@ configure(relocatedProjects) {
 
 // NB: Configure in a new closure so that all relocated projects have a 'shadedJar' or 'trimShadedJar' task.
 configure(relocatedProjects) {
-    // Make sure the main classes are ready as well when `shadedTestClasses` is run,
-    // so that the tasks that require `shadedTestClasses` have everything required to run shaded tests.
-    tasks.shadedTestClasses.configure {
+    // Make sure the main classes are ready as well when `copyShadedTestClasses` is run,
+    // so that the tasks that require `copyShadedTestClasses` have everything required to run shaded tests.
+    tasks.copyShadedTestClasses.configure {
         relocatedProjects.each {
             if (it.tasks.findByName('trimShadedJar')) {
                 dependsOn it.tasks.trimShadedJar.path
@@ -179,41 +179,61 @@ configure(relocatedProjects) {
     }
 
     // Add tests for the shaded JAR.
-    task shadedTest(
-            type: Test,
-            group: 'Verification',
-            description: 'Runs the unit tests with the shaded classes.') {
+    testing.suites {
+        shadedTest(JvmTestSuite) {
 
-        dependsOn tasks.shadedTestClasses
+            targets.configureEach {
+                testTask.configure {
 
-        // The tests against the shaded artifacts should run after the tests against the unshaded ones.
-        shouldRunAfter tasks.test
+                    def flakyTests = rootProject.findProperty('flakyTests')
+                    if (flakyTests == 'true') {
+                        options {
+                            includeTags 'FLAKY_TESTS'
+                        }
+                    } else if (flakyTests == 'false') {
+                        options {
+                            excludeTags 'FLAKY_TESTS'
+                        }
+                    } else if (flakyTests != null) {
+                        throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
+                    }
 
-        testClassesDirs = files(tasks.shadedTestClasses.destinationDir)
-        classpath = testClassesDirs
+                    group = 'Verification'
+                    description = 'Runs the unit tests with the shaded classes.'
 
-        project.ext.relocations.each {
-            exclude "${it['to'].replace('.', '/')}/**"
+                    dependsOn tasks.copyShadedTestClasses
+
+                    // The tests against the shaded artifacts should run after the tests against the unshaded ones.
+                    shouldRunAfter tasks.test
+
+                    testClassesDirs = files(tasks.copyShadedTestClasses.destinationDir)
+                    classpath = testClassesDirs
+
+                    project.ext.relocations.each {
+                        exclude "${it['to'].replace('.', '/')}/**"
+                    }
+                }
+            }
         }
     }
-    tasks.check.dependsOn tasks.shadedTest
+    tasks.check.dependsOn testing.suites.shadedTest
 
     // Configurations shouldn't be created in afterEvaluate so create it eagerly here before configuring it.
 
     // In Gradle 8, dependencies can't be declared in a resolvable (canBeResolved=true) configuration. As a
     // workaround two configurations are created to separate the declaration and resolving roles.
-    // - Directly declares dependencies to `shadedTestImplementation`.
-    // - Indirectly resolves the dependencies of `shadedTestImplementation` by creating a new configuration
-    //   and extends `shadedTestImplementation`.
+    // - Directly declares dependencies to `shadedJarTestImplementation`.
+    // - Indirectly resolves the dependencies of `shadedJarTestImplementation` by creating a new configuration
+    //   and extends `shadedJarTestImplementation`.
     // https://discuss.gradle.org/t/problem-with-compileclasspath-after-gradle-8-update/44940
-    project.configurations.create("shadedTestImplementation") {
+    project.configurations.create("shadedJarTestImplementation") {
         canBeResolved = false
         canBeConsumed = false
     }
-    project.configurations.create("shadedTestRuntime") {
+    project.configurations.create("shadedJarTestRuntime") {
         canBeResolved = true
         canBeConsumed = false
-        extendsFrom(project.configurations.shadedTestImplementation)
+        extendsFrom(project.configurations.shadedJarTestImplementation)
     }
 
     // Update the classpath of the 'shadedTest' task after all shaded projects are evaluated
@@ -224,8 +244,11 @@ configure(relocatedProjects) {
                 configureShadedTestImplementConfiguration(p)
             }
             relocatedProjects.each { p ->
-                def testTask = p.tasks.shadedTest
-                testTask.classpath += p.files(p.configurations.getByName('shadedTestRuntime').resolve())
+                p.testing.suites.shadedTest.targets.all {
+                    testTask.configure {
+                        classpath += p.files(p.configurations.getByName('shadedJarTestRuntime').resolve())
+                    }
+                }
             }
         }
     }
@@ -284,25 +307,25 @@ private void configureShadowTask(Project project, ShadowJar task, boolean isMain
 
 /**
  * Finds the dependencies of {@code project} recursively and adds the found dependencies to
- * the configuration named as {@code 'shadedTestImplementation'}.
+ * the configuration named as {@code 'shadedJarTestImplementation'}.
  */
 private Configuration configureShadedTestImplementConfiguration(
         Project project, Project recursedProject = project,
         Set<ExcludeRule> excludeRules = new HashSet<>(),
         Set<Project> visitedProjects = new HashSet<>()) {
 
-    def shadedTestImplementation = project.configurations.getByName('shadedTestImplementation')
+    def shadedJarTestImplementation = project.configurations.getByName('shadedJarTestImplementation')
 
     if (visitedProjects.contains(recursedProject)) {
-        return shadedTestImplementation
+        return shadedJarTestImplementation
     } else {
         visitedProjects.add(recursedProject);
     }
 
     if (recursedProject.tasks.findByName('trimShadedJar')) {
-        project.dependencies.add(shadedTestImplementation.name, files(recursedProject.tasks.trimShadedJar.outJarFiles))
+        project.dependencies.add(shadedJarTestImplementation.name, files(recursedProject.tasks.trimShadedJar.outJarFiles))
     } else if (recursedProject.tasks.findByName('shadedJar')) {
-        project.dependencies.add(shadedTestImplementation.name, files(recursedProject.tasks.shadedJar.archivePath))
+        project.dependencies.add(shadedJarTestImplementation.name, files(recursedProject.tasks.shadedJar.archivePath))
     }
 
     def shadedDependencyNames = project.ext.relocations.collect { it['name'] }
@@ -336,7 +359,7 @@ private Configuration configureShadedTestImplementConfiguration(
                 }
                 // Do not use `project.dependencies.add(name, dep)` that discards the classifier of
                 // a dependency. See https://github.com/gradle/gradle/issues/23096
-                project.configurations.getByName(shadedTestImplementation.name).dependencies.add(dep)
+                project.configurations.getByName(shadedJarTestImplementation.name).dependencies.add(dep)
             }
         }
     }
@@ -348,5 +371,5 @@ private Configuration configureShadedTestImplementConfiguration(
                 excludeRules + dep.excludeRules, visitedProjects)
     }
 
-    return shadedTestImplementation
+    return shadedJarTestImplementation
 }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -185,21 +185,11 @@ configure(relocatedProjects) {
             targets.configureEach {
                 testTask.configure {
 
-                    def flakyTests = rootProject.findProperty('flakyTests')
-                    if (flakyTests == 'true') {
-                        options {
-                            includeTags 'FLAKY_TESTS'
-                        }
-                    } else if (flakyTests == 'false') {
-                        options {
-                            excludeTags 'FLAKY_TESTS'
-                        }
-                    } else if (flakyTests != null) {
-                        throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
-                    }
-
                     group = 'Verification'
                     description = 'Runs the unit tests with the shaded classes.'
+
+                    project.ext.configureFlakyTests(it)
+                    project.ext.configureCommonTestSettings(it)
 
                     dependsOn tasks.copyShadedTestClasses
 
@@ -244,7 +234,7 @@ configure(relocatedProjects) {
                 configureShadedTestImplementConfiguration(p)
             }
             relocatedProjects.each { p ->
-                p.testing.suites.shadedTest.targets.all {
+                p.testing.suites.shadedTest.targets.configureEach {
                     testTask.configure {
                         classpath += p.files(p.configurations.getByName('shadedJarTestRuntime').resolve())
                     }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -145,45 +145,47 @@ configure(projectsWithFlags('java')) {
         options.compilerArgs += '-parameters'
     }
 
-    testing {
-        suites {
-            test {
-                // Use JUnit platform.
-                useJUnitJupiter()
+    testing.suites {
+        test {
+            // Use JUnit platform.
+            useJUnitJupiter()
 
-                targets {
-                    all {
-                        testTask.configure {
-                             testLogging.exceptionFormat = 'full'
-
-                            def flakyTests = rootProject.findProperty('flakyTests')
-                            if (flakyTests == 'true') {
-                                useJUnitPlatform {
-                                    includeTags 'FLAKY_TESTS'
-                                }
-                            } else if (flakyTests == 'false') {
-                                useJUnitPlatform {
-                                    excludeTags 'FLAKY_TESTS'
-                                }
-                            } else if (flakyTests != null) {
-                                throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
-                            }
-
-                            // Use a different JRE for testing if necessary.
-                            if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
-                                javaLauncher = javaToolchains.launcherFor {
-                                    languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
-                                }
-                            }
-
-                            // disable tests for projects which target a higher java version
-                            if (project.ext.testJavaVersion < project.ext.targetJavaVersion) {
-                                project.logger.lifecycle("Skipping tests for ${project.path} since the " +
-                                        "testJavaVersion(${project.ext.testJavaVersion}) is smaller than the " +
-                                        "targetJavaVersion(${project.ext.targetJavaVersion})")
-                                enabled = false
-                            }
+            targets.configureEach {
+                testTask.configure {
+                    def flakyTests = rootProject.findProperty('flakyTests')
+                    if (flakyTests == 'true') {
+                        options {
+                            includeTags 'FLAKY_TESTS'
                         }
+                    } else if (flakyTests == 'false') {
+                        options {
+                            excludeTags 'FLAKY_TESTS'
+                        }
+                    } else if (flakyTests != null) {
+                        throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
+                    }
+                }
+            }
+        }
+
+        configureEach {
+            targets.configureEach {
+                testTask.configure {
+                    testLogging.exceptionFormat = 'full'
+
+                    // Use a different JRE for testing if necessary.
+                    if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
+                        javaLauncher = javaToolchains.launcherFor {
+                            languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
+                        }
+                    }
+
+                    // disable tests for projects which target a higher java version
+                    if (project.ext.testJavaVersion < project.ext.targetJavaVersion) {
+                        project.logger.lifecycle("Skipping tests for ${project.path} since the " +
+                                                 "testJavaVersion(${project.ext.testJavaVersion}) is smaller than the " +
+                                                 "targetJavaVersion(${project.ext.targetJavaVersion})")
+                        enabled = false
                     }
                 }
             }

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -145,7 +145,7 @@ configure(projectsWithFlags('java')) {
         options.compilerArgs += '-parameters'
     }
 
-    project.ext.configureFlakyTests = { testTask ->
+    project.ext.configureFlakyTests = { Test testTask ->
         def flakyTests = rootProject.findProperty('flakyTests')
         if (flakyTests == 'true') {
             testTask.options {

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -145,6 +145,39 @@ configure(projectsWithFlags('java')) {
         options.compilerArgs += '-parameters'
     }
 
+    project.ext.configureFlakyTests = { testTask ->
+        def flakyTests = rootProject.findProperty('flakyTests')
+        if (flakyTests == 'true') {
+            testTask.options {
+                includeTags 'FLAKY_TESTS'
+            }
+        } else if (flakyTests == 'false') {
+            testTask.options {
+                excludeTags 'FLAKY_TESTS'
+            }
+        } else if (flakyTests != null) {
+            throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
+        }
+    }
+
+    project.ext.configureCommonTestSettings = { Test testTask ->
+        testTask.testLogging.exceptionFormat = 'full'
+        // Use a different JRE for testing if necessary.
+        if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
+            testTask.javaLauncher = javaToolchains.launcherFor {
+                languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
+            }
+        }
+
+        // disable tests for projects which target a higher java version
+        if (project.ext.testJavaVersion < project.ext.targetJavaVersion) {
+            project.logger.lifecycle("Skipping tests for ${project.path} since the " +
+                                     "testJavaVersion(${project.ext.testJavaVersion}) is smaller than the " +
+                                     "targetJavaVersion(${project.ext.targetJavaVersion})")
+            testTask.enabled = false
+        }
+    }
+
     testing.suites {
         test {
             // Use JUnit platform.
@@ -152,41 +185,8 @@ configure(projectsWithFlags('java')) {
 
             targets.configureEach {
                 testTask.configure {
-                    def flakyTests = rootProject.findProperty('flakyTests')
-                    if (flakyTests == 'true') {
-                        options {
-                            includeTags 'FLAKY_TESTS'
-                        }
-                    } else if (flakyTests == 'false') {
-                        options {
-                            excludeTags 'FLAKY_TESTS'
-                        }
-                    } else if (flakyTests != null) {
-                        throw new IllegalArgumentException("flakyTests: $flakyTests (expected: true, false or null)")
-                    }
-                }
-            }
-        }
-
-        configureEach {
-            targets.configureEach {
-                testTask.configure {
-                    testLogging.exceptionFormat = 'full'
-
-                    // Use a different JRE for testing if necessary.
-                    if (rootProject.ext.buildJdkVersion != project.ext.testJavaVersion) {
-                        javaLauncher = javaToolchains.launcherFor {
-                            languageVersion = JavaLanguageVersion.of(project.ext.testJavaVersion)
-                        }
-                    }
-
-                    // disable tests for projects which target a higher java version
-                    if (project.ext.testJavaVersion < project.ext.targetJavaVersion) {
-                        project.logger.lifecycle("Skipping tests for ${project.path} since the " +
-                                                 "testJavaVersion(${project.ext.testJavaVersion}) is smaller than the " +
-                                                 "targetJavaVersion(${project.ext.targetJavaVersion})")
-                        enabled = false
-                    }
+                    project.ext.configureFlakyTests(it)
+                    project.ext.configureCommonTestSettings(it)
                 }
             }
         }

--- a/gradle/scripts/lib/scala.gradle
+++ b/gradle/scripts/lib/scala.gradle
@@ -16,20 +16,16 @@ configure(scala212 + scala213 + scala3) {
         }
     }
 
-    testing {
-        suites {
-            test {
-                targets {
-                    all {
-                        testTask.configure {
-                            // A workaround for 'java.lang.InternalError: Malformed class name'
-                            // when testing scalapb module with Java 8. This bug was fixed in Java 9.
-                            // - https://github.com/gradle/gradle/issues/8432
-                            // - https://bugs.openjdk.java.net/browse/JDK-8057919
-                            if (project.ext.testJavaVersion == 8) {
-                                exclude("**/*\$*\$*.class")
-                            }
-                        }
+    testing.suites {
+        configureEach {
+            targets.configureEach {
+                testTask.configure {
+                    // A workaround for 'java.lang.InternalError: Malformed class name'
+                    // when testing scalapb module with Java 8. This bug was fixed in Java 9.
+                    // - https://github.com/gradle/gradle/issues/8432
+                    // - https://bugs.openjdk.java.net/browse/JDK-8057919
+                    if (project.ext.testJavaVersion == 8) {
+                        exclude("**/*\$*\$*.class")
                     }
                 }
             }

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/DefaultGraphqlService.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/DefaultGraphqlService.java
@@ -40,7 +40,6 @@ import com.linecorp.armeria.server.graphql.protocol.AbstractGraphqlService;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.execution.ExecutionId;
 
 final class DefaultGraphqlService extends AbstractGraphqlService implements GraphqlService {
 
@@ -89,7 +88,6 @@ final class DefaultGraphqlService extends AbstractGraphqlService implements Grap
 
         final ExecutionInput executionInput =
                 builder.context(ctx)
-                       .executionId(ExecutionId.from(ctx.id().text()))
                        .graphQLContext(GraphqlServiceContexts.graphqlContext(ctx))
                        .dataLoaderRegistry(dataLoaderRegistry)
                        .build();

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -1,9 +1,9 @@
 configurations {
     // TODO(hyangtack) The followings are not transitive dependencies and they are not in testRuntime
-    //                 dependencies. Need to figure out why they are included in shadedTestRuntime dependencies.
+    //                 dependencies. Need to figure out why they are included in shadedJarTestRuntime dependencies.
     // Exclude jetty from shadedTest.
-    shadedTestRuntime.exclude group: 'org.eclipse.jetty'
-    shadedTestRuntime.exclude group: 'org.eclipse.jetty.http2'
+    shadedJarTestRuntime.exclude group: 'org.eclipse.jetty'
+    shadedJarTestRuntime.exclude group: 'org.eclipse.jetty.http2'
 }
 
 dependencies {

--- a/spring/boot3-webflux-autoconfigure/build.gradle
+++ b/spring/boot3-webflux-autoconfigure/build.gradle
@@ -1,9 +1,9 @@
 configurations {
     // TODO(hyangtack) The followings are not transitive dependencies and they are not in testRuntime
-    //                 dependencies. Need to figure out why they are included in shadedTestRuntime dependencies.
+    //                 dependencies. Need to figure out why they are included in shadedJarTestRuntime dependencies.
     // Exclude jetty from shadedTest.
-    shadedTestRuntime.exclude group: 'org.eclipse.jetty'
-    shadedTestRuntime.exclude group: 'org.eclipse.jetty.http2'
+    shadedJarTestRuntime.exclude group: 'org.eclipse.jetty'
+    shadedJarTestRuntime.exclude group: 'org.eclipse.jetty.http2'
 }
 
 dependencies {

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolder.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolder.java
@@ -63,6 +63,10 @@ public final class TemporaryFolder {
         return Files.createTempFile(getRoot(), "", "");
     }
 
+    public Path newFile(String name) throws IOException {
+        return Files.createFile(newFolder().resolve(name));
+    }
+
     public void delete() throws IOException {
         if (root == null) {
             return;

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolderExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolderExtension.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.testing;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.linecorp.armeria.testing.junit5.common.AbstractAllOrEachExtension;
+
+/**
+ * A JUnit {@link Extension} that creates a {@link TemporaryFolder}.
+ *
+ * <pre>{@code
+ * > class MyTest {
+ * >     @RegisterExtension
+ * >     static final TemporaryFolderExtension folder = new TemporaryFolderExtension();
+ * >
+ * >     @Test
+ * >     void test() throws Exception {
+ * >         Path file = folder.newFile();
+ * >         ...
+ * >     }
+ * > }
+ * }</pre>
+ */
+public class TemporaryFolderExtension extends AbstractAllOrEachExtension {
+
+    // Forked from https://github.com/line/centraldogma/blob/e5a9c1cf402b7ea59fddb56aae40ebdd1502213e/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtension.java
+
+    private final TemporaryFolder delegate;
+
+    public TemporaryFolderExtension() {
+        delegate = new TemporaryFolder();
+    }
+
+    @Override
+    public void before(ExtensionContext context) throws Exception {
+        delegate.create();
+    }
+
+    @Override
+    public void after(ExtensionContext context) throws Exception {
+        delegate.delete();
+    }
+
+    public void create() throws IOException {
+        delegate.create();
+    }
+
+    public boolean exists() {
+        return delegate.exists();
+    }
+
+    public Path getRoot() {
+        return delegate.getRoot();
+    }
+
+    public Path newFolder() throws IOException {
+        return delegate.newFolder();
+    }
+
+    public Path newFile() throws IOException {
+        return delegate.newFile();
+    }
+
+    public void delete() throws IOException {
+        delegate.delete();
+    }
+}

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolderExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TemporaryFolderExtension.java
@@ -80,6 +80,10 @@ public class TemporaryFolderExtension extends AbstractAllOrEachExtension {
         return delegate.newFile();
     }
 
+    public Path newFile(String name) throws IOException {
+        return delegate.newFile(name);
+    }
+
     public void delete() throws IOException {
         delegate.delete();
     }


### PR DESCRIPTION
Motivation:

This PR fixes `shadedTest` task to run with JUnit 5 and the bugs that weren't caught by CI builds because of the aforementioned bug.

- `shadedTest`:
  `shadedTest` was configured to run test suites with JUnit 4. It caused CI builds to pass successfully, although they failed with `gradle test` when I run locally.
  While upgrading the Gradle version to 8, we had to use JVM test suites to use both JUnit and TestNG. In Gradle 8, `Test` didn't allow overring test frameworks. For that reason, `test` was migrated to test suites but `shadedTest` hasn't changed.

- `RequestLog.resposneCause()`:
   Recently, I've encountered the following test failure repeatedly when I was running tests locally.
  ```java
  GrpcClientTest > errorNoMessage() FAILED
    java.lang.AssertionError:
    Expecting actual not to be null
        at com.linecorp.armeria.client.grpc.GrpcClientTest.lambda$errorNoMessage$44(GrpcClientTest.java:1639)
        at com.linecorp.armeria.client.grpc.GrpcClientTest.checkRequestLogError(GrpcClientTest.java:1863)
        at com.linecorp.armeria.client.grpc.GrpcClientTest.errorNoMessage(GrpcClientTest.java:1634)
  ```
  That regression was caused by the change in #3904 that added `responseCause(Throwable)` and migrated `RpcResponse.cause()` to use the new API. https://github.com/line/armeria/pull/3904/files#diff-91096a8a0f87541eb2debf804754395c3000432ccc7af9167fd99d93e4241628
  Since `RequestLog.responseCause(Throwable)` does not allow setting an exception if an HTTP response has ended, `RpcResponse.cause()`, produced after the HTTP response ended, wasn't recode to `RequestLog`.

- `RequestLog.whenComplete()`:
  There is a case where `RequestLog.whenComplete()` is never complete when `RequestLog.whenComplete()` and `RequestLogBuilder.endResponse()` are invoked simultaneously.
- GraphQL's `ExcutionId`:
  An `ExcutionIdGenerator` can be set to `GraphQL` while building a service. But the obsolete `ExcutionId` set to `ExecutionInput` wasn't removed. #4877 

- `%3F`:
  - `RequestTarget` is fixed not to decode `%3F` into `?` in a path component but some tests weren't fixed. #4907

- Test Java version:
  `-PtestJavaVersion` wasn't properly set to non-`test` tasks such as `shadedTest`, `testNG`, `testStreaming`, and so on.

Note:

The regression has not yet been released, so there is no impact on users.

Modifications:

- Migrated `shadedTest` to JVM test suits to run tests with JUnit 5.
- Fixed broken tests caused by #4907
- Directly set `RpcResponse.cause()` to `responseCause` if it is null
- Read `flags` within `lock` before removing satisfied futures in `DefaultRequestLog`

Result:

Make CI builds run all tests