### PR TITLE
Provide a way to add a context path to a subset of services

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/RouteDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/RouteDecoratingService.java
@@ -85,9 +85,9 @@ public final class RouteDecoratingService implements HttpService {
     private final Route route;
     private final HttpService decorator;
 
-    public RouteDecoratingService(Route route,
+    public RouteDecoratingService(Route route, String contextPath,
                                   Function<? super HttpService, ? extends HttpService> decoratorFunction) {
-        this.route = requireNonNull(route, "route");
+        this.route = requireNonNull(route, "route").withPrefix(contextPath);
         decorator = requireNonNull(decoratorFunction, "decoratorFunction").apply(this);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -72,7 +72,7 @@ abstract class AbstractBindingBuilder {
         this.contextPaths = contextPaths;
     }
 
-    protected Set<String> contextPaths() {
+    Set<String> contextPaths() {
         return contextPaths;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractBindingBuilder.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.server.annotation.MatchesParam;
  * An abstract builder class for binding something to a {@link Route} fluently.
  */
 abstract class AbstractBindingBuilder {
+    static final Set<String> EMPTY_CONTEXT_PATHS = ImmutableSet.of("/");
 
     private Set<HttpMethod> methods = ImmutableSet.of();
     private Set<MediaType> consumeTypes = ImmutableSet.of();
@@ -65,6 +66,15 @@ abstract class AbstractBindingBuilder {
     private final Set<RouteBuilder> pathBuilders = new LinkedHashSet<>();
     private final List<Route> additionalRoutes = new ArrayList<>();
     private final List<Route> excludedRoutes = new ArrayList<>();
+    private final Set<String> contextPaths;
+
+    AbstractBindingBuilder(Set<String> contextPaths) {
+        this.contextPaths = contextPaths;
+    }
+
+    protected Set<String> contextPaths() {
+        return contextPaths;
+    }
 
     /**
      * Sets the path pattern that an {@link HttpService} will be bound to.

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
@@ -212,6 +212,10 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
     abstract void serviceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder);
 
     final void build0(HttpService service) {
+        build0(service, "/");
+    }
+
+    final void build0(HttpService service, String contextPath) {
         final ServiceWithRoutes<?, ?> serviceWithRoutes = service.as(ServiceWithRoutes.class);
         final Set<Route> fallbackRoutes =
                 firstNonNull(serviceWithRoutes != null ? serviceWithRoutes.routes() : null,
@@ -221,7 +225,8 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
         final HttpService decoratedService = defaultServiceConfigSetters.decorator().apply(service);
         for (Route route : routes) {
             final ServiceConfigBuilder serviceConfigBuilder =
-                    defaultServiceConfigSetters.toServiceConfigBuilder(route, decoratedService);
+                    defaultServiceConfigSetters.toServiceConfigBuilder(
+                            route, contextPath, decoratedService);
             serviceConfigBuilder(serviceConfigBuilder);
         }
     }
@@ -231,7 +236,7 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
         assert routes.size() == 1; // Only one route is set via addRoute().
         final HttpService decoratedService = defaultServiceConfigSetters.decorator().apply(service);
         final ServiceConfigBuilder serviceConfigBuilder =
-                defaultServiceConfigSetters.toServiceConfigBuilder(routes.get(0), decoratedService);
+                defaultServiceConfigSetters.toServiceConfigBuilder(routes.get(0), "/", decoratedService);
         serviceConfigBuilder.addMappedRoute(mappedRoute);
         serviceConfigBuilder(serviceConfigBuilder);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
@@ -44,6 +44,10 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
 
     private final DefaultServiceConfigSetters defaultServiceConfigSetters = new DefaultServiceConfigSetters();
 
+    AbstractServiceBindingBuilder(Set<String> contextPaths) {
+        super(contextPaths);
+    }
+
     @Override
     public AbstractServiceBindingBuilder requestTimeout(Duration requestTimeout) {
         return requestTimeoutMillis(requireNonNull(requestTimeout, "requestTimeout").toMillis());
@@ -212,10 +216,6 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
     abstract void serviceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder);
 
     final void build0(HttpService service) {
-        build0(service, "/");
-    }
-
-    final void build0(HttpService service, String contextPath) {
         final ServiceWithRoutes<?, ?> serviceWithRoutes = service.as(ServiceWithRoutes.class);
         final Set<Route> fallbackRoutes =
                 firstNonNull(serviceWithRoutes != null ? serviceWithRoutes.routes() : null,
@@ -223,11 +223,13 @@ abstract class AbstractServiceBindingBuilder extends AbstractBindingBuilder impl
 
         final List<Route> routes = buildRouteList(fallbackRoutes);
         final HttpService decoratedService = defaultServiceConfigSetters.decorator().apply(service);
-        for (Route route : routes) {
-            final ServiceConfigBuilder serviceConfigBuilder =
-                    defaultServiceConfigSetters.toServiceConfigBuilder(
-                            route, contextPath, decoratedService);
-            serviceConfigBuilder(serviceConfigBuilder);
+        for (String contextPath: contextPaths()) {
+            for (Route route : routes) {
+                final ServiceConfigBuilder serviceConfigBuilder =
+                        defaultServiceConfigSetters.toServiceConfigBuilder(
+                                route, contextPath, decoratedService);
+                serviceConfigBuilder(serviceConfigBuilder);
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
@@ -48,10 +48,9 @@ public final class ContextPathAnnotatedServiceConfigSetters<T extends ServiceCon
     private final ContextPathServicesBuilder<T> builder;
     private final Set<String> contextPaths;
 
-    ContextPathAnnotatedServiceConfigSetters(ContextPathServicesBuilder<T> builder,
-                                             Set<String> contextPaths) {
+    ContextPathAnnotatedServiceConfigSetters(ContextPathServicesBuilder<T> builder) {
         this.builder = builder;
-        this.contextPaths = contextPaths;
+        this.contextPaths = builder.contextPaths();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
@@ -50,7 +50,7 @@ public final class ContextPathAnnotatedServiceConfigSetters<T extends ServiceCon
 
     ContextPathAnnotatedServiceConfigSetters(ContextPathServicesBuilder<T> builder) {
         this.builder = builder;
-        this.contextPaths = builder.contextPaths();
+        contextPaths = builder.contextPaths();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
@@ -21,11 +21,13 @@ import static java.util.Objects.requireNonNull;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -34,17 +36,22 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
- * An {@link AbstractAnnotatedServiceConfigSetters} builder which configures an {@link AnnotatedService}.
+ * An {@link AbstractAnnotatedServiceConfigSetters} builder which configures an {@link AnnotatedService}
+ * under a set of context paths.
  *
  * @param <T> the type of object to be returned once the builder is built
  */
-final class ContextPathAnnotatedServiceConfigSetters<T extends ServiceConfigsBuilder>
+@UnstableApi
+public final class ContextPathAnnotatedServiceConfigSetters<T extends ServiceConfigsBuilder>
         extends AbstractAnnotatedServiceConfigSetters {
 
     private final ContextPathServicesBuilder<T> builder;
+    private final Set<String> contextPaths;
 
-    ContextPathAnnotatedServiceConfigSetters(ContextPathServicesBuilder<T> builder) {
+    ContextPathAnnotatedServiceConfigSetters(ContextPathServicesBuilder<T> builder,
+                                             Set<String> contextPaths) {
         this.builder = builder;
+        this.contextPaths = contextPaths;
     }
 
     /**
@@ -55,9 +62,10 @@ final class ContextPathAnnotatedServiceConfigSetters<T extends ServiceConfigsBui
      *                If path prefix is not set then this service is registered to handle requests matching
      *                {@code /}
      */
-    ContextPathServicesBuilder<T> build(Object service) {
+    public ContextPathServicesBuilder<T> build(Object service) {
         requireNonNull(service, "service");
         service(service);
+        contextPaths(contextPaths);
         builder.addServiceConfigSetters(this);
         return builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
@@ -41,6 +41,8 @@ import com.linecorp.armeria.internal.server.RouteDecoratingService;
  *       .path("/decorated")
  *       .build(myDecorator) // decorator under /v1/api/decorated, /v2/api/decorated
  * }</pre>
+ *
+ * @param <T> the type this decorator will be added to.
  */
 @UnstableApi
 public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsBuilder>

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
@@ -50,10 +50,9 @@ public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsB
     private final ContextPathServicesBuilder<T> builder;
     private final Set<String> contextPaths;
 
-    ContextPathDecoratingBindingBuilder(ContextPathServicesBuilder<T> builder,
-                                        Set<String> contextPaths) {
+    ContextPathDecoratingBindingBuilder(ContextPathServicesBuilder<T> builder) {
         this.builder = builder;
-        this.contextPaths = contextPaths;
+        this.contextPaths = builder.contextPaths();
     }
 
     @SuppressWarnings("unchecked")
@@ -215,7 +214,7 @@ public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsB
     }
 
     /**
-     * Sets the {@code decorator} and returns the (ContextPathDecoratingBindingBuilder)
+     * Sets the {@code decorator} and returns the (ContextPathServicesBuilder)
      * that this {@link ContextPathDecoratingBindingBuilder} was created from.
      *
      * @param decorator the {@link Function} that decorates {@link HttpService}

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.server;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -48,11 +47,10 @@ public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsB
         extends AbstractBindingBuilder {
 
     private final ContextPathServicesBuilder<T> builder;
-    private final Set<String> contextPaths;
 
     ContextPathDecoratingBindingBuilder(ContextPathServicesBuilder<T> builder) {
+        super(builder.contextPaths());
         this.builder = builder;
-        this.contextPaths = builder.contextPaths();
     }
 
     @SuppressWarnings("unchecked")
@@ -223,7 +221,7 @@ public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsB
             Function<? super HttpService, ? extends HttpService> decorator) {
         requireNonNull(decorator, "decorator");
         buildRouteList().forEach(
-                route -> contextPaths.forEach(contextPath -> builder.addRouteDecoratingService(
+                route -> contextPaths().forEach(contextPath -> builder.addRouteDecoratingService(
                         new RouteDecoratingService(route, contextPath, decorator))));
         return builder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.internal.server.RouteDecoratingService;
+
+/**
+ * A builder class for binding a {@code decorator} with {@link Route} fluently
+ * under a set of context paths.
+ *
+ * <p>Call {@link #build(Function)} or {@link #build(DecoratingHttpServiceFunction)}
+ * to build the {@code decorator}.
+ *
+ * <pre>{@code
+ * Server.builder()
+ *       .contextPath("/v1", "/v2")
+ *       .routeDecorator()
+ *       .pathPrefix("/api")
+ *       .path("/decorated")
+ *       .build(myDecorator) // decorator under /v1/api/decorated, /v2/api/decorated
+ * }</pre>
+ */
+@UnstableApi
+public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsBuilder>
+        extends AbstractBindingBuilder {
+
+    private final ContextPathServicesBuilder<T> builder;
+    private final Set<String> contextPaths;
+
+    ContextPathDecoratingBindingBuilder(ContextPathServicesBuilder<T> builder,
+                                        Set<String> contextPaths) {
+        this.builder = builder;
+        this.contextPaths = contextPaths;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> path(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.path(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> pathPrefix(String prefix) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.pathPrefix(prefix);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> get(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.get(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> post(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.post(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> put(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.put(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> patch(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.patch(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> delete(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.delete(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> options(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.options(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> head(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.head(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> trace(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.trace(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> connect(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.connect(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> methods(HttpMethod... methods) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.methods(methods);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> methods(Iterable<HttpMethod> methods) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.methods(methods);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> consumes(MediaType... consumeTypes) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.consumes(consumeTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> consumes(Iterable<MediaType> consumeTypes) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.consumes(consumeTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> produces(MediaType... produceTypes) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.produces(produceTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> produces(Iterable<MediaType> produceTypes) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.produces(produceTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesParams(String... paramPredicates) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesParams(paramPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesParams(Iterable<String> paramPredicates) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesParams(paramPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesParams(
+            String paramName, Predicate<? super String> valuePredicate) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesParams(paramName, valuePredicate);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesHeaders(String... headerPredicates) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesHeaders(headerPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesHeaders(Iterable<String> headerPredicates) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesHeaders(headerPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> matchesHeaders(CharSequence headerName,
+                                                                 Predicate<? super String> valuePredicate) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.matchesHeaders(headerName, valuePredicate);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> addRoute(Route route) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.addRoute(route);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> exclude(String pathPattern) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.exclude(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> exclude(Route excludedRoute) {
+        return (ContextPathDecoratingBindingBuilder<T>) super.exclude(excludedRoute);
+    }
+
+    /**
+     * Sets the {@code decorator} and returns the (ContextPathDecoratingBindingBuilder)
+     * that this {@link ContextPathDecoratingBindingBuilder} was created from.
+     *
+     * @param decorator the {@link Function} that decorates {@link HttpService}
+     */
+    public ContextPathServicesBuilder<T> build(
+            Function<? super HttpService, ? extends HttpService> decorator) {
+        requireNonNull(decorator, "decorator");
+        buildRouteList().forEach(
+                route -> contextPaths.forEach(contextPath -> builder.addRouteDecoratingService(
+                        new RouteDecoratingService(route, contextPath, decorator))));
+        return builder;
+    }
+
+    /**
+     * Sets the {@link DecoratingHttpServiceFunction} and returns the {@link ContextPathServicesBuilder}
+     * that this {@link ContextPathDecoratingBindingBuilder} was created from.
+     *
+     * @param decoratingHttpServiceFunction the {@link DecoratingHttpServiceFunction} that decorates
+     *                                      {@link HttpService}
+     */
+    public ContextPathServicesBuilder<T> build(
+            DecoratingHttpServiceFunction decoratingHttpServiceFunction) {
+        requireNonNull(decoratingHttpServiceFunction, "decoratingHttpServiceFunction");
+        return build(delegate -> new FunctionalDecoratingHttpService(delegate, decoratingHttpServiceFunction));
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathDecoratingBindingBuilder.java
@@ -212,7 +212,7 @@ public final class ContextPathDecoratingBindingBuilder<T extends ServiceConfigsB
     }
 
     /**
-     * Sets the {@code decorator} and returns the (ContextPathServicesBuilder)
+     * Sets the {@code decorator} and returns the {@link ContextPathServicesBuilder}
      * that this {@link ContextPathDecoratingBindingBuilder} was created from.
      *
      * @param decorator the {@link Function} that decorates {@link HttpService}

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server;
 
+import static java.util.Objects.requireNonNull;
+
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map.Entry;
@@ -62,7 +64,7 @@ public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuil
 
     ContextPathServiceBindingBuilder(ContextPathServicesBuilder<T> builder) {
         super(builder.contextPaths());
-        this.contextPathServicesBuilder = builder;
+        contextPathServicesBuilder = builder;
     }
 
     @SuppressWarnings("unchecked")
@@ -401,6 +403,7 @@ public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuil
      * {@link ContextPathServiceBindingBuilder} was created from.
      */
     public ContextPathServicesBuilder<T> build(HttpService service) {
+        requireNonNull(service, "service");
         build0(service);
         return contextPathServicesBuilder;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import com.linecorp.armeria.server.logging.AccessLogWriter;
+
+/**
+ * A builder class for binding an {@link HttpService} fluently. This class can be instantiated through
+ * {@link ServerBuilder#contextPath(String...)} or {@link VirtualHostBuilder#contextPath(String...)}.
+ *
+ * <p>Call {@link #build(HttpService)} to build the {@link HttpService} and return to the {@link ServerBuilder}
+ * or {@link VirtualHostBuilder}.
+ *
+ * <pre>{@code
+ * Server.builder()
+ *       .contextPath("/v1", "/v2")
+ *       .route()
+ *       .get("/service1")
+ *       .build(service1) // served under "/v1/service1" and "/v2/service1"
+ *       .and()
+ *       .virtualHost("foo.com")
+ *       .contextPath("/v3")
+ *       .route()
+ *       .get("/service2")
+ *       .build(service2); // served under "/v3/service2"
+ * }</pre>
+ *
+ * @see VirtualHostServiceBindingBuilder
+ */
+@UnstableApi
+public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuilder>
+        extends AbstractServiceBindingBuilder {
+
+    private final ContextPathServicesBuilder<T> contextPathServicesBuilder;
+    private final Set<String> contextPaths;
+
+    ContextPathServiceBindingBuilder(ContextPathServicesBuilder<T> contextPathServicesBuilder,
+                                     Set<String> contextPaths) {
+        this.contextPathServicesBuilder = contextPathServicesBuilder;
+        this.contextPaths = contextPaths;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> requestTimeout(Duration requestTimeout) {
+        return (ContextPathServiceBindingBuilder<T>) super.requestTimeout(requestTimeout);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> requestTimeoutMillis(long requestTimeoutMillis) {
+        return (ContextPathServiceBindingBuilder<T>) super.requestTimeoutMillis(requestTimeoutMillis);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> maxRequestLength(long maxRequestLength) {
+        return (ContextPathServiceBindingBuilder<T>) super.maxRequestLength(maxRequestLength);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> verboseResponses(boolean verboseResponses) {
+        return (ContextPathServiceBindingBuilder<T>) super.verboseResponses(verboseResponses);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> accessLogFormat(String accessLogFormat) {
+        return (ContextPathServiceBindingBuilder<T>) super.accessLogFormat(accessLogFormat);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> accessLogWriter(AccessLogWriter accessLogWriter,
+                                                               boolean shutdownOnStop) {
+        return (ContextPathServiceBindingBuilder<T>) super.accessLogWriter(accessLogWriter, shutdownOnStop);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> decorator(
+            DecoratingHttpServiceFunction decoratingHttpServiceFunction) {
+        return (ContextPathServiceBindingBuilder<T>) super.decorator(decoratingHttpServiceFunction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> decorator(
+            Function<? super HttpService, ? extends HttpService> decorator) {
+        return (ContextPathServiceBindingBuilder<T>) super.decorator(decorator);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> decorators(
+            Function<? super HttpService, ? extends HttpService>... decorators) {
+        return (ContextPathServiceBindingBuilder<T>) super.decorators(decorators);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> decorators(
+            Iterable<? extends Function<? super HttpService, ? extends HttpService>> decorators) {
+        return (ContextPathServiceBindingBuilder<T>) super.decorators(decorators);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> defaultServiceName(String defaultServiceName) {
+        return (ContextPathServiceBindingBuilder<T>) super.defaultServiceName(defaultServiceName);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> defaultServiceNaming(ServiceNaming defaultServiceNaming) {
+        return (ContextPathServiceBindingBuilder<T>) super.defaultServiceNaming(defaultServiceNaming);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> defaultLogName(String defaultLogName) {
+        return (ContextPathServiceBindingBuilder<T>) super.defaultLogName(defaultLogName);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> blockingTaskExecutor(
+            ScheduledExecutorService blockingTaskExecutor, boolean shutdownOnStop) {
+        return (ContextPathServiceBindingBuilder<T>) super.blockingTaskExecutor(blockingTaskExecutor,
+                                                                                shutdownOnStop);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> blockingTaskExecutor(BlockingTaskExecutor blockingTaskExecutor,
+                                                                    boolean shutdownOnStop) {
+        return (ContextPathServiceBindingBuilder<T>) super.blockingTaskExecutor(blockingTaskExecutor,
+                                                                                shutdownOnStop);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> blockingTaskExecutor(int numThreads) {
+        return (ContextPathServiceBindingBuilder<T>) super.blockingTaskExecutor(numThreads);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> successFunction(SuccessFunction successFunction) {
+        return (ContextPathServiceBindingBuilder<T>) super.successFunction(successFunction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> requestAutoAbortDelay(Duration delay) {
+        return (ContextPathServiceBindingBuilder<T>) super.requestAutoAbortDelay(delay);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> requestAutoAbortDelayMillis(long delayMillis) {
+        return (ContextPathServiceBindingBuilder<T>) super.requestAutoAbortDelayMillis(delayMillis);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> multipartUploadsLocation(Path multipartUploadsLocation) {
+        return (ContextPathServiceBindingBuilder<T>) super.multipartUploadsLocation(multipartUploadsLocation);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> requestIdGenerator(
+            Function<? super RoutingContext, ? extends RequestId> requestIdGenerator) {
+        return (ContextPathServiceBindingBuilder<T>) super.requestIdGenerator(requestIdGenerator);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> addHeader(CharSequence name, Object value) {
+        return (ContextPathServiceBindingBuilder<T>) super.addHeader(name, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> addHeaders(
+            Iterable<? extends Entry<? extends CharSequence, ?>> defaultHeaders) {
+        return (ContextPathServiceBindingBuilder<T>) super.addHeaders(defaultHeaders);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> setHeader(CharSequence name, Object value) {
+        return (ContextPathServiceBindingBuilder<T>) super.setHeader(name, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> setHeaders(
+            Iterable<? extends Entry<? extends CharSequence, ?>> defaultHeaders) {
+        return (ContextPathServiceBindingBuilder<T>) super.setHeaders(defaultHeaders);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> errorHandler(ServiceErrorHandler serviceErrorHandler) {
+        return (ContextPathServiceBindingBuilder<T>) super.errorHandler(serviceErrorHandler);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> path(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.path(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> pathPrefix(String prefix) {
+        return (ContextPathServiceBindingBuilder<T>) super.pathPrefix(prefix);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> get(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.get(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> post(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.post(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> put(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.put(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> patch(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.patch(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> delete(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.delete(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> options(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.options(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> head(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.head(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> trace(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.trace(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> connect(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.connect(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> methods(HttpMethod... methods) {
+        return (ContextPathServiceBindingBuilder<T>) super.methods(methods);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> methods(Iterable<HttpMethod> methods) {
+        return (ContextPathServiceBindingBuilder<T>) super.methods(methods);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> consumes(MediaType... consumeTypes) {
+        return (ContextPathServiceBindingBuilder<T>) super.consumes(consumeTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> consumes(Iterable<MediaType> consumeTypes) {
+        return (ContextPathServiceBindingBuilder<T>) super.consumes(consumeTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> produces(MediaType... produceTypes) {
+        return (ContextPathServiceBindingBuilder<T>) super.produces(produceTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> produces(Iterable<MediaType> produceTypes) {
+        return (ContextPathServiceBindingBuilder<T>) super.produces(produceTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesParams(String... paramPredicates) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesParams(paramPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesParams(Iterable<String> paramPredicates) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesParams(paramPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesParams(String paramName,
+                                                             Predicate<? super String> valuePredicate) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesParams(paramName, valuePredicate);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesHeaders(String... headerPredicates) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesHeaders(headerPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesHeaders(Iterable<String> headerPredicates) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesHeaders(headerPredicates);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> matchesHeaders(CharSequence headerName,
+                                                              Predicate<? super String> valuePredicate) {
+        return (ContextPathServiceBindingBuilder<T>) super.matchesHeaders(headerName, valuePredicate);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> addRoute(Route route) {
+        return (ContextPathServiceBindingBuilder<T>) super.addRoute(route);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> exclude(String pathPattern) {
+        return (ContextPathServiceBindingBuilder<T>) super.exclude(pathPattern);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public ContextPathServiceBindingBuilder<T> exclude(Route excludedRoute) {
+        return (ContextPathServiceBindingBuilder<T>) super.exclude(excludedRoute);
+    }
+
+    @Override
+    void serviceConfigBuilder(ServiceConfigBuilder serviceConfigBuilder) {
+        contextPathServicesBuilder.addServiceConfigSetters(serviceConfigBuilder);
+    }
+
+    /**
+     * Sets the {@link HttpService} and returns the object that this
+     * {@link ContextPathServiceBindingBuilder} was created from.
+     */
+    public ContextPathServicesBuilder<T> build(HttpService service) {
+        for (String contextPath: contextPaths) {
+            build0(service, contextPath);
+        }
+        return contextPathServicesBuilder;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -62,10 +62,9 @@ public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuil
     private final ContextPathServicesBuilder<T> contextPathServicesBuilder;
     private final Set<String> contextPaths;
 
-    ContextPathServiceBindingBuilder(ContextPathServicesBuilder<T> contextPathServicesBuilder,
-                                     Set<String> contextPaths) {
-        this.contextPathServicesBuilder = contextPathServicesBuilder;
-        this.contextPaths = contextPaths;
+    ContextPathServiceBindingBuilder(ContextPathServicesBuilder<T> builder) {
+        this.contextPathServicesBuilder = builder;
+        this.contextPaths = builder.contextPaths();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -54,8 +54,8 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
  *       .build(service2); // served under "/v3/service2"
  * }</pre>
  *
- * @see VirtualHostServiceBindingBuilder
  * @param <T> the type this service will be added to.
+ * @see VirtualHostServiceBindingBuilder
  */
 @UnstableApi
 public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuilder>

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
  * }</pre>
  *
  * @see VirtualHostServiceBindingBuilder
+ * @param <T> the type this service will be added to.
  */
 @UnstableApi
 public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuilder>

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServiceBindingBuilder.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -60,11 +59,10 @@ public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuil
         extends AbstractServiceBindingBuilder {
 
     private final ContextPathServicesBuilder<T> contextPathServicesBuilder;
-    private final Set<String> contextPaths;
 
     ContextPathServiceBindingBuilder(ContextPathServicesBuilder<T> builder) {
+        super(builder.contextPaths());
         this.contextPathServicesBuilder = builder;
-        this.contextPaths = builder.contextPaths();
     }
 
     @SuppressWarnings("unchecked")
@@ -403,9 +401,7 @@ public final class ContextPathServiceBindingBuilder<T extends ServiceConfigsBuil
      * {@link ContextPathServiceBindingBuilder} was created from.
      */
     public ContextPathServicesBuilder<T> build(HttpService service) {
-        for (String contextPath: contextPaths) {
-            build0(service, contextPath);
-        }
+        build0(service);
         return contextPathServicesBuilder;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
@@ -77,6 +77,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     public ContextPathServicesBuilder<T> withRoute(
             Consumer<? super ContextPathServiceBindingBuilder<T>> customizer) {
+        requireNonNull(customizer, "customizer");
         customizer.accept(new ContextPathServiceBindingBuilder<>(this));
         return this;
     }
@@ -480,10 +481,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
         return parent;
     }
 
-    /**
-     * Returns the context paths that will prefix all services and decorators.
-     */
-    public Set<String> contextPaths() {
+    Set<String> contextPaths() {
         return contextPaths;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
@@ -16,45 +16,86 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.server.ServerBuilder.decorate;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.internal.server.RouteDecoratingService;
+import com.linecorp.armeria.internal.server.RouteUtil;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceExtensions;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 
 /**
- * Builds {@link ServiceConfig}s for a {@link VirtualHostBuilder}. All {@link ServiceConfig}s
- * built by this builder will be served under a context path.
+ * Builds {@link ServiceConfig}s for a {@link ServerBuilder} or {@link VirtualHostBuilder}.
+ * All {@link ServiceConfig}s built by this builder will be served under the specified context paths.
+ *
+ * <pre>{@code
+ * Server.builder()
+ *       .contextPath("/v1", "/v2")
+ *       .service(myService) // served under "/v1" and "/v2"
+ *       .and()
+ *       .virtualHost("foo.com")
+ *       .contextPath("/v3")
+ *       .service(myService) // served by virtual host "foo.com" under "/v3"
+ * }</pre>
  *
  * @param <T> the original type which will be returned once the {@link ServiceConfig}
  *            is built using {@link #and()}.
  */
-final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
+@UnstableApi
+public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
         implements ServiceConfigsBuilder {
 
+    private final Set<String> contextPaths;
     private final T parent;
     private final VirtualHostBuilder virtualHostBuilder;
 
-    ContextPathServicesBuilder(T parent, VirtualHostBuilder virtualHostBuilder) {
+    ContextPathServicesBuilder(T parent, VirtualHostBuilder virtualHostBuilder,
+                               String... contextPaths) {
+        checkArgument(contextPaths.length > 0, "At least one context path is required");
+        for (String contextPath: contextPaths) {
+            RouteUtil.ensureAbsolutePath(contextPath, "contextPath");
+        }
+
         this.parent = parent;
+        this.contextPaths = ImmutableSet.copyOf(contextPaths);
         this.virtualHostBuilder = virtualHostBuilder;
     }
 
-    @Override
-    public AbstractServiceBindingBuilder route() {
-        throw new UnsupportedOperationException("Not supported yet");
+    /**
+     * Configures an {@link HttpService} under the context path with the {@code customizer}.
+     */
+    public ContextPathServicesBuilder<T> withRoute(
+            Consumer<? super ContextPathServiceBindingBuilder<T>> customizer) {
+        customizer.accept(new ContextPathServiceBindingBuilder<>(this, contextPaths));
+        return this;
     }
 
+    /**
+     * Returns a {@link ContextPathServiceBindingBuilder} which is for binding an {@link HttpService} fluently.
+     */
     @Override
-    public AbstractBindingBuilder routeDecorator() {
-        throw new UnsupportedOperationException("Not supported yet");
+    public ContextPathServiceBindingBuilder<T> route() {
+        return new ContextPathServiceBindingBuilder<>(this, contextPaths);
+    }
+
+    /**
+     * Returns a {@link ContextPathDecoratingBindingBuilder} which is for binding a {@code decorator} fluently.
+     * The specified decorator(s) is/are executed in reverse order of the insertion.
+     */
+    @Override
+    public ContextPathDecoratingBindingBuilder<T> routeDecorator() {
+        return new ContextPathDecoratingBindingBuilder<>(this, contextPaths);
     }
 
     /**
@@ -88,10 +129,12 @@ final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
         final HttpServiceWithRoutes serviceWithRoutes = service.as(HttpServiceWithRoutes.class);
         if (serviceWithRoutes != null) {
             serviceWithRoutes.routes().forEach(route -> {
-                final ServiceConfigBuilder serviceConfigBuilder =
-                        new ServiceConfigBuilder(route.withPrefix(pathPrefix), service);
-                serviceConfigBuilder.addMappedRoute(route);
-                addServiceConfigSetters(serviceConfigBuilder);
+                for (String contextPath: contextPaths) {
+                    final ServiceConfigBuilder serviceConfigBuilder =
+                            new ServiceConfigBuilder(route.withPrefix(pathPrefix), contextPath, service);
+                    serviceConfigBuilder.addMappedRoute(route);
+                    addServiceConfigSetters(serviceConfigBuilder);
+                }
             });
         } else {
             service(Route.builder().pathPrefix(pathPrefix).build(), service);
@@ -124,7 +167,10 @@ final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     @Override
     public ContextPathServicesBuilder<T> service(Route route, HttpService service) {
-        return addServiceConfigSetters(new ServiceConfigBuilder(route, service));
+        for (String contextPath: contextPaths) {
+            addServiceConfigSetters(new ServiceConfigBuilder(route, contextPath, service));
+        }
+        return this;
     }
 
     /**
@@ -306,12 +352,12 @@ final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
     }
 
     /**
-     * Returns a new instance of {@link VirtualHostAnnotatedServiceBindingBuilder} to build
+     * Returns a new instance of {@link ContextPathAnnotatedServiceConfigSetters} to build
      * an annotated service fluently.
      */
     @Override
     public ContextPathAnnotatedServiceConfigSetters<T> annotatedService() {
-        return new ContextPathAnnotatedServiceConfigSetters<>(this);
+        return new ContextPathAnnotatedServiceConfigSetters<>(this, contextPaths);
     }
 
     /**
@@ -371,7 +417,10 @@ final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
             Route route, Function<? super HttpService, ? extends HttpService> decorator) {
         requireNonNull(route, "route");
         requireNonNull(decorator, "decorator");
-        return addRouteDecoratingService(new RouteDecoratingService(route, decorator));
+        for (String contextPath: contextPaths) {
+            addRouteDecoratingService(new RouteDecoratingService(route, contextPath, decorator));
+        }
+        return this;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
@@ -77,7 +77,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     public ContextPathServicesBuilder<T> withRoute(
             Consumer<? super ContextPathServiceBindingBuilder<T>> customizer) {
-        customizer.accept(new ContextPathServiceBindingBuilder<>(this, contextPaths));
+        customizer.accept(new ContextPathServiceBindingBuilder<>(this));
         return this;
     }
 
@@ -86,7 +86,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     @Override
     public ContextPathServiceBindingBuilder<T> route() {
-        return new ContextPathServiceBindingBuilder<>(this, contextPaths);
+        return new ContextPathServiceBindingBuilder<>(this);
     }
 
     /**
@@ -95,7 +95,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     @Override
     public ContextPathDecoratingBindingBuilder<T> routeDecorator() {
-        return new ContextPathDecoratingBindingBuilder<>(this, contextPaths);
+        return new ContextPathDecoratingBindingBuilder<>(this);
     }
 
     /**
@@ -357,7 +357,7 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     @Override
     public ContextPathAnnotatedServiceConfigSetters<T> annotatedService() {
-        return new ContextPathAnnotatedServiceConfigSetters<>(this, contextPaths);
+        return new ContextPathAnnotatedServiceConfigSetters<>(this);
     }
 
     /**
@@ -478,5 +478,12 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
      */
     public T and() {
         return parent;
+    }
+
+    /**
+     * Returns the context paths that will prefix all services and decorators.
+     */
+    public Set<String> contextPaths() {
+        return contextPaths;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
@@ -61,8 +61,8 @@ public final class ContextPathServicesBuilder<T extends ServiceConfigsBuilder>
     private final VirtualHostBuilder virtualHostBuilder;
 
     ContextPathServicesBuilder(T parent, VirtualHostBuilder virtualHostBuilder,
-                               String... contextPaths) {
-        checkArgument(contextPaths.length > 0, "At least one context path is required");
+                               Set<String> contextPaths) {
+        checkArgument(!contextPaths.isEmpty(), "At least one context path is required");
         for (String contextPath: contextPaths) {
             RouteUtil.ensureAbsolutePath(contextPath, "contextPath");
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
@@ -196,7 +196,7 @@ public final class DecoratingServiceBindingBuilder extends AbstractBindingBuilde
     public ServerBuilder build(Function<? super HttpService, ? extends HttpService> decorator) {
         requireNonNull(decorator, "decorator");
         buildRouteList().forEach(
-                route -> serverBuilder.routingDecorator(new RouteDecoratingService(route, decorator)));
+                route -> serverBuilder.routingDecorator(new RouteDecoratingService(route, "/", decorator)));
         return serverBuilder;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingServiceBindingBuilder.java
@@ -52,6 +52,7 @@ public final class DecoratingServiceBindingBuilder extends AbstractBindingBuilde
     private final ServerBuilder serverBuilder;
 
     DecoratingServiceBindingBuilder(ServerBuilder serverBuilder) {
+        super(EMPTY_CONTEXT_PATHS);
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -43,8 +43,8 @@ import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 /**
  * A default implementation of {@link ServiceConfigSetters} that stores service related settings
- * and provides a method {@link DefaultServiceConfigSetters#toServiceConfigBuilder(Route, HttpService)} to build
- * {@link ServiceConfigBuilder}.
+ * and provides a method {@link DefaultServiceConfigSetters#toServiceConfigBuilder(Route, String, HttpService)}
+ * to build {@link ServiceConfigBuilder}.
  */
 final class DefaultServiceConfigSetters implements ServiceConfigSetters {
 
@@ -284,8 +284,9 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
      * {@link AnnotatedServiceBindingBuilder} needs exception handling decorators to be the last to handle
      * any exceptions thrown by the service and other decorators.
      */
-    ServiceConfigBuilder toServiceConfigBuilder(Route route, HttpService service) {
-        final ServiceConfigBuilder serviceConfigBuilder = new ServiceConfigBuilder(route, service);
+    ServiceConfigBuilder toServiceConfigBuilder(Route route, String contextPath, HttpService service) {
+        final ServiceConfigBuilder serviceConfigBuilder =
+                new ServiceConfigBuilder(route, contextPath, service);
 
         final AnnotatedService annotatedService;
         if (defaultServiceNaming == null || defaultLogName == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -63,6 +63,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 
@@ -1136,9 +1137,23 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     }
 
     /**
+     * Returns a {@link ContextPathServicesBuilder} which binds {@link HttpService}s under the
+     * specified context paths.
+     *
+     * @see ContextPathServicesBuilder
+     */
+    @UnstableApi
+    public ContextPathServicesBuilder<ServerBuilder> contextPath(Iterable<String> contextPaths) {
+        return new ContextPathServicesBuilder<>(
+                this, defaultVirtualHostBuilder,
+                Iterables.toArray(ImmutableList.copyOf(contextPaths), String.class));
+    }
+
+    /**
      * Configures an {@link HttpService} of the default {@link VirtualHost} with the {@code customizer}.
      */
     public ServerBuilder withRoute(Consumer<? super ServiceBindingBuilder> customizer) {
+        requireNonNull(customizer, "customizer");
         final ServiceBindingBuilder serviceBindingBuilder = new ServiceBindingBuilder(this);
         customizer.accept(serviceBindingBuilder);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 
@@ -1133,7 +1133,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
      */
     @UnstableApi
     public ContextPathServicesBuilder<ServerBuilder> contextPath(String... contextPaths) {
-        return new ContextPathServicesBuilder<>(this, defaultVirtualHostBuilder, contextPaths);
+        return contextPath(ImmutableSet.copyOf(requireNonNull(contextPaths, "contextPaths")));
     }
 
     /**
@@ -1144,9 +1144,9 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
      */
     @UnstableApi
     public ContextPathServicesBuilder<ServerBuilder> contextPath(Iterable<String> contextPaths) {
+        requireNonNull(contextPaths, "contextPaths");
         return new ContextPathServicesBuilder<>(
-                this, defaultVirtualHostBuilder,
-                Iterables.toArray(ImmutableList.copyOf(contextPaths), String.class));
+                this, defaultVirtualHostBuilder, ImmutableSet.copyOf(contextPaths));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1125,6 +1125,17 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     }
 
     /**
+     * Returns a {@link ContextPathServicesBuilder} which binds {@link HttpService}s under the
+     * specified context paths.
+     *
+     * @see ContextPathServicesBuilder
+     */
+    @UnstableApi
+    public ContextPathServicesBuilder<ServerBuilder> contextPath(String... contextPaths) {
+        return new ContextPathServicesBuilder<>(this, defaultVirtualHostBuilder, contextPaths);
+    }
+
+    /**
      * Configures an {@link HttpService} of the default {@link VirtualHost} with the {@code customizer}.
      */
     public ServerBuilder withRoute(Consumer<? super ServiceBindingBuilder> customizer) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
@@ -354,6 +354,7 @@ public final class ServiceBindingBuilder extends AbstractServiceBindingBuilder {
      * @throws IllegalStateException if the path that the {@link HttpService} will be bound to is not specified
      */
     public ServerBuilder build(HttpService service) {
+        requireNonNull(service, "service");
         if (mappedRoute != null) {
             // mappedRoute is only set when the service is an HttpServiceWithRoutes
             assert service.as(HttpServiceWithRoutes.class) != null;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceBindingBuilder.java
@@ -68,6 +68,7 @@ public final class ServiceBindingBuilder extends AbstractServiceBindingBuilder {
     private Route mappedRoute;
 
     ServiceBindingBuilder(ServerBuilder serverBuilder) {
+        super(EMPTY_CONTEXT_PATHS);
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -79,8 +79,8 @@ final class ServiceConfigBuilder implements ServiceConfigSetters {
     @Nullable
     private Function<? super RoutingContext, ? extends RequestId> requestIdGenerator;
 
-    ServiceConfigBuilder(Route route, HttpService service) {
-        this.route = requireNonNull(route, "route");
+    ServiceConfigBuilder(Route route, String contextPath, HttpService service) {
+        this.route = requireNonNull(route, "route").withPrefix(contextPath);
         this.service = requireNonNull(service, "service");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -162,7 +162,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     @Nullable
     private ServiceErrorHandler errorHandler;
     private final ContextPathServicesBuilder<VirtualHostBuilder> servicesBuilder =
-            new ContextPathServicesBuilder<>(this, this);
+            new ContextPathServicesBuilder<>(this, this, "/");
 
     /**
      * Creates a new {@link VirtualHostBuilder}.
@@ -397,6 +397,17 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     public VirtualHostBuilder tlsAllowUnsafeCiphers(boolean tlsAllowUnsafeCiphers) {
         this.tlsAllowUnsafeCiphers = tlsAllowUnsafeCiphers;
         return this;
+    }
+
+    /**
+     * Returns a {@link ContextPathServicesBuilder} which binds {@link HttpService}s under the
+     * specified context paths.
+     *
+     * @see ContextPathServicesBuilder
+     */
+    @UnstableApi
+    public ContextPathServicesBuilder<VirtualHostBuilder> contextPath(String... contextPaths) {
+        return new ContextPathServicesBuilder<>(this, this, contextPaths);
     }
 
     /**
@@ -1291,7 +1302,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                 }).collect(toImmutableList());
 
         final ServiceConfig fallbackServiceConfig =
-                new ServiceConfigBuilder(RouteBuilder.FALLBACK_ROUTE, FallbackService.INSTANCE)
+                new ServiceConfigBuilder(RouteBuilder.FALLBACK_ROUTE, "/", FallbackService.INSTANCE)
                         .build(defaultServiceNaming, requestTimeoutMillis, maxRequestLength, verboseResponses,
                                accessLogWriter, blockingTaskExecutor, successFunction,
                                requestAutoAbortDelayMillis, multipartUploadsLocation,

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.HostAndPort;
 
@@ -163,7 +163,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     @Nullable
     private ServiceErrorHandler errorHandler;
     private final ContextPathServicesBuilder<VirtualHostBuilder> servicesBuilder =
-            new ContextPathServicesBuilder<>(this, this, "/");
+            new ContextPathServicesBuilder<>(this, this, ImmutableSet.of("/"));
 
     /**
      * Creates a new {@link VirtualHostBuilder}.
@@ -408,7 +408,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
      */
     @UnstableApi
     public ContextPathServicesBuilder<VirtualHostBuilder> contextPath(String... contextPaths) {
-        return new ContextPathServicesBuilder<>(this, this, contextPaths);
+        return contextPath(ImmutableSet.copyOf(requireNonNull(contextPaths, "contextPaths")));
     }
 
     /**
@@ -419,8 +419,8 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
      */
     @UnstableApi
     public ContextPathServicesBuilder<VirtualHostBuilder> contextPath(Iterable<String> contextPaths) {
-        return new ContextPathServicesBuilder<>(
-                this, this, Iterables.toArray(ImmutableList.copyOf(contextPaths), String.class));
+        requireNonNull(contextPaths, "contextPaths");
+        return new ContextPathServicesBuilder<>(this, this, ImmutableSet.copyOf(contextPaths));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.HostAndPort;
 
@@ -411,9 +412,22 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     }
 
     /**
+     * Returns a {@link ContextPathServicesBuilder} which binds {@link HttpService}s under the
+     * specified context paths.
+     *
+     * @see ContextPathServicesBuilder
+     */
+    @UnstableApi
+    public ContextPathServicesBuilder<VirtualHostBuilder> contextPath(Iterable<String> contextPaths) {
+        return new ContextPathServicesBuilder<>(
+                this, this, Iterables.toArray(ImmutableList.copyOf(contextPaths), String.class));
+    }
+
+    /**
      * Configures an {@link HttpService} of the {@link VirtualHost} with the {@code customizer}.
      */
     public VirtualHostBuilder withRoute(Consumer<? super VirtualHostServiceBindingBuilder> customizer) {
+        requireNonNull(customizer, "customizer");
         final VirtualHostServiceBindingBuilder builder = new VirtualHostServiceBindingBuilder(this);
         customizer.accept(builder);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
@@ -197,7 +197,7 @@ public final class VirtualHostDecoratingServiceBindingBuilder extends AbstractBi
     public VirtualHostBuilder build(Function<? super HttpService, ? extends HttpService> decorator) {
         requireNonNull(decorator, "decorator");
         buildRouteList().forEach(route -> virtualHostBuilder.addRouteDecoratingService(
-                new RouteDecoratingService(route, decorator)));
+                new RouteDecoratingService(route, "/", decorator)));
         return virtualHostBuilder;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostDecoratingServiceBindingBuilder.java
@@ -53,6 +53,7 @@ public final class VirtualHostDecoratingServiceBindingBuilder extends AbstractBi
     private final VirtualHostBuilder virtualHostBuilder;
 
     VirtualHostDecoratingServiceBindingBuilder(VirtualHostBuilder virtualHostBuilder) {
+        super(EMPTY_CONTEXT_PATHS);
         this.virtualHostBuilder = requireNonNull(virtualHostBuilder, "virtualHostBuilder");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -66,6 +66,7 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
     private final VirtualHostBuilder virtualHostBuilder;
 
     VirtualHostServiceBindingBuilder(VirtualHostBuilder virtualHostBuilder) {
+        super(EMPTY_CONTEXT_PATHS);
         this.virtualHostBuilder = requireNonNull(virtualHostBuilder, "virtualHostBuilder");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostServiceBindingBuilder.java
@@ -354,6 +354,7 @@ public final class VirtualHostServiceBindingBuilder extends AbstractServiceBindi
      * @throws IllegalStateException if the path that the {@link HttpService} will be bound to is not specified
      */
     public VirtualHostBuilder build(HttpService service) {
+        requireNonNull(service, "service");
         build0(service);
         return virtualHostBuilder;
     }

--- a/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
@@ -19,9 +19,16 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reflections.ReflectionUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -115,5 +122,30 @@ class AbstractBindingBuilderTest {
         assertThatThrownBy(() -> new AbstractBindingBuilder() {}.methods(ImmutableList.of()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("methods can't be empty.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            ContextPathDecoratingBindingBuilder.class,
+            ContextPathServiceBindingBuilder.class,
+            DecoratingServiceBindingBuilder.class,
+            ServiceBindingBuilder.class,
+            VirtualHostDecoratingServiceBindingBuilder.class,
+            VirtualHostServiceBindingBuilder.class,
+    })
+    void apiConsistency(Class<?> clazz) {
+        final Set<Method> overriddenMethods =
+                ReflectionUtils.getMethods(clazz,
+                                           method -> Modifier.isPublic(method.getModifiers()) &&
+                                                     method.getReturnType().equals(clazz));
+        final Set<Method> superMethods =
+                ReflectionUtils.getMethods(AbstractBindingBuilder.class,
+                                           method -> Modifier.isPublic(method.getModifiers()));
+        for (final Method method : superMethods) {
+            assertThat(overriddenMethods).filteredOn(tMethod -> {
+                return method.getName().equals(tMethod.getName()) &&
+                       Arrays.equals(method.getParameterTypes(), tMethod.getParameterTypes());
+            }).hasSize(1);
+        }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbstractBindingBuilderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.reflections.ReflectionUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -39,7 +40,7 @@ class AbstractBindingBuilderTest {
 
     @Test
     void multiRouteBuilder() {
-        final List<Route> routes = new AbstractBindingBuilder() {}
+        final List<Route> routes = new AbstractBindingBuilder(ImmutableSet.of("/")) {}
                 .path("/foo")
                 .pathPrefix("/bar")
                 .get("/baz")
@@ -80,15 +81,15 @@ class AbstractBindingBuilderTest {
 
     @Test
     void shouldSetPath() {
-        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.buildRouteList())
+        assertThatThrownBy(() -> new AbstractBindingBuilder(ImmutableSet.of("/")) {}.buildRouteList())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Should set at least");
     }
 
     @Test
     void shouldHaveKnownMethods() {
-        final List<Route> routes = new AbstractBindingBuilder() {}.path("/foo")
-                                                                  .buildRouteList();
+        final List<Route> routes = new AbstractBindingBuilder(ImmutableSet.of("/")) {}.path("/foo")
+                                                                                      .buildRouteList();
         assertThat(routes.size()).isEqualTo(1);
         assertThat(routes.get(0).methods()).isEqualTo(HttpMethod.knownMethods());
     }
@@ -96,30 +97,31 @@ class AbstractBindingBuilderTest {
     @Test
     void shouldFailOnMethodWithoutPath() {
         // empty route path
-        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.methods(HttpMethod.GET)
-                                                                .buildRouteList())
+        assertThatThrownBy(() -> new AbstractBindingBuilder(ImmutableSet.of("/")) {}.methods(HttpMethod.GET)
+                                                                                    .buildRouteList())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Should set at least");
 
         // only method without calling path
-        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.get("/foo")
-                                                                .methods(HttpMethod.POST)
-                                                                .buildRouteList())
+        assertThatThrownBy(() -> new AbstractBindingBuilder(ImmutableSet.of("/")) {}.get("/foo")
+                                                                                    .methods(HttpMethod.POST)
+                                                                                    .buildRouteList())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Should set a path");
     }
 
     @Test
     void shouldFailOnDuplicatedMethod() {
-        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.get("/foo")
-                                                                .get("/foo"))
+        assertThatThrownBy(() -> new AbstractBindingBuilder(ImmutableSet.of("/")) {}.get("/foo")
+                                                                                    .get("/foo"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("duplicate HTTP method");
     }
 
     @Test
     void nonEmptyMethod() {
-        assertThatThrownBy(() -> new AbstractBindingBuilder() {}.methods(ImmutableList.of()))
+        assertThatThrownBy(
+                () -> new AbstractBindingBuilder(ImmutableSet.of("/")) {}.methods(ImmutableList.of()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("methods can't be empty.");
     }

--- a/core/src/test/java/com/linecorp/armeria/server/AbstractServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AbstractServiceBindingBuilderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reflections.ReflectionUtils;
+
+class AbstractServiceBindingBuilderTest {
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            ContextPathServiceBindingBuilder.class,
+            ServiceBindingBuilder.class,
+            VirtualHostServiceBindingBuilder.class,
+    })
+    void apiConsistency(Class<?> clazz) {
+        final Set<Method> overriddenMethods =
+                ReflectionUtils.getMethods(clazz,
+                                           method -> Modifier.isPublic(method.getModifiers()) &&
+                                                     method.getReturnType().equals(clazz));
+        final Set<Method> superMethods =
+                ReflectionUtils.getMethods(AbstractServiceBindingBuilder.class,
+                                           method -> Modifier.isPublic(method.getModifiers()));
+        for (final Method method : superMethods) {
+            assertThat(overriddenMethods).filteredOn(tMethod -> {
+                return method.getName().equals(tMethod.getName()) &&
+                       Arrays.equals(method.getParameterTypes(), tMethod.getParameterTypes());
+            }).hasSize(1);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ContextPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ContextPathTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ContextPathTest {
+
+    static HttpServiceWithRoutes serviceWithRoutes = new HttpServiceWithRoutes() {
+        @Override
+        public Set<Route> routes() {
+            return ImmutableSet.of(Route.builder().path("/serviceWithRoutes1").build(),
+                                   Route.builder().path("/serviceWithRoutes2").build());
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            final String path = req.path();
+            return HttpResponse.of(path.substring(path.lastIndexOf('/') + 1));
+        }
+    };
+
+    static final Object annotatedService = new Object() {
+        @Get("/annotated1")
+        public HttpResponse get() {
+            return HttpResponse.of("annotated1");
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            // server builder context path
+            sb.contextPath("/v1", "/v2")
+              .service("/service1", (ctx, req) -> HttpResponse.of("service1"))
+              .service(serviceWithRoutes)
+              .service("/route2", serviceWithRoutes)
+              .annotatedService(annotatedService)
+              .annotatedService()
+              .pathPrefix("/prefix")
+              .build(annotatedService)
+              .route()
+              .get("/route1")
+              .build((ctx, req) -> HttpResponse.of("route1"))
+              .serviceUnder("/serviceUnder1", (ctx, req) -> HttpResponse.of("serviceUnder1"))
+              .serviceUnder("/serviceUnder2", serviceWithRoutes)
+              .and()
+              // server builder
+              .service("/service1", (ctx, req) -> HttpResponse.of("service1"))
+              .service(serviceWithRoutes)
+              .service("/route2", serviceWithRoutes)
+              .annotatedService(annotatedService)
+              .annotatedService()
+              .pathPrefix("/prefix")
+              .build(annotatedService)
+              .route()
+              .get("/route1")
+              .build((ctx, req) -> HttpResponse.of("route1"))
+              .serviceUnder("/serviceUnder1", (ctx, req) -> HttpResponse.of("serviceUnder1"))
+              .serviceUnder("/serviceUnder2", serviceWithRoutes)
+              // server decorator with context path
+              .contextPath("/v5", "/v6")
+              .service("/decorated1", (ctx, req) -> HttpResponse.of(500))
+              .decorator("/decorated1", (delegate, ctx, req) -> HttpResponse.of("decorated1"))
+              .routeDecorator()
+              .path("/decorated2")
+              .build((delegate, ctx, req) -> HttpResponse.of("decorated2"))
+              .and()
+              // server decorator
+              .service("/decorated1", (ctx, req) -> HttpResponse.of(500))
+              .decorator("/decorated1", (delegate, ctx, req) -> HttpResponse.of("decorated1"))
+              .routeDecorator()
+              .path("/decorated2")
+              .build((delegate, ctx, req) -> HttpResponse.of("decorated2"))
+              // virtual host service context path
+              .virtualHost("foo.com")
+              .contextPath("/v3", "/v4")
+              .service("/service1", (ctx, req) -> HttpResponse.of("service1"))
+              .service(serviceWithRoutes)
+              .service("/route2", serviceWithRoutes)
+              .annotatedService(annotatedService)
+              .annotatedService()
+              .pathPrefix("/prefix")
+              .build(annotatedService)
+              .route()
+              .get("/route1")
+              .build((ctx, req) -> HttpResponse.of("route1"))
+              .serviceUnder("/serviceUnder1", (ctx, req) -> HttpResponse.of("serviceUnder1"))
+              .serviceUnder("/serviceUnder2", serviceWithRoutes)
+              .and()
+              // virtual host decorator context path
+              .contextPath("/v5", "/v6")
+              .service("/decorated1", (ctx, req) -> HttpResponse.of(500))
+              .decorator("/decorated1", (delegate, ctx, req) -> HttpResponse.of("decorated1"))
+              .routeDecorator()
+              .path("/decorated2")
+              .build((delegate, ctx, req) -> HttpResponse.of("decorated2"))
+              // virtual host
+              .service("/service1", (ctx, req) -> HttpResponse.of("service1"))
+              .service(serviceWithRoutes)
+              .service("/route2", serviceWithRoutes)
+              .annotatedService(annotatedService)
+              .annotatedService()
+              .pathPrefix("/prefix")
+              .build(annotatedService)
+              .route()
+              .get("/route1")
+              .build((ctx, req) -> HttpResponse.of("route1"))
+              .serviceUnder("/serviceUnder1", (ctx, req) -> HttpResponse.of("serviceUnder1"))
+              .serviceUnder("/serviceUnder2", serviceWithRoutes)
+              // virtual host decorator
+              .service("/decorated1", (ctx, req) -> HttpResponse.of(500))
+              .decorator("/decorated1", (delegate, ctx, req) -> HttpResponse.of("decorated1"))
+              .routeDecorator()
+              .path("/decorated2")
+              .build((delegate, ctx, req) -> HttpResponse.of("decorated2"));
+            sb.decorator(LoggingService.newDecorator());
+            sb.rejectedRouteHandler(RejectedRouteHandler.FAIL);
+        }
+    };
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/v1", "/v2"})
+    void testServerService(String contextPath) {
+        final BlockingWebClient client = server.blockingWebClient();
+
+        assertResult(client.get(contextPath + "/service1"), "service1");
+        assertResult(client.get(contextPath + "/route1"), "route1");
+        assertResult(client.get(contextPath + "/serviceWithRoutes1"), "serviceWithRoutes1");
+        assertResult(client.get(contextPath + "/serviceWithRoutes2"), "serviceWithRoutes2");
+        assertResult(client.get(contextPath + "/annotated1"), "annotated1");
+        assertResult(client.get(contextPath + "/prefix/annotated1"), "annotated1");
+        assertResult(client.get(contextPath + "/serviceUnder1/"), "serviceUnder1");
+        assertResult(client.get(contextPath + "/serviceUnder2/serviceWithRoutes1"), "serviceWithRoutes1");
+        assertResult(client.get(contextPath + "/serviceUnder2/serviceWithRoutes2"), "serviceWithRoutes2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/v3", "/v4"})
+    void testVHostService(String contextPath) {
+        final BlockingWebClient client =
+                server.blockingWebClient(cb -> cb.setHeader(HttpHeaderNames.HOST, "foo.com"));
+        assertResult(client.get(contextPath + "/service1"), "service1");
+        assertResult(client.get(contextPath + "/route1"), "route1");
+        assertResult(client.get(contextPath + "/serviceWithRoutes1"), "serviceWithRoutes1");
+        assertResult(client.get(contextPath + "/serviceWithRoutes2"), "serviceWithRoutes2");
+        assertResult(client.get(contextPath + "/annotated1"), "annotated1");
+        assertResult(client.get(contextPath + "/prefix/annotated1"), "annotated1");
+        assertResult(client.get(contextPath + "/serviceUnder1/"), "serviceUnder1");
+        assertResult(client.get(contextPath + "/serviceUnder2/serviceWithRoutes1"), "serviceWithRoutes1");
+        assertResult(client.get(contextPath + "/serviceUnder2/serviceWithRoutes2"), "serviceWithRoutes2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/v5", "/v6"})
+    void testServerDecorator(String contextPath) {
+        final BlockingWebClient client = server.blockingWebClient();
+        assertResult(client.get(contextPath + "/decorated1"), "decorated1");
+        assertResult(client.get(contextPath + "/decorated2"), "decorated2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "", "/v5", "/v6"})
+    void testVHostDecorator(String contextPath) {
+        final BlockingWebClient client =
+                server.blockingWebClient(cb -> cb.setHeader(HttpHeaderNames.HOST, "foo.com"));
+        assertResult(client.get(contextPath + "/decorated1"), "decorated1");
+        assertResult(client.get(contextPath + "/decorated2"), "decorated2");
+    }
+
+    @Test
+    void invalidContextPath() {
+        assertThatThrownBy(() -> Server.builder().contextPath())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one context path is required");
+
+        assertThatThrownBy(() -> Server.builder().contextPath(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: an absolute path starting with");
+
+        assertThatThrownBy(() -> Server.builder().contextPath("/", "relative"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: an absolute path starting with");
+    }
+
+    private static void assertResult(AggregatedHttpResponse res, String expectedContent) {
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(res.contentUtf8()).isEqualTo(expectedContent);
+    }
+}


### PR DESCRIPTION
Motivation:

It has been pointed out that users may want to add services/decorators under a certain prefix easily.
I propose that we introduce `ServerBuilder#contextPath(String...)`, `VirtualHostBuilder#contextPath(String...)` to achieve this. These methods will apply the same set of APIs as `ServerBuilder`, `VirtualHostBuilder` to ensure migration is easy.

```
Server.builder()
       .contextPath("/v1", "/v2")
       .service(myService) // served under "/v1" and "/v2"
       .and()
       .virtualHost("foo.com")
       .contextPath("/v3")
       .service(myService) // served by virtual host "foo.com" under "/v3"
```

Conceptually,
- `ServerBuilder#contextPaths`, `VirtualHostBuilder#contextPaths` has been added, which returns a `ContextPathServicesBuilder`
- `ContextPathServicesBuilder` now accepts a parameter `contextPaths`
- All paths leading to a `new ServiceConfigBuilder`, `new RouteDecoratingService` use `contextPaths` from the `ContextPathServicesBuilder`

Modifications:

- Added `ServerBuilder#contextPath`, `VirtualHostBuilder#contextPath`
  - Made `ContextPathServicesBuilder` public to return it from the above methods
- Modified `ContextPathServicesBuilder` to accept `contextPaths`
  - When services/decorators are directly built from `ContextPathServicesBuilder`, the context path prefixes are supplied to each route
  - When services/decorators are built from fluent builders, each builder is responsible for supplying the context path
  - Added a `contextPath` parameter to `ServiceConfigBuilder`, `RouteDecoratingService` constructors so that we can check call paths using `contextPath` at compile-time. (and routes aren't double-applied with a prefix by mistake)
    - Following this change, `DefaultServiceConfigSetters#toServiceConfigBuilder` also accepts a `contextPath` parameter
- Added fluent builders that will be used from the `ContextPathServicesBuilder`
  - Introduced a `ContextPathDecoratingBindingBuilder` to support the `#routeDecorator()` fluent builder
  - Introduced a `ContextPathServiceBindingBuilder` to support the `#route()` fluent builder
    - `AbstractServiceBindingBuilder` now also accepts a `contextPaths` parameter when building `ServiceConfigBuilder`s
  - Made `ContextPathAnnotatedServiceConfigSetters` public to support the `#annotatedService()` fluent builder
    - Modified `AbstractAnnotatedServiceConfigSetters` to set `contextPaths` and use them to build `ServiceConfigBuilder`s later on


Result:

- Users can now add services/decorators under a context path fluently

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
