### PR TITLE
Better caching for `thriftCompile` tasks

### DIFF
--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -16,10 +16,11 @@ configure(projectsWithFlags('java')) {
         def scope = sourceSet.name
         // Create the task assuming the source directory exists
         // so that subprojects can refer to the task.
-        def task = project.tasks.create([
+        CompileThriftTask task = project.tasks.create([
                 name: sourceSet.getTaskName('compile', 'thrift'),
                 group: 'Build',
-                description: "Compiles the ${sourceSet.name} .thrift files."
+                description: "Compiles the ${sourceSet.name} .thrift files.",
+                type: CompileThriftTask.class,
         ])
 
         def sourcesJarTask = project.tasks.findByName(sourceSet.getTaskName('sources', 'jar'))
@@ -51,14 +52,14 @@ configure(projectsWithFlags('java')) {
             def jsonOutputDir = "${project.ext.genSrcDir}/${scope}/resources"
             task.configure {
                 // configure caching
-                srcDirs.each { inputs.dir projectDir.relativePath(new File(it.toString())) }
-                includeDirs.each { inputs.dir projectDir.relativePath(new File(it.toString())) }
+                srcDirs.each { task.thriftDirs.add(it) }
+                includeDirs.each { task.thriftDirs.add(it) }
                 inputs.property("thriftVersion", project.ext.thriftVersion ?: "null")
                 inputs.property("thriftPath", project.ext.thriftPath ?: "null")
                 inputs.property("thriftJsonEnabled", thriftJsonEnabled)
                 inputs.property("fullCamel", fullCamel)
-                outputs.dir projectDir.relativePath(new File(javaOutputDir))
-                outputs.dir projectDir.relativePath(new File(jsonOutputDir))
+                outputs.dir javaOutputDir
+                outputs.dir jsonOutputDir
 
                 outputs.cacheIf { true }
 
@@ -121,5 +122,17 @@ configure(projectsWithFlags('java')) {
 
             project.ext.getGenerateSourcesTask().dependsOn(task)
         }
+    }
+}
+
+class CompileThriftTask extends DefaultTask {
+
+    @Internal
+    def thriftDirs = []
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    Iterable<File> getInputFiles() {
+        return project.files(thriftDirs)
     }
 }

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -57,8 +57,8 @@ configure(projectsWithFlags('java')) {
                 inputs.property("thriftPath", project.ext.thriftPath ?: "null")
                 inputs.property("thriftJsonEnabled", thriftJsonEnabled)
                 inputs.property("fullCamel", fullCamel)
-                outputs.dir javaOutputDir
-                outputs.dir jsonOutputDir
+                outputs.dir projectDir.relativePath(new File(javaOutputDir))
+                outputs.dir projectDir.relativePath(new File(jsonOutputDir))
 
                 outputs.cacheIf { true }
 

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -50,10 +50,9 @@ configure(projectsWithFlags('java')) {
             def javaOutputDir = "${project.ext.genSrcDir}/${scope}/java"
             def jsonOutputDir = "${project.ext.genSrcDir}/${scope}/resources"
             task.configure {
-
                 // configure caching
-                srcDirs.each { inputs.dir it }
-                includeDirs.each { inputs.dir it }
+                srcDirs.each { inputs.dir projectDir.relativePath(new File(it.toString())) }
+                includeDirs.each { inputs.dir projectDir.relativePath(new File(it.toString())) }
                 inputs.property("thriftVersion", project.ext.thriftVersion ?: "null")
                 inputs.property("thriftPath", project.ext.thriftPath ?: "null")
                 inputs.property("thriftJsonEnabled", thriftJsonEnabled)

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -54,10 +54,10 @@ configure(projectsWithFlags('java')) {
                 // configure caching
                 srcDirs.each { task.thriftDirs.add(it) }
                 includeDirs.each { task.thriftDirs.add(it) }
-                inputs.property("thriftVersion", project.ext.thriftVersion ?: "null")
-                inputs.property("thriftPath", project.ext.thriftPath ?: "null")
-                inputs.property("thriftJsonEnabled", thriftJsonEnabled)
-                inputs.property("fullCamel", fullCamel)
+                task.thriftVersion = project.ext.thriftVersion
+                task.thriftBinaryPath = project.ext.thriftPath
+                task.thriftJsonEnabled = thriftJsonEnabled
+                task.fullCamel = fullCamel
                 outputs.dir javaOutputDir
                 outputs.dir jsonOutputDir
 
@@ -130,9 +130,28 @@ class CompileThriftTask extends DefaultTask {
     @Internal
     def thriftDirs = []
 
+    @Input
+    @Optional
+    def thriftVersion
+
+    @Internal
+    def thriftBinaryPath
+
+    @Input
+    def thriftJsonEnabled
+
+    @Input
+    def fullCamel
+
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     Iterable<File> getInputFiles() {
         return project.files(thriftDirs)
+    }
+
+    @InputFile
+    @Optional
+    File getThriftBinary() {
+        return thriftBinaryPath != null ? project.file(thriftBinaryPath) : null
     }
 }

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -50,10 +50,18 @@ configure(projectsWithFlags('java')) {
             def javaOutputDir = "${project.ext.genSrcDir}/${scope}/java"
             def jsonOutputDir = "${project.ext.genSrcDir}/${scope}/resources"
             task.configure {
+
+                // configure caching
                 srcDirs.each { inputs.dir it }
                 includeDirs.each { inputs.dir it }
+                inputs.property("thriftVersion", project.ext.thriftVersion ?: "null")
+                inputs.property("thriftPath", project.ext.thriftPath ?: "null")
+                inputs.property("thriftJsonEnabled", thriftJsonEnabled)
+                inputs.property("fullCamel", fullCamel)
                 outputs.dir javaOutputDir
                 outputs.dir jsonOutputDir
+
+                outputs.cacheIf { true }
 
                 doFirst {
                     def actualThriftPath
@@ -62,7 +70,7 @@ configure(projectsWithFlags('java')) {
                     } else {
                         actualThriftPath =
                                 "${libDir}/thrift" +
-                                "/${project.findProperty('thriftVersion')?: '0.16'}" +
+                                "/${project.findProperty('thriftVersion')?: '0.18'}" +
                                 "/thrift.${rootProject.osdetector.classifier}"
                     }
 

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -150,6 +150,7 @@ class CompileThriftTask extends DefaultTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     File getThriftBinary() {
         return thriftBinaryPath != null ? project.file(thriftBinaryPath) : null

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -16,12 +16,12 @@ configure(projectsWithFlags('java')) {
         def scope = sourceSet.name
         // Create the task assuming the source directory exists
         // so that subprojects can refer to the task.
-        CompileThriftTask task = project.tasks.create([
+        def task = project.tasks.create([
                 name: sourceSet.getTaskName('compile', 'thrift'),
                 group: 'Build',
                 description: "Compiles the ${sourceSet.name} .thrift files.",
                 type: CompileThriftTask.class,
-        ])
+        ]) as CompileThriftTask
 
         def sourcesJarTask = project.tasks.findByName(sourceSet.getTaskName('sources', 'jar'))
         if (sourcesJarTask) {


### PR DESCRIPTION
Motivation:

We may save up to a minute if we properly define inputs/outputs for the `thriftCompile` gradle task.
The task is marked as cacheable by specifying `outputs.cacheIf { true }`.
Note that although `cacheIf { true }`, the task will still run if inputs/outputs change.

- Check without modifying input
  - https://ge.armeria.dev/c/pp3h4hh4ivj6e/zg5b57ucqvvjg/task-inputs
- Check while modifying a single input manually
  - https://ge.armeria.dev/c/qd4vy3a3da554/pp3h4hh4ivj6e/task-inputs

Build scan comparison with exp3:
- https://ge.armeria.dev/c/xvkcw3olkh2hk/bccchwpbbvo44/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure

Modifications:

- Specified the task inputs to all values defined in `project.ext` for thrift tasks.
- Marked `thriftCompile` tasks as cacheable

Result:

- Better input/output caching for `thriftCompile` tasks.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
