### PR TITLE
Apply the gradle enterprise test retry plugin

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -99,7 +99,7 @@ jobs:
           ${{ matrix.blockhound && '-Pblockhound' || '' }} \
           -PnoLint \
           -PflakyTests=false \
-          -Pretry \
+          -Pretry=true \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
@@ -254,7 +254,7 @@ jobs:
       - name: Run flaky tests
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check \
-          -PnoLint -PflakyTests=true -Pretry \
+          -PnoLint -PflakyTests=true -Pretry=true \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ env.BUILD_JDK_VERSION }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -99,6 +99,7 @@ jobs:
           ${{ matrix.blockhound && '-Pblockhound' || '' }} \
           -PnoLint \
           -PflakyTests=false \
+          -Pretry \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
@@ -252,7 +253,8 @@ jobs:
 
       - name: Run flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check -PnoLint -PflakyTests=true \
+          ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check \
+          -PnoLint -PflakyTests=true -Pretry \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ env.BUILD_JDK_VERSION }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
     alias libs.plugins.kotlin apply false
     alias libs.plugins.ktlint apply false
     alias libs.plugins.errorprone apply false
-    alias libs.plugins.test.retry apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ allprojects {
         }
 
         retry {
-            if (System.getenv().containsKey("CI")) {
+            if (System.getenv().containsKey("CI") || rootProject.hasProperty('retry')) {
                 maxRetries = 3
                 failOnPassedAfterRetry = true
             }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     alias libs.plugins.kotlin apply false
     alias libs.plugins.ktlint apply false
     alias libs.plugins.errorprone apply false
+    alias libs.plugins.test.retry apply false
 }
 
 allprojects {
@@ -108,6 +109,13 @@ allprojects {
                     hasLeak.set(true)
                 }
             })
+        }
+
+        retry {
+            if (System.getenv().containsKey("CI")) {
+                maxRetries = 3
+                failOnPassedAfterRetry = true
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ allprojects {
         }
 
         retry {
-            if (System.getenv().containsKey("CI") || rootProject.hasProperty('retry')) {
+            if (rootProject.findProperty('retry') == 'true') {
                 maxRetries = 3
                 failOnPassedAfterRetry = true
             }

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -32,6 +32,7 @@ findbugs = "3.0.2"
 futures-completable = "0.3.5"
 futures-extra = "4.3.1"
 gax-grpc = "2.29.0"
+test-retry = "1.5.3"
 graphql-java = "20.4"
 graphql-kotlin = "6.5.2"
 groovy = "3.0.17"
@@ -1303,3 +1304,4 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle-pl
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-gradle-plugin" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle-plugin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot2" }
+test-retry = { id = 'org.gradle.test-retry', version.ref = "test-retry" }

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -32,7 +32,6 @@ findbugs = "3.0.2"
 futures-completable = "0.3.5"
 futures-extra = "4.3.1"
 gax-grpc = "2.29.0"
-test-retry = "1.5.3"
 graphql-java = "20.4"
 graphql-kotlin = "6.5.2"
 groovy = "3.0.17"
@@ -1304,4 +1303,3 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle-pl
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-gradle-plugin" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle-plugin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot2" }
-test-retry = { id = 'org.gradle.test-retry', version.ref = "test-retry" }


### PR DESCRIPTION
Motivation:

Tests are run up to 4 times by applying the retry plugin.
Even if the test passes on the nth try, the overall build still fails. (while recording test related metrics to gradle enterprise)

Locally verified: 
- https://ge.armeria.dev/s/qyplnd3amofjq
- Check the console logs to verify how many tasks have been actually run
  - https://ge.armeria.dev/s/qyplnd3amofjq/console-log?task=:core:test

Modifications:

- Apply the gradle retry plugin

Result:

- More information on tests at the cost of slightly slower builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
