### PR TITLE
Enable gradle enterprise build scan upload for pull requests

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -6,7 +6,7 @@ on:
     tags-ignore:
       # The release versions will be verified by 'publish-release.yml'
       - armeria-*
-  pull_request:
+  pull_request_target:
   merge_group:
 
 concurrency:


### PR DESCRIPTION
Motivation:

`pull_request_target` uses the main branch's actions workflow, whereas `pull_request` uses the pull request branch's actions workflow. Another difference is `pull_request` doesn't allow secrets to be used, which is required for uploading build scans to gradle enterprise.

I propose that we switch to `pull_request_target` so that pull requests may also upload build scans.
I've checked that the other tasks using secrets are:
- uploading snapshots, which is already protected by a branch condition.
  - https://github.com/line/armeria/blob/eb3e0126fb99d6e0e373eb0407f6c84f4418a67e/.github/workflows/actions_build.yml#L108
- Building the site with a token, which I would argue we should actually use secrets since it can make the build flaky.
  - https://github.com/line/armeria/blob/eb3e0126fb99d6e0e373eb0407f6c84f4418a67e/.github/workflows/actions_build.yml#L233

Useful references: https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks


Run from my repo:
- pull request: https://github.com/jrhee17/armeria/pull/13
- build scan: https://github.com/jrhee17/armeria/actions/runs/5408094444/jobs/9827015923#step:7:3627

Modifications:

- Listen for `pull_request_target` instead of `pull_request`

Result:

- Build scans are published from pull request runs now

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
