### PR TITLE
Fix 'Copy cURL command' logic on debug page

### DIFF
--- a/docs-client/README.md
+++ b/docs-client/README.md
@@ -28,7 +28,7 @@ $ ARMERIA_PORT=51234 npm run develop
 or with Gradle
 
 ```console
-$ ARMERIA_PORT=51234 ./gradlew :docs-client:npm_run_start --no-daemon
+$ ARMERIA_PORT=51234 ./gradlew :docs-client:npm_run_develop --no-daemon
 ```
 
 Replacing the port of the docs page in the running server with `3000` will use the dev server to render while

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -106,11 +106,14 @@ const copyTextToClipboard = (text: string) => {
   const textArea = document.createElement('textarea');
   textArea.style.opacity = '0.0';
   textArea.value = text;
-  document.body.appendChild(textArea);
+
+  const modal = document.getElementById('debug-form')!;
+  modal.appendChild(textArea);
+
   textArea.focus();
   textArea.select();
   document.execCommand('copy');
-  document.body.removeChild(textArea);
+  modal.removeChild(textArea);
 };
 
 const toggle = (prev: boolean, override: unknown) => {
@@ -343,7 +346,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
         } else {
           endpoint = transport.getDebugMimeTypeEndpoint(method, additionalPath);
           uri =
-            `'${host}${escapeSingleQuote(additionalPath)}'` +
+            `'${host}${escapeSingleQuote(additionalPath)}` +
             `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
         }
       } else if (additionalPath.length > 0) {


### PR DESCRIPTION
### Motivation

After introducing the Debug modal on DocService, the "Copy as a cURL command" and "Copy response" logic has stopped working because the temporary `<textarea>` element cannot be focused.

Additionally, when copying the cURL command for non-exact paths, it includes an extra trailing `'`, which breaks the command. For example `'http://localhost:8080''` or `'http://localhost:8080'?foo=bar'`.

### Modifications:

- When copying request or response, create `<textarea>` element on the modal instead of `document.body`
- Remove an extra `'` when building the URI for non-exact paths

### Result

- Copy to clipboard functionality works on debug page
- cURL command for non-exact paths is valid
