### PR TITLE
Add circuit breaker service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -205,7 +205,7 @@ public final class CircuitBreakerBuilder {
     }
 
     @VisibleForTesting
-    CircuitBreakerBuilder ticker(Ticker ticker) {
+    public CircuitBreakerBuilder ticker(Ticker ticker) {
         this.ticker = requireNonNull(ticker, "ticker");
         return this;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/AbstractCircuitBreakerService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/AbstractCircuitBreakerService.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+
+/**
+ * Decorates a {@link Service} to circuit break.
+ */
+public abstract class AbstractCircuitBreakerService<I extends Request, O extends Response>
+        extends SimpleDecoratingService<I, O> {
+
+    private final CircuitBreaker circuitBreaker;
+    private final Function<CompletionStage<? extends O>, O> responseConverter;
+    private final CircuitBreakerAcceptHandler<I, O> acceptHandler;
+    private final CircuitBreakerRejectHandler<I, O> rejectHandler;
+
+    /**
+     * Creates a new instance that decorates the specified {@link Service}.
+     */
+    protected AbstractCircuitBreakerService(Service<I, O> delegate, CircuitBreaker circuitBreaker,
+                                            Function<CompletionStage<? extends O>, O> responseConverter,
+                                            CircuitBreakerAcceptHandler<I, O> acceptHandler,
+                                            CircuitBreakerRejectHandler<I, O> rejectHandler) {
+        super(delegate);
+        this.circuitBreaker = requireNonNull(circuitBreaker, "circuitBreaker");
+        this.responseConverter = requireNonNull(responseConverter, "responseConverter");
+        this.acceptHandler = requireNonNull(acceptHandler, "acceptHandler");
+        this.rejectHandler = requireNonNull(rejectHandler, "rejectHandler");
+    }
+
+    @Override
+    public final O serve(ServiceRequestContext ctx, I req) throws Exception {
+        return responseConverter.apply(
+                CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                if (circuitBreaker.tryRequest()) {
+                                    return acceptHandler.handleAccepted(unwrap(), ctx, req);
+                                } else {
+                                    return rejectHandler.handleRejected(unwrap(), ctx, req);
+                                }
+                            } catch (Exception e) {
+                                return Exceptions.throwUnsafely(e);
+                            }
+                        },
+                        ctx.eventLoop()
+                )
+        );
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/AbstractCircuitBreakerServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/AbstractCircuitBreakerServiceBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Builds a new {@link AbstractCircuitBreakerService}.
+ * @param <I> type of the request
+ * @param <O> type of the response
+ */
+abstract class AbstractCircuitBreakerServiceBuilder<I extends Request, O extends Response> {
+
+    private final CircuitBreaker circuitBreaker;
+    private CircuitBreakerAcceptHandler<I, O> acceptHandler;
+    private CircuitBreakerRejectHandler<I, O> rejectHandler;
+
+    AbstractCircuitBreakerServiceBuilder(CircuitBreaker circuitBreaker,
+                                         CircuitBreakerRejectHandler<I, O> defaultRejectHandler) {
+        this.circuitBreaker = requireNonNull(circuitBreaker, "circuitBreaker");
+        acceptHandler = Service::serve;
+        rejectHandler = requireNonNull(defaultRejectHandler, "defaultRejectHandler");
+    }
+
+    final CircuitBreaker getCircuitBreaker() {
+        return circuitBreaker;
+    }
+
+    /**
+     * Sets {@link CircuitBreakerAcceptHandler}.
+     */
+    final void setAcceptHandler(
+            CircuitBreakerAcceptHandler<I, O> acceptHandler) {
+        this.acceptHandler = requireNonNull(acceptHandler, "acceptHandler");
+    }
+
+    final CircuitBreakerAcceptHandler<I, O> getAcceptHandler() {
+        return acceptHandler;
+    }
+
+    /**
+     * Sets {@link CircuitBreakerRejectHandler}.
+     */
+    final void setRejectHandler(
+            CircuitBreakerRejectHandler<I, O> rejectHandler) {
+        this.rejectHandler = requireNonNull(rejectHandler, "rejectHandler");
+    }
+
+    final CircuitBreakerRejectHandler<I, O> getRejectHandler() {
+        return rejectHandler;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerAcceptHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A callback which is invoked to handle accepted (successful) requests based on {@link CircuitBreaker} state.
+ *
+ * @param <I> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
+ * @param <O> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
+ *
+ * @see CircuitBreakerServiceBuilder#onAcceptedRequest(CircuitBreakerAcceptHandler)
+ */
+@FunctionalInterface
+public interface CircuitBreakerAcceptHandler<I extends Request, O extends Response> {
+    /**
+     * Invoked when the {@link CircuitBreaker} accepts the specified {@link Request}.
+     *
+     * @param delegate the next {@link Service} in the decoration chain
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link Request} being accepted
+     * @throws Exception when something wrong happens
+     */
+    O handleAccepted(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRejectHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRejectHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * A callback which is invoked to handle rejected (failure) requests based on {@link CircuitBreaker} state.
+ *
+ * @param <I> the type of incoming {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
+ * @param <O> the type of outgoing {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
+ *
+ * @see CircuitBreakerServiceBuilder#onRejectedRequest(CircuitBreakerRejectHandler)
+ */
+@FunctionalInterface
+public interface CircuitBreakerRejectHandler<I extends Request, O extends Response> {
+    /**
+     * Invoked when the {@link CircuitBreaker} rejects the specified {@link Request}.
+     *
+     * @param delegate the next {@link Service} in the decoration chain
+     * @param ctx the {@link ServiceRequestContext} of {@code req}
+     * @param req the {@link Request} being rejected
+     * @throws Exception when something wrong happens
+     */
+    O handleRejected(Service<I, O> delegate, ServiceRequestContext ctx, I req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRpcService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRpcService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.RpcService;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Decorates an RPC {@link Service} to circuit break incoming requests.
+ */
+public final class CircuitBreakerRpcService extends AbstractCircuitBreakerService<RpcRequest, RpcResponse>
+        implements RpcService {
+    /**
+     * Creates a new decorator using the specified {@link CircuitBreaker} and
+     * {@link CircuitBreakerRejectHandler}.
+     *
+     * @param circuitBreaker The {@link CircuitBreaker} instance to define circuit breaker
+     * @param rejectHandler The {@link CircuitBreakerRejectHandler} instance to define request rejection behaviour
+     */
+    public static Function<? super RpcService, CircuitBreakerRpcService>
+    newDecorator(CircuitBreaker circuitBreaker,
+                 CircuitBreakerRejectHandler<RpcRequest, RpcResponse> rejectHandler) {
+        return builder(circuitBreaker).onRejectedRequest(rejectHandler).newDecorator();
+    }
+
+    /**
+     * Creates a new decorator using the specified {@link CircuitBreaker}.
+     *
+     * @param circuitBreaker The {@link CircuitBreaker} instance to define circuit breaker
+     */
+    public static Function<? super RpcService, CircuitBreakerRpcService>
+    newDecorator(CircuitBreaker circuitBreaker) {
+        return builder(circuitBreaker).newDecorator();
+    }
+
+    /**
+     * Returns a new {@link CircuitBreakerRpcServiceBuilder}.
+     */
+    public static CircuitBreakerRpcServiceBuilder builder(CircuitBreaker circuitBreaker) {
+        return new CircuitBreakerRpcServiceBuilder(circuitBreaker);
+    }
+
+    /**
+     * Creates a new instance that decorates the specified {@link RpcService}.
+     */
+    CircuitBreakerRpcService(RpcService delegate, CircuitBreaker circuitBreaker,
+                             CircuitBreakerAcceptHandler<RpcRequest, RpcResponse> acceptHandler,
+                             CircuitBreakerRejectHandler<RpcRequest, RpcResponse> rejectHandler) {
+        super(delegate, circuitBreaker, RpcResponse::from, acceptHandler, rejectHandler);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRpcServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerRpcServiceBuilder.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.RpcService;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Builds a new {@link CircuitBreakerRpcService}.
+ */
+public final class CircuitBreakerRpcServiceBuilder
+        extends AbstractCircuitBreakerServiceBuilder<RpcRequest, RpcResponse> {
+
+    /**
+     * Provides default circuit breaker reject behaviour for {@link RpcRequest}.
+     * Responds with {@link HttpStatusException} with {@code 503 Service Unavailable}.
+     */
+    private static final CircuitBreakerRejectHandler<RpcRequest, RpcResponse>
+            DEFAULT_REJECT_HANDLER =
+            (delegate, ctx, req) ->
+                    RpcResponse.ofFailure(HttpStatusException.of(HttpStatus.SERVICE_UNAVAILABLE));
+
+    CircuitBreakerRpcServiceBuilder(CircuitBreaker circuitBreaker) {
+        super(circuitBreaker, DEFAULT_REJECT_HANDLER);
+    }
+
+    /**
+     * Sets {@link CircuitBreakerAcceptHandler}.
+     */
+    public CircuitBreakerRpcServiceBuilder onAcceptedRequest(
+            CircuitBreakerAcceptHandler<RpcRequest, RpcResponse> acceptHandler) {
+        setAcceptHandler(acceptHandler);
+        return this;
+    }
+
+    /**
+     * Sets {@link CircuitBreakerRejectHandler}.
+     */
+    public CircuitBreakerRpcServiceBuilder onRejectedRequest(
+            CircuitBreakerRejectHandler<RpcRequest, RpcResponse> rejectHandler) {
+        setRejectHandler(rejectHandler);
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link CircuitBreakerRpcService} based on the {@link CircuitBreaker}s added to
+     * this builder.
+     */
+    public CircuitBreakerRpcService build(RpcService delegate) {
+        return new CircuitBreakerRpcService(requireNonNull(delegate, "delegate"), getCircuitBreaker(),
+                                            getAcceptHandler(), getRejectHandler());
+    }
+
+    /**
+     * Returns a newly-created decorator that decorates an {@link Service} with a new
+     * {@link CircuitBreakerService} based on the {@link CircuitBreaker} added to this builder.
+     */
+    public Function<? super RpcService, CircuitBreakerRpcService> newDecorator() {
+        final CircuitBreaker circuitBreaker = getCircuitBreaker();
+        final CircuitBreakerAcceptHandler<RpcRequest, RpcResponse> acceptHandler = getAcceptHandler();
+        final CircuitBreakerRejectHandler<RpcRequest, RpcResponse> rejectHandler = getRejectHandler();
+        return service ->
+                new CircuitBreakerRpcService(service, circuitBreaker, acceptHandler, rejectHandler);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.HttpService;
+
+/**
+ * Decorates an {@link HttpService} to circuit break the incoming requests.
+ */
+public final class CircuitBreakerService extends AbstractCircuitBreakerService<HttpRequest, HttpResponse>
+        implements HttpService {
+    /**
+     * Creates a new decorator using the specified {@link CircuitBreaker} and
+     * {@link CircuitBreakerRejectHandler}.
+     *
+     * @param circuitBreaker The {@link CircuitBreaker} instance to define the circuit breaker to be used.
+     * @param rejectHandler The {@link CircuitBreakerRejectHandler} instance to define request rejection behaviour
+     */
+    public static Function<? super HttpService, CircuitBreakerService>
+    newDecorator(CircuitBreaker circuitBreaker,
+                 CircuitBreakerRejectHandler<HttpRequest, HttpResponse> rejectHandler) {
+        return builder(circuitBreaker).onRejectedRequest(rejectHandler).newDecorator();
+    }
+
+    /**
+     * Creates a new decorator using the specified {@link CircuitBreaker}.
+     *
+     * @param circuitBreaker The {@link CircuitBreaker} instance to define the circuit breaker to be used.
+     */
+    public static Function<? super HttpService, CircuitBreakerService>
+    newDecorator(CircuitBreaker circuitBreaker) {
+        return builder(circuitBreaker).newDecorator();
+    }
+
+    /**
+     * Returns a new {@link CircuitBreakerServiceBuilder}.
+     */
+    public static CircuitBreakerServiceBuilder builder(CircuitBreaker circuitBreaker) {
+        return new CircuitBreakerServiceBuilder(circuitBreaker);
+    }
+
+    /**
+     * Creates a new instance that decorates the specified {@link HttpService}.
+     */
+    CircuitBreakerService(HttpService delegate, CircuitBreaker circuitBreaker,
+                          CircuitBreakerAcceptHandler<HttpRequest, HttpResponse> acceptHandler,
+                          CircuitBreakerRejectHandler<HttpRequest, HttpResponse> rejectHandler) {
+        super(delegate, circuitBreaker, HttpResponse::from, acceptHandler, rejectHandler);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerServiceBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Service;
+
+/**
+ * Builds a new {@link CircuitBreakerService}.
+ */
+public final class CircuitBreakerServiceBuilder
+        extends
+        AbstractCircuitBreakerServiceBuilder<HttpRequest, HttpResponse> {
+
+    /**
+     * Provides default circuit breaking behaviour for {@link HttpRequest}.
+     * Returns an {@link HttpResponse} with {@link HttpStatus#SERVICE_UNAVAILABLE}.
+     */
+    private static final CircuitBreakerRejectHandler<HttpRequest, HttpResponse>
+            DEFAULT_REJECT_HANDLER =
+            (delegate, ctx, req) -> HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+
+    CircuitBreakerServiceBuilder(CircuitBreaker circuitBreaker) {
+        super(circuitBreaker, DEFAULT_REJECT_HANDLER);
+    }
+
+    /**
+     * Sets {@link CircuitBreakerAcceptHandler}.
+     */
+    public CircuitBreakerServiceBuilder onAcceptedRequest(
+            CircuitBreakerAcceptHandler<HttpRequest, HttpResponse> acceptHandler) {
+        setAcceptHandler(acceptHandler);
+        return this;
+    }
+
+    /**
+     * Sets {@link CircuitBreakerRejectHandler}.
+     */
+    public CircuitBreakerServiceBuilder onRejectedRequest(
+            CircuitBreakerRejectHandler<HttpRequest, HttpResponse> rejectHandler) {
+        setRejectHandler(rejectHandler);
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link CircuitBreakerService} based on the {@link CircuitBreaker} added to
+     * this builder.
+     */
+    public CircuitBreakerService build(HttpService delegate) {
+        return new CircuitBreakerService(requireNonNull(delegate, "delegate"), getCircuitBreaker(),
+                                         getAcceptHandler(), getRejectHandler());
+    }
+
+    /**
+     * Returns a newly-created decorator that decorates an {@link Service} with a new
+     * {@link CircuitBreakerService} based on the {@link CircuitBreaker} added to this builder.
+     */
+    public Function<? super HttpService, CircuitBreakerService> newDecorator() {
+        final CircuitBreaker circuitBreaker = getCircuitBreaker();
+        final CircuitBreakerAcceptHandler<HttpRequest, HttpResponse> acceptHandler = getAcceptHandler();
+        final CircuitBreakerRejectHandler<HttpRequest, HttpResponse> rejectHandler = getRejectHandler();
+        return service ->
+                new CircuitBreakerService(service, circuitBreaker, acceptHandler, rejectHandler);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/circuitbreaker/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Request throttling service decorators and strategies.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.server.circuitbreaker;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/circuitbreaker/CircuitBreakerServiceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.circuitbreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.CircuitState;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.util.Ticker;
+import com.linecorp.armeria.server.AbstractHttpService;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit4.server.ServerRule;
+
+public class CircuitBreakerServiceTest {
+
+    static final HttpService OK_SERVICE = new AbstractHttpService() {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            return HttpResponse.of(HttpStatus.OK);
+        }
+    };
+
+    static final HttpService BAD_SERVICE = new AbstractHttpService() {
+        @Override
+        protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        }
+    };
+
+    static final class MockTicker implements Ticker {
+        private long value = 0;
+
+        @Override
+        public long read() {
+            return value;
+        }
+
+        public void set(long newValue) {
+            value = newValue;
+        }
+    }
+
+    final MockTicker ticker = new MockTicker();
+
+    private final CircuitBreaker defaultCircuitBreaker =
+            CircuitBreaker
+                    .builder()
+                    .minimumRequestThreshold(10)
+                    .counterUpdateInterval(Duration.ofMillis(10))
+                    .ticker(ticker).build();
+
+    @Rule
+    public ServerRule serverRule = new ServerRule() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/http-always",
+                       OK_SERVICE.decorate(CircuitBreakerService.newDecorator(defaultCircuitBreaker)));
+            sb.service("/http-never",
+                       BAD_SERVICE.decorate(CircuitBreakerService.newDecorator(defaultCircuitBreaker)));
+        }
+    };
+
+    @Test
+    public void statusBasedOnCircuitState() throws Exception {
+        final WebClient client = WebClient.of(serverRule.httpUri());
+
+        defaultCircuitBreaker.enterState(CircuitState.CLOSED);
+        assertThat(client.get("/http-always").aggregate().get().status())
+                .isEqualTo(HttpStatus.OK);
+
+        defaultCircuitBreaker.enterState(CircuitState.FORCED_OPEN);
+        assertThat(client.get("/http-always").aggregate().get().status())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void circuitTripsAutomatically() throws Exception {
+        final WebClient client = WebClient.of(serverRule.httpUri());
+
+        defaultCircuitBreaker.enterState(CircuitState.CLOSED);
+        assertThat(client.get("/http-never").aggregate().get().status())
+                .isEqualTo(HttpStatus.BAD_REQUEST);
+
+        for (int i = 0; i < 100; i++) {
+            assertThat(client.get("/http-never").aggregate().get().status())
+                    .isEqualTo(HttpStatus.BAD_REQUEST);
+            ticker.set(ticker.value + 10L);
+        }
+
+        assertThat(client.get("/http-never").aggregate().get().status())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
Motivation:

Create a service breaker service to decorate services to allow them fail fast.

Modifications:

- Add `CircuitBreakerService` and `CircuitBreakerRpcService`.

Result:

- Closes #3721 

