### PR TITLE
Deprecate HttpResponse.from() methods

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/client/WebClientIntegrationBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/client/WebClientIntegrationBenchmark.java
@@ -49,7 +49,7 @@ public class WebClientIntegrationBenchmark {
                       .service("/get", (ctx, req) -> {
                           return HttpResponse.of("Hello! Armeria");
                       }).service("/post", (ctx, req) -> {
-                          return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                          return HttpResponse.of(req.aggregate().thenApply(agg -> {
                               return HttpResponse.of(agg.contentUtf8());
                           }));
                       }).build();

--- a/brave/src/test/java/com/linecorp/armeria/client/brave/TraceContextPropagationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/TraceContextPropagationTest.java
@@ -78,7 +78,7 @@ class TraceContextPropagationTest {
                       .responseTimeoutMillis(0);
                 });
 
-                return HttpResponse.from(CompletableFuture.supplyAsync(() -> {
+                return HttpResponse.of(CompletableFuture.supplyAsync(() -> {
                     // Make sure the current thread is not context-aware.
                     assertThat(ServiceRequestContext.currentOrNull()).isNull();
                     assertThat(currentTraceContext.get()).isNull();

--- a/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/it/brave/BraveIntegrationTest.java
@@ -165,7 +165,7 @@ class BraveIntegrationTest {
                                     }))).collect(toImmutableList()));
 
                     final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                    final HttpResponse res = HttpResponse.from(responseFuture);
+                    final HttpResponse res = HttpResponse.of(responseFuture);
                     transformAsync(spanAware,
                                    result -> allAsList(IntStream.range(1, 3).mapToObj(
                                            i -> executorService.submit(

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceIntegrationTest.java
@@ -118,7 +118,7 @@ public class BraveServiceIntegrationTest extends ITHttpServer {
 
     HttpResponse asyncResponse(Consumer<CompletableFuture<HttpResponse>> completeResponse) {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture);
+        final HttpResponse res = HttpResponse.of(responseFuture);
         CommonPools.workerGroup().next().submit(
                 () -> completeResponse.accept(responseFuture));
         return res;

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/SpanPropagationTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/SpanPropagationTest.java
@@ -66,7 +66,7 @@ class SpanPropagationTest {
                    .thenAcceptAsync(log -> {
                        serviceMdcContextRef.set(MDC.getCopyOfContextMap());
                    }, ctx.eventLoop());
-                return HttpResponse.from(
+                return HttpResponse.of(
                         server.webClient(cb -> cb.decorator(BraveClient.newDecorator(tracing)))
                               .get("/bar").aggregate().thenApply(res -> {
                                   return HttpResponse.of("OK");

--- a/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
+++ b/consul/src/test/java/com/linecorp/armeria/internal/consul/ConsulTestBase.java
@@ -194,16 +194,16 @@ public abstract class ConsulTestBase {
 
         @Override
         protected final HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(req.aggregate()
-                                        .thenApply(aReq -> HttpResponse.of(HttpStatus.OK))
-                                        .exceptionally(CompletionActions::log));
+            return HttpResponse.of(req.aggregate()
+                                      .thenApply(aReq -> HttpResponse.of(HttpStatus.OK))
+                                      .exceptionally(CompletionActions::log));
         }
 
         @Override
         protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(req.aggregate()
-                                        .thenApply(this::echo)
-                                        .exceptionally(CompletionActions::log));
+            return HttpResponse.of(req.aggregate()
+                                      .thenApply(this::echo)
+                                      .exceptionally(CompletionActions::log));
         }
 
         protected HttpResponse echo(AggregatedHttpRequest aReq) {

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -48,7 +48,7 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
 
     DefaultWebClient(ClientBuilderParams params, HttpClient delegate, MeterRegistry meterRegistry) {
         super(params, delegate, meterRegistry,
-              HttpResponse::from, (ctx, cause) -> HttpResponse.ofFailure(cause));
+              HttpResponse::of, (ctx, cause) -> HttpResponse.ofFailure(cause));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -133,7 +133,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
     @Override
     public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
+        final HttpResponse res = HttpResponse.of(responseFuture, ctx.eventLoop());
         final RedirectContext redirectCtx = new RedirectContext(ctx, req, res, responseFuture);
         if (ctx.exchangeType().isRequestStreaming()) {
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -73,7 +73,7 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param delegate the {@link Client} that will process {@link Request}s
      * @param meterRegistry the {@link MeterRegistry} that collects various stats
      * @param futureConverter the {@link Function} that converts a {@link CompletableFuture} of response
-     *                        into a response, e.g. {@link HttpResponse#from(CompletionStage)}
+     *                        into a response, e.g. {@link HttpResponse#of(CompletionStage)}
      *                        and {@link RpcResponse#from(CompletionStage)}
      * @param errorResponseFactory the {@link BiFunction} that returns a new response failed with
      *                             the given exception

--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -142,7 +142,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
     /**
      * Implement this method to return a new {@link Response} which delegates to the {@link Response}
      * the specified {@link CompletionStage} is completed with. For example, you could use
-     * {@link HttpResponse#from(CompletionStage, EventExecutor)}:
+     * {@link HttpResponse#of(CompletionStage, EventExecutor)}:
      * <pre>{@code
      * protected HttpResponse newDeferredResponse(
      *         ClientRequestContext ctx, CompletionStage<HttpResponse> resFuture) {

--- a/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClient.java
@@ -93,6 +93,6 @@ public final class ConcurrencyLimitingClient
     @Override
     protected HttpResponse newDeferredResponse(ClientRequestContext ctx,
                                                CompletionStage<HttpResponse> resFuture) throws Exception {
-        return HttpResponse.from(resFuture, ctx.eventLoop());
+        return HttpResponse.of(resFuture, ctx.eventLoop());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -240,7 +240,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     @Override
     protected HttpResponse doExecute(ClientRequestContext ctx, HttpRequest req) throws Exception {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture, ctx.eventLoop());
+        final HttpResponse res = HttpResponse.of(responseFuture, ctx.eventLoop());
         if (ctx.exchangeType().isRequestStreaming()) {
             final HttpRequestDuplicator reqDuplicator = req.toDuplicator(ctx.eventLoop().withoutContext(), 0);
             doExecute0(ctx, reqDuplicator, req, res, responseFuture);
@@ -318,7 +318,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             ClientPendingThrowableUtil.removePendingThrowable(derivedCtx);
             // if the endpoint hasn't been selected, try to initialize the ctx with a new endpoint/event loop
             response = initContextAndExecuteWithFallback(
-                    unwrap(), ctxExtension, endpointGroup, HttpResponse::from,
+                    unwrap(), ctxExtension, endpointGroup, HttpResponse::of,
                     (context, cause) -> HttpResponse.ofFailure(cause));
         } else {
             response = executeWithFallback(unwrap(), derivedCtx,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AggregatedResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AggregatedResponseConverterFunction.java
@@ -77,7 +77,7 @@ final class AggregatedResponseConverterFunction implements ResponseConverterFunc
             return ResponseConverterFunction.fallthrough();
         }
 
-        return HttpResponse.from(f.thenApply(aggregated -> {
+        return HttpResponse.of(f.thenApply(aggregated -> {
             try {
                 return responseConverter.convertResponse(ctx, headers, aggregated, trailers);
             } catch (Exception ex) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedService.java
@@ -295,7 +295,7 @@ public final class AnnotatedService implements HttpService {
             }
         }
 
-        return HttpResponse.from(serve1(ctx, req, aggregationType));
+        return HttpResponse.of(serve1(ctx, req, aggregationType));
     }
 
     /**
@@ -415,7 +415,7 @@ public final class AnnotatedService implements HttpService {
                                                  HttpHeaders trailers) {
         if (result instanceof CompletionStage) {
             final CompletionStage<?> future = (CompletionStage<?>) result;
-            return HttpResponse.from(
+            return HttpResponse.of(
                     future.thenApply(object -> convertResponseInternal(ctx, headers, object, trailers)));
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
@@ -86,8 +86,8 @@ public final class AuthService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        return HttpResponse.from(AuthorizerUtil.authorizeAndSupplyHandlers(authorizer, ctx, req)
-                                               .handleAsync((result, cause) -> {
+        return HttpResponse.of(AuthorizerUtil.authorizeAndSupplyHandlers(authorizer, ctx, req)
+                                             .handleAsync((result, cause) -> {
             try {
                 final HttpService delegate = (HttpService) unwrap();
                 if (cause == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -250,7 +250,7 @@ public abstract class AbstractHttpFile implements HttpFile {
                 return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
             }
 
-            return HttpResponse.from(readAttributes(ctx.blockingTaskExecutor()).thenApply(attrs -> {
+            return HttpResponse.of(readAttributes(ctx.blockingTaskExecutor()).thenApply(attrs -> {
                 if (attrs == null) {
                     return HttpResponse.of(HttpStatus.NOT_FOUND);
                 }

--- a/core/src/main/java/com/linecorp/armeria/server/file/DeferredHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/DeferredHttpFile.java
@@ -136,7 +136,7 @@ final class DeferredHttpFile implements HttpFile {
             return delegate.asService();
         }
 
-        return (ctx, req) -> HttpResponse.from(stage.thenApply(file -> {
+        return (ctx, req) -> HttpResponse.of(stage.thenApply(file -> {
             setDelegate(file);
             try {
                 return file.asService().serve(ctx, req);

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -485,7 +485,7 @@ public final class FileService extends AbstractHttpService {
 
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(
+            return HttpResponse.of(
                     first.findFile(ctx, req)
                          .readAttributes(ctx.blockingTaskExecutor())
                          .thenApply(firstAttrs -> {

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckService.java
@@ -431,7 +431,7 @@ public final class HealthCheckService implements TransientHttpService {
             return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
         }
 
-        return HttpResponse.from(updateHandler.handle(ctx, req).thenApply(updateResult -> {
+        return HttpResponse.of(updateHandler.handle(ctx, req).thenApply(updateResult -> {
             if (updateResult != null) {
                 switch (updateResult) {
                     case HEALTHY:

--- a/core/src/main/java/com/linecorp/armeria/server/management/HeapDumpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/management/HeapDumpService.java
@@ -135,7 +135,7 @@ enum HeapDumpService implements HttpService {
             }
         });
 
-        return HttpResponse.from(responseFuture);
+        return HttpResponse.of(responseFuture);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingService.java
@@ -62,6 +62,6 @@ public final class ThrottlingService extends AbstractThrottlingService<HttpReque
     ThrottlingService(HttpService delegate, ThrottlingStrategy<HttpRequest> strategy,
                       ThrottlingAcceptHandler<HttpRequest, HttpResponse> acceptHandler,
                       ThrottlingRejectHandler<HttpRequest, HttpResponse> rejectHandler) {
-        super(delegate, strategy, HttpResponse::from, acceptHandler, rejectHandler);
+        super(delegate, strategy, HttpResponse::of, acceptHandler, rejectHandler);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientIntegrationTest.java
@@ -220,7 +220,7 @@ class HttpClientIntegrationTest {
                                 accept);
                     }
 
-                    return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                    return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                         if (cause != null) {
                             return HttpResponse.of(
                                     HttpStatus.INTERNAL_SERVER_ERROR,

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientMaxConcurrentStreamTest.java
@@ -68,7 +68,7 @@ public class HttpClientMaxConcurrentStreamTest {
             sb.service(PATH, (ctx, req) -> {
                 final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
                 responses.add(f);
-                return HttpResponse.from(f);
+                return HttpResponse.of(f);
             });
             sb.http2MaxStreamsPerConnection(MAX_CONCURRENT_STREAMS);
             sb.maxNumConnections(MAX_NUM_CONNECTIONS);
@@ -83,7 +83,7 @@ public class HttpClientMaxConcurrentStreamTest {
             sb.service(PATH, (ctx, req) -> {
                 final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
                 responses.add(f);
-                return HttpResponse.from(f);
+                return HttpResponse.of(f);
             });
             sb.http2MaxStreamsPerConnection(1);
             sb.maxNumConnections(MAX_NUM_CONNECTIONS);

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientPipeliningTest.java
@@ -61,7 +61,7 @@ public class HttpClientPipeliningTest {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
                     // Consume the request completely so that the connection can be returned to the pool.
-                    return HttpResponse.from(req.aggregate().handle((unused1, unused2) -> {
+                    return HttpResponse.of(req.aggregate().handle((unused1, unused2) -> {
                         // Signal the main thread that the connection has been returned to the pool.
                         // Note that this is true only when pipelining is enabled. The connection is returned
                         // after response is fully sent if pipelining is disabled.

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectContextTest.java
@@ -40,7 +40,7 @@ class RedirectContextTest {
     @Test
     void buildOriginalUri() {
         final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-        final HttpResponse response = HttpResponse.from(future);
+        final HttpResponse response = HttpResponse.of(future);
 
         HttpRequest request = request(HttpHeaders.of(HttpHeaderNames.AUTHORITY, "foo"));
         RedirectContext redirectCtx = new RedirectContext(ClientRequestContext.of(request), request,

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
@@ -79,7 +79,7 @@ class RedirectingClientTest {
                 }
             });
 
-            sb.service("/seeOther", (ctx, req) -> HttpResponse.from(
+            sb.service("/seeOther", (ctx, req) -> HttpResponse.of(
                       req.aggregate().thenApply(aggregatedReq -> {
                           assertThat(aggregatedReq.contentUtf8()).isEqualTo("hello!");
                           return HttpResponse.ofRedirect(HttpStatus.SEE_OTHER, "/seeOtherRedirect");

--- a/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/ContentPreviewingClientTest.java
@@ -77,7 +77,7 @@ class ContentPreviewingClientTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/", (ctx, req) -> HttpResponse.from(
+            sb.service("/", (ctx, req) -> HttpResponse.of(
                     req.aggregate()
                        .thenApply(aggregated -> {
                            final ResponseHeaders responseHeaders =

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientTest.java
@@ -269,7 +269,7 @@ class RetryingClientTest {
                 @Override
                 protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req)
                         throws Exception {
-                    return HttpResponse.from(req.aggregate().handle((aggregatedRequest, thrown) -> {
+                    return HttpResponse.of(req.aggregate().handle((aggregatedRequest, thrown) -> {
                         if (reqPostCount.getAndIncrement() < 1) {
                             return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
                         } else {

--- a/core/src/test/java/com/linecorp/armeria/common/DeferredHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DeferredHttpResponseTest.java
@@ -70,8 +70,8 @@ class DeferredHttpResponseTest {
         @SuppressWarnings("checkstyle:PreferUnmodifiableFuture")
         final CompletableFuture<HttpResponse> completedFuture = CompletableFuture.completedFuture(originalRes);
 
-        final HttpResponse res1 = HttpResponse.from(completedFuture);
-        final HttpResponse res2 = HttpResponse.from((CompletionStage<? extends HttpResponse>) completedFuture);
+        final HttpResponse res1 = HttpResponse.of(completedFuture);
+        final HttpResponse res2 = HttpResponse.of((CompletionStage<? extends HttpResponse>) completedFuture);
         assertThat(res1).isSameAs(originalRes);
         assertThat(res2).isSameAs(originalRes);
     }
@@ -87,8 +87,8 @@ class DeferredHttpResponseTest {
         final CompletableFuture<HttpResponse> completedFuture = new CompletableFuture<>();
         completedFuture.completeExceptionally(originalCause);
 
-        final HttpResponse res1 = HttpResponse.from(completedFuture);
-        final HttpResponse res2 = HttpResponse.from((CompletionStage<? extends HttpResponse>) completedFuture);
+        final HttpResponse res1 = HttpResponse.of(completedFuture);
+        final HttpResponse res2 = HttpResponse.of((CompletionStage<? extends HttpResponse>) completedFuture);
         assertThat(res1).isInstanceOf(AbortedHttpResponse.class);
         assertThat(res2).isInstanceOf(AbortedHttpResponse.class);
         assertThatThrownBy(() -> res1.collect().join()).hasCause(originalCause);

--- a/core/src/test/java/com/linecorp/armeria/common/HttpRequestSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpRequestSubscriberTest.java
@@ -62,7 +62,7 @@ public class HttpRequestSubscriberTest {
                            final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
                            executor.schedule(() -> f.complete(HttpResponse.of(HttpStatus.OK)),
                                              100, TimeUnit.MILLISECONDS);
-                           return HttpResponse.from(f);
+                           return HttpResponse.of(f);
                        }
             );
         }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseTest.java
@@ -161,8 +161,8 @@ class HttpResponseTest {
     @Test
     void httpResponseUsingDeliveredExecutor() {
         final Supplier<HttpResponse> responseSupplier = () -> HttpResponse.of(HttpStatus.OK);
-        final HttpResponse res = HttpResponse.from(responseSupplier,
-                                                   Executors.newSingleThreadScheduledExecutor());
+        final HttpResponse res = HttpResponse.of(responseSupplier,
+                                                 Executors.newSingleThreadScheduledExecutor());
 
         assertThat(res.aggregate().join().status()).isEqualTo(HttpStatus.OK);
     }

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewInLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewInLogFormatterTest.java
@@ -42,7 +42,7 @@ class ContentPreviewInLogFormatterTest {
             sb.decorator(LoggingService.newDecorator());
             sb.decorator(ContentPreviewingService.newDecorator(ContentPreviewerFactory.text(10000)));
             sb.service("/foo", (ctx, req) -> {
-                return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                return HttpResponse.of(req.aggregate().thenApply(agg -> {
                     return HttpResponse.of("World");
                 }));
             });

--- a/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/multipart/MultipartIntegrationTest.java
@@ -139,7 +139,7 @@ class MultipartIntegrationTest {
 
             sb.service("/simple", (ctx, req) -> {
                 final Multipart multipart = Multipart.from(req);
-                return HttpResponse.from(multipart.aggregate().thenApply(agg -> {
+                return HttpResponse.of(multipart.aggregate().thenApply(agg -> {
                     return HttpResponse.of(200);
                 }));
             });
@@ -194,7 +194,7 @@ class MultipartIntegrationTest {
             });
 
             sb.service("/echo", (ctx, req) -> {
-                return HttpResponse.from(
+                return HttpResponse.of(
                         req.aggregate()
                            .thenApply(r -> HttpResponse.of(HttpStatus.OK,
                                                            requireNonNull(r.contentType(), "contentType"),

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceExceptionHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceExceptionHandlerTest.java
@@ -225,14 +225,14 @@ class AnnotatedServiceExceptionHandlerTest {
 
         @Get("/resp1")
         public HttpResponse httpResponse(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(raiseExceptionImmediately());
+            return HttpResponse.of(raiseExceptionImmediately());
         }
 
         @Get("/resp2")
         @ExceptionHandler(NoExceptionHandler.class)
         @ExceptionHandler(AnticipatedExceptionHandler2.class)
         public HttpResponse asyncHttpResponse(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(completeExceptionallyLater(ctx));
+            return HttpResponse.of(completeExceptionallyLater(ctx));
         }
     }
 
@@ -266,19 +266,19 @@ class AnnotatedServiceExceptionHandlerTest {
 
         @Get("/bad1")
         public HttpResponse bad1(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(completeExceptionallyLater(ctx));
+            return HttpResponse.of(completeExceptionallyLater(ctx));
         }
 
         @Get("/bad2")
         @ExceptionHandler(BadExceptionHandler2.class)
         public HttpResponse bad2(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(completeExceptionallyLater(ctx));
+            return HttpResponse.of(completeExceptionallyLater(ctx));
         }
 
         @Get("/bad3")
         @ExceptionHandler(BadExceptionHandler3.class)
         public HttpResponse bad3(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(completeExceptionallyLater(ctx));
+            return HttpResponse.of(completeExceptionallyLater(ctx));
         }
     }
 
@@ -286,7 +286,7 @@ class AnnotatedServiceExceptionHandlerTest {
     public static class MyService4 extends MyService1 {
         @Get("/handler3")
         public HttpResponse handler3(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(completeExceptionallyLater(ctx));
+            return HttpResponse.of(completeExceptionallyLater(ctx));
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceMultipartTest.java
@@ -165,7 +165,7 @@ class AnnotatedServiceMultipartTest {
         @Post
         @Path("/uploadWithMultipartObject")
         public HttpResponse uploadWithMultipartObject(Multipart multipart) {
-            return HttpResponse.from(multipart.aggregate().handle((aggregated, cause) -> {
+            return HttpResponse.of(multipart.aggregate().handle((aggregated, cause) -> {
                 if (cause != null) {
                     return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
                                            cause.getMessage());

--- a/core/src/test/java/com/linecorp/armeria/server/AggregatedHttpResponseHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AggregatedHttpResponseHandlerTest.java
@@ -87,7 +87,7 @@ class AggregatedHttpResponseHandlerTest {
                     assertThat(req).isInstanceOf(AggregatingDecodedHttpRequest.class);
                     // Make sure that the stream was closed already.
                     assertThat(req.isOpen()).isFalse();
-                    return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                    return HttpResponse.of(req.aggregate().thenApply(agg -> {
                         return HttpResponse.of(agg.contentUtf8());
                     }));
                 }

--- a/core/src/test/java/com/linecorp/armeria/server/CustomServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CustomServerErrorHandlerTest.java
@@ -71,9 +71,9 @@ class CustomServerErrorHandlerTest {
                 final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
                 ctx.eventLoop().schedule(() -> future.completeExceptionally(
                         new UnsupportedOperationException("Unsupported!")), 100, TimeUnit.MILLISECONDS);
-                return HttpResponse.from(future);
+                return HttpResponse.of(future);
             });
-            sb.service("/post", (ctx, req) -> HttpResponse.from(
+            sb.service("/post", (ctx, req) -> HttpResponse.of(
                     req.aggregate().thenApply(aggregated -> HttpResponse.of(HttpStatus.OK))));
 
             sb.virtualHost(TEST_HOST)

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultServerErrorHandlerTest.java
@@ -58,7 +58,7 @@ class DefaultServerErrorHandlerTest {
 
         sb.service("/", (ctx, req) -> {
             // Consume the request to trigger 413 Request Entity Too Large.
-            return HttpResponse.from(req.aggregate().thenApply(unused -> HttpResponse.of(200)));
+            return HttpResponse.of(req.aggregate().thenApply(unused -> HttpResponse.of(200)));
         });
 
         sb.annotatedService(new Object() {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerProtocolViolationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerProtocolViolationTest.java
@@ -44,7 +44,7 @@ class HttpServerProtocolViolationTest {
             sb.maxRequestLength(MAX_CONTENT_LENGTH);
             sb.decorator(LoggingService.newDecorator());
             sb.service("/echo", (ctx, req) -> {
-                return HttpResponse.from(req.aggregate().thenApply(
+                return HttpResponse.of(req.aggregate().thenApply(
                         agg -> HttpResponse.of(ResponseHeaders.of(200), agg.content())));
             });
         }

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerRequestTimeoutTest.java
@@ -98,7 +98,7 @@ class HttpServerRequestTimeoutTest {
                       Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(20));
                       future.complete(HttpResponse.of(200));
                   });
-                  return HttpResponse.from(future);
+                  return HttpResponse.of(future);
               })
               .serviceUnder("/timeout-by-decorator", (ctx, req) ->
                       HttpResponse.delayed(HttpResponse.of(200), Duration.ofSeconds(1)))

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerStreamingTest.java
@@ -309,7 +309,7 @@ class HttpServerStreamingTest {
         @Override
         protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
             final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-            final HttpResponse res = HttpResponse.from(responseFuture);
+            final HttpResponse res = HttpResponse.of(responseFuture);
             req.subscribe(new StreamConsumer(ctx.eventLoop(), slow) {
                 @Override
                 public void onError(Throwable cause) {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerTest.java
@@ -134,7 +134,7 @@ class HttpServerTest {
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
                     final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
                     final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                    final HttpResponse res = HttpResponse.from(responseFuture);
+                    final HttpResponse res = HttpResponse.of(responseFuture);
                     ctx.eventLoop().schedule(() -> responseFuture.complete(HttpResponse.of(HttpStatus.OK)),
                                              delayMillis, TimeUnit.MILLISECONDS);
                     return res;
@@ -143,7 +143,7 @@ class HttpServerTest {
 
             sb.service("/delay-deferred/{delay}", (ctx, req) -> {
                 final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                final HttpResponse res = HttpResponse.from(responseFuture);
+                final HttpResponse res = HttpResponse.of(responseFuture);
                 final long delayMillis = Long.parseLong(ctx.pathParam("delay"));
                 ctx.eventLoop().schedule(() -> responseFuture.complete(HttpResponse.of(HttpStatus.OK)),
                                          delayMillis, TimeUnit.MILLISECONDS);
@@ -154,7 +154,7 @@ class HttpServerTest {
                 @Override
                 protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) {
                     final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                    final HttpResponse res = HttpResponse.from(responseFuture);
+                    final HttpResponse res = HttpResponse.of(responseFuture);
                     ctx.whenRequestCancelling().thenRun(
                             () -> responseFuture.complete(
                                     HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "timed out")));
@@ -167,7 +167,7 @@ class HttpServerTest {
 
             sb.service("/delay-custom-deferred/{delay}", (ctx, req) -> {
                 final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                final HttpResponse res = HttpResponse.from(responseFuture);
+                final HttpResponse res = HttpResponse.of(responseFuture);
                 ctx.whenRequestCancelling().thenRun(
                         () -> responseFuture.complete(HttpResponse.of(
                                 HttpStatus.OK, MediaType.PLAIN_TEXT_UTF_8, "timed out")));

--- a/core/src/test/java/com/linecorp/armeria/server/ServerRequestDurationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerRequestDurationTest.java
@@ -58,7 +58,7 @@ class ServerRequestDurationTest {
 
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                    return HttpResponse.of(req.aggregate().thenApply(agg -> {
                         return HttpResponse.of(agg.contentUtf8());
                     }));
                 }
@@ -76,7 +76,7 @@ class ServerRequestDurationTest {
 
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                    return HttpResponse.of(req.aggregate().thenApply(agg -> {
                         final HttpResponseWriter writer = HttpResponse.streaming();
                         writer.write(ResponseHeaders.of(HttpStatus.OK));
                         writer.write(HttpData.ofUtf8("12"));

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -122,7 +122,7 @@ class ServerTest {
                 @Override
                 protected HttpResponse echo(AggregatedHttpRequest aReq) {
                     final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-                    final HttpResponse res = HttpResponse.from(responseFuture);
+                    final HttpResponse res = HttpResponse.of(responseFuture);
                     asyncExecutorGroup.schedule(
                             () -> super.echo(aReq), processDelayMillis, TimeUnit.MILLISECONDS)
                                       .addListener((Future<HttpResponse> future) ->
@@ -569,9 +569,9 @@ class ServerTest {
     private static class EchoService extends AbstractHttpService {
         @Override
         protected final HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) {
-            return HttpResponse.from(req.aggregate()
-                                        .thenApply(this::echo)
-                                        .exceptionally(CompletionActions::log));
+            return HttpResponse.of(req.aggregate()
+                                      .thenApply(this::echo)
+                                      .exceptionally(CompletionActions::log));
         }
 
         protected HttpResponse echo(AggregatedHttpRequest aReq) {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceBindingTest.java
@@ -84,7 +84,7 @@ class ServiceBindingTest {
                       return HttpResponse.of(ctx.pathParam("name"));
                   }
                   if (req.method() == HttpMethod.POST) {
-                      return HttpResponse.from(
+                      return HttpResponse.of(
                               req.aggregate().thenApply(request -> HttpResponse.of(request.contentUtf8())));
                   }
                   fail("Should never reach here");
@@ -96,7 +96,7 @@ class ServiceBindingTest {
               .consumes(MediaType.JSON, MediaType.PLAIN_TEXT_UTF_8)
               .produces(MediaType.JSON, MediaType.PLAIN_TEXT_UTF_8)
               .decorators(decorator1, decorator2, decorator3)
-              .build((ctx, req) -> HttpResponse.from(
+              .build((ctx, req) -> HttpResponse.of(
                       req.aggregate().thenApply(request -> {
                           final String resContent;
                           final MediaType contentType = req.contentType();

--- a/core/src/test/java/com/linecorp/armeria/server/encoding/DecodingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/encoding/DecodingServiceTest.java
@@ -63,7 +63,7 @@ class DecodingServiceTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/decodeTest", (ctx1, req1) -> HttpResponse.from(
+            sb.service("/decodeTest", (ctx1, req1) -> HttpResponse.of(
                     req1.aggregate()
                         .thenApply(aggregated -> {
                             return HttpResponse.of("Hello " + aggregated.contentUtf8() + '!');
@@ -73,7 +73,7 @@ class DecodingServiceTest {
               .path("/length-limit")
               .maxRequestLength(ORIGINAL_MESSAGE_LENGTH - 1)
               .build((ctx, req) -> {
-                  return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                  return HttpResponse.of(req.aggregate().thenApply(agg -> {
                       // The large decoded content should be rejected by DecodingService.
                       return HttpResponse.of("Should never reach here");
                   }));

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewingServiceTest.java
@@ -98,7 +98,7 @@ class ContentPreviewingServiceTest {
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            final HttpService httpService = (ctx, req) -> HttpResponse.from(
+            final HttpService httpService = (ctx, req) -> HttpResponse.of(
                     req.aggregate()
                        .thenApply(aggregated -> {
                            final ResponseHeaders responseHeaders =
@@ -140,7 +140,7 @@ class ContentPreviewingServiceTest {
 
             sb.service("/deferred", httpService);
             sb.decorator("/deferred", ContentPreviewingService.newDecorator(100));
-            sb.decorator("/deferred", (delegate, ctx, req) -> HttpResponse.from(
+            sb.decorator("/deferred", (delegate, ctx, req) -> HttpResponse.of(
                     completedFuture(null).handleAsync((ignored, cause) -> {
                         try {
                             return delegate.serve(ctx, req);

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
@@ -71,7 +71,7 @@ class WebSocketServiceHandshakeTest {
                 if (!threadRescheduling.get()) {
                     return delegate.serve(ctx, req);
                 }
-                return HttpResponse.from(() -> {
+                return HttpResponse.of(() -> {
                     try {
                         return delegate.serve(ctx, req);
                     } catch (Exception e) {

--- a/core/src/test/java12/com/linecorp/armeria/server/InvalidPathWithDataTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/InvalidPathWithDataTest.java
@@ -46,7 +46,7 @@ class InvalidPathWithDataTest {
             sb.requestTimeoutMillis(0);
             sb.decorator(LoggingService.newDecorator());
             sb.service("/foo", (ctx, req) -> {
-                return HttpResponse.from(req.aggregate().thenApply(agg -> HttpResponse.of(agg.contentUtf8())));
+                return HttpResponse.of(req.aggregate().thenApply(agg -> HttpResponse.of(agg.contentUtf8())));
             });
         }
     };

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -47,7 +47,7 @@ class JavaHttpClientUpgradeTest {
             sb.maxRequestLength(maxRequestLength);
             sb.decorator(LoggingService.newDecorator());
             sb.service("/echo", (ctx, req) -> {
-                return HttpResponse.from(req.aggregate().thenApply(agg -> {
+                return HttpResponse.of(req.aggregate().thenApply(agg -> {
                     return HttpResponse.of(ResponseHeaders.of(200), agg.content());
                 }));
             });

--- a/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
@@ -79,7 +79,7 @@ class EurekaUpdatingListenerTest {
                     future.complete(HttpResponse.of(HttpStatus.NO_CONTENT));
                     return null;
                 });
-                return HttpResponse.from(future);
+                return HttpResponse.of(future);
             });
             sb.service("/apps/" + APP_NAME + '/' + INSTANCE_ID, (ctx, req) -> {
                 req.aggregate();

--- a/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/FileUploadService.java
+++ b/examples/annotated-http-service/src/main/java/example/armeria/server/annotated/FileUploadService.java
@@ -29,7 +29,7 @@ import com.linecorp.armeria.server.annotation.decorator.LoggingDecorator;
 public class FileUploadService {
     @Post("/upload")
     public HttpResponse upload(@Param String text, @Param File file) throws IOException {
-        return HttpResponse.from(() -> {
+        return HttpResponse.of(() -> {
             try {
                 final String content = Files.readString(file.toPath());
                 return HttpResponse.ofJson(Arrays.asList(text, content));
@@ -43,7 +43,7 @@ public class FileUploadService {
 
     @Post("/multipartObject")
     public HttpResponse multipartObject(Multipart multipart) throws IOException {
-        return HttpResponse.from(
+        return HttpResponse.of(
                 multipart.aggregate()
                          .thenApply(AggregatedMultipart::bodyParts)
                          .thenApply(aggregatedBodyParts ->

--- a/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
+++ b/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
@@ -35,7 +35,7 @@ public class Main {
             return Server.builder()
                          .http(8080)
                          .serviceUnder("/", ((ctx, req) ->
-                                 HttpResponse.from(
+                                 HttpResponse.of(
                                          ListenableFuturesExtra.toCompletableFuture(
                                                  graphBuilder.get().request(req).build().execute()))))
                          .build();

--- a/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
+++ b/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
@@ -71,7 +71,7 @@ class MainService(private val backendClient: WebClient) : HttpService {
                     .collect(Collectors.joining("\n"))
             )
         }
-        return HttpResponse.from(response)
+        return HttpResponse.of(response)
     }
 
     private suspend fun fetchFromRequest(ctx: ServiceRequestContext, req: HttpRequest): List<Long> {

--- a/examples/context-propagation/manual/src/main/java/example/armeria/contextpropagation/manual/MainService.java
+++ b/examples/context-propagation/manual/src/main/java/example/armeria/contextpropagation/manual/MainService.java
@@ -110,6 +110,6 @@ public class MainService implements HttpService {
                                         // mounted and stay on a single thread to reduce concurrency issues.
                                         ctxExecutor);
 
-        return HttpResponse.from(response);
+        return HttpResponse.of(response);
     }
 }

--- a/examples/context-propagation/reactor/src/main/java/example/armeria/contextpropagation/reactor/MainService.java
+++ b/examples/context-propagation/reactor/src/main/java/example/armeria/contextpropagation/reactor/MainService.java
@@ -105,6 +105,6 @@ public class MainService implements HttpService {
                     .map(content -> HttpResponse.of(content.toString()))
                     .onErrorResume(t -> Mono.just(HttpResponse.ofFailure(t)));
 
-        return HttpResponse.from(response.toFuture());
+        return HttpResponse.of(response.toFuture());
     }
 }

--- a/examples/context-propagation/rxjava/src/main/java/example/armeria/contextpropagation/rxjava/MainService.java
+++ b/examples/context-propagation/rxjava/src/main/java/example/armeria/contextpropagation/rxjava/MainService.java
@@ -105,6 +105,6 @@ public class MainService implements HttpService {
                         .map(content -> HttpResponse.of(content.toString()))
                         .onErrorReturn(HttpResponse::ofFailure);
 
-        return HttpResponse.from(response.toCompletionStage());
+        return HttpResponse.of(response.toCompletionStage());
     }
 }

--- a/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
+++ b/graphql-protocol/src/main/java/com/linecorp/armeria/server/graphql/protocol/AbstractGraphqlService.java
@@ -100,8 +100,8 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
 
         // See https://github.com/jaydenseric/graphql-multipart-request-spec/blob/master/readme.md
         if (contentType.is(MediaType.MULTIPART_FORM_DATA)) {
-            return HttpResponse.from(FileAggregatedMultipart.aggregateMultipart(ctx, request)
-                                                            .thenApply(multipart -> {
+            return HttpResponse.of(FileAggregatedMultipart.aggregateMultipart(ctx, request)
+                                                          .thenApply(multipart -> {
                 try {
                     final ListMultimap<String, String> multipartParams = multipart.params();
                     final String operationsParam = getValueFromMultipartParam("operations", multipartParams);
@@ -135,7 +135,7 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
         }
 
         if (contentType.isJson()) {
-            return HttpResponse.from(request.aggregate(ctx.eventLoop()).thenApply(req -> {
+            return HttpResponse.of(request.aggregate(ctx.eventLoop()).thenApply(req -> {
                 try (SafeCloseable ignored = ctx.push()) {
                     final String body = req.contentUtf8();
                     if (Strings.isNullOrEmpty(body)) {
@@ -171,7 +171,7 @@ public abstract class AbstractGraphqlService extends AbstractHttpService {
         }
 
         if (contentType.is(MediaType.GRAPHQL)) {
-            return HttpResponse.from(request.aggregate(ctx.eventLoop()).thenApply(req -> {
+            return HttpResponse.of(request.aggregate(ctx.eventLoop()).thenApply(req -> {
                 try (SafeCloseable ignored = ctx.push()) {
                     final String query = req.contentUtf8();
                     if (Strings.isNullOrEmpty(query)) {

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/DefaultGraphqlService.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/DefaultGraphqlService.java
@@ -107,7 +107,7 @@ final class DefaultGraphqlService extends AbstractGraphqlService implements Grap
         } else {
             future = graphQL.executeAsync(input);
         }
-        return HttpResponse.from(
+        return HttpResponse.of(
                 future.handle((executionResult, cause) -> {
                     if (executionResult.getData() instanceof Publisher) {
                         logger.warn("executionResult.getData() returns a {} that is not supported yet.",

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/client/grpc/protocol/UnaryGrpcClient.java
@@ -180,7 +180,7 @@ public final class UnaryGrpcClient {
         public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) {
             final AggregationOptions aggregationOptions =
                     AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop());
-            return HttpResponse.from(
+            return HttpResponse.of(
                     req.aggregate(aggregationOptions)
                        .thenCompose(
                                msg -> {

--- a/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
+++ b/grpc-protocol/src/main/java/com/linecorp/armeria/server/grpc/protocol/AbstractUnsafeUnaryGrpcService.java
@@ -172,7 +172,7 @@ public abstract class AbstractUnsafeUnaryGrpcService extends AbstractHttpService
                     return HttpResponse.of(trailers);
                 });
 
-        return HttpResponse.from(responseFuture);
+        return HttpResponse.of(responseFuture);
     }
 
     private static Subscriber<DeframedMessage> singleSubscriber(CompletableFuture<ByteBuf> deframed) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -241,7 +241,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         prepareHeaders(compressor, metadata, remainingNanos);
 
         final HttpResponse res = initContextAndExecuteWithFallback(
-                httpClient, ctx, endpointGroup, HttpResponse::from,
+                httpClient, ctx, endpointGroup, HttpResponse::of,
                 (unused, cause) -> HttpResponse.ofFailure(GrpcStatus.fromThrowable(cause)
                                                                     .withDescription(cause.getMessage())
                                                                     .asRuntimeException()));

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/CallCredentialsDecoratingClient.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/CallCredentialsDecoratingClient.java
@@ -106,6 +106,6 @@ final class CallCredentialsDecoratingClient extends SimpleDecoratingHttpClient {
                     }
                 });
 
-        return HttpResponse.from(response);
+        return HttpResponse.of(response);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -252,7 +252,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         final HttpResponse res;
         if (method.getMethodDescriptor().getType() == MethodType.UNARY) {
             final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
-            res = HttpResponse.from(resFuture);
+            res = HttpResponse.of(resFuture);
             startCall(registry.simpleMethodName(method.getMethodDescriptor()), method, ctx, req, res,
                       resFuture, serializationFormat);
         } else {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -585,7 +585,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
             }
             return null;
         });
-        return HttpResponse.from(responseFuture);
+        return HttpResponse.of(responseFuture);
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnframedGrpcService.java
@@ -159,6 +159,6 @@ final class UnframedGrpcService extends AbstractUnframedGrpcService {
                }
                return null;
            });
-        return HttpResponse.from(responseFuture);
+        return HttpResponse.of(responseFuture);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcWebTextTest.java
@@ -111,7 +111,7 @@ class GrpcWebTextTest {
                                 return streaming;
                             });
 
-            return HttpResponse.from(responseFuture);
+            return HttpResponse.of(responseFuture);
         }
 
         private static void writeEncodedMessageAcrossFrames(

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -95,7 +95,7 @@ class UnaryServerCallTest {
     @BeforeEach
     void setUp() {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        res = HttpResponse.from(responseFuture);
+        res = HttpResponse.of(responseFuture);
 
         ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
                                    .eventLoop(EventLoopGroups.directEventLoop())
@@ -211,7 +211,7 @@ class UnaryServerCallTest {
     @Test
     void deferResponseHeaders() {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse response = HttpResponse.from(responseFuture);
+        final HttpResponse response = HttpResponse.of(responseFuture);
         call = newServerCall(response, responseFuture, false);
 
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -256,7 +256,7 @@ class UnaryServerCallTest {
     @Test
     void deferResponseHeaders_unary_nonResponseMessage() {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse response = HttpResponse.from(responseFuture);
+        final HttpResponse response = HttpResponse.of(responseFuture);
         call = newServerCall(response, responseFuture, false);
 
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -305,7 +305,7 @@ class UnaryServerCallTest {
     @Test
     void decodeMultipleChunks() {
         final CompletableFuture<HttpResponse> resFuture = new CompletableFuture<>();
-        final HttpResponse response = HttpResponse.from(resFuture);
+        final HttpResponse response = HttpResponse.of(resFuture);
         final byte[] bytes = GrpcTestUtil.uncompressedFrame(GrpcTestUtil.requestByteBuf());
         final int length = bytes.length;
         final int middle = length / 2;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnframedGrpcServiceTest.java
@@ -171,7 +171,7 @@ class UnframedGrpcServiceTest {
                 .of(responseHeaders, HttpData.wrap(byteBuf));
         AbstractUnframedGrpcService.deframeAndRespond(ctx, framedResponse, res, UnframedGrpcErrorHandler.of(),
                                                       null, MediaType.PROTOBUF);
-        assertThat(HttpResponse.from(res).aggregate().get().status()).isEqualTo(HttpStatus.OK);
+        assertThat(HttpResponse.of(res).aggregate().get().status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test

--- a/it/multipart/src/test/java/com/linecorp/armeria/common/multipart/MultipartCollectIntegrationTest.java
+++ b/it/multipart/src/test/java/com/linecorp/armeria/common/multipart/MultipartCollectIntegrationTest.java
@@ -62,7 +62,7 @@ class MultipartCollectIntegrationTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
-            sb.service("/multipart/file", (ctx, req) -> HttpResponse.from(
+            sb.service("/multipart/file", (ctx, req) -> HttpResponse.of(
                       Multipart.from(req)
                                .collect(bodyPart -> {
                                    if (bodyPart.filename() != null) {
@@ -111,7 +111,7 @@ class MultipartCollectIntegrationTest {
                                        throw new UncheckedIOException(e);
                                    }
                                }, ctx.blockingTaskExecutor())))
-              .service("/multipart/large-file", (ctx, req) -> HttpResponse.from(
+              .service("/multipart/large-file", (ctx, req) -> HttpResponse.of(
                       Multipart.from(req).collect(bodyPart -> {
                                    final Path path = tempDir.resolve(bodyPart.name());
                                    return bodyPart.writeTo(path)

--- a/it/multipart/src/test/java/com/linecorp/armeria/common/multipart/RestTemplateMultipartTest.java
+++ b/it/multipart/src/test/java/com/linecorp/armeria/common/multipart/RestTemplateMultipartTest.java
@@ -39,7 +39,7 @@ class RestTemplateMultipartTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/multipart/text", (ctx, req) -> {
-                return HttpResponse.from(
+                return HttpResponse.of(
                         Multipart.from(req).aggregate().thenApply(multiPart -> {
                             final AggregatedBodyPart user = multiPart.field("user");
                             final AggregatedBodyPart org = multiPart.field("org");
@@ -48,7 +48,7 @@ class RestTemplateMultipartTest {
             });
 
             sb.service("/multipart/file", (ctx, req) -> {
-                return HttpResponse.from(
+                return HttpResponse.of(
                         Multipart.from(req).aggregate().thenApply(multiPart -> {
                             final AggregatedBodyPart file = multiPart.field("file");
                             return HttpResponse

--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServerExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/mock/MockWebServerExtension.java
@@ -173,7 +173,7 @@ public class MockWebServerExtension extends ServerExtension implements BeforeTes
     private class MockWebService implements HttpService {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-            return HttpResponse.from(req.aggregate().thenApply(aggReq -> {
+            return HttpResponse.of(req.aggregate().thenApply(aggReq -> {
                 recordedRequests.add(new RecordedRequest(ctx, aggReq));
 
                 final HttpResponse response = mockResponses.poll();

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClientTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/client/kotlin/CoroutineRestClientTest.kt
@@ -67,7 +67,7 @@ class RestClientTest {
         var server: ServerExtension = object : ServerExtension() {
             override fun configure(sb: ServerBuilder) {
                 sb.service("/rest/{id}") { ctx: ServiceRequestContext, req: HttpRequest ->
-                    HttpResponse.from(
+                    HttpResponse.of(
                         req.aggregate().thenApply { agg: AggregatedHttpRequest ->
                             val restResponse =
                                 RestResponse(

--- a/oauth2/src/main/java/com/linecorp/armeria/client/auth/oauth2/OAuth2Client.java
+++ b/oauth2/src/main/java/com/linecorp/armeria/client/auth/oauth2/OAuth2Client.java
@@ -66,6 +66,6 @@ public final class OAuth2Client extends SimpleDecoratingHttpClient {
             ctx.updateRequest(newReq);
             return executeWithFallback(unwrap(), ctx, (context, cause) -> HttpResponse.ofFailure(cause));
         });
-        return HttpResponse.from(future);
+        return HttpResponse.of(future);
     }
 }

--- a/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/server/resteasy/ResteasyService.java
@@ -162,9 +162,9 @@ public final class ResteasyService<T> implements HttpService {
         final long contentLength = headers.contentLength();
         if (contentLength >= -1 && contentLength <= maxRequestBufferSize) {
             // aggregate bounded requests
-            return HttpResponse.from(req.aggregate().thenCompose(r -> serveAsync(ctx, r)));
+            return HttpResponse.of(req.aggregate().thenCompose(r -> serveAsync(ctx, r)));
         } else {
-            return HttpResponse.from(serveAsync(ctx, req));
+            return HttpResponse.of(serveAsync(ctx, req));
         }
     }
 

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaCallFactoryTest.java
@@ -189,7 +189,7 @@ class ArmeriaCallFactoryTest {
 
                   @Override
                   protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                      return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                           final String name = ctx.mappedPath().substring(1);
                           final int age = QueryParams.fromQueryString(ctx.query()).getInt("age", -1);
                           return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
@@ -216,7 +216,7 @@ class ArmeriaCallFactoryTest {
               .service("/queryString", new AbstractHttpService() {
                   @Override
                   protected HttpResponse doGet(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                      return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                           final QueryParams params = QueryParams.fromQueryString(ctx.query());
                           return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
                                                  "{\"name\":\"" + params.get("name", "<NULL>") + "\", " +
@@ -227,7 +227,7 @@ class ArmeriaCallFactoryTest {
               .service("/post", new AbstractHttpService() {
                   @Override
                   protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                      return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
@@ -250,7 +250,7 @@ class ArmeriaCallFactoryTest {
               .service("/postForm", new AbstractHttpService() {
                   @Override
                   protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                      return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,
@@ -267,7 +267,7 @@ class ArmeriaCallFactoryTest {
               .service("/postCustomContentType", new AbstractHttpService() {
                   @Override
                   protected HttpResponse doPost(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      return HttpResponse.from(req.aggregate().handle((aReq, cause) -> {
+                      return HttpResponse.of(req.aggregate().handle((aReq, cause) -> {
                           if (cause != null) {
                               return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,
                                                      MediaType.PLAIN_TEXT_UTF_8,

--- a/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilderTest.java
+++ b/retrofit2/src/test/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilderTest.java
@@ -55,7 +55,7 @@ class ArmeriaRetrofitBuilderTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             sb.service("/secret", (ctx, req) -> {
-                return HttpResponse.from(req.aggregate().thenApply(aggReq -> {
+                return HttpResponse.of(req.aggregate().thenApply(aggReq -> {
                     if ("Bearer: access-token".equals(aggReq.headers().get(HttpHeaderNames.AUTHORIZATION))) {
                         return HttpResponse.of("\"OK\"");
                     } else {

--- a/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
+++ b/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
@@ -159,7 +159,7 @@ public final class ObservableResponseConverterFunction implements ResponseConver
     }
 
     private static HttpResponse respond(CompletableFuture<HttpResponse> future, Disposable disposable) {
-        final HttpResponse response = HttpResponse.from(future);
+        final HttpResponse response = HttpResponse.of(future);
         response.whenComplete().exceptionally(cause -> {
             disposable.dispose();
             return null;

--- a/rxjava2/src/test/java/com/linecorp/armeria/common/rxjava2/RequestContextAssemblyTest.java
+++ b/rxjava2/src/test/java/com/linecorp/armeria/common/rxjava2/RequestContextAssemblyTest.java
@@ -68,7 +68,7 @@ public class RequestContextAssemblyTest {
                             .flatMapCompletable(RequestContextAssemblyTest::completable)
                             .subscribe(() -> res.complete(HttpResponse.of(HttpStatus.OK)),
                                        res::completeExceptionally);
-                    return HttpResponse.from(res);
+                    return HttpResponse.of(res);
                 }
 
                 @SuppressWarnings("CheckReturnValue")
@@ -78,7 +78,7 @@ public class RequestContextAssemblyTest {
                     Single.just("")
                           .flatMap(RequestContextAssemblyTest::single)
                           .subscribe((s, throwable) -> res.complete(HttpResponse.of(HttpStatus.OK)));
-                    return HttpResponse.from(res);
+                    return HttpResponse.of(res);
                 }
             });
         }

--- a/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
+++ b/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
@@ -113,18 +113,18 @@ public final class ObservableResponseConverterFunction implements ResponseConver
         if (result instanceof Maybe) {
             @SuppressWarnings("unchecked")
             final CompletionStage<Object> future = ((Maybe<Object>) result).toCompletionStage(null);
-            return HttpResponse.from(future.handle(handleResult(ctx, headers, trailers)));
+            return HttpResponse.of(future.handle(handleResult(ctx, headers, trailers)));
         }
 
         if (result instanceof Single) {
             @SuppressWarnings("unchecked")
             final CompletionStage<Object> future = ((Single<Object>) result).toCompletionStage();
-            return HttpResponse.from(future.handle(handleResult(ctx, headers, trailers)));
+            return HttpResponse.of(future.handle(handleResult(ctx, headers, trailers)));
         }
 
         if (result instanceof Completable) {
             final CompletionStage<Object> future = ((Completable) result).toCompletionStage(null);
-            return HttpResponse.from(future.handle(handleResult(ctx, headers, trailers)));
+            return HttpResponse.of(future.handle(handleResult(ctx, headers, trailers)));
         }
 
         return ResponseConverterFunction.fallthrough();

--- a/rxjava3/src/test/java/com/linecorp/armeria/common/rxjava3/RequestContextAssemblyTest.java
+++ b/rxjava3/src/test/java/com/linecorp/armeria/common/rxjava3/RequestContextAssemblyTest.java
@@ -67,7 +67,7 @@ class RequestContextAssemblyTest {
                             .flatMapCompletable(RequestContextAssemblyTest::completable)
                             .subscribe(() -> res.complete(HttpResponse.of(HttpStatus.OK)),
                                        res::completeExceptionally);
-                    return HttpResponse.from(res);
+                    return HttpResponse.of(res);
                 }
 
                 @Get("/single")
@@ -77,7 +77,7 @@ class RequestContextAssemblyTest {
                     Single.just("")
                           .flatMap(RequestContextAssemblyTest::single)
                           .subscribe((s, throwable) -> res.complete(HttpResponse.of(HttpStatus.OK)));
-                    return HttpResponse.from(res);
+                    return HttpResponse.of(res);
                 }
             });
         }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlDecorator.java
@@ -106,7 +106,7 @@ final class SamlDecorator extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        return HttpResponse.from(authorizer.authorize(ctx, req).handle((result, cause) -> {
+        return HttpResponse.of(authorizer.authorize(ctx, req).handle((result, cause) -> {
             if (cause == null && result) {
                 // Already authenticated.
                 try {
@@ -124,7 +124,7 @@ final class SamlDecorator extends SimpleDecoratingHttpService {
                         unused -> sp.idpConfigSelector().select(sp, ctx, req));
             }
             // Find an identity provider first where the request is to be sent to.
-            return HttpResponse.from(f.thenApply(idp -> {
+            return HttpResponse.of(f.thenApply(idp -> {
                 if (idp == null) {
                     throw new RuntimeException("cannot find a suitable identity provider from configurations");
                 }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlService.java
@@ -152,7 +152,7 @@ final class SamlService implements HttpServiceWithRoutes {
         } else {
             f = portConfigHolder.future().thenCompose(unused -> req.aggregate());
         }
-        return HttpResponse.from(f.handleAsync((aggregatedReq, cause) -> {
+        return HttpResponse.of(f.handleAsync((aggregatedReq, cause) -> {
             if (cause != null) {
                 logger.warn("{} Failed to aggregate a SAML request.", ctx, cause);
                 return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -105,21 +105,21 @@ final class SamlSingleLogoutFunction implements SamlServiceFunction {
             final SamlEndpoint sloResEndpoint = idp.sloResEndpoint();
             if (sloResEndpoint == null) {
                 // No response URL. Just return 200 OK.
-                return HttpResponse.from(sloHandler.logoutSucceeded(ctx, req, messageContext)
-                                                   .thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
+                return HttpResponse.of(sloHandler.logoutSucceeded(ctx, req, messageContext)
+                                                 .thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
             }
 
             final LogoutResponse logoutResponse = createLogoutResponse(logoutRequest, StatusCode.SUCCESS);
             try {
                 final HttpResponse response = respond(logoutResponse, sloResEndpoint);
-                return HttpResponse.from(sloHandler.logoutSucceeded(ctx, req, messageContext)
-                                                   .thenApply(unused -> response));
+                return HttpResponse.of(sloHandler.logoutSucceeded(ctx, req, messageContext)
+                                                 .thenApply(unused -> response));
             } catch (SamlException e) {
                 logger.warn("{} Cannot respond a logout response in response to {}",
                             ctx, logoutRequest.getID(), e);
                 final HttpResponse response = fail(ctx, logoutRequest, sloResEndpoint);
-                return HttpResponse.from(sloHandler.logoutFailed(ctx, req, e)
-                                                   .thenApply(unused -> response));
+                return HttpResponse.of(sloHandler.logoutFailed(ctx, req, e)
+                                                 .thenApply(unused -> response));
             }
         } catch (SamlException e) {
             return fail(ctx, e);

--- a/spring/boot3-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot3-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -139,9 +139,9 @@ final class WebOperationService implements HttpService {
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
         if (operation.isBlocking()) {
-            return HttpResponse.from(req.aggregate().thenApplyAsync(invoke(ctx), ctx.blockingTaskExecutor()));
+            return HttpResponse.of(req.aggregate().thenApplyAsync(invoke(ctx), ctx.blockingTaskExecutor()));
         } else {
-            return HttpResponse.from(req.aggregate().thenApply(invoke(ctx)));
+            return HttpResponse.of(req.aggregate().thenApply(invoke(ctx)));
         }
     }
 

--- a/spring/boot3-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
+++ b/spring/boot3-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactory.java
@@ -348,7 +348,7 @@ public class ArmeriaReactiveWebServerFactory extends AbstractReactiveWebServerFa
                  .defaultServiceName("SpringWebFlux")
                  .build((ctx, req) -> {
                      final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-                     final HttpResponse response = HttpResponse.from(future);
+                     final HttpResponse response = HttpResponse.of(future);
                      final Disposable disposable = handler.handle(ctx, req, future, serverHeader).subscribe();
                      response.whenComplete().handle((unused, cause) -> {
                          if (cause != null) {

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -369,7 +369,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         }
 
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-        final HttpResponse res = HttpResponse.from(responseFuture);
+        final HttpResponse res = HttpResponse.of(responseFuture);
         ctx.logBuilder().serializationFormat(serializationFormat);
         ctx.logBuilder().defer(RequestLogProperty.REQUEST_CONTENT);
         req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))


### PR DESCRIPTION
Motivation:
We have decided to deprecate `HttpResponse.from(...)` methods and use `HttpResponse.of(...)` instead for consistency. https://github.com/line/armeria/pull/4995#discussion_r1253972919

Modification:
- Deprecate `HttpResponse.from(CompletionStage)` and its variants.
  - `HttpResponse.of(CompletionStage)` and its variants are added.

Result:
- `HttpResponse.from(CompletionStage)` and its variants methods are deprecated.
  - Use `HttpResponse.of(CompletionStage)` and its variants instead.
