### PR TITLE
Add WWW-Authenticate header if basic access authentication is configured

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthServiceBuilder.java
@@ -46,8 +46,6 @@ public final class AuthServiceBuilder {
                 HttpStatus.UNAUTHORIZED, HttpHeaderNames.WWW_AUTHENTICATE, this.authorizer.authenticationScheme()
         ));
     };
-    @Nullable
-    private String authenticationScheme;
     private boolean authenticationSchemeSet;
 
     /**
@@ -59,8 +57,6 @@ public final class AuthServiceBuilder {
      * authenticationScheme setter
      */
     public AuthServiceBuilder authenticationScheme(String authenticationScheme) {
-        this.authenticationScheme = requireNonNull(authenticationScheme, "authenticationScheme");
-
         requireNonNull(this.authorizer, "authorizer");
         checkState(this.failureHandler == null, "authenticationScheme() and onFailure() are mutually exclusive.");
         this.authorizer.setAuthenticationScheme(authenticationScheme);
@@ -178,28 +174,7 @@ public final class AuthServiceBuilder {
     /**
      * Returns a newly-created {@link AuthService} based on the {@link Authorizer}s added to this builder.
      */
-//    public AuthService build(HttpService delegate) {
-//        return new AuthService(requireNonNull(delegate, "delegate"), authorizer(),
-//                successHandler, failureHandler);
-//    }
-
     public AuthService build(HttpService delegate) {
-        final AuthFailureHandler failureHandler;
-        if (this.failureHandler != null) {
-            failureHandler = this.failureHandler;
-        } else {
-            final String authenticationScheme = this.authenticationScheme;
-            failureHandler = (unused, ctx, req, cause) -> {
-                if (cause != null) {
-                    AuthService.logger.warn("Unexpected exception during authorization.", cause);
-                }
-                if (authenticationScheme == null) {
-                    return HttpResponse.of(HttpStatus.UNAUTHORIZED);
-                }
-                return HttpResponse.of(ResponseHeaders.of(
-                        HttpStatus.UNAUTHORIZED, HttpHeaderNames.WWW_AUTHENTICATE, authenticationScheme));
-            };
-        }
         return new AuthService(requireNonNull(delegate, "delegate"), authorizer(),
                 successHandler, failureHandler);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/auth/Authorizer.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/Authorizer.java
@@ -16,14 +16,22 @@
 
 package com.linecorp.armeria.server.auth;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
+import com.google.common.collect.ImmutableSet;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.multipart.AggregatedBodyPart;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.auth.AuthorizerChain.AuthorizerSelectionStrategy;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Determines whether a given {@code data} is authorized for the service registered in.
@@ -33,6 +41,17 @@ import com.linecorp.armeria.server.auth.AuthorizerChain.AuthorizerSelectionStrat
  */
 @FunctionalInterface
 public interface Authorizer<T> {
+    HashSet<String> authenticationSchemes = new HashSet<>();
+
+    default Authorizer<T> setAuthenticationScheme(String scheme) {
+        requireNonNull(scheme, "scheme");
+        this.authenticationSchemes.add(scheme);
+        return this;
+    }
+
+    default String authenticationScheme() {
+        return requireNonNull(this.authenticationSchemes.stream().findFirst().get().toString());
+    }
 
     /**
      * Authorizes the given {@code data}.

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -245,13 +245,6 @@ class AuthServiceTest {
                 assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
                 assertThat(res.getHeaders()[0].getValue()).isEqualTo("Basic");
             }
-            try (CloseableHttpResponse res = hc.execute(
-                    basicGetRequest("/basic", AuthToken.ofBasic("choco", "pangyo"),
-                                    AUTHORIZATION))) {
-                assertThat(res.getCode()).isEqualTo(401);
-                assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
-                assertThat(res.getHeaders()[0].getValue()).isEqualTo("Basic");
-            }
         }
     }
 
@@ -308,8 +301,7 @@ class AuthServiceTest {
                 assertThat(res.getCode()).isEqualTo(200);
             }
             try (CloseableHttpResponse res = hc.execute(
-                    oauth2GetRequest("/oauth2", AuthToken.ofOAuth2("DUMMY_oauth2_token"),
-                                     AUTHORIZATION))) {
+                    new HttpGet(server.httpUri() + "/oauth2"))) {
                 assertThat(res.getCode()).isEqualTo(401);
                 assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
                 assertThat(res.getHeaders()[0].getValue()).isEqualTo("Bearer");

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -311,6 +311,8 @@ class AuthServiceTest {
                     oauth2GetRequest("/oauth2", AuthToken.ofOAuth2("DUMMY_oauth2_token"),
                                      AUTHORIZATION))) {
                 assertThat(res.getCode()).isEqualTo(401);
+                assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
+                assertThat(res.getHeaders()[0].getValue()).isEqualTo("Bearer");
             }
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -242,11 +242,15 @@ class AuthServiceTest {
             }
             try (CloseableHttpResponse res = hc.execute(new HttpGet(server.httpUri() + "/basic"))) {
                 assertThat(res.getCode()).isEqualTo(401);
+                assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
+                assertThat(res.getHeaders()[0].getValue()).isEqualTo("Basic");
             }
             try (CloseableHttpResponse res = hc.execute(
                     basicGetRequest("/basic", AuthToken.ofBasic("choco", "pangyo"),
                                     AUTHORIZATION))) {
                 assertThat(res.getCode()).isEqualTo(401);
+                assertThat(res.getHeaders("WWW-Authenticate")).hasSize(1);
+                assertThat(res.getHeaders()[0].getValue()).isEqualTo("Basic");
             }
         }
     }


### PR DESCRIPTION
Motivation:

resovles #4997 

Modifications:

- Add the isBasicAuth variable to check if HTTP Basic Auth is enabled."
- Add `.add(HttpHeaderNames.WWW_AUTHENTICATE, "Basic")` in AuthFailureHandler for basic auth request.

Result:

- Closes #4997 
