### PR TITLE
Use fewer event loops when using `io_uring` as transport

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -166,9 +166,13 @@ final class DefaultFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Integer numCommonWorkers() {
-        final int defaultNumCpuCores = Runtime.getRuntime().availableProcessors();
-        return defaultNumCpuCores * 2;
+    public Integer numCommonWorkers(TransportType transportType) {
+        final int numCpuCores = Runtime.getRuntime().availableProcessors();
+        if (transportType == TransportType.IO_URING) {
+            return numCpuCores;
+        } else {
+            return numCpuCores * 2;
+        }
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -195,7 +195,8 @@ public final class Flags {
             getValue(FlagsProvider::maxNumConnections, "maxNumConnections", value -> value > 0);
 
     private static final int NUM_COMMON_WORKERS =
-            getValue(FlagsProvider::numCommonWorkers, "numCommonWorkers", value -> value > 0);
+            getValue(provider -> provider.numCommonWorkers(TRANSPORT_TYPE),
+                     "numCommonWorkers", value -> value > 0);
 
     private static final int NUM_COMMON_BLOCKING_TASK_THREADS =
             getValue(FlagsProvider::numCommonBlockingTaskThreads, "numCommonBlockingTaskThreads",
@@ -600,8 +601,10 @@ public final class Flags {
      * {@link ServerBuilder#workerGroup(EventLoopGroup, boolean)} or
      * {@link ClientFactoryBuilder#workerGroup(EventLoopGroup, boolean)}.
      *
-     * <p>The default value of this flag is {@code 2 * <numCpuCores>}. Specify the
-     * {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>} JVM option to override the default value.
+     * <p>The default value of this flag is {@code 2 * <numCpuCores>} for {@link TransportType#NIO},
+     * {@link TransportType#EPOLL} and {@link TransportType#KQUEUE} and {@code <numCpuCores>} for
+     * {@link TransportType#IO_URING}. Specify the {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>}
+     * JVM option to override the default value.
      */
     public static int numCommonWorkers() {
         return NUM_COMMON_WORKERS;

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -238,11 +238,15 @@ public interface FlagsProvider {
      * {@link ServerBuilder#workerGroup(EventLoopGroup, boolean)} or
      * {@link ClientFactoryBuilder#workerGroup(EventLoopGroup, boolean)}.
      *
-     * <p>The default value of this flag is {@code 2 * <numCpuCores>}. Specify the
-     * {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>} JVM option to override the default value.
+     * <p>The default value of this flag is {@code 2 * <numCpuCores>} for {@link TransportType#NIO},
+     * {@link TransportType#EPOLL} and {@link TransportType#KQUEUE} and {@code <numCpuCores>} for
+     * {@link TransportType#IO_URING}. Specify the {@code -Dcom.linecorp.armeria.numCommonWorkers=<integer>}
+     * JVM option to override the default value.
+     *
+     * @param transportType the {@link TransportType} that will be used for I/O
      */
     @Nullable
-    default Integer numCommonWorkers() {
+    default Integer numCommonWorkers(TransportType transportType) {
         return null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -159,7 +159,7 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Integer numCommonWorkers() {
+    public Integer numCommonWorkers(TransportType transportType) {
         return getInt("numCommonWorkers");
     }
 


### PR DESCRIPTION
Motivation:

`io_uring` is known to have much smaller system call overhead than other
transport types such as NIO, `epoll` and Kqueue. Therefore, we should
use fewer event loop threads when using `io_uring`.

Modifications:

- Changed `FlagsProvider.numCommonWorkers()` to require `TransportType`
- Made `DefaultFlagsProvider.numCommonWorkers()` not double the number
  of CPU cores when the current transport type is `IO_URING`

Result:

- A user doesn't have to manually specify the optimal event loop count
  when using `io_uring`.
