### PR TITLE
Fix various `docs-client` interface issues

### DIFF
--- a/docs-client/src/components/Description/index.tsx
+++ b/docs-client/src/components/Description/index.tsx
@@ -85,7 +85,7 @@ const Description: React.FunctionComponent<DescriptionInfoProps> = ({
         />
       )}
       {descriptionInfo && descriptionInfo.markup === 'NONE' && (
-        <Typography variant="body2">
+        <Typography variant="body2" component="span">
           {renderDefaultDocString(descriptionInfo.docString)}
         </Typography>
       )}

--- a/docs-client/src/components/VariableList/index.tsx
+++ b/docs-client/src/components/VariableList/index.tsx
@@ -33,8 +33,14 @@ const useStyles = makeStyles({
   hidden: {
     display: 'none',
   },
+  description: {
+    margin: 0,
+  },
   expand: {
     textAlign: 'end',
+    '& svg': {
+      verticalAlign: 'middle',
+    },
   },
 });
 
@@ -123,9 +129,9 @@ const FieldInfo: React.FunctionComponent<FieldInfoProps> = ({
             {specification.getTypeSignatureHtml(variable.typeSignature)}
           </code>
         </TableCell>
-        <TableCell>
+        <TableCell colSpan={hasChildren ? 1 : 2}>
           {variable.descriptionInfo && (
-            <pre>
+            <pre className={styles.description}>
               <Description descriptionInfo={variable.descriptionInfo} />
             </pre>
           )}
@@ -237,7 +243,6 @@ export default ({ title, variables, specification }: Props) => {
           </TableBody>
         </Table>
       </TableContainer>
-      <Typography variant="body2" paragraph />
     </>
   );
 };

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -256,7 +256,7 @@ const AppDrawer: React.FunctionComponent<AppDrawerProps> = ({
                           </ListItemText>
                           {method.endpoints.map((endpoint) => (
                             <ListItemText
-                              key={`${method.id}`}
+                              key={`${endpoint.pathMapping}`}
                               primaryTypographyProps={{
                                 variant: 'caption',
                               }}

--- a/docs-client/src/containers/EnumPage/index.tsx
+++ b/docs-client/src/containers/EnumPage/index.tsx
@@ -58,7 +58,7 @@ const EnumPage: React.FunctionComponent<Props> = ({ match, specification }) => {
       <Typography variant="subtitle1" paragraph>
         <code>{packageName(data.name)}</code>
       </Typography>
-      {data.descriptionInfo && (
+      {data.descriptionInfo?.docString && (
         <Section>
           <Description descriptionInfo={data.descriptionInfo} />
         </Section>

--- a/docs-client/src/containers/MethodPage/ReturnType.tsx
+++ b/docs-client/src/containers/MethodPage/ReturnType.tsx
@@ -33,6 +33,9 @@ import { Method, Specification } from '../../lib/specification';
 const useStyles = makeStyles({
   expand: {
     textAlign: 'end',
+    '& svg': {
+      verticalAlign: 'middle',
+    },
   },
 });
 
@@ -54,6 +57,8 @@ const ReturnType: React.FunctionComponent<Props> = ({
   );
 
   const styles = useStyles();
+  const hasVariables = returnTypeVariables.length > 0;
+
   return (
     <Section>
       <Typography variant="h6">Return Type</Typography>
@@ -68,25 +73,23 @@ const ReturnType: React.FunctionComponent<Props> = ({
                   )}
                 </code>
               </TableCell>
-              {returnTypeVariables.length > 0 && (
+              {hasVariables && (
                 <TableCell className={styles.expand}>
                   {returnTypeExpanded ? <ExpandLess /> : <ExpandMore />}
                 </TableCell>
               )}
             </TableRow>
-            {returnTypeExpanded && returnTypeVariables.length > 0 && (
-              <TableRow>
-                <VariableList
-                  key={method.returnTypeSignature}
-                  title=""
-                  variables={returnTypeVariables}
-                  specification={specification}
-                />
-              </TableRow>
-            )}
           </TableBody>
         </Table>
       </TableContainer>
+      {returnTypeExpanded && hasVariables && (
+        <VariableList
+          key={method.returnTypeSignature}
+          title=""
+          variables={returnTypeVariables}
+          specification={specification}
+        />
+      )}
     </Section>
   );
 };

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -196,7 +196,7 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
           </Button>
         )}
       </Grid>
-      {method.descriptionInfo && (
+      {method.descriptionInfo?.docString && (
         <Section>
           <Description descriptionInfo={method.descriptionInfo} />
         </Section>

--- a/docs-client/src/containers/StructPage/index.tsx
+++ b/docs-client/src/containers/StructPage/index.tsx
@@ -52,7 +52,7 @@ const StructPage: React.FunctionComponent<Props> = ({
       <Typography variant="subtitle1" paragraph>
         <code>{packageName(data.name)}</code>
       </Typography>
-      {data.descriptionInfo && (
+      {data.descriptionInfo?.docString && (
         <Section>
           <Description descriptionInfo={data.descriptionInfo} />
         </Section>


### PR DESCRIPTION
### Motivation

This PR makes minor adjustments to the DocService UI, to reduce the number of visual artifacts and provides a more consistent experimence. Additionally, it gets rid of all runtime exceptions to avoid any potential rendering issues.

### Modifications

- Render `Typography` inside `Description` as `span` instead of `p`, to get rid of `validateDOMNesting()` errors
- Vertically align `Expand{More,Less}` with the row text
- Remove extra margin and inconsistent row height when variable fields have a description
- Make sure table rows have the same length when `Expand{More,Less}` is present
- Remove a blank `Typography` at the end of `VariableList`
- Use a correct deduplication key for method endpoints, to get rid of `Encountered two children with the same key` errors
- Hide method/struct/enum description section when it's empty
- Move `ReturnType` variable table outside of the nested table. This makes sure the table uses the full width, and gets rid of `validateDOMNesting()` errors

### Result

- The DocService UI has fewer visual artifacts and no runtime errors