### PR TITLE
Use relative path for redirection in FallbackService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -66,6 +66,7 @@ final class FallbackService implements HttpService {
         // For example, if the proxy rewrite the path /proxy/path -> /path, then we should send the location
         // with path/ so that the client can send the request to /proxy/path/ again.
         final int index = oldPath.lastIndexOf('/');
+        assert index >= 0;
         String location = oldPath.substring(index + 1) + '/';
         if (routingCtx.query() != null) {
             location += '?' + routingCtx.query();

--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -64,9 +64,9 @@ final class FallbackService implements HttpService {
         // Use relative path to handle the case where the server is behind a reverse proxy.
         // The reverse proxy might rewrite the path, so we should use the relative path.
         // For example, if the proxy rewrite the path /proxy/path -> /path, then we should send the location
-        // with ./path/ so that the client can send the request to /proxy/path/ again.
+        // with path/ so that the client can send the request to /proxy/path/ again.
         final int index = oldPath.lastIndexOf('/');
-        String location = '.' + oldPath.substring(index) + '/';
+        String location = oldPath.substring(index + 1) + '/';
         if (routingCtx.query() != null) {
             location += '?' + routingCtx.query();
         }

--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -56,20 +56,19 @@ final class FallbackService implements HttpService {
 
         // Handle the case where '/path' (or '/path?query') doesn't exist
         // but '/path/' (or '/path/?query') exists.
-        final String newPath = oldPath + '/';
-        if (!ctx.config().virtualHost().findServiceConfig(routingCtx.withPath(newPath)).isPresent()) {
+        if (!ctx.config().virtualHost().findServiceConfig(routingCtx.withPath(oldPath + '/')).isPresent()) {
             // No need to send a redirect response because '/path/' (or '/path/?query') does not exist.
             return newHeadersOnlyResponse(HttpStatus.NOT_FOUND);
         }
 
-        // '/path/' (or '/path/?query') exists. Send a redirect response.
-        final String location;
-        if (routingCtx.query() == null) {
-            // '/path/'
-            location = newPath;
-        } else {
-            // '/path/?query'
-            location = newPath + '?' + routingCtx.query();
+        // Use relative path to handle the case where the server is behind a reverse proxy.
+        // The reverse proxy might rewrite the path, so we should use the relative path.
+        // For example, if the proxy rewrite the path /proxy/path -> /path, then we should send the location
+        // with ./path/ so that the client can send the request to /proxy/path/ again.
+        final int index = oldPath.lastIndexOf('/');
+        String location = '.' + oldPath.substring(index) + '/';
+        if (routingCtx.query() != null) {
+            location += '?' + routingCtx.query();
         }
 
         return HttpResponse.of(ResponseHeaders.builder(HttpStatus.TEMPORARY_REDIRECT)

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
@@ -59,14 +59,14 @@ class FallbackServiceRedirectionTest {
     };
 
     @CsvSource({
-            "/service, ./service/",
-            "/service?a=b, ./service/?a=b",
-            "/service%2F, ./service%2F/",
-            "/service%2F?a=b, ./service%2F/?a=b",
-            "/foo/bar, ./bar/",
-            "/foo/bar?a=b, ./bar/?a=b",
-            "/foo/bar%2F, ./bar%2F/",
-            "/foo/bar%2F?a=b, ./bar%2F/?a=b"
+            "/service, service/",
+            "/service?a=b, service/?a=b",
+            "/service%2F, service%2F/",
+            "/service%2F?a=b, service%2F/?a=b",
+            "/foo/bar, bar/",
+            "/foo/bar?a=b, bar/?a=b",
+            "/foo/bar%2F, bar%2F/",
+            "/foo/bar%2F?a=b, bar%2F/?a=b"
     })
     @ParameterizedTest
     void redirection(String path, String redirectLocation) {

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
@@ -89,7 +89,7 @@ class FallbackServiceRedirectionTest {
     void redirectingClient(String path, String changedPath) {
         final BlockingWebClient client =
                 proxy.blockingWebClient(builder -> builder.followRedirects(RedirectConfig.of()));
-        AggregatedHttpResponse response = client.get(path);
+        final AggregatedHttpResponse response = client.get(path);
         assertThat(response.contentUtf8()).isEqualTo(changedPath);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceRedirectionTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.redirect.RedirectConfig;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class FallbackServiceRedirectionTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            final HttpService service = (ctx, req) -> HttpResponse.of(req.path());
+            sb.serviceUnder("/service", service);
+            sb.serviceUnder("/service%2F", service);
+            sb.serviceUnder("/foo/bar", service);
+            sb.serviceUnder("/foo/bar%2F", service);
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension proxy = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceUnder("/proxy", (ctx, req) -> {
+                final HttpRequest request = req.withHeaders(req.headers()
+                                                               .toBuilder()
+                                                               .path(req.path().replace("/proxy", ""))
+                                                               .build());
+                ctx.updateRequest(request);
+                return server.webClient().execute(request);
+            });
+        }
+    };
+
+    @CsvSource({
+            "/service, ./service/",
+            "/service?a=b, ./service/?a=b",
+            "/service%2F, ./service%2F/",
+            "/service%2F?a=b, ./service%2F/?a=b",
+            "/foo/bar, ./bar/",
+            "/foo/bar?a=b, ./bar/?a=b",
+            "/foo/bar%2F, ./bar%2F/",
+            "/foo/bar%2F?a=b, ./bar%2F/?a=b"
+    })
+    @ParameterizedTest
+    void redirection(String path, String redirectLocation) {
+        final BlockingWebClient client = server.blockingWebClient();
+        final AggregatedHttpResponse response = client.get(path);
+        assertThat(response.headers().get(HttpHeaderNames.LOCATION)).isEqualTo(redirectLocation);
+    }
+
+    @CsvSource({
+            "/proxy/service, /service/",
+            "/proxy/service?a=b, /service/?a=b",
+            "/proxy/service%2F, /service%2F/",
+            "/proxy/service%2F?a=b, /service%2F/?a=b",
+            "/proxy/foo/bar, /foo/bar/",
+            "/proxy/foo/bar?a=b, /foo/bar/?a=b",
+            "/proxy/foo/bar%2F, /foo/bar%2F/",
+            "/proxy/foo/bar%2F?a=b, /foo/bar%2F/?a=b"
+    })
+    @ParameterizedTest
+    void redirectingClient(String path, String changedPath) {
+        final BlockingWebClient client =
+                proxy.blockingWebClient(builder -> builder.followRedirects(RedirectConfig.of()));
+        AggregatedHttpResponse response = client.get(path);
+        assertThat(response.contentUtf8()).isEqualTo(changedPath);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
@@ -71,29 +71,29 @@ class HttpServerAutoRedirectTest {
 
         res = client.get("/a");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/a/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./a/");
 
         res = client.get("/b");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/b/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./b/");
 
         res = client.get("/c/1");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/c/1/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./1/");
 
         res = client.get("/d");
         assertThat(res.status()).isSameAs(HttpStatus.OK);
 
         res = client.get("/e");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/e/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./e/");
 
         res = client.delete("/e");
         assertThat(res.status()).isSameAs(HttpStatus.NOT_FOUND);
 
         res = client.get("/f");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/f/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./f/");
 
         res = client.get("/f/");
         assertThat(res.status()).isSameAs(HttpStatus.ACCEPTED);

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerAutoRedirectTest.java
@@ -71,29 +71,29 @@ class HttpServerAutoRedirectTest {
 
         res = client.get("/a");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./a/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("a/");
 
         res = client.get("/b");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./b/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("b/");
 
         res = client.get("/c/1");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./1/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("1/");
 
         res = client.get("/d");
         assertThat(res.status()).isSameAs(HttpStatus.OK);
 
         res = client.get("/e");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./e/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("e/");
 
         res = client.delete("/e");
         assertThat(res.status()).isSameAs(HttpStatus.NOT_FOUND);
 
         res = client.get("/f");
         assertThat(res.status()).isSameAs(HttpStatus.TEMPORARY_REDIRECT);
-        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("./f/");
+        assertThat(res.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("f/");
 
         res = client.get("/f/");
         assertThat(res.status()).isSameAs(HttpStatus.ACCEPTED);


### PR DESCRIPTION
Motivation:
We send redirect responses in the `FallbackService` when
- the path does not end with '/'
- the route exists if '/' is appended to the path

This works in most situations except a reverse proxy exists and it rewrites the path. If we use the relative path, the client redirects correctly even with the reverse proxy.

Modification:
- Send redirect response with relative path location.

Result:
- The client redirects correctly even if a reverse proxy rewrites the path.