### PR TITLE
Ensure task inputs are consistent for checkstyle

### DIFF
--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -13,8 +13,7 @@ logger.info("Using JDK ${buildJdkVersion} for build")
 rootProject.ext.set("buildJdkVersion", buildJdkVersion)
 
 // Enable checkstyle if the rule file exists.
-def checkstyleConfigDir =
-        project.rootProject.layout.projectDirectory.dir("settings/checkstyle").asFile.getPath()
+def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
 def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle') &&
         !rootProject.hasProperty('noLint') &&
         new File(checkstyleConfigDir).isDirectory() &&

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -13,7 +13,8 @@ logger.info("Using JDK ${buildJdkVersion} for build")
 rootProject.ext.set("buildJdkVersion", buildJdkVersion)
 
 // Enable checkstyle if the rule file exists.
-def checkstyleConfigDir = "${rootProject.projectDir}/settings/checkstyle"
+def checkstyleConfigDir =
+        project.rootProject.layout.projectDirectory.dir("settings/checkstyle").asFile.getPath()
 def checkstyleEnabled = !rootProject.hasProperty('noCheckstyle') &&
         !rootProject.hasProperty('noLint') &&
         new File(checkstyleConfigDir).isDirectory() &&
@@ -206,8 +207,8 @@ configure(projectsWithFlags('java')) {
         apply plugin: 'checkstyle'
 
         checkstyle {
+            configDirectory = new File("${checkstyleConfigDir}")
             configFile = new File("${checkstyleConfigDir}/checkstyle.xml")
-            configProperties = ['checkstyleConfigDir': "$checkstyleConfigDir"]
             if (managedVersions.containsKey('com.puppycrawl.tools:checkstyle')) {
                 toolVersion = managedVersions['com.puppycrawl.tools:checkstyle']
             }

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -10,7 +10,7 @@
 
   <module name="SuppressWarningsFilter" />
   <module name="SuppressionFilter">
-    <property name="file" value="${checkstyleConfigDir}/checkstyle-suppressions.xml"/>
+    <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
   </module>
 
   <module name="Header">


### PR DESCRIPTION
Motivation:

We are passing `configProperties` to the checkstyle task, which is resulting in inconsistent inputs to our gradle task when run from different locations.
By setting the `configDirectory` property, we can use the `config_loc` property pre-defined by `checkstyle`.

ref: https://ge.armeria.dev/scans?search.tags=exp3*%2Cgradle/checkstyle-cache&search.timeZoneId=Asia/Seoul#selection.buildScanA=r4jnvs4tiabmg&selection.buildScanB=zhqrycgjdns7q

Modifications:

- Specify `configDirectory` instead of `configProperties`

Result:

- Input caching is done properly from different locations for checkstyle tasks.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
