### PR TITLE
Ensure task inputs are consistent for `docs-client`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -26,10 +26,10 @@ class DocServiceAssetCompressionTest {
 
     @Test
     void shouldNotIncludeUncompressedAssets() {
-        String file = "index.html";
         // `doc-client` should produce compressed assets when building bundle files for DocService and
         // they should exist in the classpath of the core module.
         // If Gradle build task is executed with `-PnoWeb`, this test may be broken.
+        final String file = "index.html";
         assertThat(DocService.class.getResource(file)).isNull();
         assertThat(DocService.class.getResource(file + ".gz")).isNotNull();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DocServiceAssetCompressionTest.java
@@ -18,16 +18,15 @@ package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.server.docs.DocService;
 
 class DocServiceAssetCompressionTest {
 
-    @ValueSource(strings = {"index.html", "main.js"})
-    @ParameterizedTest
-    void shouldNotIncludeUncompressedAssets(String file) {
+    @Test
+    void shouldNotIncludeUncompressedAssets() {
+        String file = "index.html";
         // `doc-client` should produce compressed assets when building bundle files for DocService and
         // they should exist in the classpath of the core module.
         // If Gradle build task is executed with `-PnoWeb`, this test may be broken.

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -30,7 +30,7 @@ const config: Configuration = {
     path: path.resolve(process.cwd(), './build/web'),
     // We don't mount to '/' for production build since we want the code to be relocatable.
     publicPath: isDev ? '/' : '',
-    filename: '[name].[contenthash].js'
+    filename: isDev ? '[name].js' : '[name].[contenthash].js'
   },
   module: {
     rules: [

--- a/docs-client/webpack.config.ts
+++ b/docs-client/webpack.config.ts
@@ -30,6 +30,7 @@ const config: Configuration = {
     path: path.resolve(process.cwd(), './build/web'),
     // We don't mount to '/' for production build since we want the code to be relocatable.
     publicPath: isDev ? '/' : '',
+    filename: '[name].[contenthash].js'
   },
   module: {
     rules: [
@@ -54,7 +55,7 @@ const config: Configuration = {
                 ],
                 '@babel/react',
               ],
-              plugins: ['react-hot-loader/babel'],
+              plugins: isDev ? ['react-hot-loader/babel'] : [],
             },
           },
           {
@@ -117,7 +118,6 @@ const config: Configuration = {
 const plugins = config.plugins as any[];
 plugins.push(new HtmlWebpackPlugin({
   template: './src/index.html',
-  hash: true,
 }));
 plugins.push(new FaviconsWebpackPlugin({
   logo: './src/images/logo.png',


### PR DESCRIPTION
Motivation:

This PR addresses two issues:

1. `reactHotLoader` is bundled into the production build, which contains additional information about the system. This has been resolved by selectively adding the `'react-hot-loader/babel'` plugin.

This can be observed by running the following command:
```sh
zfgrep 'reactHotLoader' docs-client/build/javaweb/com/linecorp/armeria/server/docs/main.js.gz
```

![Screenshot 2023-07-20 at 6 23 39 PM](https://github.com/line/armeria/assets/8510579/ce0504f3-be66-4b25-88af-9ee1f643f1c2)

2. A random hash is added every time build is done for cache busting. Instead of using `HtmlWebpackPlugin.hash`, modified to use the `contenthash` in the filename to make the hash deterministic.
  - ref: https://webpack.js.org/guides/caching/#output-filenames

Note that `index.html` is also updated accordingly by webpack.

![Screenshot 2023-07-19 at 12 06 19 PM](https://github.com/line/armeria/assets/8510579/25c092dd-1812-4b56-9cc0-8ddc00113409)
<img width="331" alt="Screenshot 2023-07-18 at 11 49 47 PM" src="https://github.com/line/armeria/assets/8510579/a5ce8b61-8017-4a5d-990c-b348f6e7c94e">

ref: https://ge.armeria.dev/c/tvnyf5nfgy54g/wlr2xqtdkd73u/task-inputs?cacheability=cacheable

Modifications:

- Modified so that `reactHotLoader` is added only in dev mode
- Modified the filename to use `contenthash`

Result:

- Better input caching for `docs-client`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
