### PR TITLE
Remove the workaround in `TransportTypeProvider`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -196,9 +196,8 @@ public final class TransportTypeProvider {
             // TODO(trustin): Remove this block which works around the bug where loading both epoll and
             //                io_uring native libraries may revert the initialization of
             //                io.netty.channel.unix.Socket: https://github.com/netty/netty/issues/10909
-            final String unixSocketClassName = ChannelUtil.channelPackageName() + ".unix.Socket";
             try {
-                final Method initializeMethod = findClass(ChannelUtil.channelPackageName(), unixSocketClassName)
+                final Method initializeMethod = findClass(ChannelUtil.channelPackageName(), ".unix.Socket")
                         .getDeclaredMethod("initialize", boolean.class);
                 initializeMethod.setAccessible(true);
                 initializeMethod.invoke(null, NetUtil.isIpV4StackPreferred());

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -46,7 +46,6 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.channel.unix.ServerDomainSocketChannel;
-import io.netty.channel.unix.Socket;
 import io.netty.util.Version;
 
 /**
@@ -191,10 +190,6 @@ public final class TransportTypeProvider {
         } catch (Throwable cause) {
             return new TransportTypeProvider(name, null, null, null, null, null, null, null, null,
                                              Exceptions.peel(cause));
-        } finally {
-            // TODO(trustin): Remove this block once we confirm the following bug is fixed:
-            //                https://github.com/netty/netty/issues/10909
-            Socket.initialize();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -206,6 +206,8 @@ public final class TransportTypeProvider {
                 if (peeledCause instanceof UnsatisfiedLinkError ||
                     peeledCause instanceof ClassNotFoundException) {
                     // Failed to load a native library, which is fine.
+                } else if (peeledCause instanceof NoSuchMethodException) {
+                    // There's no initialize(boolean) method, which is fine.
                 } else {
                     logger.debug("Failed to force-initialize '" + ChannelUtil.channelPackageName() +
                                  ".unix.Socket':", cause);


### PR DESCRIPTION
Motivation:

In recent Netty versions, our workaround of calling `Socket.initialize(boolean)` is not necessary anymore since Netty always call `Socket.initialize()` after loading a native library:

- https://github.com/netty/netty/blob/netty-4.1.94.Final/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java#L50-L59 

Modifications:

- Removed the workaround that calls `Socket.initialize()`.

Result:

- Cleaner code
