### PR TITLE
Fix Gradle `publish` task to work

### DIFF
--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -130,6 +130,13 @@ configure(projectsWithFlags('java')) {
                     sourcesJarTask.dependsOn(task)
                 }
 
+                def kotlinSourcesJar = tasks.findByName('kotlinSourcesJar')
+                if (kotlinSourcesJar) {
+                    // A workaround for  ':grpc-kotlin:kotlinSourcesJar' uses this output of task
+                    // ':grpc-kotlin:generateProto' without declaring an explicit or implicit dependency.
+                    kotlinSourcesJar.dependsOn(task)
+                }
+
                 def copyAlpnAgentTask= tasks.findByName('copyAlpnAgent')
                 if (copyAlpnAgentTask) {
                     // A workaround for ':generateProto' uses this output of task ':copyAlpnAgent' without

--- a/gradle/scripts/lib/kotlin.gradle
+++ b/gradle/scripts/lib/kotlin.gradle
@@ -7,6 +7,7 @@ configure(projectsWithFlags('kotlin')) {
         def target = project.tasks.findByName('compileJava')?.targetCompatibility ?:
                 project.findProperty('javaTargetCompatibility') ?: '1.8'
         def compilerArgs = ['-java-parameters', '-Xjsr305=strict', '-Xskip-prerelease-check']
+        def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
         // A workaround to find all Kotlin compilation tasks.
         // The standard way, `tasks.withType(KotlinCompile)`, does not work here.
         tasks.matching {
@@ -17,10 +18,14 @@ configure(projectsWithFlags('kotlin')) {
             task.kotlinOptions.jvmTarget = target
             task.kotlinOptions.freeCompilerArgs = compilerArgs
 
-            def copyAlpnAgentTask = tasks.findByName("copyAlpnAgent")
             if (copyAlpnAgentTask != null) {
                 task.dependsOn(copyAlpnAgentTask)
             }
+        }
+
+        def kotlinSourcesJar = tasks.findByName('kotlinSourcesJar')
+        if (kotlinSourcesJar != null && copyAlpnAgentTask != null) {
+            kotlinSourcesJar.dependsOn(copyAlpnAgentTask)
         }
     }
 


### PR DESCRIPTION
Motivation:

`gradle publish` fails to publish because of illegal usage in `grpc-kotlin` without dependencies.

```
Task ':grpc-kotlin:kotlinSourcesJar' uses this output of task
':grpc-kotlin:generateProto' without declaring an explicit or
implicit dependency. This can lead to incorrect results being produced,
depending on what order the tasks are executed.
```
https://github.com/line/armeria/actions/runs/5275219571/jobs/9540456642#step:8:1415

Modifications:

- Make `kotlinSourcesJar` depend on `generateProto` and `copyAlpnAgent`

Result:

Publish artifacts to Maven Central

