### PR TITLE
Update gradle enterprise settings

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,8 @@ plugins {
     // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
     id("org.gradle.toolchains.foojay-resolver") version "0.5.0"
     id "com.gradle.enterprise" version "3.13.3"
+    // adds additional metadata to build scans
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11'
 
 }
 toolchainManagement {
@@ -21,9 +23,9 @@ toolchainManagement {
 gradleEnterprise {
     server = "https://ge.armeria.dev"
     buildScan {
-        // publish build scans if the access key is provided
-        publishAlwaysIf(System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY") != null)
-        uploadInBackground = false
+        publishIfAuthenticated()
+        publishAlways()
+        uploadInBackground = System.getenv("CI") == null
         capture {
             taskInputFiles = true
         }


### PR DESCRIPTION
Motivation:

Update gradle enterprise settings as suggested

Modifications:

- Add the commons plugin which adds additional metadata/tags
- Publish always if authenticated
- Enable uploadInBackground for local builds

Result:

- Better integration
- I've also verified locally that we don't get the `The Gradle Enterprise server (ge.armeria.dev) rejected the request due to authentication being required.` message

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
