### PR TITLE
Try enabling gradle enterprise

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   LC_ALL: "en_US.UTF-8"
   BUILD_JDK_VERSION: "19"
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:
   build:

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,8 @@ plugins {
     // automatically download one based on the foojay Disco API.
     // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
     id("org.gradle.toolchains.foojay-resolver") version "0.5.0"
+    id "com.gradle.enterprise" version "3.13.3"
+
 }
 toolchainManagement {
     jvm {
@@ -13,6 +15,17 @@ toolchainManagement {
             repository("foojay") {
                 resolverClass = org.gradle.toolchains.foojay.FoojayToolchainResolver
             }
+        }
+    }
+}
+gradleEnterprise {
+    server = "https://ge.armeria.dev"
+    buildScan {
+        // publish build scans if the access key is provided
+        publishAlwaysIf(System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") != null)
+        uploadInBackground = false
+        capture {
+            taskInputFiles = true
         }
     }
 }


### PR DESCRIPTION
Motivation:

Note that github secrets are not available for actions triggered by forked pull requests: [ref](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks)

We have two choices
1. Using `pull_request` events:
- For push (merge) events, secrets are applied and the build cache is updated
- For pull requests from forked repositories, the build cache isn't updated. This means we can't take advantage of the build cache when checking out and reviewing pull requests locally.
- We can expect fewer cache uploaded, but higher hit rate
2. Using `pull_request_target` events:
- For all opened pull requests, secrets are applied and the build cache is updated
- For this type of event, the `.github` workflow files from the base commit is used. This means updating the `.github` workflow file can be tedious. (e.g. we need to merge changes we want to test to our forked repo, and then open a PR to verify changes)

I think it's fine to go with option 1 for now. Perhaps we can pivot to option 2 later depending on how much pressure our gradle enterprise instance is experiencing.
Unfortunately, the only way to test if this PR "works" is to push this commit to the `main` branch.

Test result from my forked repo:
- PR: https://github.com/jrhee17/armeria/pull/10
- Build scan: https://ge.armeria.dev/s/hcdbl7vdcqbhc
- CI: https://github.com/jrhee17/armeria/actions/runs/5201312954/jobs/9381342458#step:5:1601

The options provided in `settings.gradle` are straightforward from Step 1 in the provided manual.

Modifications:

- Add a environment variable for gradle enterprise access key
- Add gradle enterprise configurations in `settings.gradle`

Result:

- Gradle enterprise integration

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
