### PR TITLE
Fix a failure in `TrailingDotAddressResolverTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/TrailingDotAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TrailingDotAddressResolverTest.java
@@ -92,9 +92,10 @@ class TrailingDotAddressResolverTest {
                 final AggregatedHttpResponse response = client.get(
                         "http://foo.com.:" + server.httpPort() + '/');
                 assertThat(response.contentUtf8()).isEqualTo("Hello, world!");
-                assertThat(dnsRecordCaptor.records).hasSize(1);
-                final DnsRecord record = dnsRecordCaptor.records.poll();
-                assertThat(record.name()).isEqualTo("foo.com.");
+                assertThat(dnsRecordCaptor.records).isNotEmpty();
+                dnsRecordCaptor.records.forEach(record -> {
+                    assertThat(record.name()).isEqualTo("foo.com.");
+                });
             }
         }
     }


### PR DESCRIPTION
This changeset fixes the following test failure in `TrailingDotAddressResolverTest`, which seems to affect only a certain environment:

```
TrailingDotAddressResolverTest > resolve() FAILED
    java.lang.AssertionError:
    Expected size: 1 but was: 3 in:
    [ByteArrayDnsRecord(foo.com. 0 IN A 0B),
        ByteArrayDnsRecord(foo.com. 0 IN AAAA 0B),
        ByteArrayDnsRecord(foo.com. 0 IN CNAME 0B)]
        at com.linecorp.armeria.client.TrailingDotAddressResolverTest.resolve(TrailingDotAddressResolverTest.java:95)
```