### PR TITLE
Revive the legacy debug form in `DocService`

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugInputs.tsx
+++ b/docs-client/src/containers/MethodPage/DebugInputs.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ChangeEvent, Dispatch, useCallback, useReducer } from 'react';
+import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
+import { Method, ServiceType } from '../../lib/specification';
+import { SelectOption } from '../../lib/types';
+import EndpointPath from './EndpointPath';
+import HttpHeaders from './HttpHeaders';
+import HttpQueryString from './HttpQueryString';
+import RequestBody from './RequestBody';
+import GraphqlRequestBody from './GraphqlRequestBody';
+
+SyntaxHighlighter.registerLanguage('json', json);
+
+interface OwnProps {
+  exactPathMapping: boolean;
+  exampleHeaders: SelectOption[];
+  supportedExamplePaths: SelectOption[];
+  exampleQueries: SelectOption[];
+  serviceType: ServiceType;
+  method: Method;
+  useRequestBody: boolean;
+  requestBody: string;
+  jsonSchemas: any[];
+  setRequestBody: Dispatch<React.SetStateAction<string>>;
+  additionalPath: string;
+  setAdditionalPath: Dispatch<React.SetStateAction<string>>;
+  additionalQueries: string;
+  setAdditionalQueries: Dispatch<React.SetStateAction<string>>;
+  additionalHeaders: string;
+  setAdditionalHeaders: Dispatch<React.SetStateAction<string>>;
+  stickyHeaders: boolean;
+  toggleStickyHeaders: Dispatch<React.SetStateAction<unknown>>;
+}
+
+const toggle = (prev: boolean, override: unknown) => {
+  if (typeof override === 'boolean') {
+    return override;
+  }
+  return !prev;
+};
+
+const extractUrlPath = (method: Method) => {
+  const endpoints = method.endpoints;
+  return endpoints[0].pathMapping.substring('exact:'.length);
+};
+
+const DebugInputs: React.FunctionComponent<OwnProps> = ({
+  exactPathMapping,
+  exampleHeaders,
+  exampleQueries,
+  serviceType,
+  supportedExamplePaths,
+  additionalHeaders,
+  setAdditionalHeaders,
+  additionalQueries,
+  setAdditionalQueries,
+  method,
+  useRequestBody,
+  additionalPath,
+  setAdditionalPath,
+  stickyHeaders,
+  toggleStickyHeaders,
+  requestBody,
+  setRequestBody,
+  jsonSchemas,
+}) => {
+  const [requestBodyOpen, toggleRequestBodyOpen] = useReducer(toggle, true);
+  const [additionalQueriesOpen, toggleAdditionalQueriesOpen] = useReducer(
+    toggle,
+    true,
+  );
+
+  const [additionalHeadersOpen, toggleAdditionalHeadersOpen] = useReducer(
+    toggle,
+    true,
+  );
+
+  const [endpointPathOpen, toggleEndpointPathOpen] = useReducer(toggle, true);
+
+  const onPathFormChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setAdditionalPath(e.target.value);
+    },
+    [setAdditionalPath],
+  );
+
+  const onSelectedPathChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalPath(e.target.value as string);
+    },
+    [setAdditionalPath],
+  );
+
+  const onQueriesFormChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setAdditionalQueries(e.target.value);
+    },
+    [setAdditionalQueries],
+  );
+
+  const onSelectedQueriesChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalQueries(e.target.value as string);
+    },
+    [setAdditionalQueries],
+  );
+
+  const onSelectedHeadersChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setAdditionalHeaders(e.target.value as string);
+    },
+    [setAdditionalHeaders],
+  );
+
+  const onHeadersFormChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setAdditionalHeaders(e.target.value);
+    },
+    [setAdditionalHeaders],
+  );
+
+  const onDebugFormChange = useCallback(
+    (value: string) => {
+      setRequestBody(value);
+    },
+    [setRequestBody],
+  );
+
+  const onSelectedRequestBodyChange = useCallback(
+    (e: ChangeEvent<{ value: unknown }>) => {
+      setRequestBody(e.target.value as string);
+    },
+    [setRequestBody],
+  );
+
+  return (
+    <>
+      <EndpointPath
+        examplePaths={supportedExamplePaths}
+        editable={!exactPathMapping}
+        serviceType={serviceType}
+        endpointPathOpen={endpointPathOpen}
+        additionalPath={additionalPath}
+        onEditEndpointPathClick={toggleEndpointPathOpen}
+        onPathFormChange={onPathFormChange}
+        onSelectedPathChange={onSelectedPathChange}
+      />
+      {serviceType === ServiceType.HTTP && (
+        <HttpQueryString
+          exampleQueries={exampleQueries}
+          additionalQueriesOpen={additionalQueriesOpen}
+          additionalQueries={additionalQueries}
+          onEditHttpQueriesClick={toggleAdditionalQueriesOpen}
+          onQueriesFormChange={onQueriesFormChange}
+          onSelectedQueriesChange={onSelectedQueriesChange}
+        />
+      )}
+      <HttpHeaders
+        exampleHeaders={exampleHeaders}
+        additionalHeadersOpen={additionalHeadersOpen}
+        additionalHeaders={additionalHeaders}
+        stickyHeaders={stickyHeaders}
+        onEditHttpHeadersClick={toggleAdditionalHeadersOpen}
+        onSelectedHeadersChange={onSelectedHeadersChange}
+        onHeadersFormChange={onHeadersFormChange}
+        onStickyHeadersChange={toggleStickyHeaders}
+      />
+      {useRequestBody && serviceType === ServiceType.GRAPHQL ? (
+        <GraphqlRequestBody
+          requestBodyOpen={requestBodyOpen}
+          requestBody={requestBody}
+          onEditRequestBodyClick={toggleRequestBodyOpen}
+          onDebugFormChange={onDebugFormChange}
+          schemaUrlPath={extractUrlPath(method)}
+        />
+      ) : (
+        <RequestBody
+          exampleRequests={method.exampleRequests}
+          onSelectedRequestBodyChange={onSelectedRequestBodyChange}
+          requestBodyOpen={requestBodyOpen}
+          requestBody={requestBody}
+          onEditRequestBodyClick={toggleRequestBodyOpen}
+          onDebugFormChange={onDebugFormChange}
+          method={method}
+          serviceType={serviceType}
+          jsonSchemas={jsonSchemas}
+        />
+      )}
+    </>
+  );
+};
+
+export default React.memo(DebugInputs);

