### PR TITLE
Add features to allow users specify regular expression or `Predicate` for CORS allowed origins 

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
@@ -94,13 +94,13 @@ public final class DefaultWebSocketService implements WebSocketService, WebSocke
     private final Set<String> subprotocols;
     private final boolean allowAnyOrigin;
     @Nullable
-    private final Predicate<String> originPredicate;
+    private final Predicate<? super String> originPredicate;
     private final boolean aggregateContinuation;
 
     public DefaultWebSocketService(WebSocketServiceHandler handler, @Nullable HttpService fallbackService,
                                    int maxFramePayloadLength, boolean allowMaskMismatch,
                                    Set<String> subprotocols, boolean allowAnyOrigin,
-                                   @Nullable Predicate<String> originPredicate,
+                                   @Nullable Predicate<? super String> originPredicate,
                                    boolean aggregateContinuation) {
         this.handler = handler;
         this.fallbackService = fallbackService;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -43,9 +43,9 @@ public @interface CorsDecorator {
     String[] origins() default {};
 
     /**
-     * Specify allowed origins by regular expression.
+     * Specify allowed origins by regular expressions.
      */
-    String originRegex() default "";
+    String[] originRegexes() default {};
 
     /**
      * The path patterns that this policy is supposed to be applied to. If unspecified, all paths would be

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/decorator/CorsDecorator.java
@@ -40,7 +40,12 @@ public @interface CorsDecorator {
      * Allowed origins.
      * Sets this property to be {@code "*"} to allow any origin.
      */
-    String[] origins();
+    String[] origins() default {};
+
+    /**
+     * Specify allowed origins by regular expression.
+     */
+    String originRegex() default "";
 
     /**
      * The path patterns that this policy is supposed to be applied to. If unspecified, all paths would be

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -22,7 +22,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +34,7 @@ import java.util.function.Supplier;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -55,7 +55,7 @@ import io.netty.util.AsciiString;
 abstract class AbstractCorsPolicyBuilder {
 
     private final Set<String> origins;
-    private final Predicate<String> originPredicate;
+    private final Predicate<? super String> originPredicate;
     private final List<Route> routes = new ArrayList<>();
     private boolean credentialsAllowed;
     private boolean nullOriginAllowed;
@@ -80,9 +80,9 @@ abstract class AbstractCorsPolicyBuilder {
         originPredicate = this.origins::contains;
     }
 
-    AbstractCorsPolicyBuilder(Predicate<String> originPredicate) {
+    AbstractCorsPolicyBuilder(Predicate<? super String> originPredicate) {
         requireNonNull(originPredicate, "originPredicate");
-        origins = Collections.emptySet();
+        origins = ImmutableSet.of();
         this.originPredicate = originPredicate;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
@@ -40,7 +39,6 @@ import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.decorator.CorsDecorator;
@@ -57,8 +55,7 @@ import io.netty.util.AsciiString;
 abstract class AbstractCorsPolicyBuilder {
 
     private final Set<String> origins;
-    @Nullable
-    private Predicate<String> originPredicate;
+    private final Predicate<String> originPredicate;
     private final List<Route> routes = new ArrayList<>();
     private boolean credentialsAllowed;
     private boolean nullOriginAllowed;
@@ -73,6 +70,7 @@ abstract class AbstractCorsPolicyBuilder {
 
     AbstractCorsPolicyBuilder(List<String> origins) {
         requireNonNull(origins, "origins");
+        checkArgument(!origins.isEmpty(), "origins is empty.");
         for (int i = 0; i < origins.size(); i++) {
             if (origins.get(i) == null) {
                 throw new NullPointerException("origins[" + i + ']');
@@ -86,12 +84,6 @@ abstract class AbstractCorsPolicyBuilder {
         requireNonNull(originPredicate, "originPredicate");
         origins = Collections.emptySet();
         this.originPredicate = originPredicate;
-    }
-
-    AbstractCorsPolicyBuilder(Pattern originRegex) {
-        requireNonNull(originRegex, "originRegex");
-        origins = Collections.emptySet();
-        originPredicate = origin -> originRegex.matcher(origin).matches();
     }
 
     final void setConfig(CorsDecorator corsDecorator) {

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -36,10 +36,11 @@ import com.linecorp.armeria.common.HttpMethod;
  */
 public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
 
+    private static final List<String> ALLOW_ANY_ORIGIN = ImmutableList.of("*");
     private final CorsServiceBuilder serviceBuilder;
 
     ChainedCorsPolicyBuilder(CorsServiceBuilder builder) {
-        super(ImmutableList.of("*"));
+        super(ALLOW_ANY_ORIGIN);
         requireNonNull(builder, "builder");
         serviceBuilder = builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -18,8 +18,11 @@ package com.linecorp.armeria.server.cors;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import com.linecorp.armeria.common.HttpMethod;
 
@@ -36,12 +39,25 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     private final CorsServiceBuilder serviceBuilder;
 
     ChainedCorsPolicyBuilder(CorsServiceBuilder builder) {
+        super(Collections.singletonList("*"));
         requireNonNull(builder, "builder");
         serviceBuilder = builder;
     }
 
     ChainedCorsPolicyBuilder(CorsServiceBuilder builder, List<String> origins) {
         super(origins);
+        requireNonNull(builder, "builder");
+        serviceBuilder = builder;
+    }
+
+    ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Predicate<String> originPredicate) {
+        super(originPredicate);
+        requireNonNull(builder, "builder");
+        serviceBuilder = builder;
+    }
+
+    ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Pattern originRegex) {
+        super(originRegex);
         requireNonNull(builder, "builder");
         serviceBuilder = builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import com.linecorp.armeria.common.HttpMethod;
 
@@ -52,12 +51,6 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
 
     ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Predicate<String> originPredicate) {
         super(originPredicate);
-        requireNonNull(builder, "builder");
-        serviceBuilder = builder;
-    }
-
-    ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Pattern originRegex) {
-        super(originRegex);
         requireNonNull(builder, "builder");
         serviceBuilder = builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -51,7 +51,7 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
         serviceBuilder = builder;
     }
 
