### PR TITLE
Fix flaky `PrometheusMetricExposureTest`

### DIFF
--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -22,15 +22,13 @@ def boot3ActuatorProjectDir = "${rootProject.projectDir}/spring/$boot3Actuator"
 tasks.compileJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileJava)
 tasks.compileTestJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileTestJava)
 tasks.sourcesJar.dependsOn(project(":spring:$boot3Actuator").tasks.sourcesJar)
-tasks.processTestResources.dependsOn(project(":spring:$boot3Actuator").tasks.generateTestSources)
 
 tasks.compileJava.source "${boot3ActuatorProjectDir}/src/main/java",
         "${boot3ActuatorProjectDir}/gen-src/main/java"
 tasks.processResources.from "${boot3ActuatorProjectDir}/src/main/resources"
 tasks.compileTestJava.source "${boot3ActuatorProjectDir}/src/test/java",
         "${boot3ActuatorProjectDir}/gen-src/test/java"
-tasks.processTestResources.from "${boot3ActuatorProjectDir}/src/test/resources",
-        "${boot3ActuatorProjectDir}/gen-src/test/resources"
+tasks.processTestResources.from "${boot3ActuatorProjectDir}/src/test/resources"
 tasks.sourcesJar.from "${boot3ActuatorProjectDir}/src/main/java", "${boot3ActuatorProjectDir}/gen-src/main/java"
 tasks.sourcesJar.from "${boot3ActuatorProjectDir}/src/main/resources"
 tasks.javadoc.source "${boot3ActuatorProjectDir}/src/main/java", "${boot3ActuatorProjectDir}/gen-src/main/java"

--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -22,13 +22,15 @@ def boot3ActuatorProjectDir = "${rootProject.projectDir}/spring/$boot3Actuator"
 tasks.compileJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileJava)
 tasks.compileTestJava.dependsOn(project(":spring:$boot3Actuator").tasks.compileTestJava)
 tasks.sourcesJar.dependsOn(project(":spring:$boot3Actuator").tasks.sourcesJar)
+tasks.processTestResources.dependsOn(project(":spring:$boot3Actuator").tasks.generateTestSources)
 
 tasks.compileJava.source "${boot3ActuatorProjectDir}/src/main/java",
         "${boot3ActuatorProjectDir}/gen-src/main/java"
 tasks.processResources.from "${boot3ActuatorProjectDir}/src/main/resources"
 tasks.compileTestJava.source "${boot3ActuatorProjectDir}/src/test/java",
         "${boot3ActuatorProjectDir}/gen-src/test/java"
-tasks.processTestResources.from "${boot3ActuatorProjectDir}/src/test/resources"
+tasks.processTestResources.from "${boot3ActuatorProjectDir}/src/test/resources",
+        "${boot3ActuatorProjectDir}/gen-src/test/resources"
 tasks.sourcesJar.from "${boot3ActuatorProjectDir}/src/main/java", "${boot3ActuatorProjectDir}/gen-src/main/java"
 tasks.sourcesJar.from "${boot3ActuatorProjectDir}/src/main/resources"
 tasks.javadoc.source "${boot3ActuatorProjectDir}/src/main/java", "${boot3ActuatorProjectDir}/gen-src/main/java"

--- a/spring/boot2-actuator-autoconfigure/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring/boot2-actuator-autoconfigure/src/test/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.linecorp.armeria.spring.RetryableArmeriaServerGracefulShutdownLifecycleConfiguration

--- a/spring/boot3-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationInternalServiceTest.java
+++ b/spring/boot3-actuator-autoconfigure/src/test/java/com/linecorp/armeria/spring/actuate/ArmeriaSpringActuatorAutoConfigurationInternalServiceTest.java
@@ -54,7 +54,7 @@ import com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguratio
 @AutoConfigureMetrics
 @EnableAutoConfiguration
 @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-@Timeout(10)
+@Timeout(30)
 class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
 
     // We use this logger to test the /loggers endpoint, so set the name manually instead of using class name.
@@ -110,7 +110,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class ActuatorTest {
         @LocalManagementPort
         private Integer actuatorPort;
@@ -156,7 +156,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class BasePathTest {
         @LocalManagementPort
         private Integer actuatorPort;
@@ -190,7 +190,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     @FlakyTest
     static class BasePathSamePortTest {
         @LocalManagementPort
@@ -233,7 +233,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class BasePathWithoutPortTest {
         @Inject
         private Server server;
@@ -276,7 +276,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class AllInternalServicesTest {
         @Inject
         private Server server;
@@ -317,7 +317,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class DefaultInternalServicesTest {
         @Inject
         private Server server;
@@ -361,7 +361,7 @@ class ArmeriaSpringActuatorAutoConfigurationInternalServiceTest {
     @AutoConfigureMetrics
     @EnableAutoConfiguration
     @ImportAutoConfiguration(ArmeriaSpringActuatorAutoConfiguration.class)
-    @Timeout(10)
+    @Timeout(30)
     static class ManagementLocalhostTest {
         @LocalManagementPort
         private Integer actuatorPort;


### PR DESCRIPTION
Motivation:

As `AutoConfiguration.imports` in the test resource of `spring:boot3-actuator-autoconfigure` isn't copied to `spring:boot2-actuator-autoconfigure`, `PrometheusMetricExposureTest` didn't restart a server when it fails to start.

Related issue: #4941

Modifications:

- Copy `AutoConfiguration.imports` file in `boot3-autoconfigure/src/test/...' to `spring:boot2-actuator-autoconfigure`

Result:

Stabilize the CI build state
