### PR TITLE
Fix a bug that default logger is changed for LoggingService and LoggingClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.client.logging;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
+import org.slf4j.Logger;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.logging.LoggingDecoratorBuilder;
@@ -32,6 +34,10 @@ abstract class AbstractLoggingClientBuilder extends LoggingDecoratorBuilder {
     private Sampler<? super ClientRequestContext> successSampler = Sampler.always();
 
     private Sampler<? super ClientRequestContext> failureSampler = Sampler.always();
+
+    AbstractLoggingClientBuilder(Logger defaultLogger) {
+        super(defaultLogger);
+    }
 
     /**
      * Sets the {@link Sampler} that determines which request needs logging.

--- a/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/AbstractLoggingClientBuilder.java
@@ -19,8 +19,6 @@ package com.linecorp.armeria.client.logging;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import org.slf4j.Logger;
-
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.logging.LoggingDecoratorBuilder;
@@ -34,10 +32,6 @@ abstract class AbstractLoggingClientBuilder extends LoggingDecoratorBuilder {
     private Sampler<? super ClientRequestContext> successSampler = Sampler.always();
 
     private Sampler<? super ClientRequestContext> failureSampler = Sampler.always();
-
-    AbstractLoggingClientBuilder(Logger defaultLogger) {
-        super(defaultLogger);
-    }
 
     /**
      * Sets the {@link Sampler} that determines which request needs logging.

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -44,14 +44,14 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
      * for more information on the default settings.
      */
     public static Function<? super HttpClient, LoggingClient> newDecorator() {
-        return new LoggingClientBuilder(logger).newDecorator();
+        return new LoggingClientBuilder().defaultLogger(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingClientBuilder}.
      */
     public static LoggingClientBuilder builder() {
-        return new LoggingClientBuilder(logger);
+        return new LoggingClientBuilder().defaultLogger(logger);
     }
 
     LoggingClient(HttpClient delegate, LogWriter logWriter,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -17,6 +17,9 @@ package com.linecorp.armeria.client.logging;
 
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.HttpRequest;
@@ -33,20 +36,22 @@ import com.linecorp.armeria.common.util.Sampler;
 public final class LoggingClient extends AbstractLoggingClient<HttpRequest, HttpResponse>
         implements HttpClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(LoggingClient.class);
+
     /**
      * Returns a new {@link HttpClient} decorator that logs {@link Request}s and {@link Response}s at
      * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure. See {@link LoggingClientBuilder}
      * for more information on the default settings.
      */
     public static Function<? super HttpClient, LoggingClient> newDecorator() {
-        return builder().newDecorator();
+        return new LoggingClientBuilder(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingClientBuilder}.
      */
     public static LoggingClientBuilder builder() {
-        return new LoggingClientBuilder();
+        return new LoggingClientBuilder(logger);
     }
 
     LoggingClient(HttpClient delegate, LogWriter logWriter,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClient.java
@@ -44,7 +44,7 @@ public final class LoggingClient extends AbstractLoggingClient<HttpRequest, Http
      * for more information on the default settings.
      */
     public static Function<? super HttpClient, LoggingClient> newDecorator() {
-        return new LoggingClientBuilder().defaultLogger(logger).newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -41,7 +41,9 @@ import com.linecorp.armeria.common.util.Sampler;
  */
 public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
 
-    LoggingClientBuilder() {}
+    LoggingClientBuilder(Logger defaultLogger) {
+        super(defaultLogger);
+    }
 
     /**
      * Returns a newly-created {@link LoggingClient} decorating {@code delegate} based on the properties of

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -41,10 +41,6 @@ import com.linecorp.armeria.common.util.Sampler;
  */
 public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
 
-    LoggingClientBuilder(Logger defaultLogger) {
-        super(defaultLogger);
-    }
-
     /**
      * Returns a newly-created {@link LoggingClient} decorating {@code delegate} based on the properties of
      * this builder.
@@ -61,6 +57,11 @@ public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
     }
 
     // Override the return type of the chaining methods in the superclass.
+
+    @Override
+    protected LoggingClientBuilder defaultLogger(Logger logger) {
+        return (LoggingClientBuilder) super.defaultLogger(logger);
+    }
 
     @Override
     public LoggingClientBuilder samplingRate(float samplingRate) {

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingClientBuilder.java
@@ -41,6 +41,8 @@ import com.linecorp.armeria.common.util.Sampler;
  */
 public final class LoggingClientBuilder extends AbstractLoggingClientBuilder {
 
+    LoggingClientBuilder() {}
+
     /**
      * Returns a newly-created {@link LoggingClient} decorating {@code delegate} based on the properties of
      * this builder.

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -45,7 +45,7 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
      * See {@link LoggingRpcClientBuilder} for more information on the default settings.
      */
     public static Function<? super RpcClient, LoggingRpcClient> newDecorator() {
-        return new LoggingRpcClientBuilder().defaultLogger(logger).newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.client.logging;
 
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.common.Request;
@@ -34,20 +37,22 @@ import com.linecorp.armeria.common.util.Sampler;
 public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, RpcResponse>
         implements RpcClient {
 
+    private static final Logger logger = LoggerFactory.getLogger(LoggingRpcClient.class);
+
     /**
      * Returns a new {@link RpcClient} decorator that logs {@link Request}s and {@link Response}s at
      * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure.
      * See {@link LoggingRpcClientBuilder} for more information on the default settings.
      */
     public static Function<? super RpcClient, LoggingRpcClient> newDecorator() {
-        return builder().newDecorator();
+        return new LoggingRpcClientBuilder(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingRpcClientBuilder}.
      */
     public static LoggingRpcClientBuilder builder() {
-        return new LoggingRpcClientBuilder();
+        return new LoggingRpcClientBuilder(logger);
     }
 
     LoggingRpcClient(RpcClient delegate, LogWriter logWriter,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClient.java
@@ -45,14 +45,14 @@ public final class LoggingRpcClient extends AbstractLoggingClient<RpcRequest, Rp
      * See {@link LoggingRpcClientBuilder} for more information on the default settings.
      */
     public static Function<? super RpcClient, LoggingRpcClient> newDecorator() {
-        return new LoggingRpcClientBuilder(logger).newDecorator();
+        return new LoggingRpcClientBuilder().defaultLogger(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingRpcClientBuilder}.
      */
     public static LoggingRpcClientBuilder builder() {
-        return new LoggingRpcClientBuilder(logger);
+        return new LoggingRpcClientBuilder().defaultLogger(logger);
     }
 
     LoggingRpcClient(RpcClient delegate, LogWriter logWriter,

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -42,13 +42,6 @@ import com.linecorp.armeria.common.util.Sampler;
 public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder {
 
     /**
-     * Creates a new instance.
-     */
-    LoggingRpcClientBuilder(Logger defaultLogger) {
-        super(defaultLogger);
-    }
-
-    /**
      * Returns a newly-created {@link LoggingRpcClient} decorating {@code delegate} based on the properties of
      * this builder.
      */
@@ -64,6 +57,11 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
     }
 
     // Override the return type of the chaining methods in the superclass.
+
+    @Override
+    protected LoggingRpcClientBuilder defaultLogger(Logger logger) {
+        return (LoggingRpcClientBuilder) super.defaultLogger(logger);
+    }
 
     @Override
     public LoggingRpcClientBuilder sampler(Sampler<? super ClientRequestContext> sampler) {

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -44,7 +44,9 @@ public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder 
     /**
      * Creates a new instance.
      */
-    LoggingRpcClientBuilder() {}
+    LoggingRpcClientBuilder(Logger defaultLogger) {
+        super(defaultLogger);
+    }
 
     /**
      * Returns a newly-created {@link LoggingRpcClient} decorating {@code delegate} based on the properties of

--- a/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/LoggingRpcClientBuilder.java
@@ -42,6 +42,11 @@ import com.linecorp.armeria.common.util.Sampler;
 public final class LoggingRpcClientBuilder extends AbstractLoggingClientBuilder {
 
     /**
+     * Creates a new instance.
+     */
+    LoggingRpcClientBuilder() {}
+
+    /**
      * Returns a newly-created {@link LoggingRpcClient} decorating {@code delegate} based on the properties of
      * this builder.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.common.util.SafeCloseable;
 
 final class DefaultLogWriter implements LogWriter {
 
-    static final Logger defaultLogger = LoggerFactory.getLogger(DefaultLogWriter.class);
+    static final Logger defaultLogger = LoggerFactory.getLogger(LogWriter.class);
 
     static final DefaultLogWriter DEFAULT =
             new DefaultLogWriter(defaultLogger, DEFAULT_REQUEST_LOG_LEVEL_MAPPER,

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -56,6 +56,9 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     @Nullable
+    private final Logger defaultLogger;
+
+    @Nullable
     private Logger logger;
     @Nullable
     private RequestLogLevelMapper requestLogLevelMapper;
@@ -82,6 +85,21 @@ public abstract class LoggingDecoratorBuilder {
     private LogWriter logWriter;
 
     private boolean buildLogWriter;
+
+    /**
+     * Creates a new instance.
+     */
+    protected LoggingDecoratorBuilder() {
+        defaultLogger = null;
+    }
+
+    /**
+     * Creates a new instance with the default logger. The default logger is used when neither
+     * {@link #logWriter(LogWriter)} nor {@link #logger(Logger)} is set.
+     */
+    protected LoggingDecoratorBuilder(Logger defaultLogger) {
+        this.defaultLogger = defaultLogger;
+    }
 
     /**
      * Sets the {@link Logger} to use when logging.
@@ -544,7 +562,11 @@ public abstract class LoggingDecoratorBuilder {
             return logWriter;
         }
         if (!buildLogWriter) {
-            return LogWriter.of();
+            if (defaultLogger != null) {
+                return LogWriter.of(defaultLogger);
+            } else {
+                return LogWriter.of();
+            }
         }
         final LogFormatter logFormatter =
                 LogFormatter.builderForText()
@@ -559,7 +581,10 @@ public abstract class LoggingDecoratorBuilder {
         builder.logFormatter(logFormatter);
         if (logger != null) {
             builder.logger(logger);
+        } else if (defaultLogger != null) {
+            builder.logger(defaultLogger);
         }
+
         if (requestLogLevelMapper != null) {
             builder.requestLogLevelMapper(requestLogLevelMapper);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -88,7 +88,10 @@ public abstract class LoggingDecoratorBuilder {
      * is set.
      */
     protected LoggingDecoratorBuilder defaultLogger(Logger logger) {
-        this.logger = requireNonNull(logger, "logger");
+        requireNonNull(logger, "logger");
+        if (this.logger == null) {
+            this.logger = logger;
+        }
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -56,9 +56,6 @@ public abstract class LoggingDecoratorBuilder {
     }
 
     @Nullable
-    private final Logger defaultLogger;
-
-    @Nullable
     private Logger logger;
     @Nullable
     private RequestLogLevelMapper requestLogLevelMapper;
@@ -87,18 +84,12 @@ public abstract class LoggingDecoratorBuilder {
     private boolean buildLogWriter;
 
     /**
-     * Creates a new instance.
+     * Sets the logger that is used when neither {@link #logWriter(LogWriter)} nor {@link #logger(Logger)}
+     * is set.
      */
-    protected LoggingDecoratorBuilder() {
-        defaultLogger = null;
-    }
-
-    /**
-     * Creates a new instance with the default logger. The default logger is used when neither
-     * {@link #logWriter(LogWriter)} nor {@link #logger(Logger)} is set.
-     */
-    protected LoggingDecoratorBuilder(Logger defaultLogger) {
-        this.defaultLogger = defaultLogger;
+    protected LoggingDecoratorBuilder defaultLogger(Logger logger) {
+        this.logger = requireNonNull(logger, "logger");
+        return this;
     }
 
     /**
@@ -562,8 +553,8 @@ public abstract class LoggingDecoratorBuilder {
             return logWriter;
         }
         if (!buildLogWriter) {
-            if (defaultLogger != null) {
-                return LogWriter.of(defaultLogger);
+            if (logger != null) {
+                return LogWriter.of(logger);
             } else {
                 return LogWriter.of();
             }
@@ -581,8 +572,6 @@ public abstract class LoggingDecoratorBuilder {
         builder.logFormatter(logFormatter);
         if (logger != null) {
             builder.logger(logger);
-        } else if (defaultLogger != null) {
-            builder.logger(defaultLogger);
         }
 
         if (requestLogLevelMapper != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -20,6 +20,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.logging.LogLevel;
@@ -35,20 +38,22 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
  */
 public final class LoggingService extends SimpleDecoratingHttpService {
 
+    private static final Logger logger = LoggerFactory.getLogger(LoggingService.class);
+
     /**
      * Returns a new {@link HttpService} decorator that logs {@link HttpRequest}s and {@link HttpResponse}s at
      * {@link LogLevel#DEBUG} for success, {@link LogLevel#WARN} for failure. See {@link LoggingServiceBuilder}
      * for more information on the default settings.
      */
     public static Function<? super HttpService, LoggingService> newDecorator() {
-        return builder().newDecorator();
+        return new LoggingServiceBuilder(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingServiceBuilder}.
      */
     public static LoggingServiceBuilder builder() {
-        return new LoggingServiceBuilder();
+        return new LoggingServiceBuilder(logger);
     }
 
     private final LogWriter logWriter;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -46,7 +46,7 @@ public final class LoggingService extends SimpleDecoratingHttpService {
      * for more information on the default settings.
      */
     public static Function<? super HttpService, LoggingService> newDecorator() {
-        return new LoggingServiceBuilder().defaultLogger(logger).newDecorator();
+        return builder().newDecorator();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -46,14 +46,14 @@ public final class LoggingService extends SimpleDecoratingHttpService {
      * for more information on the default settings.
      */
     public static Function<? super HttpService, LoggingService> newDecorator() {
-        return new LoggingServiceBuilder(logger).newDecorator();
+        return new LoggingServiceBuilder().defaultLogger(logger).newDecorator();
     }
 
     /**
      * Returns a newly created {@link LoggingServiceBuilder}.
      */
     public static LoggingServiceBuilder builder() {
-        return new LoggingServiceBuilder(logger);
+        return new LoggingServiceBuilder().defaultLogger(logger);
     }
 
     private final LogWriter logWriter;

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -50,6 +50,8 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
 
     private Sampler<? super ServiceRequestContext> failureSampler = Sampler.always();
 
+    LoggingServiceBuilder() {}
+
     /**
      * Sets the {@link Sampler} that determines which request needs logging.
      * This method sets both success and failure sampler.

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -50,10 +50,6 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
 
     private Sampler<? super ServiceRequestContext> failureSampler = Sampler.always();
 
-    LoggingServiceBuilder(Logger defaultLogger) {
-        super(defaultLogger);
-    }
-
     /**
      * Sets the {@link Sampler} that determines which request needs logging.
      * This method sets both success and failure sampler.
@@ -136,6 +132,11 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
     }
 
     // Override the return type of the chaining methods in the superclass.
+
+    @Override
+    protected LoggingServiceBuilder defaultLogger(Logger logger) {
+        return (LoggingServiceBuilder) super.defaultLogger(logger);
+    }
 
     @Override
     public LoggingServiceBuilder logger(Logger logger) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingServiceBuilder.java
@@ -50,7 +50,9 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
 
     private Sampler<? super ServiceRequestContext> failureSampler = Sampler.always();
 
-    LoggingServiceBuilder() {}
+    LoggingServiceBuilder(Logger defaultLogger) {
+        super(defaultLogger);
+    }
 
     /**
      * Sets the {@link Sampler} that determines which request needs logging.
@@ -60,8 +62,8 @@ public final class LoggingServiceBuilder extends LoggingDecoratorBuilder {
      */
     public LoggingServiceBuilder sampler(Sampler<? super ServiceRequestContext> sampler) {
         requireNonNull(sampler, "sampler");
-        this.successSampler = sampler;
-        this.failureSampler = sampler;
+        successSampler = sampler;
+        failureSampler = sampler;
         return this;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientDefaultLoggerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientDefaultLoggerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.logging;
+
+import static com.linecorp.armeria.client.logging.LoggingClientTest.delegate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+class LoggingClientDefaultLoggerTest {
+
+    @Spy
+    final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    final Logger defaultLogger = (Logger) LoggerFactory.getLogger(LoggingClient.class);
+
+    @BeforeEach
+    public void attachAppender() {
+        logAppender.start();
+        defaultLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    public void detachAppender() {
+        defaultLogger.detachAppender(logAppender);
+        logAppender.list.clear();
+    }
+
+    @Test
+    void defaultLoggerUsedIfLogWriterNotSet() throws Exception {
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final LoggingClient client = LoggingClient.newDecorator().apply(delegate);
+        client.execute(ctx, ctx.request());
+        assertThat(logAppender.list).hasSize(2);
+        logAppender.list.forEach(iLoggingEvent -> {
+            assertThat(iLoggingEvent.getFormattedMessage()).contains(ctx.toString());
+            assertThat(iLoggingEvent.getLoggerName()).isEqualTo(
+                    "com.linecorp.armeria.client.logging.LoggingClient");
+        });
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -50,7 +50,7 @@ import com.linecorp.armeria.common.logging.RegexBasedSanitizer;
 import com.linecorp.armeria.internal.common.logging.LoggingTestUtil;
 
 class LoggingClientTest {
-    private static final HttpClient delegate = (ctx, req) -> {
+    static final HttpClient delegate = (ctx, req) -> {
         ctx.logBuilder().endRequest();
         ctx.logBuilder().endResponse();
         return HttpResponse.of(HttpStatus.NO_CONTENT);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceDefaultLoggerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceDefaultLoggerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.logging;
+
+import static com.linecorp.armeria.server.logging.LoggingServiceTest.delegate;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+class LoggingServiceDefaultLoggerTest {
+
+    @Spy
+    final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    final Logger defaultLogger = (Logger) LoggerFactory.getLogger(LoggingService.class);
+
+    @BeforeEach
+    public void attachAppender() {
+        logAppender.start();
+        defaultLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    public void detachAppender() {
+        defaultLogger.detachAppender(logAppender);
+        logAppender.list.clear();
+    }
+
+    @Test
+    void defaultLoggerUsedIfLogWriterNotSet() throws Exception {
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final LoggingService service = LoggingService.newDecorator().apply(delegate);
+        service.serve(ctx, ctx.request());
+        assertThat(logAppender.list).hasSize(2);
+        logAppender.list.forEach(iLoggingEvent -> {
+            assertThat(iLoggingEvent.getFormattedMessage()).contains(ctx.toString());
+            assertThat(iLoggingEvent.getLoggerName()).isEqualTo(
+                    "com.linecorp.armeria.server.logging.LoggingService");
+        });
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -60,7 +60,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 class LoggingServiceTest {
 
-    private static final HttpService delegate = (ctx, req) -> {
+    static final HttpService delegate = (ctx, req) -> {
         ctx.logBuilder().endRequest();
         ctx.logBuilder().endResponse();
         return HttpResponse.of(200);


### PR DESCRIPTION
Motivation
I changed the default logger of `LoggingService` from `com.linecorp.armeria.server.logging.LoggingService` to `com.linecorp.armeria.common.logging.DefaultLogWriter` in #4943. This caused a breaking change to logging system if you are using the class name with a logger. This also applies to the `LoggingClient`.
We should fix it.

Modification
- Reverted to use `com.linecorp.armeria.server.logging.LoggingService` logger for `LoggingService` when `LogWriter` isn't set.
- Reverted to use `com.linecorp.armeria.client.logging.LoggingClient` logger for `LoggingClient` when `LogWriter` isn't set.

Result
- As in versions prior to 1.24.0, the default logger for `LoggingService` is now `com.linecorp.armeria.server.logging.LoggingService`.
  - The default logger for `LoggingClient` is also `com.linecorp.armeria.client.logging.LoggingClient`.