### PR TITLE
Add requestFullyReceivedDuration concept

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -112,6 +112,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private long requestStartTimeNanos;
     private boolean requestFirstBytesTransferredTimeNanosSet;
     private long requestFirstBytesTransferredTimeNanos;
+    private long requestFullyReceivedTimeMicros;
+    private long requestFullyReceivedTimeNanos;
     private long requestEndTimeNanos;
     private long requestLength;
     @Nullable
@@ -649,6 +651,17 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
+    public void requestFullyReceived(long requestFullyReceivedTimeNanos, long requestFullyReceivedTimeMicros) {
+        if (isAvailable(RequestLogProperty.REQUEST_FULLY_RECEIVED_TIME)) {
+            return;
+        }
+        this.requestFullyReceivedTimeNanos = requestFullyReceivedTimeNanos;
+        this.requestFullyReceivedTimeMicros = requestFullyReceivedTimeMicros;
+
+        updateFlags(RequestLogProperty.REQUEST_FULLY_RECEIVED_TIME);
+    }
+
+    @Override
     public long requestStartTimeMicros() {
         ensureAvailable(RequestLogProperty.REQUEST_START_TIME);
         return requestStartTimeMicros;
@@ -669,6 +682,23 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     public Long requestFirstBytesTransferredTimeNanos() {
         ensureAvailable(RequestLogProperty.REQUEST_FIRST_BYTES_TRANSFERRED_TIME);
         return requestFirstBytesTransferredTimeNanosSet ? requestFirstBytesTransferredTimeNanos : null;
+    }
+
+    @Override
+    public long requestFullyReceivedTimeMicros() {
+        ensureAvailable(RequestLogProperty.REQUEST_FULLY_RECEIVED_TIME);
+        return requestFullyReceivedTimeMicros;
+    }
+
+    @Override
+    public long requestFullyReceivedTimeMillis() {
+        return TimeUnit.MICROSECONDS.toMillis(requestFullyReceivedTimeMicros());
+    }
+
+    @Override
+    public long requestFullyReceivedTimeNanos() {
+        ensureAvailable(RequestLogProperty.REQUEST_FULLY_RECEIVED_TIME);
+        return requestFullyReceivedTimeNanos;
     }
 
     @Override
@@ -1622,6 +1652,21 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         @Override
         public Long requestFirstBytesTransferredTimeNanos() {
             return requestFirstBytesTransferredTimeNanosSet ? requestFirstBytesTransferredTimeNanos : null;
+        }
+
+        @Override
+        public long requestFullyReceivedTimeMicros() {
+            return 0;
+        }
+
+        @Override
+        public long requestFullyReceivedTimeMillis() {
+            return 0;
+        }
+
+        @Override
+        public long requestFullyReceivedTimeNanos() {
+            return 0;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -67,6 +67,12 @@ public interface RequestLogBuilder extends RequestLogAccess {
      */
     void startRequest(long requestStartTimeNanos, long requestStartTimeMicros);
 
+    default void requestFullyReceived() { requestFullyReceived(
+            System.nanoTime(), SystemInfo.currentTimeMicros()
+    ); }
+
+    void requestFullyReceived(long requestFullyReceivedTimeNanos, long requestFullyReceivedTimeMicros);
+
     /**
      * Sets the properties related with socket connection. This method sets the following properties:
      * <ul>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogProperty.java
@@ -48,6 +48,12 @@ public enum RequestLogProperty {
     REQUEST_FIRST_BYTES_TRANSFERRED_TIME(true),
 
     /**
+     * {@link RequestLog#requestFullyReceivedTimeMicros()}, {@link RequestLog#requestFullyReceivedTimeMillis()},
+     * {@link RequestLog#requestFullyReceivedTimeNanos()}.
+     */
+    REQUEST_FULLY_RECEIVED_TIME(true),
+
+    /**
      * {@link RequestLog#channel()}, {@link RequestLog#sessionProtocol()}, {@link RequestLog#sslSession()},
      * {@link RequestLog#connectionTimings()}.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -85,6 +85,31 @@ public interface RequestOnlyLog extends RequestLogAccess {
     Long requestFirstBytesTransferredTimeNanos();
 
     /**
+     * Returns the time when the request is fully received, in microseconds since the epoch.
+     *
+     * @throws RequestLogAvailabilityException if the property is not available yet.
+     * @see RequestLogProperty#REQUEST_FULLY_RECEIVED_TIME
+     */
+    long requestFullyReceivedTimeMicros();
+
+    /**
+     * Returns the time when the request is fully received, in milliseconds since the epoch.
+     *
+     * @throws RequestLogAvailabilityException if the property is not available yet.
+     * @see RequestLogProperty#REQUEST_FULLY_RECEIVED_TIME
+     */
+    long requestFullyReceivedTimeMillis();
+
+    /**
+     * Returns the time when the request is fully received, in nanoseconds. This value can only be
+     * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
+     *
+     * @throws RequestLogAvailabilityException if the property is not available yet.
+     * @see RequestLogProperty#REQUEST_FULLY_RECEIVED_TIME
+     */
+    long requestFullyReceivedTimeNanos();
+
+    /**
      * Returns the time when the processing of the request finished, in nanoseconds. This value can only be
      * used to measure elapsed time and is not related to any other notion of system or wall-clock time.
      *

--- a/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
@@ -149,6 +149,8 @@ public final class RequestMetricSupport {
             boolean isSuccess) {
         metrics.requestDuration().record(log.requestDurationNanos(), TimeUnit.NANOSECONDS);
         metrics.requestLength().record(log.requestLength());
+        metrics.requestFullyReceivedDuration().record(
+                log.requestFullyReceivedTimeNanos(), TimeUnit.NANOSECONDS);
         metrics.responseDuration().record(log.responseDurationNanos(), TimeUnit.NANOSECONDS);
         metrics.responseLength().record(log.responseLength());
         metrics.totalDuration().record(log.totalDurationNanos(), TimeUnit.NANOSECONDS);
@@ -183,6 +185,8 @@ public final class RequestMetricSupport {
         Timer requestDuration();
 
         DistributionSummary requestLength();
+
+        Timer requestFullyReceivedDuration();
 
         Timer responseDuration();
 
@@ -223,6 +227,7 @@ public final class RequestMetricSupport {
         private final Counter failure;
         private final Timer requestDuration;
         private final DistributionSummary requestLength;
+        private final Timer requestFullyReceivedDuration;
         private final Timer responseDuration;
         private final DistributionSummary responseLength;
         private final Timer totalDuration;
@@ -234,6 +239,8 @@ public final class RequestMetricSupport {
 
             requestDuration = newTimer(parent, idPrefix.name("request.duration"), idPrefix.tags());
             requestLength = newDistributionSummary(parent, idPrefix.name("request.length"), idPrefix.tags());
+            requestFullyReceivedDuration = newTimer(parent, idPrefix.name("request.received.duration"),
+                                                    idPrefix.tags());
             responseDuration = newTimer(parent, idPrefix.name("response.duration"), idPrefix.tags());
             responseLength = newDistributionSummary(parent, idPrefix.name("response.length"), idPrefix.tags());
             totalDuration = newTimer(parent, idPrefix.name("total.duration"), idPrefix.tags());
@@ -253,6 +260,9 @@ public final class RequestMetricSupport {
         public Timer requestDuration() {
             return requestDuration;
         }
+
+        @Override
+        public Timer requestFullyReceivedDuration() { return requestFullyReceivedDuration; }
 
         @Override
         public DistributionSummary requestLength() {

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -147,11 +147,17 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
         if (obj instanceof HttpData) {
             ((HttpData) obj).touch(routingCtx);
             if (obj.isEndOfStream()) {
+                if (ctx != null) {
+                    ctx.logBuilder().requestFullyReceived();
+                }
                 close();
             }
         }
         if (obj instanceof HttpHeaders) {
             trailers = (HttpHeaders) obj;
+            if (ctx != null) {
+                ctx.logBuilder().requestFullyReceived();
+            }
             close();
         }
         return published;

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -136,6 +136,7 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
         if (obj instanceof HttpHeaders) { // HTTP trailers.
             published = super.tryWrite(obj);
             ctx.logBuilder().requestTrailers((HttpHeaders) obj);
+            ctx.logBuilder().requestFullyReceived();
             // Close this stream because HTTP trailers is the last element of the request.
             close();
         } else {
@@ -147,6 +148,7 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
                 inboundTrafficController.inc(httpData.length());
             }
             if (obj.isEndOfStream()) {
+                ctx.logBuilder().requestFullyReceived();
                 close();
             }
         }


### PR DESCRIPTION
Motivation:

This is to allow user to calculate the duration of request after it's fully received not the very first moment of incoming.

Modifications:

- Implement logic to record `requestFullyReceivedTime` and `requestFullyReceivedDuration`
- Apply requestFullyReceivedDuration logic to metric

Result:

- Closes #5016 
- User can track the duration of request from the moment being fully received to completion

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