-    ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Predicate<String> originPredicate) {
+    ChainedCorsPolicyBuilder(CorsServiceBuilder builder, Predicate<? super String> originPredicate) {
         super(originPredicate);
         requireNonNull(builder, "builder");
         serviceBuilder = builder;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/ChainedCorsPolicyBuilder.java
@@ -18,10 +18,11 @@ package com.linecorp.armeria.server.cors;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpMethod;
 
@@ -38,7 +39,7 @@ public final class ChainedCorsPolicyBuilder extends AbstractCorsPolicyBuilder {
     private final CorsServiceBuilder serviceBuilder;
 
     ChainedCorsPolicyBuilder(CorsServiceBuilder builder) {
-        super(Collections.singletonList("*"));
+        super(ImmutableList.of("*"));
         requireNonNull(builder, "builder");
         serviceBuilder = builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -106,8 +106,7 @@ public final class CorsConfig {
                 isPathMatched(policy, routingContext)) {
                 return policy;
             } else if (!isNullOrigin && isPathMatched(policy, routingContext)) {
-                if (policy.origins().contains(lowerCaseOrigin) ||
-                    (policy.originPredicate() != null && policy.originPredicate().test(origin))) {
+                if (policy.originPredicate().test(origin)) {
                     return policy;
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -105,9 +105,11 @@ public final class CorsConfig {
             if (isNullOrigin && policy.isNullOriginAllowed() &&
                 isPathMatched(policy, routingContext)) {
                 return policy;
-            } else if (!isNullOrigin && policy.origins().contains(lowerCaseOrigin) &&
-                       isPathMatched(policy, routingContext)) {
-                return policy;
+            } else if (!isNullOrigin && isPathMatched(policy, routingContext)) {
+                if (policy.origins().contains(lowerCaseOrigin) ||
+                    (policy.originPredicate() != null && policy.originPredicate().test(origin))) {
+                    return policy;
+                }
             }
         }
         return null;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
@@ -44,14 +44,16 @@ public final class CorsDecoratorFactoryFunction implements DecoratorFactoryFunct
         if (!origins.isEmpty() && origins.contains("*")) {
             cb = CorsService.builderForAnyOrigin();
         } else {
-            Predicate<String> originPredicate = (unused) -> false;
-            for (String origin: origins) {
-                originPredicate = originPredicate.or(Predicate.isEqual(origin));
+            Predicate<String> originPredicate;
+            if (!origins.isEmpty()) {
+                originPredicate = origins::contains;
+            } else {
+                originPredicate = origin -> false;
             }
 
             if (!parameter.originRegex().isEmpty()) {
-                final Pattern pattern = Pattern.compile(parameter.originRegex());
-                originPredicate = originPredicate.or(pattern.asPredicate());
+                final Pattern regex = Pattern.compile(parameter.originRegex());
+                originPredicate = originPredicate.or(regex.asPredicate());
             }
 
             cb = CorsService.builder(originPredicate);

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
@@ -35,7 +35,7 @@ public final class CorsDecoratorFactoryFunction implements DecoratorFactoryFunct
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(CorsDecorator parameter) {
         requireNonNull(parameter, "parameter");
-        if (parameter.origins().length == 0 && parameter.originRegex().isEmpty()) {
+        if (parameter.origins().length == 0 && parameter.originRegexes().length == 0) {
             throw new IllegalArgumentException("Either origins or originRegex must be configured");
         }
 
@@ -51,8 +51,8 @@ public final class CorsDecoratorFactoryFunction implements DecoratorFactoryFunct
                 originPredicate = origin -> false;
             }
 
-            if (!parameter.originRegex().isEmpty()) {
-                final Pattern regex = Pattern.compile(parameter.originRegex());
+            for (String originRegex : parameter.originRegexes()) {
+                final Pattern regex = Pattern.compile(originRegex);
                 originPredicate = originPredicate.or(regex.asPredicate());
             }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsDecoratorFactoryFunction.java
@@ -17,7 +17,11 @@ package com.linecorp.armeria.server.cors;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
@@ -31,7 +35,28 @@ public final class CorsDecoratorFactoryFunction implements DecoratorFactoryFunct
     @Override
     public Function<? super HttpService, ? extends HttpService> newDecorator(CorsDecorator parameter) {
         requireNonNull(parameter, "parameter");
-        final CorsServiceBuilder cb = CorsService.builder(parameter.origins());
+        if (parameter.origins().length == 0 && parameter.originRegex().isEmpty()) {
+            throw new IllegalArgumentException("Either origins or originRegex must be configured");
+        }
+
+        final CorsServiceBuilder cb;
+        final List<String> origins = Arrays.asList(parameter.origins());
+        if (!origins.isEmpty() && origins.contains("*")) {
+            cb = CorsService.builderForAnyOrigin();
+        } else {
+            Predicate<String> originPredicate = (unused) -> false;
+            for (String origin: origins) {
+                originPredicate = originPredicate.or(Predicate.isEqual(origin));
+            }
+
+            if (!parameter.originRegex().isEmpty()) {
+                final Pattern pattern = Pattern.compile(parameter.originRegex());
+                originPredicate = originPredicate.or(pattern.asPredicate());
+            }
+
+            cb = CorsService.builder(originPredicate);
+        }
+
         cb.firstPolicyBuilder.setConfig(parameter);
 
         final Function<? super HttpService, CorsService> decorator = cb.newDecorator();

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -82,7 +82,7 @@ public final class CorsPolicy {
     /**
      * Returns a new {@link CorsPolicyBuilder} with origins matching the {@code predicate}.
      */
-    public static CorsPolicyBuilder builder(Predicate<String> predicate) {
+    public static CorsPolicyBuilder builder(Predicate<? super String> predicate) {
         return new CorsPolicyBuilder(predicate);
     }
 
@@ -101,7 +101,7 @@ public final class CorsPolicy {
     }
 
     private final Set<String> origins;
-    private final Predicate<String> originPredicate;
+    private final Predicate<? super String> originPredicate;
     private final List<Route> routes;
     private final boolean credentialsAllowed;
     private final boolean nullOriginAllowed;
@@ -115,7 +115,7 @@ public final class CorsPolicy {
     private final String joinedAllowedRequestMethods;
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
 
-    CorsPolicy(Set<String> origins, Predicate<String> originPredicate,
+    CorsPolicy(Set<String> origins, Predicate<? super String> originPredicate,
                List<Route> routes, boolean credentialsAllowed, long maxAge,
                boolean nullOriginAllowed, Set<AsciiString> exposedHeaders,
                boolean allowAllRequestHeaders, Set<AsciiString> allowedRequestHeaders,
@@ -172,7 +172,7 @@ public final class CorsPolicy {
     /**
      * Returns predicate to match origins.
      */
-    public Predicate<String> originPredicate() {
+    public Predicate<? super String> originPredicate() {
         return originPredicate;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -101,7 +101,7 @@ public final class CorsPolicy {
     }
 
     private final Set<String> origins;
-    private final Predicate<? super String> originPredicate;
+    private final Predicate<String> originPredicate;
     private final List<Route> routes;
     private final boolean credentialsAllowed;
     private final boolean nullOriginAllowed;
@@ -122,7 +122,7 @@ public final class CorsPolicy {
                EnumSet<HttpMethod> allowedRequestMethods, boolean preflightResponseHeadersDisabled,
                Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
         this.origins = ImmutableSet.copyOf(origins);
-        this.originPredicate = originPredicate;
+        this.originPredicate = (Predicate<String>) originPredicate;
         this.routes = ImmutableList.copyOf(routes);
         this.credentialsAllowed = credentialsAllowed;
         this.maxAge = maxAge;
@@ -172,7 +172,7 @@ public final class CorsPolicy {
     /**
      * Returns predicate to match origins.
      */
-    public Predicate<? super String> originPredicate() {
+    public Predicate<String> originPredicate() {
         return originPredicate;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicy.java
@@ -23,7 +23,9 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Joiner;
@@ -76,7 +78,30 @@ public final class CorsPolicy {
         return new CorsPolicyBuilder(origins);
     }
 
+    /**
+     * Returns a new {@link CorsPolicyBuilder} with origins matching the {@code predicate}.
+     */
+    public static CorsPolicyBuilder builder(Predicate<String> predicate) {
+        return new CorsPolicyBuilder(predicate);
+    }
+
+    /**
+     * Returns a new {@link CorsPolicyBuilder} with origins matching the {@code regex}.
+     */
+    public static CorsPolicyBuilder builderForOriginRegex(String regex) {
+        return builderForOriginRegex(Pattern.compile(regex));
+    }
+
+    /**
+     * Returns a new {@link CorsPolicyBuilder} with origins matching the {@code regex}.
+     */
+    public static CorsPolicyBuilder builderForOriginRegex(Pattern regex) {
+        return new CorsPolicyBuilder(regex);
+    }
+
     private final Set<String> origins;
+    @Nullable
+    private final Predicate<String> originPredicate;
     private final List<Route> routes;
     private final boolean credentialsAllowed;
     private final boolean nullOriginAllowed;
@@ -90,12 +115,14 @@ public final class CorsPolicy {
     private final String joinedAllowedRequestMethods;
     private final Map<AsciiString, Supplier<?>> preflightResponseHeaders;
 
-    CorsPolicy(Set<String> origins, List<Route> routes, boolean credentialsAllowed, long maxAge,
+    CorsPolicy(Set<String> origins, @Nullable Predicate<String> originPredicate,
+               List<Route> routes, boolean credentialsAllowed, long maxAge,
                boolean nullOriginAllowed, Set<AsciiString> exposedHeaders,
                boolean allowAllRequestHeaders, Set<AsciiString> allowedRequestHeaders,
                EnumSet<HttpMethod> allowedRequestMethods, boolean preflightResponseHeadersDisabled,
                Map<AsciiString, Supplier<?>> preflightResponseHeaders) {
         this.origins = ImmutableSet.copyOf(origins);
+        this.originPredicate = originPredicate;
         this.routes = ImmutableList.copyOf(routes);
         this.credentialsAllowed = credentialsAllowed;
         this.maxAge = maxAge;
@@ -134,6 +161,14 @@ public final class CorsPolicy {
      */
     public Set<String> origins() {
         return origins;
+    }
+
+    /**
+     * Returns predicate to match origins.
+     */
+    @Nullable
+    public Predicate<String> originPredicate() {
+        return originPredicate;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.armeria.server.cors;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -37,9 +37,10 @@ import com.linecorp.armeria.common.HttpMethod;
  *
  */
 public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
+    private static final List<String> ALLOW_ANY_ORIGIN = ImmutableList.of("*");
 
     CorsPolicyBuilder() {
-        super(Collections.singletonList("*"));
+        super(ALLOW_ANY_ORIGIN);
     }
 
     CorsPolicyBuilder(String... origins) {
@@ -50,7 +51,7 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
         super(ImmutableList.copyOf(origins));
     }
 
-    CorsPolicyBuilder(Predicate<String> predicate) {
+    CorsPolicyBuilder(Predicate<? super String> predicate) {
         super(predicate);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server.cors;
 import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
 
@@ -53,10 +52,6 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
 
     CorsPolicyBuilder(Predicate<String> predicate) {
         super(predicate);
-    }
-
-    CorsPolicyBuilder(Pattern regex) {
-        super(regex);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsPolicyBuilder.java
@@ -15,7 +15,10 @@
  */
 package com.linecorp.armeria.server.cors;
 
+import java.util.Collections;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
 
@@ -36,7 +39,9 @@ import com.linecorp.armeria.common.HttpMethod;
  */
 public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
 
-    CorsPolicyBuilder() {}
+    CorsPolicyBuilder() {
+        super(Collections.singletonList("*"));
+    }
 
     CorsPolicyBuilder(String... origins) {
         super(ImmutableList.copyOf(origins));
@@ -44,6 +49,14 @@ public final class CorsPolicyBuilder extends AbstractCorsPolicyBuilder {
 
     CorsPolicyBuilder(Iterable<String> origins) {
         super(ImmutableList.copyOf(origins));
+    }
+
+    CorsPolicyBuilder(Predicate<String> predicate) {
+        super(predicate);
+    }
+
+    CorsPolicyBuilder(Pattern regex) {
+        super(regex);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -91,7 +91,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
      * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originPredicate}.
      */
     @UnstableApi
-    public static CorsServiceBuilder builder(Predicate<String> originPredicate) {
+    public static CorsServiceBuilder builder(Predicate<? super String> originPredicate) {
         requireNonNull(originPredicate, "originPredicate");
         return new CorsServiceBuilder(originPredicate);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
@@ -89,6 +90,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
     /**
      * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originPredicate}.
      */
+    @UnstableApi
     public static CorsServiceBuilder builder(Predicate<String> originPredicate) {
         requireNonNull(originPredicate, "originPredicate");
         return new CorsServiceBuilder(originPredicate);
@@ -97,6 +99,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
     /**
      * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originRegex}.
      */
+    @UnstableApi
     public static CorsServiceBuilder builderForOriginRegex(String originRegex) {
         requireNonNull(originRegex, "originRegex");
         return builderForOriginRegex(Pattern.compile(originRegex));
@@ -105,6 +108,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
     /**
      * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originRegex}.
      */
+    @UnstableApi
     public static CorsServiceBuilder builderForOriginRegex(Pattern originRegex) {
         return builder(requireNonNull(originRegex, "originRegex").asPredicate());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -20,6 +20,8 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isCorsPreflig
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -82,6 +84,30 @@ public final class CorsService extends SimpleDecoratingHttpService {
             return builderForAnyOrigin();
         }
         return new CorsServiceBuilder(copied);
+    }
+
+    /**
+     * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originPredicate}.
+     */
+    public static CorsServiceBuilder builder(Predicate<String> originPredicate) {
+        requireNonNull(originPredicate, "originPredicate");
+        return new CorsServiceBuilder(originPredicate);
+    }
+
+    /**
+     * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originRegex}.
+     */
+    public static CorsServiceBuilder builderForOriginRegex(String originRegex) {
+        requireNonNull(originRegex, "originRegex");
+        return builderForOriginRegex(Pattern.compile(originRegex));
+    }
+
+    /**
+     * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originRegex}.
+     */
+    public static CorsServiceBuilder builderForOriginRegex(Pattern originRegex) {
+        requireNonNull(originRegex, "originRegex");
+        return new CorsServiceBuilder(originRegex);
     }
 
     private final CorsConfig config;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -106,8 +106,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
      * Returns a new {@link CorsServiceBuilder} with origins matching the {@code originRegex}.
      */
     public static CorsServiceBuilder builderForOriginRegex(Pattern originRegex) {
-        requireNonNull(originRegex, "originRegex");
-        return new CorsServiceBuilder(originRegex);
+        return builder(requireNonNull(originRegex, "originRegex").asPredicate());
     }
 
     private final CorsConfig config;

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -67,7 +67,6 @@ public final class CorsServiceBuilder {
 
     /**
      * Creates a new instance for a {@link CorsService} with a {@link CorsPolicy} allowing {@code origins}.
-     *
      */
     CorsServiceBuilder(List<String> origins) {
         anyOriginSupported = false;
@@ -81,15 +80,6 @@ public final class CorsServiceBuilder {
     CorsServiceBuilder(Predicate<String> originPredicate) {
         anyOriginSupported = false;
         firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, originPredicate);
-    }
-
-    /**
-     * Creates a new instance for a {@link CorsService} with a {@link CorsPolicy} allowing origins matched by
-     * {@code originRegex}.
-     */
-    CorsServiceBuilder(Pattern originRegex) {
-        anyOriginSupported = false;
-        firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, originRegex);
     }
 
     /**
@@ -492,8 +482,7 @@ public final class CorsServiceBuilder {
      * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
      */
     public ChainedCorsPolicyBuilder andForOriginRegex(Pattern regex) {
-        requireNonNull(regex, "regex");
-        return new ChainedCorsPolicyBuilder(this, regex);
+        return andForOrigin(requireNonNull(regex, "regex").asPredicate());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -78,7 +78,7 @@ public final class CorsServiceBuilder {
      * Creates a new instance for a {@link CorsService} with a {@link CorsPolicy} allowing origins matched by
      * {@code originPredicate}.
      */
-    CorsServiceBuilder(Predicate<String> originPredicate) {
+    CorsServiceBuilder(Predicate<? super String> originPredicate) {
         anyOriginSupported = false;
         firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, originPredicate);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +72,24 @@ public final class CorsServiceBuilder {
     CorsServiceBuilder(List<String> origins) {
         anyOriginSupported = false;
         firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, origins);
+    }
+
+    /**
+     * Creates a new instance for a {@link CorsService} with a {@link CorsPolicy} allowing origins matched by
+     * {@code originPredicate}.
+     */
+    CorsServiceBuilder(Predicate<String> originPredicate) {
+        anyOriginSupported = false;
+        firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, originPredicate);
+    }
+
+    /**
+     * Creates a new instance for a {@link CorsService} with a {@link CorsPolicy} allowing origins matched by
+     * {@code originRegex}.
+     */
+    CorsServiceBuilder(Pattern originRegex) {
+        anyOriginSupported = false;
+        firstPolicyBuilder = new ChainedCorsPolicyBuilder(this, originRegex);
     }
 
     /**
@@ -154,7 +174,7 @@ public final class CorsServiceBuilder {
      *
      * <p>CORS headers are set after a request is processed. This may not always be desired
      * and this setting will check that the Origin is valid and if it is not valid no
-     * further processing will take place, and a error will be returned to the calling client.
+     * further processing will take place, and an error will be returned to the calling client.
      *
      * @return {@link CorsServiceBuilder} to support method chaining.
      * @throws IllegalStateException if {@link #anyOriginSupported} is {@code true}.
@@ -445,7 +465,35 @@ public final class CorsServiceBuilder {
      * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
      */
     public ChainedCorsPolicyBuilder andForOrigin(String origin) {
+        requireNonNull(origin, "origin");
         return andForOrigins(ImmutableList.of(origin));
+    }
+
+    /**
+     * Creates a new builder instance for a new {@link CorsPolicy}.
+     * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
+     */
+    public ChainedCorsPolicyBuilder andForOrigin(Predicate<String> originPredicate) {
+        requireNonNull(originPredicate, "originPredicate");
+        return new ChainedCorsPolicyBuilder(this, originPredicate);
+    }
+
+    /**
+     * Creates a new builder instance for a new {@link CorsPolicy}.
+     * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
+     */
+    public ChainedCorsPolicyBuilder andForOriginRegex(String regex) {
+        requireNonNull(regex, "regex");
+        return andForOriginRegex(Pattern.compile(regex));
+    }
+
+    /**
+     * Creates a new builder instance for a new {@link CorsPolicy}.
+     * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
+     */
+    public ChainedCorsPolicyBuilder andForOriginRegex(Pattern regex) {
+        requireNonNull(regex, "regex");
+        return new ChainedCorsPolicyBuilder(this, regex);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsServiceBuilder.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.HttpService;
 
 /**
@@ -463,6 +464,7 @@ public final class CorsServiceBuilder {
      * Creates a new builder instance for a new {@link CorsPolicy}.
      * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
      */
+    @UnstableApi
     public ChainedCorsPolicyBuilder andForOrigin(Predicate<String> originPredicate) {
         requireNonNull(originPredicate, "originPredicate");
         return new ChainedCorsPolicyBuilder(this, originPredicate);
@@ -472,6 +474,7 @@ public final class CorsServiceBuilder {
      * Creates a new builder instance for a new {@link CorsPolicy}.
      * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
      */
+    @UnstableApi
     public ChainedCorsPolicyBuilder andForOriginRegex(String regex) {
         requireNonNull(regex, "regex");
         return andForOriginRegex(Pattern.compile(regex));
@@ -481,6 +484,7 @@ public final class CorsServiceBuilder {
      * Creates a new builder instance for a new {@link CorsPolicy}.
      * @return {@link ChainedCorsPolicyBuilder} to support method chaining.
      */
+    @UnstableApi
     public ChainedCorsPolicyBuilder andForOriginRegex(Pattern regex) {
         return andForOrigin(requireNonNull(regex, "regex").asPredicate());
     }

--- a/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
@@ -159,6 +159,11 @@ public final class WebSocketServiceBuilder {
         return this;
     }
 
+    /**
+     * Sets the regex pattern to match allowed origins. The same-origin is allowed by default.
+     *
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-10.2">Origin Considerations</a>
+     */
     public WebSocketServiceBuilder allowedOrigins(Pattern regex) {
         originMatchingPredicate = originMatchingPredicate.or(regex.asPredicate());
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -155,6 +156,11 @@ public final class WebSocketServiceBuilder {
      */
     public WebSocketServiceBuilder allowedOrigins(Predicate<String> predicate) {
         originMatchingPredicate = originMatchingPredicate.or(predicate);
+        return this;
+    }
+
+    public WebSocketServiceBuilder allowedOrigins(Pattern regex) {
+        originMatchingPredicate = originMatchingPredicate.or(regex.asPredicate());
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
@@ -67,7 +67,7 @@ public final class WebSocketServiceBuilder {
     @Nullable
     private Set<String> allowedOrigins;
     @Nullable
-    private Predicate<String> originPredicate;
+    private Predicate<? super String> originPredicate;
     private boolean aggregateContinuation;
     @Nullable
     private HttpService fallbackService;
@@ -158,7 +158,7 @@ public final class WebSocketServiceBuilder {
      *
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-10.2">Origin Considerations</a>
      */
-    public WebSocketServiceBuilder allowedOrigin(Predicate<String> predicate) {
+    public WebSocketServiceBuilder allowedOrigin(Predicate<? super String> predicate) {
         checkState(allowedOrigins == null, "allowedOrigins and originPredicate are mutually exclusive.");
         originPredicate = requireNonNull(predicate, "predicate");
         return this;
@@ -211,7 +211,7 @@ public final class WebSocketServiceBuilder {
      */
     public WebSocketService build() {
         final boolean allowAnyOrigin;
-        final Predicate<String> originPredicate;
+        final Predicate<? super String> originPredicate;
         if (allowedOrigins != null) {
             allowAnyOrigin = allowedOrigins.contains(ANY_ORIGIN);
             originPredicate = allowedOrigins::contains;

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -69,7 +69,7 @@ class HttpServerCorsTest {
         @Get("/dup_test")
         @StatusCode(200)
         @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                allowedRequestHeaders = "content-type")
+                       allowedRequestHeaders = "content-type")
         public void dupTest() {}
     }
 
@@ -210,7 +210,7 @@ class HttpServerCorsTest {
                         allowedRequestMethods = HttpMethod.GET, maxAge = 3600,
                         preflightRequestHeaders = {
                                 @AdditionalHeader(name = "x-preflight-cors",
-                                        value = { "Hello CORS", "Hello CORS2" })
+                                                  value = { "Hello CORS", "Hello CORS2" })
                         })
                 public HttpResponse anyoneGet() {
                     return HttpResponse.of(HttpStatus.OK);
@@ -231,9 +231,9 @@ class HttpServerCorsTest {
 
                 @Get("/multi/get")
                 @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1",
-                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 public HttpResponse multiGet() {
                     return HttpResponse.of(HttpStatus.OK);
                 }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -98,7 +98,7 @@ class HttpServerCorsTest {
     }
 
     @CorsDecorator(
-            originRegex = "http:\\/\\/example.*",
+            originRegexes = "http:\\/\\/example.*",
             allowedRequestMethods = HttpMethod.GET
     )
     private static class MyAnnotatedService4 {
@@ -109,7 +109,7 @@ class HttpServerCorsTest {
 
     @CorsDecorator(
             origins = "http://armeria.com",
-            originRegex = "http:\\/\\/line.*",
+            originRegexes = { "http:\\/\\/line.*", "http:\\/\\/test.*" },
             allowedRequestMethods = HttpMethod.GET
     )
     private static class MyAnnotatedService5 {
@@ -360,7 +360,7 @@ class HttpServerCorsTest {
                                   HttpHeaderNames.ACCEPT, "utf-8",
                                   HttpHeaderNames.ORIGIN, origin,
                                   HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, requestMethod)
-                             ).aggregate().join();
+        ).aggregate().join();
     }
 
     static AggregatedHttpResponse preflightRequest(WebClient client, String path, String origin,
@@ -534,7 +534,8 @@ class HttpServerCorsTest {
     @Test
     void testCorsPreflightWithQueryParams() throws Exception {
         final WebClient client = client();
-        final AggregatedHttpResponse response = preflightRequest(client, "/cors?a=b", "http://example.com", "POST");
+        final AggregatedHttpResponse response = preflightRequest(client, "/cors?a=b", "http://example.com",
+                                                                 "POST");
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
                 .isEqualTo("http://example.com");
@@ -807,6 +808,9 @@ class HttpServerCorsTest {
         res = request(client, HttpMethod.GET, "/cors17/index", "http://line2.org", "GET");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
                 .isEqualTo("http://line2.org");
+        res = request(client, HttpMethod.GET, "/cors17/index", "http://test.org", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://test.org");
 
         res = request(client, HttpMethod.GET, "/cors17/index", "http://invalid.com", "GET");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -41,6 +42,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Options;
 import com.linecorp.armeria.server.annotation.Param;
@@ -67,7 +69,7 @@ class HttpServerCorsTest {
         @Get("/dup_test")
         @StatusCode(200)
         @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                       allowedRequestHeaders = "content-type")
+                allowedRequestHeaders = "content-type")
         public void dupTest() {}
     }
 
@@ -90,6 +92,27 @@ class HttpServerCorsTest {
             allowAllRequestHeaders = true
     )
     private static class MyAnnotatedService3 {
+        @Get("/index")
+        @StatusCode(200)
+        public void index() {}
+    }
+
+    @CorsDecorator(
+            originRegex = "http:\\/\\/example.*",
+            allowedRequestMethods = HttpMethod.GET
+    )
+    private static class MyAnnotatedService4 {
+        @Get("/index")
+        @StatusCode(200)
+        public void index() {}
+    }
+
+    @CorsDecorator(
+            origins = "http://armeria.com",
+            originRegex = "http:\\/\\/line.*",
+            allowedRequestMethods = HttpMethod.GET
+    )
+    private static class MyAnnotatedService5 {
         @Get("/index")
         @StatusCode(200)
         public void index() {}
@@ -187,7 +210,7 @@ class HttpServerCorsTest {
                         allowedRequestMethods = HttpMethod.GET, maxAge = 3600,
                         preflightRequestHeaders = {
                                 @AdditionalHeader(name = "x-preflight-cors",
-                                                  value = { "Hello CORS", "Hello CORS2" })
+                                        value = { "Hello CORS", "Hello CORS2" })
                         })
                 public HttpResponse anyoneGet() {
                     return HttpResponse.of(HttpStatus.OK);
@@ -208,9 +231,9 @@ class HttpServerCorsTest {
 
                 @Get("/multi/get")
                 @CorsDecorator(origins = "http://example.com", exposedHeaders = "expose_header_1",
-                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 @CorsDecorator(origins = "http://example2.com", exposedHeaders = "expose_header_2",
-                               allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
+                        allowedRequestMethods = HttpMethod.GET, credentialsAllowed = true)
                 public HttpResponse multiGet() {
                     return HttpResponse.of(HttpStatus.OK);
                 }
@@ -276,11 +299,53 @@ class HttpServerCorsTest {
             sb.route().get("/cors12/get")
               .build((ctx, req) -> HttpResponse.of(HttpStatus.OK));
 
-            sb.service("/cors13", myService.decorate(CorsService.builder("http://example.com")
-                                                                .allowRequestMethods(HttpMethod.GET)
-                                                                .allowAllRequestHeaders(true)
-                                                                .newDecorator()));
+            sb.service("/cors13", myService.decorate(
+                    CorsService.builder("http://example.com")
+                               .allowRequestMethods(HttpMethod.GET)
+                               .allowAllRequestHeaders(true)
+                               .newDecorator()));
+
             sb.annotatedService("/cors14", new MyAnnotatedService3());
+
+            sb.service("/cors15", myService.decorate(
+                    CorsService.builderForOriginRegex("^http:\\/\\/.*example.com$")
+                               .shortCircuit()
+                               .allowRequestMethods(HttpMethod.GET)
+                               .newDecorator()));
+
+            sb.annotatedService("/cors16", new MyAnnotatedService4());
+
+            sb.annotatedService("/cors17", new MyAnnotatedService5());
+
+            sb.service("/cors18", myService.decorate(
+                    CorsService.builder(origin -> origin.contains("example") || origin.contains("line"))
+                               .shortCircuit()
+                               .allowRequestMethods(HttpMethod.GET)
+                               .newDecorator()));
+
+            sb.annotatedService("/cors19", new Object() {
+                @Get("/index1")
+                public void index1() {}
+
+                @Post("/index2")
+                public void index2() {}
+
+                @Delete("/index3")
+                public void index3() {}
+            }, CorsService.builder()
+                          .andForOriginRegex("^http:\\/\\/example.*")
+                          .route("/cors19/index1")
+                          .allowRequestMethods(HttpMethod.GET)
+                          .and()
+                          .andForOriginRegex(Pattern.compile(".*line.*"))
+                          .route("/cors19/index2")
+                          .allowRequestMethods(HttpMethod.POST)
+                          .and()
+                          .andForOrigin((origin) -> origin.contains("armeria"))
+                          .route("/cors19/index3")
+                          .allowRequestMethods(HttpMethod.DELETE)
+                          .and()
+                          .newDecorator());
         }
     };
 
@@ -693,5 +758,108 @@ class HttpServerCorsTest {
                 .isEqualTo("http://example.com");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo("foo,bar");
+    }
+
+    @Test
+    public void testBuilderForOriginRegex() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = request(client, HttpMethod.GET, "/cors15", "http://example.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        res = request(client, HttpMethod.GET, "/cors15", "http://1.example.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        res = request(client, HttpMethod.GET, "/cors15", "http://2.example.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+
+        res = request(client, HttpMethod.GET, "/cors15", "http://invalid.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    public void testAnnotatedServiceOriginRegex() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = request(client, HttpMethod.GET, "/cors16/index", "http://example.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        res = request(client, HttpMethod.GET, "/cors16/index", "http://example1.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example1.com");
+        res = request(client, HttpMethod.GET, "/cors16/index", "http://example.org", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.org");
+
+        res = request(client, HttpMethod.GET, "/cors16/index", "http://invalid.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
+    }
+
+    @Test
+    public void testAnnotatedServiceOriginAndOriginRegex() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = request(client, HttpMethod.GET, "/cors17/index", "http://armeria.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://armeria.com");
+        res = request(client, HttpMethod.GET, "/cors17/index", "http://line1.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://line1.com");
+        res = request(client, HttpMethod.GET, "/cors17/index", "http://line2.org", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://line2.org");
+
+        res = request(client, HttpMethod.GET, "/cors17/index", "http://invalid.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
+    }
+
+    @Test
+    public void testOriginPredicate() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = request(client, HttpMethod.GET, "/cors18", "http://example.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        res = request(client, HttpMethod.GET, "/cors18", "http://line.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://line.com");
+        res = request(client, HttpMethod.GET, "/cors18", "http://example.line.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.line.com");
+
+        res = request(client, HttpMethod.GET, "/cors18", "http://invalid.com", "GET");
+        assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    public void testOriginRegexAndPredicatePerRoute() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = preflightRequest(client, "/cors19/index1", "http://example.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://example.com");
+        res = preflightRequest(client, "/cors19/index1", "http://invalid.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
+
+        res = preflightRequest(client, "/cors19/index2", "http://line.com", "POST");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("POST");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://line.com");
+        res = preflightRequest(client, "/cors19/index2", "http://invalid.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
+
+        res = preflightRequest(client, "/cors19/index3", "http://armeria.com", "DELETE");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isEqualTo("DELETE");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://armeria.com");
+        res = preflightRequest(client, "/cors19/index3", "http://invalid.com", "DELETE");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -332,11 +332,9 @@ class HttpServerCorsTest {
 
                 @Delete("/index3")
                 public void index3() {}
-            }, CorsService.builder()
-                          .andForOriginRegex("^http:\\/\\/example.*")
+            }, CorsService.builderForOriginRegex("^http:\\/\\/example.*")
                           .route("/cors19/index1")
                           .allowRequestMethods(HttpMethod.GET)
-                          .and()
                           .andForOriginRegex(Pattern.compile(".*line.*"))
                           .route("/cors19/index2")
                           .allowRequestMethods(HttpMethod.POST)

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
@@ -76,20 +76,7 @@ class WebSocketServiceCorsTest {
             sb.route()
               .path("/chat")
               .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
-                                     .allowedOrigins(origin -> origin.contains("armeria"))
-                                     .build());
-        }
-    };
-
-    @RegisterExtension
-    static final ServerExtension server4 = new ServerExtension() {
-        @Override
-        protected void configure(ServerBuilder sb) {
-            sb.route()
-              .path("/chat")
-              .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
-                                     .allowedOrigins(origin -> origin.contains("armeria"))
-                                     .allowedOrigins("http://line.com")
+                                     .allowedOrigin(origin -> origin.contains("armeria"))
                                      .build());
         }
     };
@@ -129,18 +116,7 @@ class WebSocketServiceCorsTest {
                 .isEqualTo(HttpStatus.FORBIDDEN);
     }
 
-    @Test
-    void testWhenBothStringAndPredicateForAllowedOriginsAreSpecified() {
-        final WebClient client = WebClient.builder(server4.uri(SessionProtocol.H1C))
-                                          .responseTimeoutMillis(0)
-                                          .build();
-        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria.com").status())
-                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
-        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://line.com").status())
-                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
-    }
-
-    private ResponseHeaders sendRequestAndRetrieveResponseHeaders(WebClient client, String origin) {
+    private static ResponseHeaders sendRequestAndRetrieveResponseHeaders(WebClient client, String origin) {
         final RequestHeaders requestHeaders = webSocketUpgradeHeaders(origin);
         final CompletableFuture<ResponseHeaders> informationalHeadersFuture = new CompletableFuture<>();
         client.execute(requestHeaders).subscribe(new WebSocketClientSubscriber(informationalHeadersFuture));

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.websocket.CloseWebSocketFrame;
+import com.linecorp.armeria.common.websocket.WebSocket;
+import com.linecorp.armeria.common.websocket.WebSocketFrame;
+import com.linecorp.armeria.common.websocket.WebSocketWriter;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+
+class WebSocketServiceCorsTest {
+
+    @RegisterExtension
+    static final ServerExtension server1 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.route()
+              .path("/chat")
+              .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
+                                     .allowedOrigins("*")
+                                     .build());
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server2 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.route()
+              .path("/chat")
+              .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
+                                     .allowedOrigins("http://armeria.com")
+                                     .build());
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server3 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.route()
+              .path("/chat")
+              .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
+                                     .allowedOrigins(origin -> origin.contains("armeria"))
+                                     .build());
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server4 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.route()
+              .path("/chat")
+              .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
+                                     .allowedOrigins(origin -> origin.contains("armeria"))
+                                     .allowedOrigins("http://line.com")
+                                     .build());
+        }
+    };
+
+    @Test
+    void testWhenAllOriginsAreAllowed() {
+        final WebClient client = WebClient.builder(server1.uri(SessionProtocol.H1C))
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://line.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+    }
+
+    @Test
+    void testWhenAllowedOriginsAreMatchedByString() {
+        final WebClient client = WebClient.builder(server2.uri(SessionProtocol.H1C))
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://line.com").status())
+                .isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void testWhenAllowedOriginsAreMatchedByPredicate() {
+        final WebClient client = WebClient.builder(server3.uri(SessionProtocol.H1C))
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria2.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://line.com").status())
+                .isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void testWhenBothStringAndPredicateForAllowedOriginsAreSpecified() {
+        final WebClient client = WebClient.builder(server4.uri(SessionProtocol.H1C))
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://armeria.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://line.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+    }
+
+    private ResponseHeaders sendRequestAndRetrieveResponseHeaders(WebClient client, String origin) {
+        final RequestHeaders requestHeaders = webSocketUpgradeHeaders(origin);
+        final CompletableFuture<ResponseHeaders> informationalHeadersFuture = new CompletableFuture<>();
+        client.execute(requestHeaders).subscribe(new WebSocketClientSubscriber(informationalHeadersFuture));
+        return informationalHeadersFuture.join();
+    }
+
+    private static RequestHeaders webSocketUpgradeHeaders(String origin) {
+        return RequestHeaders.builder(HttpMethod.GET, "/chat")
+                             .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE.toString())
+                             .add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toString())
+                             .add(HttpHeaderNames.HOST, "foo.com")
+                             .add(HttpHeaderNames.ORIGIN, origin)
+                             .addInt(HttpHeaderNames.SEC_WEBSOCKET_VERSION, 13)
+                             .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                             .add(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "superchat")
+                             .build();
+    }
+
+    static final class CustomWebSocketServiceHandler implements WebSocketServiceHandler {
+
+        @Override
+        public WebSocket handle(ServiceRequestContext ctx, WebSocket in) {
+            final WebSocketWriter webSocketWriter = WebSocket.streaming();
+            in.subscribe(new Subscriber<WebSocketFrame>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(WebSocketFrame webSocketFrame) {
+                    try (WebSocketFrame frame = webSocketFrame) {
+                        switch (frame.type()) {
+                            case TEXT:
+                                System.out.println("text");
+                                webSocketWriter.write(frame.text());
+                                break;
+                            case BINARY:
+                                System.out.println("binary");
+                                break;
+                            case CLOSE:
+                                System.out.println("close");
+                                final CloseWebSocketFrame closeFrame = (CloseWebSocketFrame) frame;
+                                webSocketWriter.close(closeFrame.status(), closeFrame.reasonPhrase());
+                                break;
+                            default:
+                                System.out.println("default");
+                        }
+                    } catch (Throwable t) {
+                        webSocketWriter.close(t);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    webSocketWriter.close(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    webSocketWriter.close();
+                }
+            });
+            return webSocketWriter;
+        }
+    }
+
+    static final class WebSocketClientSubscriber implements Subscriber<HttpObject> {
+
+        private final CompletableFuture<ResponseHeaders> informationalHeadersFuture;
+
+        WebSocketClientSubscriber(CompletableFuture<ResponseHeaders> informationalHeadersFuture) {
+            this.informationalHeadersFuture = informationalHeadersFuture;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(HttpObject httpObject) {
+            informationalHeadersFuture.complete((ResponseHeaders) httpObject);
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onComplete() {}
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
@@ -151,19 +151,15 @@ class WebSocketServiceCorsTest {
                     try (WebSocketFrame frame = webSocketFrame) {
                         switch (frame.type()) {
                             case TEXT:
-                                System.out.println("text");
                                 webSocketWriter.write(frame.text());
                                 break;
                             case BINARY:
-                                System.out.println("binary");
                                 break;
                             case CLOSE:
-                                System.out.println("close");
                                 final CloseWebSocketFrame closeFrame = (CloseWebSocketFrame) frame;
                                 webSocketWriter.close(closeFrame.status(), closeFrame.reasonPhrase());
                                 break;
                             default:
-                                System.out.println("default");
                         }
                     } catch (Throwable t) {
                         webSocketWriter.close(t);


### PR DESCRIPTION
Motivation:

Allow users to specify CORS allowed origins by regular expression or `Predicate<String>` 

Modifications:

Users can specify allowed origins by using regular expression or `Predicate<String>` like below. 

<b>CorsDecorator</b> 
```
@CorsDecorator(
        originRegex = "http://example.*",
        allowedRequestMethods = HttpMethod.GET
)
``` 

<b>`CorsService`'s `builderForOriginRegex` or `builder(Predicate<String> originPredicate)`</b>
```
  sb.service("/cors15", myService.decorate(
          CorsService.builderForOriginRegex("http://example.*")
                     .allowRequestMethods(HttpMethod.GET)
                     .newDecorator()));

  sb.service("/cors17", myService.decorate(
          CorsService.builder(origin -> origin.contains("example") || origin.contains("line"))
                     .allowRequestMethods(HttpMethod.GET)
                     .newDecorator()));
```

or per route 
```
sb.annotatedService("/cors18", new Object() {
                        @Get("/index1")
                        public void index1() {}

                        @Post("/index2")
                        public void index2() {}

                        @Delete("/index3")
                        public void index3() {}
                    }, CorsService.builder()
                                  .andForOriginRegex("http://example.*")
                                  .route("/cors18/index1")
                                  .allowRequestMethods(HttpMethod.GET)
                                  .and()
                                  .andForOriginRegex(Pattern.compile(".*line.*"))
                                  .route("/cors18/index2")
                                  .allowRequestMethods(HttpMethod.POST)
                                  .and()
                                  .andForOrigin((origin) -> origin.contains("armeria"))
                                  .route("/cors18/index3")
                                  .allowRequestMethods(HttpMethod.DELETE)
                                  .and()
                                  .newDecorator()
```

<b>`WebSocketServiceBuilder`'s  `allowedOrigins(Predicate<String> originPredicate>`</b>
```
 sb.route()
    .path("/chat")
    .build(WebSocketService.builder(new CustomWebSocketServiceHandler())
                           .allowedOrigins(origin -> origin.contains("armeria"))
                           .build());
```

Result:

- Closes #<https://github.com/line/armeria/issues/4963>. (If this resolves the issue.)
- Users can use regular expression or `Predicate<String>` to specify allowed origins 
