### PR TITLE
Do not include Thrift required field information in response

### DIFF
--- a/thrift/thrift0.12/src/test/thrift/main.thrift
+++ b/thrift/thrift0.12/src/test/thrift/main.thrift
@@ -26,6 +26,15 @@ service FileService {
     void create(1:string path) throws (1:FileServiceException ouch)
 }
 
+// Tests required field.
+struct RequiredName {
+    1: required string first
+}
+
+service HelloRequiredNameService {
+    string hello(1:RequiredName name)
+}
+
 // Tests structs and lists.
 struct Name {
     1: string first

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -539,7 +539,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                     cause = new TApplicationException(TApplicationException.PROTOCOL_ERROR,
                                                       "failed to decode arguments for " + header.name);
                 }
-                handleException(ctx, httpRes, serializationFormat, seqId, f, cause);
+                handlePreDecodeException(ctx, httpRes, cause, serializationFormat, seqId, methodName);
                 return;
             }
         } finally {

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
@@ -41,7 +41,8 @@ class ThriftRequiredFieldVerboseTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/hello", THttpService.ofFormats(HELLO_SERVICE, TEXT))
+            sb.verboseResponses(true)
+              .service("/hello", THttpService.ofFormats(HELLO_SERVICE, TEXT))
               .route().verboseResponses(false)
               .path("/hello_no_verbose")
               .build(THttpService.ofFormats(HELLO_SERVICE, TEXT));
@@ -50,7 +51,7 @@ class ThriftRequiredFieldVerboseTest {
 
     @CsvSource({ "true", "false" })
     @ParameterizedTest
-    public void containRequiredFiledIfVerbose(boolean verbose) throws Exception {
+    void containRequiredFiledIfVerbose(boolean verbose) throws Exception {
         final String path = verbose ? "/hello" : "/hello_no_verbose";
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, path,
                                                          HttpHeaderNames.CONTENT_TYPE, "application/x-thrift");

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
@@ -64,7 +64,7 @@ class ThriftRequiredFieldVerboseTest {
         if (verbose) {
             assertThat(response.contentUtf8()).contains("Required field", "was not present");
         } else {
-            assertThat(response.contentUtf8()).doesNotContain("Required filed", "was not present");
+            assertThat(response.contentUtf8()).doesNotContain("Required field", "was not present");
         }
     }
 }

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/ThriftRequiredFieldVerboseTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.thrift;
+
+import static com.linecorp.armeria.common.thrift.ThriftSerializationFormats.TEXT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.service.test.thrift.main.HelloRequiredNameService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ThriftRequiredFieldVerboseTest {
+
+    private static final HelloRequiredNameService.Iface HELLO_SERVICE =
+            name -> "Hello, " + name.getFirst() + '!';
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/hello", THttpService.ofFormats(HELLO_SERVICE, TEXT))
+              .route().verboseResponses(false)
+              .path("/hello_no_verbose")
+              .build(THttpService.ofFormats(HELLO_SERVICE, TEXT));
+        }
+    };
+
+    @CsvSource({ "true", "false" })
+    @ParameterizedTest
+    public void containRequiredFiledIfVerbose(boolean verbose) throws Exception {
+        final String path = verbose ? "/hello" : "/hello_no_verbose";
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, path,
+                                                         HttpHeaderNames.CONTENT_TYPE, "application/x-thrift");
+        final String body = '{' +
+                            "  \"method\": \"hello\"," +
+                            "  \"type\":\"CALL\"," +
+                            "  \"args\": {\"name\": {}}" +
+                            '}';
+        final AggregatedHttpResponse response = server.blockingWebClient()
+                                                      .execute(HttpRequest.of(headers, HttpData.ofUtf8(body)));
+        if (verbose) {
+            assertThat(response.contentUtf8()).contains("Required field", "was not present");
+        } else {
+            assertThat(response.contentUtf8()).doesNotContain("Required filed", "was not present");
+        }
+    }
+}

--- a/thrift/thrift0.13/src/test/thrift/main.thrift
+++ b/thrift/thrift0.13/src/test/thrift/main.thrift
@@ -26,6 +26,15 @@ service FileService {
     void create(1:string path) throws (1:FileServiceException ouch)
 }
 
+// Tests required field.
+struct RequiredName {
+    1: required string first
+}
+
+service HelloRequiredNameService {
+    string hello(1:RequiredName name)
+}
+
 // Tests structs and lists.
 struct Name {
     1: string first

--- a/thrift/thrift0.9/src/test/thrift/main.thrift
+++ b/thrift/thrift0.9/src/test/thrift/main.thrift
@@ -26,6 +26,15 @@ service FileService {
     void create(1:string path) throws (1:FileServiceException ouch)
 }
 
+// Tests required field.
+struct RequiredName {
+    1: required string first
+}
+
+service HelloRequiredNameService {
+    string hello(1:RequiredName name)
+}
+
 // Tests structs and lists.
 struct Name {
     1: string first


### PR DESCRIPTION
Motivation:
We contain Thrift required field information if a Thrift request does not have the fields. Our Risk Assessment team recommended not having that information for security reasons.

Modification:
- Do not include Thrift required fields information in response
  - They are included when `verboseResponses` is `true`.

Result:
- Thrift required field information is not included in the response by default.