### PR TITLE
Set NVM dir correctly for post release process

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Perform post-release process
         working-directory: .github/actions
         run: |
+          export NVM_DIR=~/.nvm
+          source ~/.nvm/nvm.sh
           npm install
           npm run post-release ${{ github.ref_name }}
         env:


### PR DESCRIPTION
Motivation:
npm isn't detected because NVM doesn't install node in `/usr/local/bin` Should set `NVM_DIR` and source `nvm.sh` for npm work correctly.
https://stackoverflow.com/questions/62863080/github-actions-err-bash-line-3-npm-command-not-found https://gist.github.com/danielwetan/4f4db933531db5dd1af2e69ec8d54d8a?permalink_comment_id=4057972
