### PR TITLE
Omit date when writing `armeria.versions.properties`

### DIFF
--- a/gradle/scripts/lib/java-versionprops.gradle
+++ b/gradle/scripts/lib/java-versionprops.gradle
@@ -21,6 +21,7 @@ configure(projectsWithFlags('java', 'publish')) {
     task versionProperties {
         def propsFile = project.file("${generatedResourcesDir}/META-INF/${project.group}.versions.properties")
         outputs.file propsFile
+        inputs.property("project.ext.repoStatus", project.ext.repoStatus)
         doLast {
             def artifactId = project.ext.artifactId
 

--- a/gradle/scripts/lib/java-versionprops.gradle
+++ b/gradle/scripts/lib/java-versionprops.gradle
@@ -1,3 +1,15 @@
+import java.nio.charset.StandardCharsets
+
+/**
+ * Writes {@link Properties} without the date format for better caching.
+ */
+static def writeProps(Properties props, OutputStream os) {
+    props.entrySet().forEach {e ->
+        os.write("${e.key}=${e.value}\n".getBytes(StandardCharsets.UTF_8))
+    }
+    os.flush()
+}
+
 configure(projectsWithFlags('java', 'publish')) {
     def generatedResourcesDir = project.file("${project.projectDir}/gen-src/main/resources")
     sourceSets.main.resources.srcDir generatedResourcesDir
@@ -32,7 +44,7 @@ configure(projectsWithFlags('java', 'publish')) {
             if (!upToDate) {
                 project.mkdir(propsFile.parentFile)
                 logger.info("Writing ${propsFile} ..")
-                propsFile.withOutputStream { props.store(it, null) }
+                propsFile.withOutputStream { writeProps(props, it) }
             } else {
                 logger.info("${propsFile} is up-to-date.")
             }


### PR DESCRIPTION
Motivation:

We have previously been writing `armeria.versions.properties` using `Properties#store`.
However, this behavior by default writes the current timestamp, and there is no way to configure this.
Meanwhile, the downstream `ShadedJar` task uses the properties file as an input.
Thus, `shadedJar` is not being cached on each invocation.
Since `assemble` depends on `shadedJar`, this is at least 30 seconds wasted on each build.

I've verified that the file is written correctly without the timestamp:
![Screenshot 2023-07-17 at 4 37 06 PM](https://github.com/line/armeria/assets/8510579/c6e2b45f-f5e0-4401-8be7-e8edf29f8bb0)
![Screenshot 2023-07-17 at 4 58 54 PM](https://github.com/line/armeria/assets/8510579/353cc717-40b6-48fe-8961-69b8bca790af)

Also, the build scan comparison shows the inputs aren't changed on each `./gradlew core:clean core:shadedJar` invocation
build scan: https://ge.armeria.dev/scans?search.tags=coreShadedJar&search.timeZoneId=Asia/Seoul&selection.buildScanA=vxfiu2y47fpxe&selection.buildScanB=rmidkmhzhv5ak

Modifications:

- Write a map instead of properties

Result:

- Better input caching

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
