### PR TITLE
Add getIfAvailable API (#4956)

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/ClientRequestContextAdapter.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/ClientRequestContextAdapter.java
@@ -82,11 +82,8 @@ final class ClientRequestContextAdapter {
         @Override
         public long startTimestamp() {
             final RequestLogAccess logAccess = ctx.log();
-            if (logAccess.isAvailable(RequestLogProperty.REQUEST_START_TIME)) {
-                return logAccess.partial().requestStartTimeMicros();
-            } else {
-                return 0;
-            }
+            final RequestLog requestLog = logAccess.getIfAvailable(RequestLogProperty.REQUEST_START_TIME);
+            return requestLog != null ? requestLog.requestStartTimeMicros() : 0;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.common.HttpResponseDuplicator;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
@@ -480,11 +481,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     private static long getRetryAfterMillis(ClientRequestContext ctx) {
         final RequestLogAccess log = ctx.log();
         final String value;
-        if (log.isAvailable(RequestLogProperty.RESPONSE_HEADERS)) {
-            value = log.partial().responseHeaders().get(HttpHeaderNames.RETRY_AFTER);
-        } else {
-            value = null;
-        }
+        final RequestLog requestLog = log.getIfAvailable(RequestLogProperty.RESPONSE_HEADERS);
+        value = requestLog != null ? requestLog.responseHeaders().get(HttpHeaderNames.RETRY_AFTER) : null;
 
         if (value != null) {
             try {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -212,6 +212,18 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return hasInterestedFlags(flags, interestedFlags);
     }
 
+    @Nullable
+    @Override
+    public RequestLog getIfAvailable(RequestLogProperty... properties) {
+        return isAvailable(properties) ? this : null;
+    }
+
+    @Nullable
+    @Override
+    public RequestLog getIfAvailable(Iterable<RequestLogProperty> properties) {
+        return isAvailable(properties) ? this : null;
+    }
+
     private static boolean hasInterestedFlags(int flags, RequestLogProperty property) {
         return hasInterestedFlags(flags, property.flag());
     }
@@ -1519,6 +1531,22 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             requireNonNull(properties, "properties");
             checkArgument(!Iterables.isEmpty(properties), "properties is empty.");
             return true;
+        }
+
+        @Nullable
+        @Override
+        public RequestLog getIfAvailable(RequestLogProperty... properties) {
+            requireNonNull(properties, "properties");
+            checkArgument(properties.length != 0, "properties is empty.");
+            return this;
+        }
+
+        @Nullable
+        @Override
+        public RequestLog getIfAvailable(Iterable<RequestLogProperty> properties) {
+            requireNonNull(properties, "properties");
+            checkArgument(!Iterables.isEmpty(properties), "properties is empty.");
+            return this;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogAccess.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * Provides the access to a {@link RequestLog} or {@link RequestOnlyLog}, while ensuring the interested
@@ -75,6 +76,20 @@ public interface RequestLogAccess {
      * @throws IllegalArgumentException if {@code properties} is empty.
      */
     boolean isAvailable(Iterable<RequestLogProperty> properties);
+
+    /**
+     * Returns {@link RequestLog} if all of the specified {@link RequestLogProperty}s are available.
+     */
+    @UnstableApi
+    @Nullable
+    RequestLog getIfAvailable(RequestLogProperty... properties);
+
+    /**
+     * Returns {@link RequestLog} if all of the specified {@link RequestLogProperty}s are available.
+     */
+    @UnstableApi
+    @Nullable
+    RequestLog getIfAvailable(Iterable<RequestLogProperty> properties);
 
     /**
      * Returns a {@link CompletableFuture} which will be completed when the {@link Request} has been processed

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -647,11 +647,8 @@ public final class DefaultClientRequestContext
     @Nullable
     @Override
     public SSLSession sslSession() {
-        if (log.isAvailable(RequestLogProperty.SESSION)) {
-            return log.partial().sslSession();
-        } else {
-            return null;
-        }
+        final RequestLog requestLog = log.getIfAvailable(RequestLogProperty.SESSION);
+        return requestLog != null ? requestLog.sslSession() : null;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
@@ -113,8 +114,9 @@ abstract class AbstractHttpResponseHandler {
         //    the subscriber attempts to write the next data to the stream closed at 2).
         if (!isWritable()) {
             Throwable cause = null;
-            if (reqCtx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
-                cause = reqCtx.log().ensureAvailable(RequestLogProperty.RESPONSE_CAUSE).responseCause();
+            final RequestLog requestLog = reqCtx.log().getIfAvailable(RequestLogProperty.RESPONSE_CAUSE);
+            if (requestLog != null) {
+                cause = requestLog.responseCause();
             }
             if (cause == null) {
                 if (reqCtx.sessionProtocol().isMultiplex()) {

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
@@ -331,8 +332,9 @@ abstract class AbstractHttpResponseSubscriber extends AbstractHttpResponseHandle
     private void succeed() {
         if (tryComplete(null)) {
             Throwable cause = null;
-            if (reqCtx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
-                cause = reqCtx.log().ensureAvailable(RequestLogProperty.RESPONSE_CAUSE).responseCause();
+            final RequestLog requestLog = reqCtx.log().getIfAvailable(RequestLogProperty.RESPONSE_CAUSE);
+            if (requestLog != null) {
+                cause = requestLog.responseCause();
             }
             endLogRequestAndResponse(cause);
             maybeWriteAccessLog();

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -493,4 +493,19 @@ class DefaultRequestLogTest {
         assertThat(lines[2]).matches("^\\t\\{Request: \\{.*}, Response: \\{.*}}$");
         assertThat(lines[3]).matches("^\\t\\{Request: \\{.*}, Response: \\{.*}}$");
     }
+
+    @Test
+    void testGetIfAvailable() {
+        // Given
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final RequestLogAccess log = ctx.log();
+
+        // When
+        assertThat(log.isAvailable(RequestLogProperty.REQUEST_HEADERS)).isTrue();
+        assertThat(log.isAvailable(RequestLogProperty.NAME)).isFalse();
+
+        // Then
+        assertThat(log.getIfAvailable(RequestLogProperty.REQUEST_HEADERS)).isEqualTo(log);
+        assertThat(log.getIfAvailable(RequestLogProperty.NAME)).isNull();
+    }
 }

--- a/resilience4j2/src/main/java/com/linecorp/armeria/resilience4j/circuitbreaker/client/Resilience4JCircuitBreakerCallback.java
+++ b/resilience4j2/src/main/java/com/linecorp/armeria/resilience4j/circuitbreaker/client/Resilience4JCircuitBreakerCallback.java
@@ -48,10 +48,8 @@ final class Resilience4JCircuitBreakerCallback implements CircuitBreakerCallback
         final long duration = circuitBreaker.getCurrentTimestamp() - startTimestamp;
 
         if (cause == null) {
-            final RequestLog log = ctx.log().partial();
-            if (ctx.log().isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
-                cause = log.responseCause();
-            }
+            final RequestLog requestLog = ctx.log().getIfAvailable(RequestLogProperty.RESPONSE_CAUSE);
+            cause = requestLog != null ? requestLog.responseCause() : null;
         }
         if (cause == null) {
             cause = FailedCircuitBreakerDecisionException.of();


### PR DESCRIPTION
Motivation:

The current implementation of RequestLog access in AbstractHttpResponseHandler is verbose and potentially inefficient. Each operation checks the availability of RequestLog properties separately, accessing a volatile variable and computing the available flags multiple times. Additionally, the code style does not align with efficient and concise Kotlin programming practices.

Modifications:

Introduce new API for accessing RequestLog only when specific flags are available
Provide Kotlin users with the ability to utilize null-safe calls

Result:

Improved efficiency of RequestLog access by reducing redundant checks and computations
Enhanced compatibility for Kotlin developers by enabling null-safe calls when accessing RequestLog properties

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
