### PR TITLE
Map `FailFastException` to gRPC `Status.UNAVAILABLE`

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java
@@ -45,6 +45,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.circuitbreaker.FailFastException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -122,7 +123,9 @@ public final class GrpcStatus {
         if (t instanceof ClosedStreamException || t instanceof RequestTimeoutException) {
             return Status.CANCELLED.withCause(t);
         }
-        if (t instanceof UnprocessedRequestException || t instanceof IOException) {
+        if (t instanceof UnprocessedRequestException ||
+            t instanceof IOException ||
+            t instanceof FailFastException) {
             return Status.UNAVAILABLE.withCause(t);
         }
         if (t instanceof Http2Exception) {

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/GrpcStatusTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/GrpcStatusTest.java
@@ -37,6 +37,9 @@ import org.junit.jupiter.api.Test;
 
 import com.google.api.gax.grpc.GrpcStatusCode;
 
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.FailFastException;
+
 import io.grpc.Status;
 
 class GrpcStatusTest {
@@ -47,5 +50,12 @@ class GrpcStatusTest {
                     .as("gRPC code: {}", code)
                     .isEqualTo(GrpcStatusCode.of(code).getCode().getHttpStatusCode());
         }
+    }
+
+    @Test
+    void failFastExceptionToUnavailableCode() {
+        assertThat(GrpcStatus.fromThrowable(new FailFastException(CircuitBreaker.ofDefaultName()))
+                             .getCode())
+                .isEqualTo(Status.Code.UNAVAILABLE);
     }
 }


### PR DESCRIPTION
Motivation:

`FailFastException` is mapped to `Status.UNKNOWN` while `UnprocessedRequestException` is mapped to `Status.UNAVAILABLE`. https://github.com/line/armeria/blob/4c9dccf996dc062f8f77d7013de504141d9c8306/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcStatus.java#L125-L127
Both `FailFastException` and `UnprocessedRequestException` mean that a request did not work on a server, so it would be better to map to the same `Status`.

See #4805 for the detail.

Modifications:

- Fixed `GrpcStatus.fromThrowable()` to convert `FailFastException` to `Status.UNAVAILABLE`

Result:

- `FailFastException` is now correctly converted to `Status.UNAVAILABLE`.
- Fixes #4805