### PR TITLE
Add LogWriter

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
@@ -38,8 +38,8 @@ abstract class AbstractLoggingClientBuilder extends LoggingDecoratorBuilder {
      */
     public AbstractLoggingClientBuilder sampler(Sampler<? super ClientRequestContext> sampler) {
         requireNonNull(sampler, "sampler");
-        this.successSampler = sampler;
-        this.failureSampler = sampler;
+        successSampler = sampler;
+        failureSampler = sampler;
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -16,9 +16,6 @@
 package com.linecorp.armeria.client.logging;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
-
-import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
@@ -26,11 +23,8 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -55,22 +49,9 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
         return new LoggingClientBuilder();
     }
 
-    /**
-     * Creates a new instance that logs {@link Request}s and {@link Response}s at the specified
-     * {@link LogLevel}s with the {@link LogFormatter}.
-     * If the logger is null, it means that the default logger is used.
-     */
-    LoggingClient(
-            HttpClient delegate,
-            @Nullable Logger logger,
-            RequestLogLevelMapper requestLogLevelMapper,
-            ResponseLogLevelMapper responseLogLevelMapper,
-            Predicate<Throwable> responseCauseFilter,
-            Sampler<? super ClientRequestContext> successSampler,
-            Sampler<? super ClientRequestContext> failureSampler,
-            LogFormatter logFormatter) {
-
-        super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
-              responseCauseFilter, successSampler, failureSampler, logFormatter);
+    LoggingClient(HttpClient delegate, LogWriter logWriter,
+                  Sampler<? super ClientRequestContext> successSampler,
+                  Sampler<? super ClientRequestContext> failureSampler) {
+        super(delegate, logWriter, successSampler, failureSampler);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -28,8 +28,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
@@ -48,14 +48,7 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
      * this builder.
      */
     public LoggingClient build(HttpClient delegate) {
-        return new LoggingClient(delegate,
-                                 logger(),
-                                 requestLogLevelMapper(),
-                                 responseLogLevelMapper(),
-                                 responseCauseFilter(),
-                                 successSampler(),
-                                 failureSampler(),
-                                 logFormatter());
+        return new LoggingClient(delegate, logWriter(), successSampler(), failureSampler());
     }
 
     /**
@@ -246,7 +239,7 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
     }
 
     @Override
-    public LoggingClientBuilder logFormatter(LogFormatter logFormatter) {
-        return (LoggingClientBuilder) super.logFormatter(logFormatter);
+    public LoggingClientBuilder logWriter(LogWriter logWriter) {
+        return (LoggingClientBuilder) super.logWriter(logWriter);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -17,9 +17,6 @@
 package com.linecorp.armeria.client.logging;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
-
-import org.slf4j.Logger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.RpcClient;
@@ -27,11 +24,8 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -56,22 +50,9 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
         return new LoggingRpcClientBuilder();
     }
 
-    /**
-     * Creates a new instance that logs {@link Request}s and {@link Response}s at the specified
-     * {@link LogLevel}s with the {@link LogFormatter}.
-     * If the logger is null, it means that the default logger is used.
-     */
-    LoggingRpcClient(
-            RpcClient delegate,
-            @Nullable Logger logger,
-            RequestLogLevelMapper requestLogLevelMapper,
-            ResponseLogLevelMapper responseLogLevelMapper,
-            Predicate<Throwable> responseCauseFilter,
-            Sampler<? super ClientRequestContext> successSampler,
-            Sampler<? super ClientRequestContext> failureSampler,
-            LogFormatter logFormatter) {
-
-        super(delegate, logger, requestLogLevelMapper, responseLogLevelMapper,
-              responseCauseFilter, successSampler, failureSampler, logFormatter);
+    LoggingRpcClient(RpcClient delegate, LogWriter logWriter,
+                     Sampler<? super ClientRequestContext> successSampler,
+                     Sampler<? super ClientRequestContext> failureSampler) {
+        super(delegate, logWriter, successSampler, failureSampler);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -28,8 +28,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
@@ -51,14 +51,7 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
      * this builder.
      */
     public LoggingRpcClient build(RpcClient delegate) {
-        return new LoggingRpcClient(delegate,
-                                    logger(),
-                                    requestLogLevelMapper(),
-                                    responseLogLevelMapper(),
-                                    responseCauseFilter(),
-                                    successSampler(),
-                                    failureSampler(),
-                                    logFormatter());
+        return new LoggingRpcClient(delegate, logWriter(), successSampler(), failureSampler());
     }
 
     /**
@@ -248,7 +241,7 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
     }
 
     @Override
-    public LoggingRpcClientBuilder logFormatter(LogFormatter logFormatter) {
-        return (LoggingRpcClientBuilder) super.logFormatter(logFormatter);
+    public LoggingRpcClientBuilder logWriter(LogWriter logWriter) {
+        return (LoggingRpcClientBuilder) super.logWriter(logWriter);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -16,8 +16,9 @@
 
 package com.linecorp.armeria.common.logging;
 
-import static com.linecorp.armeria.common.logging.DefaultLogWriterBuilder.DEFAULT_REQUEST_LOG_LEVEL_MAPPER;
-import static com.linecorp.armeria.common.logging.DefaultLogWriterBuilder.DEFAULT_RESPONSE_LOG_LEVEL_MAPPER;
+import static com.linecorp.armeria.common.logging.LogWriterBuilder.DEFAULT_REQUEST_LOG_LEVEL;
+import static com.linecorp.armeria.common.logging.LogWriterBuilder.DEFAULT_REQUEST_LOG_LEVEL_MAPPER;
+import static com.linecorp.armeria.common.logging.LogWriterBuilder.DEFAULT_RESPONSE_LOG_LEVEL_MAPPER;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Predicate;
@@ -41,6 +42,9 @@ final class DefaultLogWriter implements LogWriter {
                                  DEFAULT_RESPONSE_LOG_LEVEL_MAPPER,
                                  throwable -> false, LogFormatter.ofText());
 
+    private static boolean warnedNullRequestLogLevelMapper;
+    private static boolean warnedNullResponseLogLevelMapper;
+
     private final Logger logger;
     private final RequestLogLevelMapper requestLogLevelMapper;
     private final ResponseLogLevelMapper responseLogLevelMapper;
@@ -60,8 +64,14 @@ final class DefaultLogWriter implements LogWriter {
     @Override
     public void logRequest(RequestOnlyLog log) {
         requireNonNull(log, "log");
-        final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
-        assert requestLogLevel != null;
+        LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
+        if (requestLogLevel == null) {
+            if (!warnedNullRequestLogLevelMapper) {
+                warnedNullRequestLogLevelMapper = true;
+                logger.warn("requestLogLevelMapper.apply() returned null; using default log level");
+            }
+            requestLogLevel = DEFAULT_REQUEST_LOG_LEVEL;
+        }
         if (requestLogLevel.isEnabled(logger)) {
             final RequestContext ctx = log.context();
             if (log.requestCause() == null && isTransientService(ctx)) {
@@ -70,7 +80,7 @@ final class DefaultLogWriter implements LogWriter {
             try (SafeCloseable ignored = ctx.push()) {
                 // We don't log requestCause when it's not null because responseCause is the same exception when
                 // the requestCause is not null. That's way we don't have requestCauseSanitizer.
-                requestLogLevel.log(logger, logFormatter.formatRequest(log, true));
+                requestLogLevel.log(logger, logFormatter.formatRequest(log));
             }
         }
     }
@@ -78,8 +88,15 @@ final class DefaultLogWriter implements LogWriter {
     @Override
     public void logResponse(RequestLog log) {
         requireNonNull(log, "log");
-        final LogLevel responseLogLevel = responseLogLevelMapper.apply(log);
-        assert responseLogLevel != null;
+        LogLevel responseLogLevel = responseLogLevelMapper.apply(log);
+        if (responseLogLevel == null) {
+            if (!warnedNullResponseLogLevelMapper) {
+                warnedNullResponseLogLevelMapper = true;
+                logger.warn("responseLogLevelMapper.apply() returned null; using default log level mapper");
+            }
+            responseLogLevel = DEFAULT_RESPONSE_LOG_LEVEL_MAPPER.apply(log);
+            assert responseLogLevel != null;
+        }
         final Throwable responseCause = log.responseCause();
 
         if (responseLogLevel.isEnabled(logger)) {
@@ -90,9 +107,10 @@ final class DefaultLogWriter implements LogWriter {
                 return;
             }
 
-            final String responseStr = logFormatter.formatResponse(log, true);
+            final String responseStr = logFormatter.formatResponse(log);
             try (SafeCloseable ignored = ctx.push()) {
                 if (responseCause == null) {
+                    String format = "{} Response: {}";
                     responseLogLevel.log(logger, responseStr);
                     return;
                 }
@@ -102,7 +120,7 @@ final class DefaultLogWriter implements LogWriter {
                 if (!requestLogLevel.isEnabled(logger)) {
                     // Request wasn't logged, but this is an unsuccessful response,
                     // so we log the request too to help debugging.
-                    responseLogLevel.log(logger, logFormatter.formatRequest(log, true));
+                    responseLogLevel.log(logger, logFormatter.formatRequest(log));
                 }
 
                 if (responseCauseFilter.test(responseCause)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -70,7 +70,7 @@ final class DefaultLogWriter implements LogWriter {
             try (SafeCloseable ignored = ctx.push()) {
                 // We don't log requestCause when it's not null because responseCause is the same exception when
                 // the requestCause is not null. That's way we don't have requestCauseSanitizer.
-                requestLogLevel.log(logger, logFormatter.formatRequest(log));
+                requestLogLevel.log(logger, logFormatter.formatRequest(log, true));
             }
         }
     }
@@ -90,7 +90,7 @@ final class DefaultLogWriter implements LogWriter {
                 return;
             }
 
-            final String responseStr = logFormatter.formatResponse(log);
+            final String responseStr = logFormatter.formatResponse(log, true);
             try (SafeCloseable ignored = ctx.push()) {
                 if (responseCause == null) {
                     responseLogLevel.log(logger, responseStr);
@@ -102,7 +102,7 @@ final class DefaultLogWriter implements LogWriter {
                 if (!requestLogLevel.isEnabled(logger)) {
                     // Request wasn't logged, but this is an unsuccessful response,
                     // so we log the request too to help debugging.
-                    responseLogLevel.log(logger, logFormatter.formatRequest(log));
+                    responseLogLevel.log(logger, logFormatter.formatRequest(log, true));
                 }
 
                 if (responseCauseFilter.test(responseCause)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static com.linecorp.armeria.common.logging.DefaultLogWriterBuilder.DEFAULT_REQUEST_LOG_LEVEL_MAPPER;
+import static com.linecorp.armeria.common.logging.DefaultLogWriterBuilder.DEFAULT_RESPONSE_LOG_LEVEL_MAPPER;
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.TransientServiceOption;
+
+final class DefaultLogWriter implements LogWriter {
+
+    static final Logger defaultLogger = LoggerFactory.getLogger(DefaultLogWriter.class);
+
+    static final DefaultLogWriter DEFAULT =
+            new DefaultLogWriter(defaultLogger, DEFAULT_REQUEST_LOG_LEVEL_MAPPER,
+                                 DEFAULT_RESPONSE_LOG_LEVEL_MAPPER,
+                                 throwable -> false, LogFormatter.ofText());
+
+    private static final String REQUEST_FORMAT = "{} Request: {}";
+    private static final String RESPONSE_FORMAT = "{} Response: {}";
+
+    private final Logger logger;
+    private final RequestLogLevelMapper requestLogLevelMapper;
+    private final ResponseLogLevelMapper responseLogLevelMapper;
+    private final Predicate<Throwable> responseCauseFilter;
+    private final LogFormatter logFormatter;
+
+    DefaultLogWriter(Logger logger, RequestLogLevelMapper requestLogLevelMapper,
+                     ResponseLogLevelMapper responseLogLevelMapper,
+                     Predicate<Throwable> responseCauseFilter, LogFormatter logFormatter) {
+        this.logger = logger;
+        this.requestLogLevelMapper = requestLogLevelMapper;
+        this.responseLogLevelMapper = responseLogLevelMapper;
+        this.responseCauseFilter = responseCauseFilter;
+        this.logFormatter = logFormatter;
+    }
+
+    @Override
+    public void logRequest(RequestOnlyLog log) {
+        requireNonNull(log, "log");
+        final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
+        assert requestLogLevel != null;
+        if (requestLogLevel.isEnabled(logger)) {
+            final RequestContext ctx = log.context();
+            if (log.requestCause() == null && isTransientService(ctx)) {
+                return;
+            }
+            final String requestStr = logFormatter.formatRequest(log);
+
+            try (SafeCloseable ignored = ctx.push()) {
+                // We don't log requestCause when it's not null because responseCause is the same exception when
+                // the requestCause is not null. That's way we don't have requestCauseSanitizer.
+                requestLogLevel.log(logger, REQUEST_FORMAT, ctx, requestStr);
+            }
+        }
+    }
+
+    @Override
+    public void logResponse(RequestLog log) {
+        requireNonNull(log, "log");
+        final LogLevel responseLogLevel = responseLogLevelMapper.apply(log);
+        assert responseLogLevel != null;
+        final Throwable responseCause = log.responseCause();
+
+        if (responseLogLevel.isEnabled(logger)) {
+            final RequestContext ctx = log.context();
+            if (responseCause == null &&
+                !log.responseHeaders().status().isServerError() &&
+                isTransientService(ctx)) {
+                return;
+            }
+
+            final String responseStr = logFormatter.formatResponse(log);
+            try (SafeCloseable ignored = ctx.push()) {
+                if (responseCause == null) {
+                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
+                    return;
+                }
+
+                final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
+                assert requestLogLevel != null;
+                if (!requestLogLevel.isEnabled(logger)) {
+                    // Request wasn't logged, but this is an unsuccessful response,
+                    // so we log the request too to help debugging.
+                    responseLogLevel.log(logger, REQUEST_FORMAT, ctx, logFormatter.formatRequest(log));
+                }
+
+                if (responseCauseFilter.test(responseCause)) {
+                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
+                } else {
+                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr, responseCause);
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("logger", logger)
+                          .add("requestLogLevelMapper", requestLogLevelMapper)
+                          .add("responseLogLevelMapper", responseLogLevelMapper)
+                          .add("responseCauseFilter", responseCauseFilter)
+                          .add("logFormatter", logFormatter)
+                          .toString();
+    }
+
+    private static boolean isTransientService(RequestContext ctx) {
+        return ctx instanceof ServiceRequestContext &&
+               !((ServiceRequestContext) ctx).config()
+                                             .transientServiceOptions()
+                                             .contains(TransientServiceOption.WITH_SERVICE_LOGGING);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -110,7 +110,6 @@ final class DefaultLogWriter implements LogWriter {
             final String responseStr = logFormatter.formatResponse(log);
             try (SafeCloseable ignored = ctx.push()) {
                 if (responseCause == null) {
-                    String format = "{} Response: {}";
                     responseLogLevel.log(logger, responseStr);
                     return;
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -45,12 +45,12 @@ final class DefaultLogWriter implements LogWriter {
     private final Logger logger;
     private final RequestLogLevelMapper requestLogLevelMapper;
     private final ResponseLogLevelMapper responseLogLevelMapper;
-    private final Predicate<Throwable> responseCauseFilter;
+    private final Predicate<? super Throwable> responseCauseFilter;
     private final LogFormatter logFormatter;
 
     DefaultLogWriter(Logger logger, RequestLogLevelMapper requestLogLevelMapper,
                      ResponseLogLevelMapper responseLogLevelMapper,
-                     Predicate<Throwable> responseCauseFilter, LogFormatter logFormatter) {
+                     Predicate<? super Throwable> responseCauseFilter, LogFormatter logFormatter) {
         this.logger = logger;
         this.requestLogLevelMapper = requestLogLevelMapper;
         this.responseLogLevelMapper = responseLogLevelMapper;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriterBuilder.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Builds a new {@link LogWriter}.
+ */
+@UnstableApi
+public final class DefaultLogWriterBuilder {
+
+    static final RequestLogLevelMapper DEFAULT_REQUEST_LOG_LEVEL_MAPPER =
+            RequestLogLevelMapper.of(LogLevel.DEBUG);
+
+    static final ResponseLogLevelMapper DEFAULT_RESPONSE_LOG_LEVEL_MAPPER =
+            ResponseLogLevelMapper.of(LogLevel.DEBUG, LogLevel.WARN);
+
+    private Logger logger = DefaultLogWriter.defaultLogger;
+    @Nullable
+    private RequestLogLevelMapper requestLogLevelMapper;
+    @Nullable
+    private ResponseLogLevelMapper responseLogLevelMapper;
+    private Predicate<Throwable> responseCauseFilter = throwable -> false;
+    private LogFormatter logFormatter = LogFormatter.ofText();
+
+    DefaultLogWriterBuilder() {}
+
+    /**
+     * Sets the {@link Logger} to use when logging.
+     * If unset, a default {@link Logger} will be used.
+     */
+    public DefaultLogWriterBuilder logger(Logger logger) {
+        this.logger = requireNonNull(logger, "logger");
+        return this;
+    }
+
+    /**
+     * Sets the name of the {@link Logger} to use when logging.
+     * This method is a shortcut for {@code this.logger(LoggerFactory.getLogger(loggerName))}.
+     */
+    public DefaultLogWriterBuilder logger(String loggerName) {
+        requireNonNull(loggerName, "loggerName");
+        logger = LoggerFactory.getLogger(loggerName);
+        return this;
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#DEBUG}.
+     */
+    public DefaultLogWriterBuilder requestLogLevel(LogLevel requestLogLevel) {
+        requireNonNull(requestLogLevel, "requestLogLevel");
+        return requestLogLevelMapper(RequestLogLevelMapper.of(requestLogLevel));
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
+     */
+    public DefaultLogWriterBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(requestLogLevel, "requestLogLevel");
+        return requestLogLevelMapper(RequestLogLevelMapper.of(clazz, requestLogLevel));
+    }
+
+    /**
+     * Sets the {@link RequestLogLevelMapper} to use when mapping the log level of request logs.
+     */
+    public DefaultLogWriterBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
+        requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
+        if (this.requestLogLevelMapper == null) {
+            this.requestLogLevelMapper = requestLogLevelMapper;
+        } else {
+            this.requestLogLevelMapper = this.requestLogLevelMapper.orElse(requestLogLevelMapper);
+        }
+        return this;
+    }
+
+    private RequestLogLevelMapper requestLogLevelMapper() {
+        if (requestLogLevelMapper == null) {
+            return DEFAULT_REQUEST_LOG_LEVEL_MAPPER;
+        }
+        return requestLogLevelMapper.orElse(DEFAULT_REQUEST_LOG_LEVEL_MAPPER);
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when logging responses whose status is equal to the specified
+     * {@link HttpStatus}.
+     */
+    public DefaultLogWriterBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
+        return responseLogLevelMapper(ResponseLogLevelMapper.of(status, logLevel));
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when logging responses whose status belongs to the specified
+     * {@link HttpStatusClass}.
+     */
+    public DefaultLogWriterBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
+        return responseLogLevelMapper(ResponseLogLevelMapper.of(statusClass, logLevel));
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
+     */
+    public DefaultLogWriterBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
+        requireNonNull(clazz, "clazz");
+        requireNonNull(logLevel, "logLevel");
+        return responseLogLevelMapper(ResponseLogLevelMapper.of(clazz, logLevel));
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when logging successful responses (e.g., no unhandled exception).
+     * {@link LogLevel#DEBUG} will be used by default.
+     */
+    public DefaultLogWriterBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
+        requireNonNull(successfulResponseLogLevel, "successfulResponseLogLevel");
+        return responseLogLevelMapper(log -> log.responseCause() == null ? successfulResponseLogLevel : null);
+    }
+
+    /**
+     * Sets the {@link LogLevel} to use when logging failure responses (e.g., failed with an exception).
+     * {@link LogLevel#WARN} will be used by default.
+     */
+    public DefaultLogWriterBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
+        requireNonNull(failedResponseLogLevel, "failedResponseLogLevel");
+        return responseLogLevelMapper(log -> log.responseCause() != null ? failedResponseLogLevel : null);
+    }
+
+    /**
+     * Sets the {@link ResponseLogLevelMapper} to use when mapping the log level of response logs.
+     */
+    public DefaultLogWriterBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
+        requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");
+        if (this.responseLogLevelMapper == null) {
+            this.responseLogLevelMapper = responseLogLevelMapper;
+        } else {
+            this.responseLogLevelMapper = this.responseLogLevelMapper.orElse(responseLogLevelMapper);
+        }
+        return this;
+    }
+
+    private ResponseLogLevelMapper responseLogLevelMapper() {
+        if (responseLogLevelMapper == null) {
+            return DEFAULT_RESPONSE_LOG_LEVEL_MAPPER;
+        }
+        return responseLogLevelMapper.orElse(DEFAULT_RESPONSE_LOG_LEVEL_MAPPER);
+    }
+
+    /**
+     * Sets the {@link Predicate} used for evaluating whether to log the response cause or not.
+     * You can prevent logging the response cause by returning {@code true}
+     * in the {@link Predicate}. By default, the response cause will always be logged.
+     */
+    public DefaultLogWriterBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
+        this.responseCauseFilter = requireNonNull(responseCauseFilter, "responseCauseFilter");
+        return this;
+    }
+
+    /**
+     * Sets the {@link LogFormatter} which converts a {@link RequestOnlyLog} or {@link RequestLog}
+     * into a log message. By default {@link LogFormatter#ofText()} will be used.
+     *
+     * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
+     */
+    public DefaultLogWriterBuilder logFormatter(LogFormatter logFormatter) {
+        this.logFormatter = requireNonNull(logFormatter, "logFormatter");
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link LogWriter} based on the properties of this builder.
+     */
+    public LogWriter build() {
+        return new DefaultLogWriter(logger, requestLogLevelMapper(), responseLogLevelMapper(),
+                                    responseCauseFilter, logFormatter);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1436,9 +1436,9 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private static StringBuilder toStringWithoutChildren(StringBuilder buf, String req, String res) {
-        return buf.append("{req=")
+        return buf.append('{')
                   .append(req)
-                  .append(", res=")
+                  .append(", ")
                   .append(res)
                   .append('}');
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatter.java
@@ -84,13 +84,17 @@ final class JsonLogFormatter implements LogFormatter {
     }
 
     @Override
-    public String formatRequest(RequestOnlyLog log) {
+    public String formatRequest(RequestOnlyLog log, boolean containContext) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
         final RequestContext ctx = log.context();
         if (!RequestLogProperty.REQUEST_START_TIME.isAvailable(flags)) {
-            return "{\"ctx\": \"" + ctx + "\", \"request\": {}}";
+            if (containContext) {
+                return "{\"ctx\": \"" + ctx + "\", \"request\": {}}";
+            } else {
+                return "{\"request\": {}}";
+            }
         }
 
         try {
@@ -131,7 +135,9 @@ final class JsonLogFormatter implements LogFormatter {
             }
 
             final ObjectNode objectNode = objectMapper.createObjectNode();
-            objectNode.put("ctx", ctx.toString());
+            if (containContext) {
+                objectNode.put("ctx", ctx.toString());
+            }
             final ObjectNode requestNode = objectMapper.createObjectNode();
             objectNode.set("request", requestNode);
             requestNode.put("startTime",
@@ -184,7 +190,7 @@ final class JsonLogFormatter implements LogFormatter {
     }
 
     @Override
-    public String formatResponse(RequestLog log) {
+    public String formatResponse(RequestLog log, boolean containContext) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatter.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
@@ -72,8 +73,7 @@ final class JsonLogFormatter implements LogFormatter {
                     responseTrailersSanitizer,
             BiFunction<? super RequestContext, Object, ? extends JsonNode> requestContentSanitizer,
             BiFunction<? super RequestContext, Object, ? extends JsonNode> responseContentSanitizer,
-            ObjectMapper objectMapper
-    ) {
+            ObjectMapper objectMapper) {
         this.requestHeadersSanitizer = requestHeadersSanitizer;
         this.responseHeadersSanitizer = responseHeadersSanitizer;
         this.requestTrailersSanitizer = requestTrailersSanitizer;
@@ -268,5 +268,18 @@ final class JsonLogFormatter implements LogFormatter {
             logger.warn("Unexpected exception while formatting a response log: {}", log, e);
             return "{}";
         }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("objectMapper", objectMapper)
+                          .add("requestHeadersSanitizer", requestHeadersSanitizer)
+                          .add("requestContentSanitizer", requestContentSanitizer)
+                          .add("requestTrailersSanitizer", requestTrailersSanitizer)
+                          .add("responseHeadersSanitizer", responseHeadersSanitizer)
+                          .add("responseContentSanitizer", responseContentSanitizer)
+                          .add("responseTrailersSanitizer", responseTrailersSanitizer)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogFormatter.java
@@ -68,10 +68,10 @@ public interface LogFormatter {
     /**
      * Returns the formatted request log message of the {@link RequestOnlyLog}.
      */
-    String formatRequest(RequestOnlyLog log);
+    String formatRequest(RequestOnlyLog log, boolean containContext);
 
     /**
      * Returns the formatted response log message that is constructed by {@link RequestLog}.
      */
-    String formatResponse(RequestLog log);
+    String formatResponse(RequestLog log, boolean containContext);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogFormatter.java
@@ -68,10 +68,10 @@ public interface LogFormatter {
     /**
      * Returns the formatted request log message of the {@link RequestOnlyLog}.
      */
-    String formatRequest(RequestOnlyLog log, boolean containContext);
+    String formatRequest(RequestOnlyLog log);
 
     /**
      * Returns the formatted response log message that is constructed by {@link RequestLog}.
      */
-    String formatResponse(RequestLog log, boolean containContext);
+    String formatResponse(RequestLog log);
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
@@ -109,6 +109,10 @@ public enum LogLevel {
     public void log(Logger logger, String format, @Nullable Object arg1) {
         requireNonNull(logger, "logger");
         requireNonNull(format, "format");
+        if (arg1 instanceof Throwable) {
+            log(logger, format, (Throwable) arg1);
+            return;
+        }
         switch (this) {
             case OFF:
                 break;
@@ -135,9 +139,7 @@ public enum LogLevel {
     /**
      * Logs a message at this level.
      */
-    public void log(Logger logger, String format, Throwable throwable) {
-        requireNonNull(logger, "logger");
-        requireNonNull(format, "format");
+    private void log(Logger logger, String format, Throwable throwable) {
         switch (this) {
             case OFF:
                 break;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogLevel.java
@@ -135,6 +135,35 @@ public enum LogLevel {
     /**
      * Logs a message at this level.
      */
+    public void log(Logger logger, String format, Throwable throwable) {
+        requireNonNull(logger, "logger");
+        requireNonNull(format, "format");
+        switch (this) {
+            case OFF:
+                break;
+            case TRACE:
+                logger.trace(format, throwable);
+                break;
+            case DEBUG:
+                logger.debug(format, throwable);
+                break;
+            case INFO:
+                logger.info(format, throwable);
+                break;
+            case WARN:
+                logger.warn(format, throwable);
+                break;
+            case ERROR:
+                logger.error(format, throwable);
+                break;
+            default:
+                throw new Error();
+        }
+    }
+
+    /**
+     * Logs a message at this level.
+     */
     @SuppressWarnings("MethodParameterNamingConvention")
     public void log(Logger logger, String format, @Nullable Object arg1, @Nullable Object arg2) {
         requireNonNull(logger, "logger");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogWriter.java
@@ -57,7 +57,7 @@ public interface LogWriter {
     }
 
     /**
-     * Writes the request-side {@link RequestLog}.
+     * Writes the request-side {@link RequestOnlyLog}.
      */
     void logRequest(RequestOnlyLog log);
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import org.slf4j.Logger;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Writes logs of a {@link RequestLog}.
+ */
+@UnstableApi
+public interface LogWriter {
+
+    /**
+     * Returns the default {@link LogWriter}.
+     */
+    static LogWriter of() {
+        return DefaultLogWriter.DEFAULT;
+    }
+
+    /**
+     * Returns a newly created {@link LogWriter} with the specified {@link Logger}.
+     */
+    static LogWriter of(Logger logger) {
+        return builder().logger(logger).build();
+    }
+
+    /**
+     * Returns a newly created {@link LogWriter} with the specified {@link LogFormatter}.
+     */
+    static LogWriter of(LogFormatter logFormatter) {
+        return builder().logFormatter(logFormatter).build();
+    }
+
+    /**
+     * Returns the {@link DefaultLogWriterBuilder} for building a new {@link LogWriter}.
+     */
+    static DefaultLogWriterBuilder builder() {
+        return new DefaultLogWriterBuilder();
+    }
+
+    /**
+     * Writes the request-side {@link RequestLog}.
+     */
+    void logRequest(RequestOnlyLog log);
+
+    /**
+     * Writes the response-side {@link RequestLog}.
+     */
+    void logResponse(RequestLog log);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogWriterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogWriterBuilder.java
@@ -47,7 +47,7 @@ public final class LogWriterBuilder {
     private RequestLogLevelMapper requestLogLevelMapper;
     @Nullable
     private ResponseLogLevelMapper responseLogLevelMapper;
-    private Predicate<Throwable> responseCauseFilter = throwable -> false;
+    private Predicate<? super Throwable> responseCauseFilter = throwable -> false;
     private LogFormatter logFormatter = LogFormatter.ofText();
 
     LogWriterBuilder() {}
@@ -176,7 +176,7 @@ public final class LogWriterBuilder {
      * You can prevent logging the response cause by returning {@code true}
      * in the {@link Predicate}. By default, the response cause will always be logged.
      */
-    public LogWriterBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
+    public LogWriterBuilder responseCauseFilter(Predicate<? super Throwable> responseCauseFilter) {
         this.responseCauseFilter = requireNonNull(responseCauseFilter, "responseCauseFilter");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LogWriterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LogWriterBuilder.java
@@ -32,10 +32,12 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * Builds a new {@link LogWriter}.
  */
 @UnstableApi
-public final class DefaultLogWriterBuilder {
+public final class LogWriterBuilder {
+
+    static final LogLevel DEFAULT_REQUEST_LOG_LEVEL = LogLevel.DEBUG;
 
     static final RequestLogLevelMapper DEFAULT_REQUEST_LOG_LEVEL_MAPPER =
-            RequestLogLevelMapper.of(LogLevel.DEBUG);
+            RequestLogLevelMapper.of(DEFAULT_REQUEST_LOG_LEVEL);
 
     static final ResponseLogLevelMapper DEFAULT_RESPONSE_LOG_LEVEL_MAPPER =
             ResponseLogLevelMapper.of(LogLevel.DEBUG, LogLevel.WARN);
@@ -48,13 +50,13 @@ public final class DefaultLogWriterBuilder {
     private Predicate<Throwable> responseCauseFilter = throwable -> false;
     private LogFormatter logFormatter = LogFormatter.ofText();
 
-    DefaultLogWriterBuilder() {}
+    LogWriterBuilder() {}
 
     /**
      * Sets the {@link Logger} to use when logging.
      * If unset, a default {@link Logger} will be used.
      */
-    public DefaultLogWriterBuilder logger(Logger logger) {
+    public LogWriterBuilder logger(Logger logger) {
         this.logger = requireNonNull(logger, "logger");
         return this;
     }
@@ -63,7 +65,7 @@ public final class DefaultLogWriterBuilder {
      * Sets the name of the {@link Logger} to use when logging.
      * This method is a shortcut for {@code this.logger(LoggerFactory.getLogger(loggerName))}.
      */
-    public DefaultLogWriterBuilder logger(String loggerName) {
+    public LogWriterBuilder logger(String loggerName) {
         requireNonNull(loggerName, "loggerName");
         logger = LoggerFactory.getLogger(loggerName);
         return this;
@@ -72,7 +74,7 @@ public final class DefaultLogWriterBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#DEBUG}.
      */
-    public DefaultLogWriterBuilder requestLogLevel(LogLevel requestLogLevel) {
+    public LogWriterBuilder requestLogLevel(LogLevel requestLogLevel) {
         requireNonNull(requestLogLevel, "requestLogLevel");
         return requestLogLevelMapper(RequestLogLevelMapper.of(requestLogLevel));
     }
@@ -80,7 +82,7 @@ public final class DefaultLogWriterBuilder {
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
      */
-    public DefaultLogWriterBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
+    public LogWriterBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
         requireNonNull(clazz, "clazz");
         requireNonNull(requestLogLevel, "requestLogLevel");
         return requestLogLevelMapper(RequestLogLevelMapper.of(clazz, requestLogLevel));
@@ -89,7 +91,7 @@ public final class DefaultLogWriterBuilder {
     /**
      * Sets the {@link RequestLogLevelMapper} to use when mapping the log level of request logs.
      */
-    public DefaultLogWriterBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
+    public LogWriterBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
         requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
         if (this.requestLogLevelMapper == null) {
             this.requestLogLevelMapper = requestLogLevelMapper;
@@ -110,7 +112,7 @@ public final class DefaultLogWriterBuilder {
      * Sets the {@link LogLevel} to use when logging responses whose status is equal to the specified
      * {@link HttpStatus}.
      */
-    public DefaultLogWriterBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
+    public LogWriterBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
         return responseLogLevelMapper(ResponseLogLevelMapper.of(status, logLevel));
     }
 
@@ -118,14 +120,14 @@ public final class DefaultLogWriterBuilder {
      * Sets the {@link LogLevel} to use when logging responses whose status belongs to the specified
      * {@link HttpStatusClass}.
      */
-    public DefaultLogWriterBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
+    public LogWriterBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
         return responseLogLevelMapper(ResponseLogLevelMapper.of(statusClass, logLevel));
     }
 
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
      */
-    public DefaultLogWriterBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
+    public LogWriterBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
         requireNonNull(clazz, "clazz");
         requireNonNull(logLevel, "logLevel");
         return responseLogLevelMapper(ResponseLogLevelMapper.of(clazz, logLevel));
@@ -135,7 +137,7 @@ public final class DefaultLogWriterBuilder {
      * Sets the {@link LogLevel} to use when logging successful responses (e.g., no unhandled exception).
      * {@link LogLevel#DEBUG} will be used by default.
      */
-    public DefaultLogWriterBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
+    public LogWriterBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
         requireNonNull(successfulResponseLogLevel, "successfulResponseLogLevel");
         return responseLogLevelMapper(log -> log.responseCause() == null ? successfulResponseLogLevel : null);
     }
@@ -144,7 +146,7 @@ public final class DefaultLogWriterBuilder {
      * Sets the {@link LogLevel} to use when logging failure responses (e.g., failed with an exception).
      * {@link LogLevel#WARN} will be used by default.
      */
-    public DefaultLogWriterBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
+    public LogWriterBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
         requireNonNull(failedResponseLogLevel, "failedResponseLogLevel");
         return responseLogLevelMapper(log -> log.responseCause() != null ? failedResponseLogLevel : null);
     }
@@ -152,7 +154,7 @@ public final class DefaultLogWriterBuilder {
     /**
      * Sets the {@link ResponseLogLevelMapper} to use when mapping the log level of response logs.
      */
-    public DefaultLogWriterBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
+    public LogWriterBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
         requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");
         if (this.responseLogLevelMapper == null) {
             this.responseLogLevelMapper = responseLogLevelMapper;
@@ -174,7 +176,7 @@ public final class DefaultLogWriterBuilder {
      * You can prevent logging the response cause by returning {@code true}
      * in the {@link Predicate}. By default, the response cause will always be logged.
      */
-    public DefaultLogWriterBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
+    public LogWriterBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
         this.responseCauseFilter = requireNonNull(responseCauseFilter, "responseCauseFilter");
         return this;
     }
@@ -185,7 +187,7 @@ public final class DefaultLogWriterBuilder {
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
      */
-    public DefaultLogWriterBuilder logFormatter(LogFormatter logFormatter) {
+    public LogWriterBuilder logFormatter(LogFormatter logFormatter) {
         this.logFormatter = requireNonNull(logFormatter, "logFormatter");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -87,7 +87,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link Logger} to use when logging.
      * If unset, a default {@link Logger} will be used.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#logger(Logger)} instead.
+     * @deprecated Use {@link LogWriterBuilder#logger(Logger)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder logger(Logger logger) {
@@ -100,7 +100,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the name of the {@link Logger} to use when logging.
      * This method is a shortcut for {@code this.logger(LoggerFactory.getLogger(loggerName))}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#logger(String)} instead.
+     * @deprecated Use {@link LogWriterBuilder#logger(String)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder logger(String loggerName) {
@@ -122,7 +122,7 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#DEBUG}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevel(LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#requestLogLevel(LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(LogLevel requestLogLevel) {
@@ -133,7 +133,7 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevel(Class, LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#requestLogLevel(Class, LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
@@ -157,7 +157,7 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link RequestLogLevelMapper} to use when mapping the log level of request logs.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)} instead.
+     * @deprecated Use {@link LogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
@@ -185,7 +185,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link LogLevel} to use when logging responses whose status is equal to the specified
      * {@link HttpStatus}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(HttpStatus, LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseLogLevel(HttpStatus, LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
@@ -196,7 +196,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link LogLevel} to use when logging responses whose status belongs to the specified
      * {@link HttpStatusClass}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(HttpStatusClass, LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseLogLevel(HttpStatusClass, LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
@@ -206,7 +206,7 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(Class, LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseLogLevel(Class, LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
@@ -219,7 +219,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link LogLevel} to use when logging successful responses (e.g., no unhandled exception).
      * {@link LogLevel#DEBUG} will be used by default.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#successfulResponseLogLevel(LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#successfulResponseLogLevel(LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
@@ -231,7 +231,7 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link LogLevel} to use when logging failure responses (e.g., failed with an exception).
      * {@link LogLevel#WARN} will be used by default.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#failureResponseLogLevel(LogLevel)} instead.
+     * @deprecated Use {@link LogWriterBuilder#failureResponseLogLevel(LogLevel)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
@@ -254,7 +254,7 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link ResponseLogLevelMapper} to use when mapping the log level of response logs.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
@@ -487,7 +487,7 @@ public abstract class LoggingDecoratorBuilder {
      * sanitize a response cause.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseCauseFilter(Predicate)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseCauseFilter(Predicate)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseCauseSanitizer(
@@ -511,7 +511,7 @@ public abstract class LoggingDecoratorBuilder {
      * You can prevent logging the response cause by returning {@code true}
      * in the {@link Predicate}. By default, the response cause will always be logged.
      *
-     * @deprecated Use {@link DefaultLogWriterBuilder#responseCauseFilter(Predicate)} instead.
+     * @deprecated Use {@link LogWriterBuilder#responseCauseFilter(Predicate)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
@@ -555,7 +555,7 @@ public abstract class LoggingDecoratorBuilder {
                             .requestContentSanitizer(convertToStringSanitizer(requestContentSanitizer))
                             .responseContentSanitizer(convertToStringSanitizer(responseContentSanitizer))
                             .build();
-        final DefaultLogWriterBuilder builder = LogWriter.builder();
+        final LogWriterBuilder builder = LogWriter.builder();
         builder.logFormatter(logFormatter);
         if (logger != null) {
             builder.logger(logger);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -79,15 +79,19 @@ public abstract class LoggingDecoratorBuilder {
             responseTrailersSanitizer = DEFAULT_HEADERS_SANITIZER;
     private Predicate<Throwable> responseCauseFilter = throwable -> false;
     @Nullable
-    private LogFormatter logFormatter;
+    private LogWriter logWriter;
 
-    private boolean useSanitizers;
+    private boolean buildLogWriter;
 
     /**
      * Sets the {@link Logger} to use when logging.
      * If unset, a default {@link Logger} will be used.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#logger(Logger)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder logger(Logger logger) {
+        setBuildLogWriter();
         this.logger = requireNonNull(logger, "logger");
         return this;
     }
@@ -95,8 +99,12 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the name of the {@link Logger} to use when logging.
      * This method is a shortcut for {@code this.logger(LoggerFactory.getLogger(loggerName))}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#logger(String)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder logger(String loggerName) {
+        setBuildLogWriter();
         requireNonNull(loggerName, "loggerName");
         logger = LoggerFactory.getLogger(loggerName);
         return this;
@@ -113,7 +121,10 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link LogLevel} to use when logging requests. If unset, will use {@link LogLevel#DEBUG}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevel(LogLevel)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(LogLevel requestLogLevel) {
         requireNonNull(requestLogLevel, "requestLogLevel");
         return requestLogLevelMapper(RequestLogLevelMapper.of(requestLogLevel));
@@ -121,7 +132,10 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevel(Class, LogLevel)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
         requireNonNull(clazz, "clazz");
         requireNonNull(requestLogLevel, "requestLogLevel");
@@ -142,9 +156,12 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link RequestLogLevelMapper} to use when mapping the log level of request logs.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
+        setBuildLogWriter();
         requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
         if (this.requestLogLevelMapper == null) {
             this.requestLogLevelMapper = requestLogLevelMapper;
@@ -167,8 +184,10 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging responses whose status is equal to the specified
      * {@link HttpStatus}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(HttpStatus, LogLevel)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
         return responseLogLevelMapper(ResponseLogLevelMapper.of(status, logLevel));
     }
@@ -176,16 +195,20 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging responses whose status belongs to the specified
      * {@link HttpStatusClass}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(HttpStatusClass, LogLevel)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
         return responseLogLevelMapper(ResponseLogLevelMapper.of(statusClass, logLevel));
     }
 
     /**
      * Sets the {@link LogLevel} to use when the response fails with the specified {@link Throwable}.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevel(Class, LogLevel)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
         requireNonNull(clazz, "clazz");
         requireNonNull(logLevel, "logLevel");
@@ -195,7 +218,10 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging successful responses (e.g., no unhandled exception).
      * {@link LogLevel#DEBUG} will be used by default.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#successfulResponseLogLevel(LogLevel)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
         requireNonNull(successfulResponseLogLevel, "successfulResponseLogLevel");
         return responseLogLevelMapper(log -> log.responseCause() == null ? successfulResponseLogLevel : null);
@@ -204,7 +230,10 @@ public abstract class LoggingDecoratorBuilder {
     /**
      * Sets the {@link LogLevel} to use when logging failure responses (e.g., failed with an exception).
      * {@link LogLevel#WARN} will be used by default.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#failureResponseLogLevel(LogLevel)} instead.
      */
+    @Deprecated
     public LoggingDecoratorBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
         requireNonNull(failedResponseLogLevel, "failedResponseLogLevel");
         return responseLogLevelMapper(log -> log.responseCause() != null ? failedResponseLogLevel : null);
@@ -224,9 +253,12 @@ public abstract class LoggingDecoratorBuilder {
 
     /**
      * Sets the {@link ResponseLogLevelMapper} to use when mapping the log level of response logs.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
+        setBuildLogWriter();
         requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");
         if (this.responseLogLevelMapper == null) {
             this.responseLogLevelMapper = responseLogLevelMapper;
@@ -252,18 +284,14 @@ public abstract class LoggingDecoratorBuilder {
      * not sanitize request headers.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestHeadersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> requestHeadersSanitizer) {
+        setBuildLogWriter();
         this.requestHeadersSanitizer = requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -281,18 +309,14 @@ public abstract class LoggingDecoratorBuilder {
      * will not sanitize response headers.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseHeadersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> responseHeadersSanitizer) {
+        setBuildLogWriter();
         this.responseHeadersSanitizer = requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -309,18 +333,14 @@ public abstract class LoggingDecoratorBuilder {
      * will not sanitize request trailers.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestTrailersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> requestTrailersSanitizer) {
+        setBuildLogWriter();
         this.requestTrailersSanitizer = requireNonNull(requestTrailersSanitizer, "requestTrailersSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -337,18 +357,14 @@ public abstract class LoggingDecoratorBuilder {
      * will not sanitize response trailers.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseTrailersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> responseTrailersSanitizer) {
+        setBuildLogWriter();
         this.responseTrailersSanitizer = requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -376,13 +392,12 @@ public abstract class LoggingDecoratorBuilder {
      * @see #requestTrailersSanitizer(BiFunction)
      * @see #responseHeadersSanitizer(BiFunction)
      * @see #responseTrailersSanitizer(BiFunction)
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder headersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> headersSanitizer) {
-
         requireNonNull(headersSanitizer, "headersSanitizer");
         requestHeadersSanitizer(headersSanitizer);
         requestTrailersSanitizer(headersSanitizer);
@@ -397,18 +412,14 @@ public abstract class LoggingDecoratorBuilder {
      * If unset, will not sanitize request content.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder requestContentSanitizer(
             BiFunction<? super RequestContext, Object,
                     ? extends @Nullable Object> requestContentSanitizer) {
+        setBuildLogWriter();
         this.requestContentSanitizer = requireNonNull(requestContentSanitizer, "requestContentSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -426,18 +437,14 @@ public abstract class LoggingDecoratorBuilder {
      * will not sanitize response content.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseContentSanitizer(
             BiFunction<? super RequestContext, Object,
                     ? extends @Nullable Object> responseContentSanitizer) {
+        setBuildLogWriter();
         this.responseContentSanitizer = requireNonNull(responseContentSanitizer, "responseContentSanitizer");
-        useSanitizers = true;
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -462,7 +469,7 @@ public abstract class LoggingDecoratorBuilder {
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
      * @see #requestContentSanitizer(BiFunction)
      * @see #responseContentSanitizer(BiFunction)
-     * @deprecated Use {@link #logFormatter(LogFormatter)} instead.
+     * @deprecated Use {@link LogFormatter} to set the sanitizer.
      */
     @Deprecated
     public LoggingDecoratorBuilder contentSanitizer(
@@ -480,17 +487,14 @@ public abstract class LoggingDecoratorBuilder {
      * sanitize a response cause.
      *
      * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     * @deprecated Use {@link #responseCauseFilter(Predicate)} instead.
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseCauseFilter(Predicate)} instead.
      */
     @Deprecated
     public LoggingDecoratorBuilder responseCauseSanitizer(
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer) {
+        setBuildLogWriter();
         this.responseCauseSanitizer = requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
-        if (logFormatter != null) {
-            throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
-        }
         return this;
     }
 
@@ -506,57 +510,71 @@ public abstract class LoggingDecoratorBuilder {
      * Sets the {@link Predicate} used for evaluating whether to log the response cause or not.
      * You can prevent logging the response cause by returning {@code true}
      * in the {@link Predicate}. By default, the response cause will always be logged.
+     *
+     * @deprecated Use {@link DefaultLogWriterBuilder#responseCauseFilter(Predicate)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public LoggingDecoratorBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
+        setBuildLogWriter();
         this.responseCauseFilter = requireNonNull(responseCauseFilter, "responseCauseFilter");
         return this;
     }
 
     /**
-     * Returns the {@link Predicate} used to evaluate whether to log the response cause.
+     * Sets the {@link LogWriter} which write a {@link RequestOnlyLog} or {@link RequestLog}.
+     * By default {@link LogWriter#of()} will be used.
+     *
+     * @throws IllegalStateException If both the log sanitizers and the {@link LogWriter} are specified.
      */
     @UnstableApi
-    protected final Predicate<Throwable> responseCauseFilter() {
-        return responseCauseFilter;
-    }
-
-    /**
-     * Sets the {@link LogFormatter} which converts a {@link RequestOnlyLog} or {@link RequestLog}
-     * into a log message. By default {@link LogFormatter#ofText()} will be used.
-     *
-     *
-     * @throws IllegalStateException If both the log sanitizers and the {@link LogFormatter} are specified.
-     */
-    @UnstableApi
-    public LoggingDecoratorBuilder logFormatter(LogFormatter logFormatter) {
-        this.logFormatter = requireNonNull(logFormatter, "logFormatter");
-        if (useSanitizers) {
+    public LoggingDecoratorBuilder logWriter(LogWriter logWriter) {
+        if (buildLogWriter) {
             throw new IllegalStateException(
-                    "The log sanitizers and the LogFormatter cannot be used at the same time");
+                    "The logWriter and the log properties cannot be set together.");
         }
+        this.logWriter = requireNonNull(logWriter, "logWriter");
         return this;
     }
 
     /**
-     * Returns a {@link LogFormatter} which converts a {@link RequestOnlyLog} or {@link RequestLog}
-     * into a log message. If a {@link LogFormatter} has been set using {@link #logFormatter}, it is returned.
-     * Otherwise, a text based {@link LogFormatter} built using the set sanitizers is returned.
+     * Returns {@link LogWriter} if set.
      */
-    @UnstableApi
-    protected LogFormatter logFormatter() {
-        if (logFormatter != null) {
-            return logFormatter;
-        } else {
-            return LogFormatter.builderForText()
-                               .requestHeadersSanitizer(convertToStringSanitizer(requestHeadersSanitizer))
-                               .responseHeadersSanitizer(convertToStringSanitizer(responseHeadersSanitizer))
-                               .requestTrailersSanitizer(convertToStringSanitizer(requestTrailersSanitizer))
-                               .responseTrailersSanitizer(convertToStringSanitizer(responseTrailersSanitizer))
-                               .requestContentSanitizer(convertToStringSanitizer(requestContentSanitizer))
-                               .responseContentSanitizer(convertToStringSanitizer(responseContentSanitizer))
-                               .build();
+    protected final LogWriter logWriter() {
+        if (logWriter != null) {
+            return logWriter;
         }
+        if (!buildLogWriter) {
+            return LogWriter.of();
+        }
+        final TextLogFormatter logFormatter =
+                LogFormatter.builderForText()
+                            .requestHeadersSanitizer(convertToStringSanitizer(requestHeadersSanitizer))
+                            .responseHeadersSanitizer(convertToStringSanitizer(responseHeadersSanitizer))
+                            .requestTrailersSanitizer(convertToStringSanitizer(requestTrailersSanitizer))
+                            .responseTrailersSanitizer(convertToStringSanitizer(responseTrailersSanitizer))
+                            .requestContentSanitizer(convertToStringSanitizer(requestContentSanitizer))
+                            .responseContentSanitizer(convertToStringSanitizer(responseContentSanitizer))
+                            .build();
+        final DefaultLogWriterBuilder builder = LogWriter.builder();
+        builder.logFormatter(logFormatter);
+        if (logger != null) {
+            builder.logger(logger);
+        }
+        if (requestLogLevelMapper != null) {
+            builder.requestLogLevelMapper(requestLogLevelMapper);
+        }
+        if (responseLogLevelMapper != null) {
+            builder.responseLogLevelMapper(responseLogLevelMapper);
+        }
+        builder.responseCauseFilter(responseCauseFilter);
+        return builder.build();
+    }
+
+    private void setBuildLogWriter() {
+        if (logWriter != null) {
+            throw new IllegalStateException("The logWriter and the log properties cannot be set together.");
+        }
+        buildLogWriter = true;
     }
 
     @Override
@@ -564,7 +582,7 @@ public abstract class LoggingDecoratorBuilder {
         return toString(this, logger, requestLogLevelMapper(), responseLogLevelMapper(),
                         requestHeadersSanitizer, requestContentSanitizer, requestTrailersSanitizer,
                         responseHeadersSanitizer, responseContentSanitizer, responseTrailersSanitizer,
-                        responseCauseSanitizer, logFormatter);
+                        responseCauseSanitizer, logWriter);
     }
 
     private static String toString(
@@ -586,12 +604,12 @@ public abstract class LoggingDecoratorBuilder {
                     ? extends @Nullable Object> responseTrailersSanitizer,
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer,
-            @Nullable LogFormatter logFormatter) {
+            @Nullable LogWriter logWriter) {
 
         final ToStringHelper helper = MoreObjects.toStringHelper(self)
                                                  .omitNullValues()
                                                  .add("logger", logger)
-                                                 .add("logFormatter", logFormatter);
+                                                 .add("logWriter", logWriter);
 
         helper.add("requestLogLevelMapper", requestLogLevelMapper);
         helper.add("responseLogLevelMapper", responseLogLevelMapper);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -210,7 +210,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                      (ctx, content) -> content,
      *                      (ctx, trailers) -> trailers);
      * }</pre>
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
      */
     @Deprecated
     default String toStringResponseOnly() {
@@ -227,7 +227,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                         the {@link BiFunction} is what is actually logged as headers.
      * @param contentSanitizer a {@link BiFunction} for sanitizing response content for logging. The result of
      *                         the {@link BiFunction} is what is actually logged as content.
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
      */
     @Deprecated
     default String toStringResponseOnly(
@@ -247,7 +247,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                         the {@link BiFunction} is what is actually logged as content.
      * @param trailersSanitizer a {@link BiFunction} for sanitizing HTTP trailers for logging. The result of
      *                          the {@link BiFunction} is what is actually logged as trailers.
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
      */
     @Deprecated
     default String toStringResponseOnly(
@@ -281,6 +281,6 @@ public interface RequestLog extends RequestOnlyLog {
                                return sanitized.toString();
                            })
                            .build()
-                           .formatResponse(this);
+                           .formatResponse(this, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -210,7 +210,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                      (ctx, content) -> content,
      *                      (ctx, trailers) -> trailers);
      * }</pre>
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
      */
     @Deprecated
     default String toStringResponseOnly() {
@@ -227,7 +227,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                         the {@link BiFunction} is what is actually logged as headers.
      * @param contentSanitizer a {@link BiFunction} for sanitizing response content for logging. The result of
      *                         the {@link BiFunction} is what is actually logged as content.
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
      */
     @Deprecated
     default String toStringResponseOnly(
@@ -247,7 +247,7 @@ public interface RequestLog extends RequestOnlyLog {
      *                         the {@link BiFunction} is what is actually logged as content.
      * @param trailersSanitizer a {@link BiFunction} for sanitizing HTTP trailers for logging. The result of
      *                          the {@link BiFunction} is what is actually logged as trailers.
-     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatResponse(RequestLog)} instead.
      */
     @Deprecated
     default String toStringResponseOnly(
@@ -280,7 +280,8 @@ public interface RequestLog extends RequestOnlyLog {
                                }
                                return sanitized.toString();
                            })
+                           .includeContext(false)
                            .build()
-                           .formatResponse(this, false);
+                           .formatResponse(this);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLog.java
@@ -281,6 +281,6 @@ public interface RequestLog extends RequestOnlyLog {
                                return sanitized.toString();
                            })
                            .build()
-                           .formatRequest(this);
+                           .formatResponse(this);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogLevelMapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogLevelMapper.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * A {@link Function} that determines the {@link LogLevel} of an {@link HttpRequest} from a given
  * {@link RequestOnlyLog}.
  *
- * @see LoggingDecoratorBuilder#requestLogLevelMapper(RequestLogLevelMapper)
+ * @see DefaultLogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)
  */
 // TODO(trustin): Remove 'extends Function' in the next major release.
 @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogLevelMapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogLevelMapper.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * A {@link Function} that determines the {@link LogLevel} of an {@link HttpRequest} from a given
  * {@link RequestOnlyLog}.
  *
- * @see DefaultLogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)
+ * @see LogWriterBuilder#requestLogLevelMapper(RequestLogLevelMapper)
  */
 // TODO(trustin): Remove 'extends Function' in the next major release.
 @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -279,7 +279,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                     (ctx, content) -> content,
      *                     (ctx, trailers) -> trailers);
      * }</pre>
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
      */
     @Deprecated
     default String toStringRequestOnly() {
@@ -296,7 +296,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                         the {@link BiFunction} is what is actually logged as headers.
      * @param contentSanitizer a {@link BiFunction} for sanitizing request content for logging. The result of
      *                         the {@link BiFunction} is what is actually logged as content.
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
      */
     @Deprecated
     default String toStringRequestOnly(
@@ -316,7 +316,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                         the {@link BiFunction} is what is actually logged as content.
      * @param trailersSanitizer a {@link BiFunction} for sanitizing HTTP trailers for logging. The result of
      *                          the {@link BiFunction} is what is actually logged as trailers.
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
      */
     @Deprecated
     default String toStringRequestOnly(
@@ -350,6 +350,6 @@ public interface RequestOnlyLog extends RequestLogAccess {
                                return sanitized.toString();
                            })
                            .build()
-                           .formatRequest(this);
+                           .formatRequest(this, false);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -279,7 +279,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                     (ctx, content) -> content,
      *                     (ctx, trailers) -> trailers);
      * }</pre>
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
      */
     @Deprecated
     default String toStringRequestOnly() {
@@ -296,7 +296,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                         the {@link BiFunction} is what is actually logged as headers.
      * @param contentSanitizer a {@link BiFunction} for sanitizing request content for logging. The result of
      *                         the {@link BiFunction} is what is actually logged as content.
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
      */
     @Deprecated
     default String toStringRequestOnly(
@@ -316,7 +316,7 @@ public interface RequestOnlyLog extends RequestLogAccess {
      *                         the {@link BiFunction} is what is actually logged as content.
      * @param trailersSanitizer a {@link BiFunction} for sanitizing HTTP trailers for logging. The result of
      *                          the {@link BiFunction} is what is actually logged as trailers.
-     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog, boolean)} instead.
+     * @deprecated Use {@link LogFormatter#formatRequest(RequestOnlyLog)} instead.
      */
     @Deprecated
     default String toStringRequestOnly(
@@ -349,7 +349,8 @@ public interface RequestOnlyLog extends RequestLogAccess {
                                }
                                return sanitized.toString();
                            })
+                           .includeContext(false)
                            .build()
-                           .formatRequest(this, false);
+                           .formatRequest(this);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * A {@link Function} that determines the {@link LogLevel} of an {@link HttpResponse} from a given
  * {@link RequestLog}.
  *
- * @see LoggingDecoratorBuilder#responseLogLevelMapper(ResponseLogLevelMapper)
+ * @see DefaultLogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)
  */
 // TODO(trustin): Remove 'extends Function' in the next major release.
 @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * A {@link Function} that determines the {@link LogLevel} of an {@link HttpResponse} from a given
  * {@link RequestLog}.
  *
- * @see DefaultLogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)
+ * @see LogWriterBuilder#responseLogLevelMapper(ResponseLogLevelMapper)
  */
 // TODO(trustin): Remove 'extends Function' in the next major release.
 @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
@@ -53,6 +53,7 @@ final class TextLogFormatter implements LogFormatter {
     private final BiFunction<? super RequestContext, Object, ? extends String> requestContentSanitizer;
 
     private final BiFunction<? super RequestContext, Object, ? extends String> responseContentSanitizer;
+    private final boolean includeContext;
 
     TextLogFormatter(
             BiFunction<? super RequestContext, ? super HttpHeaders, ? extends String> requestHeadersSanitizer,
@@ -60,23 +61,25 @@ final class TextLogFormatter implements LogFormatter {
             BiFunction<? super RequestContext, ? super HttpHeaders, ? extends String> requestTrailersSanitizer,
             BiFunction<? super RequestContext, ? super HttpHeaders, ? extends String> responseTrailersSanitizer,
             BiFunction<? super RequestContext, Object, ? extends String> requestContentSanitizer,
-            BiFunction<? super RequestContext, Object, ? extends String> responseContentSanitizer) {
+            BiFunction<? super RequestContext, Object, ? extends String> responseContentSanitizer,
+            boolean includeContext) {
         this.requestHeadersSanitizer = requestHeadersSanitizer;
         this.responseHeadersSanitizer = responseHeadersSanitizer;
         this.requestTrailersSanitizer = requestTrailersSanitizer;
         this.responseTrailersSanitizer = responseTrailersSanitizer;
         this.requestContentSanitizer = requestContentSanitizer;
         this.responseContentSanitizer = responseContentSanitizer;
+        this.includeContext = includeContext;
     }
 
     @Override
-    public String formatRequest(RequestOnlyLog log, boolean containContext) {
+    public String formatRequest(RequestOnlyLog log) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
         final RequestContext ctx = log.context();
         if (!RequestLogProperty.REQUEST_START_TIME.isAvailable(flags)) {
-            if (containContext) {
+            if (includeContext) {
                 return ctx + " Request: {}";
             } else {
                 return "Request: {}";
@@ -120,7 +123,7 @@ final class TextLogFormatter implements LogFormatter {
         }
 
         final String ctxString;
-        if (containContext) {
+        if (includeContext) {
             // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
             ctxString = ctx.toString() + ' ';
         } else {
@@ -184,13 +187,13 @@ final class TextLogFormatter implements LogFormatter {
     }
 
     @Override
-    public String formatResponse(RequestLog log, boolean containContext) {
+    public String formatResponse(RequestLog log) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
         final RequestContext ctx = log.context();
         if (!RequestLogProperty.RESPONSE_START_TIME.isAvailable(flags)) {
-            if (containContext) {
+            if (includeContext) {
                 return ctx + " Response: {}";
             } else {
                 return "Response: {}";
@@ -234,7 +237,7 @@ final class TextLogFormatter implements LogFormatter {
         }
 
         final String ctxString;
-        if (containContext) {
+        if (includeContext) {
             // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
             ctxString = ctx.toString() + ' ';
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -58,8 +60,7 @@ final class TextLogFormatter implements LogFormatter {
             BiFunction<? super RequestContext, ? super HttpHeaders, ? extends String> requestTrailersSanitizer,
             BiFunction<? super RequestContext, ? super HttpHeaders, ? extends String> responseTrailersSanitizer,
             BiFunction<? super RequestContext, Object, ? extends String> requestContentSanitizer,
-            BiFunction<? super RequestContext, Object, ? extends String> responseContentSanitizer
-    ) {
+            BiFunction<? super RequestContext, Object, ? extends String> responseContentSanitizer) {
         this.requestHeadersSanitizer = requestHeadersSanitizer;
         this.responseHeadersSanitizer = responseHeadersSanitizer;
         this.requestTrailersSanitizer = requestTrailersSanitizer;
@@ -258,5 +259,17 @@ final class TextLogFormatter implements LogFormatter {
 
             return buf.toString();
         }
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("requestHeadersSanitizer", requestHeadersSanitizer)
+                          .add("requestContentSanitizer", requestContentSanitizer)
+                          .add("requestTrailersSanitizer", requestTrailersSanitizer)
+                          .add("responseHeadersSanitizer", responseHeadersSanitizer)
+                          .add("responseContentSanitizer", responseContentSanitizer)
+                          .add("responseTrailersSanitizer", responseTrailersSanitizer)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
@@ -70,13 +70,17 @@ final class TextLogFormatter implements LogFormatter {
     }
 
     @Override
-    public String formatRequest(RequestOnlyLog log) {
+    public String formatRequest(RequestOnlyLog log, boolean containContext) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
         final RequestContext ctx = log.context();
         if (!RequestLogProperty.REQUEST_START_TIME.isAvailable(flags)) {
-            return ctx + " Request: {}";
+            if (containContext) {
+                return ctx + " Request: {}";
+            } else {
+                return "Request: {}";
+            }
         }
 
         String requestCauseString = null;
@@ -115,11 +119,20 @@ final class TextLogFormatter implements LogFormatter {
             sanitizedTrailers = null;
         }
 
-        // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
-        final String ctxString = ctx.toString();
+        final String ctxString;
+        if (containContext) {
+            // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
+            ctxString = ctx.toString() + ' ';
+        } else {
+            ctxString = null;
+        }
+
         try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tempThreadLocals.stringBuilder();
-            buf.append(ctxString).append(" Request: {startTime=");
+            if (ctxString != null) {
+                buf.append(ctxString);
+            }
+            buf.append("Request: {startTime=");
             TextFormatter.appendEpochMicros(buf, log.requestStartTimeMicros());
 
             if (RequestLogProperty.REQUEST_LENGTH.isAvailable(flags)) {
@@ -171,13 +184,17 @@ final class TextLogFormatter implements LogFormatter {
     }
 
     @Override
-    public String formatResponse(RequestLog log) {
+    public String formatResponse(RequestLog log, boolean containContext) {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
         final RequestContext ctx = log.context();
         if (!RequestLogProperty.RESPONSE_START_TIME.isAvailable(flags)) {
-            return ctx + " Response: {}";
+            if (containContext) {
+                return ctx + " Response: {}";
+            } else {
+                return "Response: {}";
+            }
         }
 
         String responseCauseString = null;
@@ -216,11 +233,20 @@ final class TextLogFormatter implements LogFormatter {
             sanitizedTrailers = null;
         }
 
-        // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
-        final String ctxString = ctx.toString();
+        final String ctxString;
+        if (containContext) {
+            // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
+            ctxString = ctx.toString() + ' ';
+        } else {
+            ctxString = null;
+        }
+
         try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tempThreadLocals.stringBuilder();
-            buf.append(ctxString).append(" Response: {startTime=");
+            if (ctxString != null) {
+                buf.append(ctxString);
+            }
+            buf.append("Response: {startTime=");
             TextFormatter.appendEpochMicros(buf, log.responseStartTimeMicros());
 
             if (RequestLogProperty.RESPONSE_LENGTH.isAvailable(flags)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatter.java
@@ -74,8 +74,9 @@ final class TextLogFormatter implements LogFormatter {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
+        final RequestContext ctx = log.context();
         if (!RequestLogProperty.REQUEST_START_TIME.isAvailable(flags)) {
-            return "{}";
+            return ctx + " Request: {}";
         }
 
         String requestCauseString = null;
@@ -86,7 +87,6 @@ final class TextLogFormatter implements LogFormatter {
             }
         }
 
-        final RequestContext ctx = log.context();
         final String sanitizedHeaders;
         if (RequestLogProperty.REQUEST_HEADERS.isAvailable(flags)) {
             sanitizedHeaders = requestHeadersSanitizer.apply(ctx, log.requestHeaders());
@@ -115,9 +115,11 @@ final class TextLogFormatter implements LogFormatter {
             sanitizedTrailers = null;
         }
 
+        // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
+        final String ctxString = ctx.toString();
         try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tempThreadLocals.stringBuilder();
-            buf.append("{startTime=");
+            buf.append(ctxString).append(" Request: {startTime=");
             TextFormatter.appendEpochMicros(buf, log.requestStartTimeMicros());
 
             if (RequestLogProperty.REQUEST_LENGTH.isAvailable(flags)) {
@@ -173,8 +175,9 @@ final class TextLogFormatter implements LogFormatter {
         requireNonNull(log, "log");
 
         final int flags = log.availabilityStamp();
+        final RequestContext ctx = log.context();
         if (!RequestLogProperty.RESPONSE_START_TIME.isAvailable(flags)) {
-            return "{}";
+            return ctx + " Response: {}";
         }
 
         String responseCauseString = null;
@@ -185,7 +188,6 @@ final class TextLogFormatter implements LogFormatter {
             }
         }
 
-        final RequestContext ctx = log.context();
         final String sanitizedHeaders;
         if (RequestLogProperty.RESPONSE_HEADERS.isAvailable(flags)) {
             sanitizedHeaders = responseHeadersSanitizer.apply(ctx, log.responseHeaders());
@@ -214,9 +216,11 @@ final class TextLogFormatter implements LogFormatter {
             sanitizedTrailers = null;
         }
 
+        // ctx internally uses TemporaryThreadLocals, so we should call ctx.toString() outside of acquire().
+        final String ctxString = ctx.toString();
         try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tempThreadLocals.stringBuilder();
-            buf.append("{startTime=");
+            buf.append(ctxString).append(" Response: {startTime=");
             TextFormatter.appendEpochMicros(buf, log.responseStartTimeMicros());
 
             if (RequestLogProperty.RESPONSE_LENGTH.isAvailable(flags)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
@@ -30,6 +30,8 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 @UnstableApi
 public final class TextLogFormatterBuilder extends AbstractLogFormatterBuilder<String> {
 
+    private boolean includeContext = true;
+
     TextLogFormatterBuilder() {}
 
     @Override
@@ -84,6 +86,15 @@ public final class TextLogFormatterBuilder extends AbstractLogFormatterBuilder<S
     }
 
     /**
+     * Sets whether to include stringified {@link RequestContext} in the result of
+     * {@link LogFormatter#formatRequest(RequestOnlyLog)} and {@link LogFormatter#formatResponse(RequestLog)}.
+     */
+    public TextLogFormatterBuilder includeContext(boolean includeContext) {
+        this.includeContext = includeContext;
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link TextLogFormatter} based on the properties of this builder.
      */
     public TextLogFormatter build() {
@@ -93,7 +104,8 @@ public final class TextLogFormatterBuilder extends AbstractLogFormatterBuilder<S
                 firstNonNull(requestTrailersSanitizer(), defaultSanitizer()),
                 firstNonNull(responseTrailersSanitizer(), defaultSanitizer()),
                 firstNonNull(requestContentSanitizer(), defaultSanitizer()),
-                firstNonNull(responseContentSanitizer(), defaultSanitizer()));
+                firstNonNull(responseContentSanitizer(), defaultSanitizer()),
+                includeContext);
     }
 
     private static <T> BiFunction<? super RequestContext, T, String> defaultSanitizer() {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
@@ -88,6 +88,7 @@ public final class TextLogFormatterBuilder extends AbstractLogFormatterBuilder<S
     /**
      * Sets whether to include stringified {@link RequestContext} in the result of
      * {@link LogFormatter#formatRequest(RequestOnlyLog)} and {@link LogFormatter#formatResponse(RequestLog)}.
+     * The context is included by default.
      */
     public TextLogFormatterBuilder includeContext(boolean includeContext) {
         this.includeContext = includeContext;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingUtils.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/logging/LoggingUtils.java
@@ -15,131 +15,43 @@
  */
 package com.linecorp.armeria.internal.common.logging;
 
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.logging.LogFormatter;
-import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.RequestOnlyLog;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.TransientServiceOption;
 
 /**
  * Utilities for logging decorators.
  */
 public final class LoggingUtils {
-    private static final String REQUEST_FORMAT = "{} Request: {}";
-    private static final String RESPONSE_FORMAT = "{} Response: {}";
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingUtils.class);
 
     /**
-     * Logs request and response using the specified {@code requestLogger} and {@code responseLogger}.
+     * Logs request and response using the specified {@link LogWriter}.
      */
-    public static void log(
-            Logger logger, RequestContext ctx, RequestLog requestLog,
-            Consumer<RequestOnlyLog> requestLogger, Consumer<RequestLog> responseLogger) {
+    public static void log(RequestContext ctx, RequestLog requestLog, LogWriter logWriter) {
         try {
-            requestLogger.accept(requestLog);
+            logWriter.logRequest(requestLog);
         } catch (Throwable t) {
-            logException(logger, ctx, "request", t);
+            logException(ctx, "request", t);
         }
         try {
-            responseLogger.accept(requestLog);
+            logWriter.logResponse(requestLog);
         } catch (Throwable t) {
-            logException(logger, ctx, "response", t);
+            logException(ctx, "response", t);
         }
     }
 
-    /**
-     * Logs a stringified request of {@link RequestOnlyLog}.
-     */
-    public static void logRequest(
-            Logger logger, RequestOnlyLog log,
-            RequestLogLevelMapper requestLogLevelMapper,
-            LogFormatter logFormatter) {
-
-        final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
-        assert requestLogLevel != null;
-        if (requestLogLevel.isEnabled(logger)) {
-            final RequestContext ctx = log.context();
-            if (log.requestCause() == null && isTransientService(ctx)) {
-                return;
-            }
-            final String requestStr = logFormatter.formatRequest(log);
-
-            try (SafeCloseable ignored = ctx.push()) {
-                // We don't log requestCause when it's not null because responseCause is the same exception when
-                // the requestCause is not null. That's way we don't have requestCauseSanitizer.
-                requestLogLevel.log(logger, REQUEST_FORMAT, ctx, requestStr);
-            }
-        }
-    }
-
-    /**
-     * Logs a stringified response of {@link RequestLog}.
-     */
-    public static void logResponse(
-            Logger logger, RequestLog log,
-            RequestLogLevelMapper requestLogLevelMapper,
-            ResponseLogLevelMapper responseLogLevelMapper,
-            Predicate<Throwable> responseCauseFilter,
-            LogFormatter logFormatter) {
-
-        final LogLevel responseLogLevel = responseLogLevelMapper.apply(log);
-        assert responseLogLevel != null;
-        final Throwable responseCause = log.responseCause();
-
-        if (responseLogLevel.isEnabled(logger)) {
-            final RequestContext ctx = log.context();
-            if (responseCause == null &&
-                !log.responseHeaders().status().isServerError() &&
-                isTransientService(ctx)) {
-                return;
-            }
-
-            final String responseStr = logFormatter.formatResponse(log);
-            try (SafeCloseable ignored = ctx.push()) {
-                if (responseCause == null) {
-                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
-                    return;
-                }
-
-                final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
-                assert requestLogLevel != null;
-                if (!requestLogLevel.isEnabled(logger)) {
-                    // Request wasn't logged, but this is an unsuccessful response,
-                    // so we log the request too to help debugging.
-                    responseLogLevel.log(logger, REQUEST_FORMAT, ctx, logFormatter.formatRequest(log));
-                }
-
-                if (responseCauseFilter.test(responseCause)) {
-                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr);
-                } else {
-                    responseLogLevel.log(logger, RESPONSE_FORMAT, ctx, responseStr, responseCause);
-                }
-            }
-        }
-    }
-
-    private LoggingUtils() {}
-
-    private static void logException(Logger logger, RequestContext ctx,
+    private static void logException(RequestContext ctx,
                                      String requestOrResponse, Throwable cause) {
         try (SafeCloseable ignored = ctx.push()) {
             logger.warn("{} Unexpected exception while logging {}: ", ctx, requestOrResponse, cause);
         }
     }
 
-    private static boolean isTransientService(RequestContext ctx) {
-        return ctx instanceof ServiceRequestContext &&
-               !((ServiceRequestContext) ctx).config()
-                                             .transientServiceOptions()
-                                             .contains(TransientServiceOption.WITH_SERVICE_LOGGING);
-    }
+    private LoggingUtils() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/LoggingDecoratorFactoryFunction.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.server.annotation.decorator;
 
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -38,9 +39,12 @@ public final class LoggingDecoratorFactoryFunction implements DecoratorFactoryFu
                 parameter.failureSamplingRate() >= 0.0f ? parameter.failureSamplingRate()
                                                         : parameter.samplingRate();
         return LoggingService.builder()
-                             .requestLogLevel(parameter.requestLogLevel())
-                             .successfulResponseLogLevel(parameter.successfulResponseLogLevel())
-                             .failureResponseLogLevel(parameter.failureResponseLogLevel())
+                             .logWriter(LogWriter.builder()
+                                                 .requestLogLevel(parameter.requestLogLevel())
+                                                 .successfulResponseLogLevel(
+                                                         parameter.successfulResponseLogLevel())
+                                                 .failureResponseLogLevel(parameter.failureResponseLogLevel())
+                                                 .build())
                              .successSamplingRate(successSamplingRate)
                              .failureSamplingRate(failureSamplingRate)
                              .newDecorator();

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogWriter.java
@@ -72,6 +72,7 @@ public interface AccessLogWriter {
      * Returns a new {@link AccessLogWriter} which combines two {@link AccessLogWriter}s.
      */
     default AccessLogWriter andThen(AccessLogWriter after) {
+        requireNonNull(after, "after");
         return new AccessLogWriter() {
             @Override
             public void log(RequestLog log) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -15,28 +15,16 @@
  */
 package com.linecorp.armeria.server.logging;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.armeria.internal.common.logging.LoggingUtils.log;
-import static com.linecorp.armeria.internal.common.logging.LoggingUtils.logRequest;
-import static com.linecorp.armeria.internal.common.logging.LoggingUtils.logResponse;
 import static java.util.Objects.requireNonNull;
 
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
-import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
-import com.linecorp.armeria.common.logging.RequestOnlyLog;
-import com.linecorp.armeria.common.logging.ResponseLogLevelMapper;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -46,8 +34,6 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  * Decorates an {@link HttpService} to log {@link HttpRequest}s and {@link HttpResponse}s.
  */
 public final class LoggingService extends SimpleDecoratingHttpService {
-
-    private static final Logger defaultLogger = LoggerFactory.getLogger(LoggingService.class);
 
     /**
      * Returns a new {@link HttpService} decorator that logs {@link HttpRequest}s and {@link HttpResponse}s at
@@ -65,37 +51,14 @@ public final class LoggingService extends SimpleDecoratingHttpService {
         return new LoggingServiceBuilder();
     }
 
-    private final RequestLogger requestLogger = new RequestLogger();
-    private final ResponseLogger responseLogger = new ResponseLogger();
-
-    private final Logger logger;
-    private final RequestLogLevelMapper requestLogLevelMapper;
-    private final ResponseLogLevelMapper responseLogLevelMapper;
-    private final Predicate<Throwable> responseCauseFilter;
+    private final LogWriter logWriter;
     private final Sampler<? super RequestLog> sampler;
-    private final LogFormatter logFormatter;
 
-    /**
-     * Creates a new instance that logs {@link HttpRequest}s and {@link HttpResponse}s at the specified
-     * {@link LogLevel}s with the specified sanitizers.
-     */
-    LoggingService(
-            HttpService delegate,
-            @Nullable Logger logger,
-            RequestLogLevelMapper requestLogLevelMapper,
-            ResponseLogLevelMapper responseLogLevelMapper,
-            Predicate<Throwable> responseCauseFilter,
-            Sampler<? super ServiceRequestContext> successSampler,
-            Sampler<? super ServiceRequestContext> failureSampler,
-            LogFormatter logFormatter) {
-
+    LoggingService(HttpService delegate, LogWriter logWriter,
+                   Sampler<? super ServiceRequestContext> successSampler,
+                   Sampler<? super ServiceRequestContext> failureSampler) {
         super(requireNonNull(delegate, "delegate"));
-
-        this.logger = firstNonNull(logger, defaultLogger);
-        this.requestLogLevelMapper = requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
-        this.responseLogLevelMapper = requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");
-        this.responseCauseFilter = requireNonNull(responseCauseFilter, "responseCauseFilter");
-        this.logFormatter = requireNonNull(logFormatter, "logFormatter");
+        this.logWriter = requireNonNull(logWriter, "logWriter");
         requireNonNull(successSampler, "successSampler");
         requireNonNull(failureSampler, "failureSampler");
         sampler = requestLog -> {
@@ -112,29 +75,9 @@ public final class LoggingService extends SimpleDecoratingHttpService {
         ctx.setShouldReportUnhandledExceptions(false);
         ctx.log().whenComplete().thenAccept(requestLog -> {
             if (sampler.isSampled(requestLog)) {
-                log(logger, ctx, requestLog, requestLogger, responseLogger);
+                log(ctx, requestLog, logWriter);
             }
         });
         return unwrap().serve(ctx, req);
-    }
-
-    private class RequestLogger implements Consumer<RequestOnlyLog> {
-        @Override
-        public void accept(RequestOnlyLog log) {
-            logRequest(logger, log,
-                       requestLogLevelMapper,
-                       logFormatter);
-        }
-    }
-
-    private class ResponseLogger implements Consumer<RequestLog> {
-        @Override
-        public void accept(RequestLog log) {
-            logResponse(logger, log,
-                        requestLogLevelMapper,
-                        responseLogLevelMapper,
-                        responseCauseFilter,
-                        logFormatter);
-        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.server.TransientServiceOption;
 
 /**
  * Decorates an {@link HttpService} to log {@link HttpRequest}s and {@link HttpResponse}s.
@@ -79,5 +80,11 @@ public final class LoggingService extends SimpleDecoratingHttpService {
             }
         });
         return unwrap().serve(ctx, req);
+    }
+
+    private static boolean isTransientService(ServiceRequestContext ctx) {
+        return !ctx.config()
+                   .transientServiceOptions()
+                   .contains(TransientServiceOption.WITH_SERVICE_LOGGING);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
-import com.linecorp.armeria.server.TransientServiceOption;
 
 /**
  * Decorates an {@link HttpService} to log {@link HttpRequest}s and {@link HttpResponse}s.
@@ -80,11 +79,5 @@ public final class LoggingService extends SimpleDecoratingHttpService {
             }
         });
         return unwrap().serve(ctx, req);
-    }
-
-    private static boolean isTransientService(ServiceRequestContext ctx) {
-        return !ctx.config()
-                   .transientServiceOptions()
-                   .contains(TransientServiceOption.WITH_SERVICE_LOGGING);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -30,8 +30,8 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.LoggingDecoratorBuilder;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogLevelMapper;
@@ -123,14 +123,7 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
      * of this builder.
      */
     public LoggingService build(HttpService delegate) {
-        return new LoggingService(delegate,
-                                  logger(),
-                                  requestLogLevelMapper(),
-                                  responseLogLevelMapper(),
-                                  responseCauseFilter(),
-                                  successSampler,
-                                  failureSampler,
-                                  logFormatter());
+        return new LoggingService(delegate, logWriter(), successSampler, failureSampler);
     }
 
     /**
@@ -289,7 +282,7 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
     }
 
     @Override
-    public LoggingServiceBuilder logFormatter(LogFormatter logFormatter) {
-        return (LoggingServiceBuilder) super.logFormatter(logFormatter);
+    public LoggingServiceBuilder logWriter(LogWriter logWriter) {
+        return (LoggingServiceBuilder) super.logWriter(logWriter);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.client.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.clearInvocations;
@@ -169,7 +168,7 @@ class LoggingClientTest {
         when(logger.isInfoEnabled()).thenReturn(true);
 
         // Before sanitization
-        assertThat(ctx.logBuilder().toString()).contains("trustin");
+        assertThat(ctx.logBuilder().toString()).contains(":path=/hello/trustin");
         assertThat(ctx.logBuilder().toString()).contains(":authority=test.com");
 
         final LogFormatter logFormatter =

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.times;
@@ -86,12 +87,12 @@ class LoggingClientTest {
         verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(ctx),
-                            argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
+        verify(logger).info(argThat((String actLog) -> actLog.contains("Request:") &&
+                                                       actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(ctx),
-                            argThat((String actLog) -> actLog.endsWith("headers=[:status=0]}")));
+        verify(logger).info(argThat((String actLog) -> actLog.contains("Response:") &&
+                                                       actLog.endsWith("headers=[:status=0]}")));
 
         verifyNoMoreInteractions(logger);
         clearInvocations(logger);
@@ -121,8 +122,8 @@ class LoggingClientTest {
         when(logger.isInfoEnabled()).thenReturn(true);
 
         // Before sanitization
-        assertThat(ctx.logBuilder().toString()).contains("trustin");
-        assertThat(ctx.logBuilder().toString()).contains("test.com");
+        assertThat(ctx.logBuilder().toString()).contains(":path=/hello/trustin");
+        assertThat(ctx.logBuilder().toString()).contains(":authority=test.com");
 
         final LogFormatter logFormatter = LogFormatter.builderForText()
                                                       .requestHeadersSanitizer(RegexBasedSanitizer.of(
@@ -148,13 +149,11 @@ class LoggingClientTest {
         verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(ctx),
-                            argThat((String text) -> !(text.contains("trustin") || text.contains("com"))));
-
+        verify(logger).info(argThat((String text) -> text.contains("Request:") &&
+                                                     !(text.contains(":path=/hello/trustin") ||
+                                                       text.contains(":authority=test.com"))));
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(ctx),
-                            argThat((String text) -> !(text.contains("trustin") || text.contains("com"))));
-
+        verify(logger).info(matches(".*Response:.*"));
         verifyNoMoreInteractions(logger);
     }
 
@@ -171,7 +170,7 @@ class LoggingClientTest {
 
         // Before sanitization
         assertThat(ctx.logBuilder().toString()).contains("trustin");
-        assertThat(ctx.logBuilder().toString()).contains("test.com");
+        assertThat(ctx.logBuilder().toString()).contains(":authority=test.com");
 
         final LogFormatter logFormatter =
                 LogFormatter.builderForText()
@@ -194,13 +193,11 @@ class LoggingClientTest {
         verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(ctx),
-                            argThat((String text) -> !(text.contains("trustin") || text.contains("com"))));
-
+        verify(logger).info(argThat((String text) -> text.contains("Request:") &&
+                                                     !(text.contains(":path=/hello/trustin") ||
+                                                       text.contains(":authority=test.com"))));
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(ctx),
-                            argThat((String text) -> !(text.contains("trustin") || text.contains("com"))));
-
+        verify(logger).info(matches(".*Response:.*"));
         verifyNoMoreInteractions(logger);
     }
 
@@ -240,13 +237,10 @@ class LoggingClientTest {
         verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(ctx),
-                            argThat((String text) -> !text.contains("333-490-4499")));
-
+        verify(logger).info(argThat((String text) -> text.contains("Request:") &&
+                                                     !text.contains("333-490-4499")));
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(ctx),
-                            argThat((String text) -> !text.contains("333-490-4499")));
-
+        verify(logger).info(matches(".*Response:.*"));
         verifyNoMoreInteractions(logger);
     }
 
@@ -287,13 +281,10 @@ class LoggingClientTest {
         verify(logger, times(2)).isInfoEnabled();
 
         // verify request log
-        verify(logger).info(eq("{} Request: {}"), eq(ctx),
-                            argThat((String text) -> !text.contains("333-490-4499")));
-
+        verify(logger).info(argThat((String text) -> text.contains("Request:") &&
+                                                     !text.contains("333-490-4499")));
         // verify response log
-        verify(logger).info(eq("{} Response: {}"), eq(ctx),
-                            argThat((String text) -> !text.contains("333-490-4499")));
-
+        verify(logger).info(matches(".*Response:.*"));
         verifyNoMoreInteractions(logger);
     }
 
@@ -317,12 +308,12 @@ class LoggingClientTest {
         verify(logger, times(2)).isDebugEnabled();
 
         // verify request log
-        verify(logger).debug(eq("{} Request: {}"), eq(ctx),
-                             argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
+        verify(logger).debug(argThat((String actLog) -> actLog.contains("Request:") &&
+                                                        actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).debug(eq("{} Response: {}"), eq(ctx),
-                             argThat((String actLog) -> actLog.endsWith("headers=[:status=500]}")));
+        verify(logger).debug(argThat((String actLog) -> actLog.contains("Response:") &&
+                                                        actLog.endsWith("headers=[:status=500]}")));
     }
 
     @Test
@@ -348,12 +339,12 @@ class LoggingClientTest {
         verify(logger, times(1)).isWarnEnabled();
 
         // verify request log
-        verify(logger).debug(eq("{} Request: {}"), eq(ctx),
-                             argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
+        verify(logger).debug(argThat((String actLog) -> actLog.contains("Request:") &&
+                                                        actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).warn(eq("{} Response: {}"), eq(ctx),
-                            argThat((String actLog) -> actLog.endsWith("headers=[:status=0]}")),
+        verify(logger).warn(argThat((String actLog) -> actLog.contains("Response:") &&
+                                                       actLog.endsWith("headers=[:status=0]}")),
                             same(cause));
     }
 
@@ -380,12 +371,12 @@ class LoggingClientTest {
         verify(logger, times(1)).isWarnEnabled();
 
         // verify request log
-        verify(logger).warn(eq("{} Request: {}"), eq(ctx),
-                            argThat((String actLog) -> actLog.endsWith("headers=[:method=GET, :path=/]}")));
+        verify(logger).warn(argThat((String actLog) -> actLog.contains("Request:") &&
+                                                        actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).warn(eq("{} Response: {}"), eq(ctx),
-                            argThat((String actLog) -> actLog.endsWith("headers=[:status=0]}")),
+        verify(logger).warn(argThat((String actLog) -> actLog.contains("Response:") &&
+                                                       actLog.endsWith("headers=[:status=0]}")),
                             same(cause));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientWithEmptyEndpointGroupTest.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.internal.testing.CountDownEmptyEndpointStrategy;
@@ -54,7 +55,11 @@ class RetryingClientWithEmptyEndpointGroupTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/1", (ctx, req) -> HttpResponse.of(200))
-              .decorator(LoggingService.builder().successfulResponseLogLevel(LogLevel.INFO).newDecorator());
+              .decorator(LoggingService.builder()
+                                       .logWriter(LogWriter.builder()
+                                                           .successfulResponseLogLevel(LogLevel.INFO)
+                                                           .build())
+                                       .newDecorator());
         }
     };
 
@@ -97,7 +102,11 @@ class RetryingClientWithEmptyEndpointGroupTest {
                 .decorator(RetryingClient.builder(RetryRule.onUnprocessed())
                                          .maxTotalAttempts(maxTotalAttempts)
                                          .newDecorator())
-                .decorator(LoggingClient.builder().successfulResponseLogLevel(LogLevel.INFO).newDecorator())
+                .decorator(LoggingClient.builder()
+                                        .logWriter(LogWriter.builder()
+                                                            .successfulResponseLogLevel(LogLevel.INFO)
+                                                            .build())
+                                        .newDecorator())
                 .build();
 
         try (ClientRequestContextCaptor ctxCaptor = Clients.newContextCaptor()) {
@@ -129,7 +138,11 @@ class RetryingClientWithEmptyEndpointGroupTest {
                 .builder(SessionProtocol.HTTP, endpointGroup)
                 .contextCustomizer(ctx -> ctx.addAdditionalRequestHeader(CUSTOM_HEADER, "asdf"))
                 .responseTimeout(Duration.ZERO) // since retry can depend on responseTimeout
-                .decorator(LoggingClient.builder().requestLogLevel(LogLevel.INFO).newDecorator())
+                .decorator(LoggingClient.builder()
+                                        .logWriter(LogWriter.builder()
+                                                            .requestLogLevel(LogLevel.INFO)
+                                                            .build())
+                                        .newDecorator())
                 .decorator(RetryingClient.builder(RetryRule.onUnprocessed())
                                          .maxTotalAttempts(maxTotalAttempts)
                                          .newDecorator())

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerTest.java
@@ -61,8 +61,11 @@ class ContentPreviewerTest {
 
             client = builder.decorator(ContentPreviewingClient.newDecorator(factory))
                             .decorator(LoggingClient.builder()
-                                                    .requestLogLevel(LogLevel.INFO)
-                                                    .successfulResponseLogLevel(LogLevel.INFO)
+                                                    .logWriter(LogWriter.builder()
+                                                                        .requestLogLevel(LogLevel.INFO)
+                                                                        .successfulResponseLogLevel(
+                                                                                LogLevel.INFO)
+                                                                        .build())
                                                     .newDecorator())
                             .build();
         }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -464,7 +464,7 @@ class DefaultRequestLogTest {
         log.endRequest();
         log.endResponse();
 
-        assertThat(log.toString()).matches("^\\{req=\\{.*}, res=\\{.*}}$");
+        assertThat(log.toString()).matches("^\\{Request: \\{.*}, Response: \\{.*}}$");
     }
 
     @Test
@@ -488,9 +488,9 @@ class DefaultRequestLogTest {
 
         final String[] lines = logStr.split("\\r?\\n");
         assertThat(lines).hasSize(4);
-        assertThat(lines[0]).matches("^\\{req=\\{.*}, res=\\{.*}}$");
+        assertThat(lines[0]).matches("^\\{Request: \\{.*}, Response: \\{.*}}$");
         assertThat(lines[1]).matches("^Children:$");
-        assertThat(lines[2]).matches("^\\t\\{req=\\{.*}, res=\\{.*}}$");
-        assertThat(lines[3]).matches("^\\t\\{req=\\{.*}, res=\\{.*}}$");
+        assertThat(lines[2]).matches("^\\t\\{Request: \\{.*}, Response: \\{.*}}$");
+        assertThat(lines[3]).matches("^\\t\\{Request: \\{.*}, Response: \\{.*}}$");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
@@ -19,22 +19,27 @@ package com.linecorp.armeria.common.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 class JsonLogFormatterTest {
-    @Test
+
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
     void formatRequest() {
         final LogFormatter logFormatter = LogFormatter.ofJson();
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endRequest();
-        final String requestLog = logFormatter.formatRequest(log, true);
+        final String requestLog = logFormatter.formatRequest(log);
+        System.err.println(requestLog);
         assertThat(requestLog)
-                .matches("^\\{\"startTime\":\".+\",\"length\":\".+\",\"duration\":\".+\"," +
-                         "\"scheme\":\".+\",\"name\":\".+\",\"headers\":\\{\".+\"}}$");
+                .matches("^\\{\"type\":\"request\",\"startTime\":\".+\",\"length\":\".+\"," +
+                         "\"duration\":\".+\",\"scheme\":\".+\",\"name\":\".+\",\"headers\":\\{\".+\"}}$");
     }
 
     @Test
@@ -43,9 +48,9 @@ class JsonLogFormatterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endResponse();
-        final String responseLog = logFormatter.formatResponse(log, true);
+        final String responseLog = logFormatter.formatResponse(log);
         assertThat(responseLog)
-                .matches("^\\{\"startTime\":\".+\",\"length\":\".+\",\"duration\":\".+\"," +
-                         "\"totalDuration\":\".+\",\"headers\":\\{\".+\"}}$");
+                .matches("^\\{\"type\":\"response\",\"startTime\":\".+\",\"length\":\".+\"," +
+                         "\"duration\":\".+\",\"totalDuration\":\".+\",\"headers\":\\{\".+\"}}$");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
@@ -31,7 +31,7 @@ class JsonLogFormatterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endRequest();
-        final String requestLog = logFormatter.formatRequest(log);
+        final String requestLog = logFormatter.formatRequest(log, true);
         assertThat(requestLog)
                 .matches("^\\{\"startTime\":\".+\",\"length\":\".+\",\"duration\":\".+\"," +
                          "\"scheme\":\".+\",\"name\":\".+\",\"headers\":\\{\".+\"}}$");
@@ -43,7 +43,7 @@ class JsonLogFormatterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endResponse();
-        final String responseLog = logFormatter.formatResponse(log);
+        final String responseLog = logFormatter.formatResponse(log, true);
         assertThat(responseLog)
                 .matches("^\\{\"startTime\":\".+\",\"length\":\".+\",\"duration\":\".+\"," +
                          "\"totalDuration\":\".+\",\"headers\":\\{\".+\"}}$");

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -328,25 +328,25 @@ class LoggingDecoratorBuilderTest {
     }
 
     @Test
-    void buildLogFormatter() {
-        final LogFormatter logFormatter = LogFormatter.ofJson();
-        builder.logFormatter(logFormatter);
-        assertThat(builder.logFormatter()).isEqualTo(logFormatter);
+    void buildLogWriter() {
+        final LogWriter logWriter = LogWriter.of();
+        builder.logWriter(logWriter);
+        assertThat(builder.logWriter()).isEqualTo(logWriter);
     }
 
     @Test
-    void buildLogFormatterWithoutLogFormatter() {
+    void buildLogWriterWithoutLogWriter() {
         builder.responseContentSanitizer(CONTENT_SANITIZER)
                .requestHeadersSanitizer(HEADER_SANITIZER);
-        final LogFormatter logFormatter = builder.logFormatter();
-        assertThat(logFormatter).isNotNull();
-        assertThat(logFormatter).isInstanceOf(TextLogFormatter.class);
+        final LogWriter logWriter = builder.logWriter();
+        assertThat(logWriter).isNotNull();
+        assertThat(logWriter).isInstanceOf(DefaultLogWriter.class);
     }
 
     @Test
-    void buildLogFormatterThrowsException() {
-        final LogFormatter logFormatter = LogFormatter.ofText();
-        builder.logFormatter(logFormatter);
+    void buildLogWriterThrowsException() {
+        final LogWriter logWriter = LogWriter.of();
+        builder.logWriter(logWriter);
         assertThatThrownBy(() -> builder.responseContentSanitizer(CONTENT_SANITIZER))
                 .isInstanceOf(IllegalStateException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
@@ -33,8 +33,8 @@ class TextLogFormatterTest {
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endRequest();
         final String requestLog = logFormatter.formatRequest(log);
-        assertThat(requestLog)
-                .matches("^\\{startTime=.+, length=.+, duration=.+, scheme=.+, name=.+, headers=.+}$");
+        assertThat(requestLog).matches(
+                ".* Request: .*\\{startTime=.+, length=.+, duration=.+, scheme=.+, name=.+, headers=.+}$");
     }
 
     @Test
@@ -44,7 +44,7 @@ class TextLogFormatterTest {
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endResponse();
         final String responseLog = logFormatter.formatResponse(log);
-        assertThat(responseLog)
-                .matches("^\\{startTime=.+, length=.+, duration=.+, totalDuration=.+, headers=.+}$");
+        assertThat(responseLog).matches(
+                ".* Response: .*\\{startTime=.+, length=.+, duration=.+, totalDuration=.+, headers=.+}$");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
@@ -32,7 +32,7 @@ class TextLogFormatterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endRequest();
-        final String requestLog = logFormatter.formatRequest(log);
+        final String requestLog = logFormatter.formatRequest(log, true);
         assertThat(requestLog).matches(
                 ".* Request: .*\\{startTime=.+, length=.+, duration=.+, scheme=.+, name=.+, headers=.+}$");
     }
@@ -43,7 +43,7 @@ class TextLogFormatterTest {
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endResponse();
-        final String responseLog = logFormatter.formatResponse(log);
+        final String responseLog = logFormatter.formatResponse(log, true);
         assertThat(responseLog).matches(
                 ".* Response: .*\\{startTime=.+, length=.+, duration=.+, totalDuration=.+, headers=.+}$");
     }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
@@ -18,7 +18,8 @@ package com.linecorp.armeria.common.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -26,25 +27,37 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 class TextLogFormatterTest {
 
-    @Test
-    void formatRequest() {
-        final LogFormatter logFormatter = LogFormatter.ofText();
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void formatRequest(boolean containContext) {
+        final LogFormatter logFormatter = LogFormatter.builderForText().includeContext(containContext).build();
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endRequest();
-        final String requestLog = logFormatter.formatRequest(log, true);
-        assertThat(requestLog).matches(
-                ".* Request: .*\\{startTime=.+, length=.+, duration=.+, scheme=.+, name=.+, headers=.+}$");
+        final String requestLog = logFormatter.formatRequest(log);
+        final String regex =
+                "Request: .*\\{startTime=.+, length=.+, duration=.+, scheme=.+, name=.+, headers=.+}$";
+        if (containContext) {
+            assertThat(requestLog).matches("\\[sreqId=.* " + regex);
+        } else {
+            assertThat(requestLog).matches(regex);
+        }
     }
 
-    @Test
-    void formatResponse() {
-        final LogFormatter logFormatter = LogFormatter.ofText();
+    @ParameterizedTest
+    @CsvSource({ "true", "false" })
+    void formatResponse(boolean containContext) {
+        final LogFormatter logFormatter = LogFormatter.builderForText().includeContext(containContext).build();
         final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/format"));
         final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
         log.endResponse();
-        final String responseLog = logFormatter.formatResponse(log, true);
-        assertThat(responseLog).matches(
-                ".* Response: .*\\{startTime=.+, length=.+, duration=.+, totalDuration=.+, headers=.+}$");
+        final String responseLog = logFormatter.formatResponse(log);
+        final String regex =
+                "Response: .*\\{startTime=.+, length=.+, duration=.+, totalDuration=.+, headers=.+}$";
+        if (containContext) {
+            assertThat(responseLog).matches("\\[sreqId=.* " + regex);
+        } else {
+            assertThat(responseLog).matches(regex);
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/logging/LoggingTestUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/logging/LoggingTestUtil.java
@@ -42,7 +42,7 @@ public final class LoggingTestUtil {
             if (arguments.length == 0) {
                 return;
             }
-            if (arguments[0] == null) {
+            if (arguments[0] == null || "".equals(arguments[0])) {
                 // Invoked at verification phase
                 return;
             }

--- a/core/src/test/java/com/linecorp/armeria/server/TransientHttpServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/TransientHttpServiceTest.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.logging.LogFormatter;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -61,11 +62,14 @@ class TransientHttpServiceTest {
                 return HttpResponse.streaming();
             };
             sb.service("/", noResponseService.decorate(TransientHttpService.newDecorator()));
+            final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                          .responseHeadersSanitizer(sanitizer)
+                                                          .build();
             sb.decorator(LoggingService.builder()
-                                       .failureResponseLogLevel(LogLevel.DEBUG)
-                                       .logFormatter(LogFormatter.builderForText()
-                                                                 .responseHeadersSanitizer(sanitizer)
-                                                                 .build())
+                                       .logWriter(LogWriter.builder()
+                                                           .failureResponseLogLevel(LogLevel.DEBUG)
+                                                           .logFormatter(logFormatter)
+                                                           .build())
                                        .newDecorator());
         }
     };

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -190,7 +190,7 @@ class HealthCheckServiceTest {
                              "connection: close\r\n\r\n" +
                              "{\"healthy\":false}");
         await().untilAsserted(() -> {
-            verify(logger).debug(anyString(), any(), any());
+            verify(logger).debug(anyString());
         });
     }
 
@@ -215,7 +215,7 @@ class HealthCheckServiceTest {
                              "armeria-lphc: 60, 5\r\n" +
                              "content-length: 17\r\n" +
                              "connection: close\r\n\r\n");
-        verify(logger).debug(anyString(), any(), any());
+        verify(logger).debug(anyString());
     }
 
     private static void assertResponseEquals(String request, String expectedResponse) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.logging.LoggingService;
@@ -123,7 +124,9 @@ class HealthCheckServiceTest {
                                              });
                                          })
                                          .build());
-            sb.decorator(LoggingService.builder().logger(logger).newDecorator());
+            sb.decorator(LoggingService.builder()
+                                       .logWriter(LogWriter.of(logger))
+                                       .newDecorator());
             sb.gracefulShutdownTimeout(Duration.ofSeconds(10), Duration.ofSeconds(10));
             sb.disableServerHeader();
             sb.disableDateHeader();

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -498,10 +498,8 @@ class HealthCheckServiceTest {
     }
 
     private static void verifyDebugEnabled(Logger logger) {
-        await().untilAsserted(() -> {
-            // 2 times for the request and the response.
-            verify(logger, times(2)).isDebugEnabled();
-        });
+        // Do not log for health check requests unless TransientServiceOption is enabled.
+        verify(logger, never()).isDebugEnabled();
     }
 
     private static CompletableFuture<AggregatedHttpResponse> sendLongPollingGet(String healthiness) {

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.healthcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -382,7 +382,7 @@ class LoggingServiceTest {
 
         // Before sanitization
         assertThat(ctx.logBuilder().toString()).contains(":path=/hello/trustin");
-        assertThat(ctx.logBuilder().toString()).contains("test.com");
+        assertThat(ctx.logBuilder().toString()).contains(":authority=test.com");
 
         final LogFormatter logFormatter =
                 LogFormatter.builderForText()
@@ -409,7 +409,7 @@ class LoggingServiceTest {
         for (int i = 0; i < 2; i++) {
             verify(logger).info(argThat((String text) -> text.contains("Request:") &&
                                                          !(text.contains(":path=/hello/trustin") ||
-                                                           text.contains("com"))));
+                                                           text.contains(":authority=test.com"))));
         }
 
         // verify response log
@@ -434,7 +434,7 @@ class LoggingServiceTest {
 
         // Before sanitization
         assertThat(ctx.logBuilder().toString()).contains(":path=/hello/trustin");
-        assertThat(ctx.logBuilder().toString()).contains("test.com");
+        assertThat(ctx.logBuilder().toString()).contains(":authority=test.com");
 
         final LogFormatter logFormatter =
                 LogFormatter.builderForText()
@@ -461,7 +461,7 @@ class LoggingServiceTest {
         for (int i = 0; i < 2; i++) {
             verify(logger).info(argThat((String text) -> text.contains("Request:") &&
                                                          !(text.contains(":path=/hello/trustin") ||
-                                                           text.contains("com"))));
+                                                           text.contains(":authority=test.com"))));
         }
 
         // verify response log

--- a/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
@@ -73,7 +74,9 @@ class PrometheusExpositionServiceTest {
                                                   .transientServiceOptions(TransientServiceOption.allOf())
                                                   .build());
             sb.accessLogWriter(logs::add, false);
-            sb.decorator(LoggingService.builder().logger(logger).newDecorator());
+            sb.decorator(LoggingService.builder()
+                                       .logWriter(LogWriter.of(logger))
+                                       .newDecorator());
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.metric;
 import static com.linecorp.armeria.common.metric.MoreMeters.measureAll;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
@@ -87,7 +87,7 @@ class PrometheusExpositionServiceTest {
         assertThat(client.get("/api").aggregate().join().status()).isSameAs(HttpStatus.OK);
         await().until(() -> logs.size() == 1);
         verify(logger, times(2)).isDebugEnabled();
-        verify(logger, times(2)).debug(anyString(), any(), any());
+        verify(logger, times(2)).debug(anyString());
 
         final String exportedContent = client.get("/disabled").aggregate().join().contentUtf8();
         assertThat(exportedContent).contains("armeria_build_info{");
@@ -107,7 +107,7 @@ class PrometheusExpositionServiceTest {
         // Access log is not written.
         await().pollDelay(500, TimeUnit.MILLISECONDS).then().until(() -> logs.size() == 1);
         verify(logger, times(4)).isDebugEnabled();
-        verify(logger, times(2)).debug(anyString(), any(), any());
+        verify(logger, times(2)).debug(anyString());
 
         client.get("/enabled").aggregate().join();
         // prometheus requests are collected.
@@ -122,7 +122,7 @@ class PrometheusExpositionServiceTest {
         // Access log is written.
         await().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> logs.size() == 2);
         verify(logger, times(6)).isDebugEnabled();
-        verify(logger, times(4)).debug(anyString(), any(), any());
+        verify(logger, times(4)).debug(anyString());
     }
 
     @Nested

--- a/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/metric/PrometheusExpositionServiceTest.java
@@ -105,7 +105,7 @@ class PrometheusExpositionServiceTest {
         });
         // Access log is not written.
         await().pollDelay(500, TimeUnit.MILLISECONDS).then().until(() -> logs.size() == 1);
-        verify(logger, times(4)).isDebugEnabled();
+        verify(logger, times(2)).isDebugEnabled();
         verify(logger, times(2)).debug(anyString());
 
         client.get("/enabled").aggregate().join();
@@ -120,7 +120,7 @@ class PrometheusExpositionServiceTest {
         });
         // Access log is written.
         await().pollDelay(500, TimeUnit.MILLISECONDS).until(() -> logs.size() == 2);
-        verify(logger, times(6)).isDebugEnabled();
+        verify(logger, times(4)).isDebugEnabled();
         verify(logger, times(4)).debug(anyString());
     }
 

--- a/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
+++ b/examples/annotated-http-service-kotlin/src/main/kotlin/example/armeria/server/annotated/kotlin/Main.kt
@@ -1,6 +1,7 @@
 package example.armeria.server.annotated.kotlin
 
 import com.linecorp.armeria.common.logging.LogLevel
+import com.linecorp.armeria.common.logging.LogWriter
 import com.linecorp.armeria.server.AnnotatedServiceBindingBuilder
 import com.linecorp.armeria.server.Server
 import com.linecorp.armeria.server.ServerBuilder
@@ -54,8 +55,12 @@ private fun AnnotatedServiceBindingBuilder.applyCommonDecorator(): AnnotatedServ
     return this
         .decorator(
             LoggingService.builder()
-                .requestLogLevel(LogLevel.INFO)
-                .successfulResponseLogLevel(LogLevel.INFO)
+                .logWriter(
+                    LogWriter.builder()
+                        .requestLogLevel(LogLevel.INFO)
+                        .successfulResponseLogLevel(LogLevel.INFO)
+                        .build()
+                )
                 .newDecorator()
         )
 }

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
@@ -236,11 +236,11 @@ public class BookServiceClientServerTest {
 
     private static WebTarget newWebTarget() {
         final LogWriter logWriter = LogWriter.builder()
-                                         .logger(logger)
-                                         .requestLogLevel(LogLevel.INFO)
-                                         .successfulResponseLogLevel(LogLevel.INFO)
-                                         .failureResponseLogLevel(LogLevel.WARN)
-                                         .build();
+                                             .logger(logger)
+                                             .requestLogLevel(LogLevel.INFO)
+                                             .successfulResponseLogLevel(LogLevel.INFO)
+                                             .failureResponseLogLevel(LogLevel.WARN)
+                                             .build();
         final WebClient httpClient = WebClient.builder()
                                               .decorator(LoggingClient.builder()
                                                                       .logWriter(logWriter)

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceClientServerTest.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.resteasy.ArmeriaJaxrsClientEngine;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
 import com.linecorp.armeria.server.jaxrs.samples.books.Book;
@@ -234,12 +235,15 @@ public class BookServiceClientServerTest {
     }
 
     private static WebTarget newWebTarget() {
+        final LogWriter logWriter = LogWriter.builder()
+                                         .logger(logger)
+                                         .requestLogLevel(LogLevel.INFO)
+                                         .successfulResponseLogLevel(LogLevel.INFO)
+                                         .failureResponseLogLevel(LogLevel.WARN)
+                                         .build();
         final WebClient httpClient = WebClient.builder()
                                               .decorator(LoggingClient.builder()
-                                                                      .logger(logger)
-                                                                      .requestLogLevel(LogLevel.INFO)
-                                                                      .successfulResponseLogLevel(LogLevel.INFO)
-                                                                      .failureResponseLogLevel(LogLevel.WARN)
+                                                                      .logWriter(logWriter)
                                                                       .newDecorator())
                                               .build();
         final Client restClient = ((ResteasyClientBuilder) ClientBuilder.newBuilder())

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/BookServiceServerTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
 import com.linecorp.armeria.server.jaxrs.samples.books.Book;
@@ -211,12 +212,15 @@ public class BookServiceServerTest {
     }
 
     private static WebClient newWebClient() {
+        final LogWriter logWriter = LogWriter.builder()
+                                             .logger(logger)
+                                             .requestLogLevel(LogLevel.INFO)
+                                             .successfulResponseLogLevel(LogLevel.INFO)
+                                             .failureResponseLogLevel(LogLevel.WARN)
+                                             .build();
         return WebClient.builder(restServer.httpUri())
                         .decorator(LoggingClient.builder()
-                                                .logger(logger)
-                                                .requestLogLevel(LogLevel.INFO)
-                                                .successfulResponseLogLevel(LogLevel.INFO)
-                                                .failureResponseLogLevel(LogLevel.WARN)
+                                                .logWriter(logWriter)
                                                 .newDecorator())
                         .build();
     }

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.resteasy.ArmeriaResteasyClientBuilder;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -106,13 +107,16 @@ public class CalculatorServiceClientServerTest {
     }
 
     private static WebTarget newWebTarget() {
+        final LogWriter logWriter = LogWriter.builder()
+                                             .logger(logger)
+                                             .requestLogLevel(LogLevel.INFO)
+                                             .successfulResponseLogLevel(LogLevel.INFO)
+                                             .failureResponseLogLevel(LogLevel.WARN)
+                                             .build();
         final WebClientBuilder webClientBuilder = WebClient.builder()
                                                            .decorator(LoggingClient.builder()
-                                                                      .logger(logger)
-                                                                      .requestLogLevel(LogLevel.INFO)
-                                                                      .successfulResponseLogLevel(LogLevel.INFO)
-                                                                      .failureResponseLogLevel(LogLevel.WARN)
-                                                                      .newDecorator());
+                                                                                   .logWriter(logWriter)
+                                                                                   .newDecorator());
         final Client restClient = ArmeriaResteasyClientBuilder.newBuilder(webClientBuilder).build();
         return restClient.target(restServer.httpUri());
     }

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceServerTest.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.logging.LogLevel;
+import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.jaxrs.samples.JaxRsApp;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -105,12 +106,15 @@ public class CalculatorServiceServerTest {
     }
 
     private static WebClient newWebClient() {
+        final LogWriter logWriter = LogWriter.builder()
+                                             .logger(logger)
+                                             .requestLogLevel(LogLevel.INFO)
+                                             .successfulResponseLogLevel(LogLevel.INFO)
+                                             .failureResponseLogLevel(LogLevel.WARN)
+                                             .build();
         return WebClient.builder(restServer.httpUri())
                         .decorator(LoggingClient.builder()
-                                                .logger(logger)
-                                                .requestLogLevel(LogLevel.INFO)
-                                                .successfulResponseLogLevel(LogLevel.INFO)
-                                                .failureResponseLogLevel(LogLevel.WARN)
+                                                .logWriter(logWriter)
                                                 .newDecorator())
                         .build();
     }


### PR DESCRIPTION
Motivation:
We introduced `LogFormatter` to provide a way to customize a log format in #4267. Also, it would be nice if we provide a way to specify different methods for writing a log. For example, a user might want to send a log to remote collector without using a logger API.

Modifications:
- Add `LogWriter` and `LoggingDecoratorBuilder.logWriter(LogWriter)`
  - `Logger`, `RequestLogLevelMapper`, `ResponseLogLevelMapper` and `responseCauseFilter` are moved to the writer from the logging client and service.
  - Add `DefaultLogWriterBuilder` for building a `LogWriter`
    - We can set a `LogFormatter` to the builder
- Remove `LogFormatter` setters in the logging builders.
  - This methods are not released yet so they can be removed.
- (Deprecated)
  - `LoggingDecoratorBuilder.logger(Logger)`
  - `LoggingDecoratorBuilder.requestLogLevelMapper(RequestLogLevelMapper)`
  - `LoggingDecoratorBuilder.responseLogLevelMapper(ResponseLogLevelMapper)`
  - `LoggingDecoratorBuilder.responseCauseFilter(Predicate)`
  - They are all added to `DefaultLogWriterBuilder`.

Result:
- You can now use a `LogWriter` to customize the way for logging.
  ```java
  LogFormatter logFormatter = ...
  LogWriter logWriter =
    LogWriter
      .builder() // Use SLF4J logger for logging.
      .logFormatter(logFormatter)
      .logger(logger)
      .build();
  
  LoggingClient
    .builder()
    .logWriter(logWriter)
    .newDecorator();    
  ```