--- a/docs-client/src/containers/MethodPage/DebugInputs.tsx
+++ b/docs-client/src/containers/MethodPage/DebugInputs.tsx
@@ -15,17 +15,13 @@
  */
 
 import React, { ChangeEvent, Dispatch, useCallback, useReducer } from 'react';
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
-import { Method, ServiceType } from '../../lib/specification';
+import { extractUrlPath, Method, ServiceType } from '../../lib/specification';
 import { SelectOption } from '../../lib/types';
 import EndpointPath from './EndpointPath';
 import HttpHeaders from './HttpHeaders';
 import HttpQueryString from './HttpQueryString';
 import RequestBody from './RequestBody';
 import GraphqlRequestBody from './GraphqlRequestBody';
-
-SyntaxHighlighter.registerLanguage('json', json);
 
 interface OwnProps {
   exactPathMapping: boolean;
@@ -53,11 +49,6 @@ const toggle = (prev: boolean, override: unknown) => {
     return override;
   }
   return !prev;
-};
-
-const extractUrlPath = (method: Method) => {
-  const endpoints = method.endpoints;
-  return endpoints[0].pathMapping.substring('exact:'.length);
 };
 
 const DebugInputs: React.FunctionComponent<OwnProps> = ({

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -23,7 +23,6 @@ import CloseIcon from '@material-ui/icons/Close';
 import DeleteSweepIcon from '@material-ui/icons/DeleteSweep';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import React, {
-  ChangeEvent,
   Dispatch,
   useCallback,
   useEffect,
@@ -46,16 +45,13 @@ import {
 import Button from '@material-ui/core/Button';
 import Alert from '@material-ui/lab/Alert';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Section from '../../components/Section';
 import { docServiceDebug } from '../../lib/header-provider';
 import jsonPrettify from '../../lib/json-prettify';
 import { Method, ServiceType } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
-import EndpointPath from './EndpointPath';
-import HttpHeaders from './HttpHeaders';
-import HttpQueryString from './HttpQueryString';
-import RequestBody from './RequestBody';
-import GraphqlRequestBody from './GraphqlRequestBody';
+import DebugInputs from './DebugInputs';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -145,20 +141,10 @@ const DebugPage: React.FunctionComponent<Props> = ({
   setDebugFormIsOpen,
   jsonSchemas,
 }) => {
-  const [requestBodyOpen, toggleRequestBodyOpen] = useReducer(toggle, true);
   const [requestBody, setRequestBody] = useState('');
   const [debugResponse, setDebugResponse] = useState('');
-  const [additionalQueriesOpen, toggleAdditionalQueriesOpen] = useReducer(
-    toggle,
-    true,
-  );
   const [additionalQueries, setAdditionalQueries] = useState('');
-  const [endpointPathOpen, toggleEndpointPathOpen] = useReducer(toggle, true);
   const [additionalPath, setAdditionalPath] = useState('');
-  const [additionalHeadersOpen, toggleAdditionalHeadersOpen] = useReducer(
-    toggle,
-    true,
-  );
   const [additionalHeaders, setAdditionalHeaders] = useState('');
   const [stickyHeaders, toggleStickyHeaders] = useReducer(toggle, false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
@@ -214,9 +200,6 @@ const DebugPage: React.FunctionComponent<Props> = ({
     setRequestBody(urlRequestBody || method.exampleRequests[0] || '');
     setAdditionalPath(urlPath || '');
     setAdditionalQueries(urlQueries || '');
-    setDebugFormIsOpen(
-      (isOpen) => isOpen || urlRequestBody !== '' || urlQueries !== '',
-    );
   }, [
     exactPathMapping,
     exampleQueries.length,
@@ -227,7 +210,6 @@ const DebugPage: React.FunctionComponent<Props> = ({
     transport,
     useRequestBody,
     keepDebugResponse,
-    setDebugFormIsOpen,
   ]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -256,56 +238,6 @@ const DebugPage: React.FunctionComponent<Props> = ({
 
   const dismissSnackbar = useCallback(() => {
     setSnackbarOpen(false);
-  }, []);
-
-  const onSelectedQueriesChange = useCallback(
-    (e: ChangeEvent<{ value: unknown }>) => {
-      setAdditionalQueries(e.target.value as string);
-    },
-    [],
-  );
-
-  const onQueriesFormChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setAdditionalQueries(e.target.value);
-    },
-    [],
-  );
-
-  const onSelectedPathChange = useCallback(
-    (e: ChangeEvent<{ value: unknown }>) => {
-      setAdditionalPath(e.target.value as string);
-    },
-    [],
-  );
-
-  const onPathFormChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    setAdditionalPath(e.target.value);
-  }, []);
-
-  const onSelectedHeadersChange = useCallback(
-    (e: ChangeEvent<{ value: unknown }>) => {
-      setAdditionalHeaders(e.target.value as string);
-    },
-    [],
-  );
-
-  const onSelectedRequestBodyChange = useCallback(
-    (e: ChangeEvent<{ value: unknown }>) => {
-      setRequestBody(e.target.value as string);
-    },
-    [],
-  );
-
-  const onHeadersFormChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setAdditionalHeaders(e.target.value);
-    },
-    [],
-  );
-
-  const onDebugFormChange = useCallback((value: string) => {
-    setRequestBody(value);
   }, []);
 
   const onExport = useCallback(() => {
@@ -566,10 +498,105 @@ const DebugPage: React.FunctionComponent<Props> = ({
     });
   }, [serviceType, transport, method, examplePaths]);
 
-  const [debugAlertIsOpen, setDebugAlertIsOpen] = React.useState(true);
-
   return (
-    <div>
+    <>
+      <Section>
+        <div id="debug-form">
+          <Typography variant="body2" paragraph />
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6}>
+              <Typography variant="h6" paragraph>
+                Debug
+              </Typography>
+              <Alert severity="info">
+                You can set the default values by{' '}
+                <a
+                  href="https://armeria.dev/docs/server-docservice/#example-requests-and-headers"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  specifying example requests and headers
+                </a>
+                .
+              </Alert>
+              <DebugInputs
+                method={method}
+                serviceType={serviceType}
+                exampleHeaders={exampleHeaders}
+                exampleQueries={exampleQueries}
+                supportedExamplePaths={supportedExamplePaths}
+                additionalPath={additionalPath}
+                setAdditionalPath={setAdditionalPath}
+                additionalQueries={additionalQueries}
+                setAdditionalQueries={setAdditionalQueries}
+                exactPathMapping={exactPathMapping}
+                useRequestBody={useRequestBody}
+                additionalHeaders={additionalHeaders}
+                setAdditionalHeaders={setAdditionalHeaders}
+                jsonSchemas={jsonSchemas}
+                stickyHeaders={stickyHeaders}
+                toggleStickyHeaders={toggleStickyHeaders}
+                requestBody={requestBody}
+                setRequestBody={setRequestBody}
+              />
+              <Typography variant="body2" paragraph />
+              <Button variant="contained" color="primary" onClick={onSubmit}>
+                Submit
+              </Button>
+              <Button variant="text" color="secondary" onClick={onExport}>
+                Copy as a curl command
+              </Button>
+            </Grid>
+            <Grid item xs={12} sm={6}>
+              <Grid container spacing={1}>
+                <Grid item xs="auto">
+                  <Tooltip title="Copy response">
+                    <div>
+                      <IconButton
+                        onClick={onCopy}
+                        disabled={debugResponse.length === 0}
+                      >
+                        <FileCopyIcon />
+                      </IconButton>
+                    </div>
+                  </Tooltip>
+                </Grid>
+                <Grid item xs="auto">
+                  <Tooltip title="Clear response">
+                    <div>
+                      <IconButton
+                        onClick={onClear}
+                        disabled={debugResponse.length === 0}
+                      >
+                        <DeleteSweepIcon />
+                      </IconButton>
+                    </div>
+                  </Tooltip>
+                </Grid>
+              </Grid>
+              <SyntaxHighlighter
+                language="json"
+                style={githubGist}
+                wrapLines={false}
+              >
+                {debugResponse}
+              </SyntaxHighlighter>
+            </Grid>
+          </Grid>
+          <Snackbar
+            open={snackbarOpen}
+            message={snackbarMessage}
+            autoHideDuration={3000}
+            onClose={dismissSnackbar}
+            action={
+              <IconButton color="inherit" onClick={dismissSnackbar}>
+                <CloseIcon />
+              </IconButton>
+            }
+          />
+        </div>
+      </Section>
+      {/* Debug modal */}
       <Dialog
         onClose={() => setDebugFormIsOpen(false)}
         open={debugFormIsOpen}
@@ -580,76 +607,32 @@ const DebugPage: React.FunctionComponent<Props> = ({
           <Typography variant="h6" paragraph>
             Debug
           </Typography>
-          {debugAlertIsOpen && (
-            <Alert severity="info" onClose={() => setDebugAlertIsOpen(false)}>
-              You can set the default values by{' '}
-              <a
-                href="https://armeria.dev/docs/server-docservice/#example-requests-and-headers"
-                rel="noreferrer"
-                target="_blank"
-              >
-                specifying example requests and headers
-              </a>
-              .
-            </Alert>
-          )}
         </DialogTitle>
         <DialogContent dividers>
           <div id="debug-form">
             <Typography variant="body2" paragraph />
             <Grid container spacing={2}>
               <Grid item xs={12} sm={6}>
-                <EndpointPath
-                  examplePaths={supportedExamplePaths}
-                  editable={!exactPathMapping}
+                <DebugInputs
+                  method={method}
                   serviceType={serviceType}
-                  endpointPathOpen={endpointPathOpen}
-                  additionalPath={additionalPath}
-                  onEditEndpointPathClick={toggleEndpointPathOpen}
-                  onPathFormChange={onPathFormChange}
-                  onSelectedPathChange={onSelectedPathChange}
-                />
-                {serviceType === ServiceType.HTTP && (
-                  <HttpQueryString
-                    exampleQueries={exampleQueries}
-                    additionalQueriesOpen={additionalQueriesOpen}
-                    additionalQueries={additionalQueries}
-                    onEditHttpQueriesClick={toggleAdditionalQueriesOpen}
-                    onQueriesFormChange={onQueriesFormChange}
-                    onSelectedQueriesChange={onSelectedQueriesChange}
-                  />
-                )}
-                <HttpHeaders
                   exampleHeaders={exampleHeaders}
-                  additionalHeadersOpen={additionalHeadersOpen}
+                  exampleQueries={exampleQueries}
+                  supportedExamplePaths={supportedExamplePaths}
+                  additionalPath={additionalPath}
+                  setAdditionalPath={setAdditionalPath}
+                  additionalQueries={additionalQueries}
+                  setAdditionalQueries={setAdditionalQueries}
+                  exactPathMapping={exactPathMapping}
+                  useRequestBody={useRequestBody}
                   additionalHeaders={additionalHeaders}
+                  setAdditionalHeaders={setAdditionalHeaders}
+                  jsonSchemas={jsonSchemas}
                   stickyHeaders={stickyHeaders}
-                  onEditHttpHeadersClick={toggleAdditionalHeadersOpen}
-                  onSelectedHeadersChange={onSelectedHeadersChange}
-                  onHeadersFormChange={onHeadersFormChange}
-                  onStickyHeadersChange={toggleStickyHeaders}
+                  toggleStickyHeaders={toggleStickyHeaders}
+                  requestBody={requestBody}
+                  setRequestBody={setRequestBody}
                 />
-                {useRequestBody && serviceType === ServiceType.GRAPHQL ? (
-                  <GraphqlRequestBody
-                    requestBodyOpen={requestBodyOpen}
-                    requestBody={requestBody}
-                    onEditRequestBodyClick={toggleRequestBodyOpen}
-                    onDebugFormChange={onDebugFormChange}
-                    schemaUrlPath={extractUrlPath(method)}
-                  />
-                ) : (
-                  <RequestBody
-                    exampleRequests={method.exampleRequests}
-                    onSelectedRequestBodyChange={onSelectedRequestBodyChange}
-                    requestBodyOpen={requestBodyOpen}
-                    requestBody={requestBody}
-                    onEditRequestBodyClick={toggleRequestBodyOpen}
-                    onDebugFormChange={onDebugFormChange}
-                    method={method}
-                    serviceType={serviceType}
-                    jsonSchemas={jsonSchemas}
-                  />
-                )}
                 <Typography variant="body2" paragraph />
               </Grid>
               <Grid item xs={12} sm={6} className={classes.responseGrid}>
@@ -720,7 +703,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
           </Button>
         </DialogActions>
       </Dialog>
-    </div>
+    </>
   );
 };
 

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -48,7 +48,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Section from '../../components/Section';
 import { docServiceDebug } from '../../lib/header-provider';
 import jsonPrettify from '../../lib/json-prettify';
-import { Method, ServiceType } from '../../lib/specification';
+import { extractUrlPath, Method, ServiceType } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
 import DebugInputs from './DebugInputs';
@@ -120,11 +120,6 @@ const toggle = (prev: boolean, override: unknown) => {
 };
 
 const escapeSingleQuote = (text: string) => text.replace(/'/g, "'\\''");
-
-const extractUrlPath = (method: Method) => {
-  const endpoints = method.endpoints;
-  return endpoints[0].pathMapping.substring('exact:'.length);
-};
 
 const DebugPage: React.FunctionComponent<Props> = ({
   exactPathMapping,
@@ -501,7 +496,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
   return (
     <>
       <Section>
-        <div id="debug-form">
+        <div id={debugFormIsOpen ? '' : 'debug-form'}>
           <Typography variant="body2" paragraph />
           <Grid container spacing={2}>
             <Grid item xs={12} sm={6}>

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -106,6 +106,11 @@ export function packageName(fullName: string): string {
   return lastDotIdx >= 0 ? fullName.substring(0, lastDotIdx) : fullName;
 }
 
+export function extractUrlPath(method: Method): string {
+  const endpoints = method.endpoints;
+  return endpoints[0].pathMapping.substring('exact:'.length);
+}
+
 interface NamedObject {
   name: string;
 }


### PR DESCRIPTION
Motivation:

Some users find it inconvenient to use the new debug form especially when they have to refer to request specifications while writing requests.

As the debug page has enough space on the bottom side, it would be better to provide the two debug form styles.

Modifications:

- Add `DebugInputs` component to reuse components used for rendering a debug form.
- Render both an inline style and a modal style.
  - Thanks to React state, the values of the two forms are fully synchronized.

Result:

You can now use either an inline debug form or a debug form modal when using `DocService`.

