### PR TITLE
Add `TlsEngineType` enum

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -152,11 +152,6 @@ final class DefaultFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Boolean useOpenSsl() {
-        return true;
-    }
-
-    @Override
     public TlsEngineType tlsEngineType() {
         return TlsEngineType.OPENSSL;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -27,6 +27,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.util.Sampler;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.TransientServiceOption;
 
@@ -153,6 +154,11 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Boolean useOpenSsl() {
         return true;
+    }
+
+    @Override
+    public TlsEngineType tlsEngineType() {
+        return TlsEngineType.OPENSSL;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.SystemInfo;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.internal.common.FlagsLoaded;
 import com.linecorp.armeria.internal.common.util.SslContextUtil;
@@ -188,6 +189,10 @@ public final class Flags {
 
     @Nullable
     private static Boolean useOpenSsl;
+
+    private static final TlsEngineType TLS_ENGINE_TYPE =
+            getValue(FlagsProvider::tlsEngineType, "tlsEngineType", value -> value != null);
+
     @Nullable
     private static Boolean dumpOpenSslInfo;
 
@@ -524,6 +529,17 @@ public final class Flags {
         }
         setUseOpenSslAndDumpOpenSslInfo();
         return useOpenSsl;
+    }
+
+    /**
+     * Returns the {@link TlsEngineType} that will be used for processing TLS connections.
+     *
+     * <p>The default value of this flag is "openssl", which means the default {@link TlsEngineType} will
+     * be used. Specify the {@code -Dcom.linecorp.armeria.tlsEngineType=<jdk|openssl>} JVM option to override
+     * the default.</p>
+     */
+    public static TlsEngineType tlsEngineType() {
+        return TLS_ENGINE_TYPE;
     }
 
     private static void setUseOpenSslAndDumpOpenSslInfo() {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -522,7 +522,10 @@ public final class Flags {
      *
      * <p>This flag is enabled by default for supported platforms. Specify the
      * {@code -Dcom.linecorp.armeria.useOpenSsl=false} JVM option to disable it.
+     *
+     * @deprecated Use {@link #tlsEngineType()} instead.
      */
+    @Deprecated
     public static boolean useOpenSsl() {
         if (useOpenSsl != null) {
             return useOpenSsl;
@@ -543,7 +546,8 @@ public final class Flags {
     }
 
     private static void setUseOpenSslAndDumpOpenSslInfo() {
-        final boolean useOpenSsl = getValue(FlagsProvider::useOpenSsl, "useOpenSsl");
+        final TlsEngineType tlsEngineType = getValue(FlagsProvider::tlsEngineType, "tlsEngineType");
+        final boolean useOpenSsl = tlsEngineType == TlsEngineType.OPENSSL;
         if (!useOpenSsl) {
             // OpenSSL explicitly disabled
             Flags.useOpenSsl = false;
@@ -583,8 +587,8 @@ public final class Flags {
      * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.dumpOpenSslInfo=true} JVM
      * option to enable it.
      *
-     * <p>If {@link #useOpenSsl()} returns {@code false}, this also returns {@code false} no matter you
-     * specified the JVM option.
+     * <p>If {@link #tlsEngineType()} does not return {@link TlsEngineType#OPENSSL}, this also returns
+     * {@code false} no matter you specified the JVM option.
      */
     public static boolean dumpOpenSslInfo() {
         if (dumpOpenSslInfo != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.SystemInfo;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -200,6 +201,18 @@ public interface FlagsProvider {
      */
     @Nullable
     default Boolean useOpenSsl() {
+        return null;
+    }
+
+    /**
+     * Returns the {@link TlsEngineType} that will be used for processing TLS connections.
+     *
+     * <p>The default value of this flag is "openssl", which means the default {@link TlsEngineType} will
+     * be used. Specify the {@code -Dcom.linecorp.armeria.tlsEngineType=<jdk|openssl>} JVM option to override
+     * the default.</p>
+     */
+    @Nullable
+    default TlsEngineType tlsEngineType() {
         return null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Predicate;
 
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
@@ -192,19 +191,6 @@ public interface FlagsProvider {
     }
 
     /**
-     * Returns whether the JNI-based TLS support with OpenSSL is enabled. When enabled, Armeria uses OpenSSL
-     * for processing TLS connections. When disabled, the current JVM's default {@link SSLEngine} is used
-     * instead.
-     *
-     * <p>This flag is enabled by default for supported platforms. Specify the
-     * {@code -Dcom.linecorp.armeria.useOpenSsl=false} JVM option to disable it.
-     */
-    @Nullable
-    default Boolean useOpenSsl() {
-        return null;
-    }
-
-    /**
      * Returns the {@link TlsEngineType} that will be used for processing TLS connections.
      *
      * <p>The default value of this flag is "openssl", which means the default {@link TlsEngineType} will
@@ -223,8 +209,8 @@ public interface FlagsProvider {
      * <p>This flag is disabled by default. Specify the {@code -Dcom.linecorp.armeria.dumpOpenSslInfo=true} JVM
      * option to enable it.
      *
-     * <p>If {@link #useOpenSsl()} returns {@code false}, this also returns {@code false} no matter you
-     * specified the JVM option.
+     * <p>If {@link #tlsEngineType()} does not return {@link TlsEngineType#OPENSSL}, this also returns
+     * {@code false} no matter you specified the JVM option.
      */
     @Nullable
     default Boolean dumpOpenSslInfo() {

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -145,11 +145,6 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Boolean useOpenSsl() {
-        return getBoolean("useOpenSsl");
-    }
-
-    @Override
     public TlsEngineType tlsEngineType() {
         final String strTlsEngineType = getNormalized("tlsEngineType");
         if (strTlsEngineType == null) {

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.InetAddressPredicates;
 import com.linecorp.armeria.common.util.Sampler;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.TransientServiceOption;
 
@@ -146,6 +147,22 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     @Override
     public Boolean useOpenSsl() {
         return getBoolean("useOpenSsl");
+    }
+
+    @Override
+    public TlsEngineType tlsEngineType() {
+        final String strTlsEngineType = getNormalized("tlsEngineType");
+        if (strTlsEngineType == null) {
+            return null;
+        }
+        switch (strTlsEngineType) {
+            case "jdk":
+                return TlsEngineType.JDK;
+            case "openssl":
+                return TlsEngineType.OPENSSL;
+            default:
+                throw new IllegalArgumentException(String.format("%s isn't TlsEngineType", strTlsEngineType));
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/util/TlsEngineType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TlsEngineType.java
@@ -1,0 +1,23 @@
+package com.linecorp.armeria.common.util;
+
+import io.netty.handler.ssl.SslProvider;
+
+/**
+ * Tls engine types.
+ */
+public enum TlsEngineType {
+    /**
+     * JDK's default implementation.
+     */
+    JDK(SslProvider.JDK),
+    /**
+     * OpenSSL-based implementation.
+     */
+    OPENSSL(SslProvider.OPENSSL);
+
+    private final SslProvider sslProvider;
+
+    TlsEngineType(SslProvider sslProvider) {
+        this.sslProvider = sslProvider;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/util/TlsEngineType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/TlsEngineType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.armeria.common.util;
 
 import io.netty.handler.ssl.SslProvider;
@@ -19,5 +35,12 @@ public enum TlsEngineType {
 
     TlsEngineType(SslProvider sslProvider) {
         this.sslProvider = sslProvider;
+    }
+
+    /**
+     * Returns the {@link SslProvider} corresponding to this {@link TlsEngineType}.
+     */
+    public SslProvider sslProvider() {
+        return sslProvider;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
@@ -98,7 +98,7 @@ public final class SslContextUtil {
 
         return MinifiedBouncyCastleProvider.call(() -> {
             final SslContextBuilder builder = builderSupplier.get();
-            final SslProvider provider = Flags.useOpenSsl() ? SslProvider.OPENSSL : SslProvider.JDK;
+            final SslProvider provider = Flags.tlsEngineType().sslProvider();
             builder.sslProvider(provider);
 
             final Set<String> supportedProtocols = supportedProtocols(builder);
@@ -141,7 +141,7 @@ public final class SslContextUtil {
                            "You must specify at least one cipher suite.");
 
                 if (forceHttp1) {
-                   // Skip validation
+                    // Skip validation
                 } else {
                     validateHttp2Ciphers(ciphers, tlsAllowUnsafeCiphers);
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -87,6 +87,7 @@ import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.ThreadFactories;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.internal.common.BuiltInDependencyInjector;
 import com.linecorp.armeria.internal.common.ReflectiveDependencyInjector;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
@@ -2028,7 +2029,8 @@ public final class ServerBuilder implements TlsSetters {
                 ports = ImmutableList.of(new ServerPort(0, HTTP));
             }
         } else {
-            if (!Flags.useOpenSsl() && !SystemInfo.jettyAlpnOptionalOrAvailable()) {
+            if (Flags.tlsEngineType() != TlsEngineType.OPENSSL &&
+                !SystemInfo.jettyAlpnOptionalOrAvailable()) {
                 throw new IllegalStateException(
                         "TLS configured but this is Java 8 and neither OpenSSL nor Jetty ALPN could be " +
                         "detected. To use TLS with Armeria, you must either use Java 9+, enable OpenSSL, " +

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.Sets;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.Sampler;
+import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
 import com.linecorp.armeria.server.TransientServiceOption;
 
@@ -109,6 +110,13 @@ class FlagsTest {
                 lookup.findStatic(flags, "dumpOpenSslInfo", MethodType.methodType(boolean.class));
         // // Call Flags.dumpOpenSslInfo();
         assertThat(dumpOpenSslInfoMethodHandle.invoke()).isSameAs(Boolean.TRUE);
+    }
+
+    @Test
+    void defaultTlsEngineType() {
+        assumeThat(System.getProperty("com.linecorp.armeria.tlsEngineType")).isNull();
+
+        assertThat(Flags.tlsEngineType()).isEqualTo(TlsEngineType.OPENSSL);
     }
 
     @Test
@@ -252,16 +260,16 @@ class FlagsTest {
     void testApiConsistencyBetweenFlagsAndFlagsProvider() {
         //Check method consistency between Flags and FlagsProvider excluding deprecated methods
         final Set<String> flagsApis = Arrays.stream(Flags.class.getMethods())
-                                             .filter(m -> !m.isAnnotationPresent(Deprecated.class))
-                                             .map(Method::getName)
-                                             .collect(Collectors.toSet());
+                                            .filter(m -> !m.isAnnotationPresent(Deprecated.class))
+                                            .map(Method::getName)
+                                            .collect(Collectors.toSet());
         flagsApis.removeAll(Arrays.stream(Object.class.getMethods())
-                                                  .map(Method::getName)
-                                                  .collect(toImmutableSet()));
+                                  .map(Method::getName)
+                                  .collect(toImmutableSet()));
 
         final Set<String> armeriaOptionsProviderApis = Arrays.stream(FlagsProvider.class.getMethods())
-                                                              .map(Method::getName)
-                                                              .collect(Collectors.toSet());
+                                                             .map(Method::getName)
+                                                             .collect(Collectors.toSet());
         final Set<String> knownIgnoreMethods = ImmutableSet.of("priority", "name");
         armeriaOptionsProviderApis.removeAll(knownIgnoreMethods);
 

--- a/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
+++ b/it/flags-provider/src/test/java/com/linecorp/armeria/common/BaseFlagsProvider.java
@@ -32,11 +32,6 @@ public final class BaseFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Boolean useOpenSsl() {
-        return false;
-    }
-
-    @Override
     public Integer maxNumConnections() {
         return 20;
     }

--- a/it/flags-provider/src/test/java/com/linecorp/armeria/common/FlagsProviderTest.java
+++ b/it/flags-provider/src/test/java/com/linecorp/armeria/common/FlagsProviderTest.java
@@ -38,6 +38,7 @@ import org.junitpioneer.jupiter.SetSystemProperty;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.InetAddressPredicates;
+import com.linecorp.armeria.common.util.TlsEngineType;
 
 import io.micrometer.core.instrument.Metrics;
 
@@ -123,6 +124,14 @@ class FlagsProviderTest {
         final Method method = flags.getDeclaredMethod("requestContextStorageProvider");
         final String actual = method.invoke(flags).getClass().getSimpleName();
         assertThat(actual).isEqualTo(Custom1RequestContextStorageProvider.class.getSimpleName());
+    }
+
+    @Test
+    @SetSystemProperty(key = "com.linecorp.armeria.tlsEngineType", value = "jdk")
+    void overrideDefaultTlsEngineType() throws Throwable {
+        final Method method = flags.getDeclaredMethod("tlsEngineType");
+        final String actual = method.invoke(flags).toString();
+        assertThat(actual).isEqualTo(TlsEngineType.JDK.toString());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Add `TlsEngineType` to let uses choose the type of tls engine. (Using `Flags`) 

Modifications:

- Add `TlsEngineType` enum 
- Deprecate `useOpenSsl` 

Result:

- Related to #<[4949](https://github.com/line/armeria/issues/4949)>.
- Related to https://github.com/line/armeria/pull/4962#discussion_r1252718359
- `TlsEngineType` is added 
- `useOpenSsl` is deprecated 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
