### PR TITLE
Fix incorrect local and remote address when using domain socket in abstract namespace

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -90,7 +90,25 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     private static final String ALLOWED_METHODS_STRING =
             HttpMethod.knownMethods().stream().map(HttpMethod::name).collect(Collectors.joining(","));
 
-    private static final InetSocketAddress UNKNOWN_ADDR = new InetSocketAddress("0.0.0.0", 1);
+    private static final InetSocketAddress UNKNOWN_ADDR;
+
+    static {
+        InetAddress unknownAddr;
+        try {
+            unknownAddr = InetAddress.getByAddress("<unknown>", new byte[] { 0, 0, 0, 0 });
+        } catch (Exception e1) {
+            // Just in case a certain JRE implementation doesn't accept the hostname '<unknown>'
+            try {
+                unknownAddr = InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 });
+            } catch (Exception e2) {
+                // Should never reach here.
+                final Error err = new Error(e2);
+                err.addSuppressed(e1);
+                throw err;
+            }
+        }
+        UNKNOWN_ADDR = new InetSocketAddress(unknownAddr, 1);
+    }
 
     private static final ChannelFutureListener CLOSE = future -> {
         final Throwable cause = future.cause();


### PR DESCRIPTION
Related issue: #5080

Motivation:

`ServiceRequestContext.localAddress()` and
`ServiceRequestContext.remoteAddress()` currently returns an
`InetSocketAddress(0.0.0.0:1)` for domain sockets in abstract namespace.

Modifications:

- Updated `ChannelUtil` to use the parent channel's local address for
  server-side domain socket channels to retrieve their socket addresses
  reliably
- Added a special hostname `<unknown>` to `HttpServerHandler.UNKNOWN_ADDR`
  so that it's less confusing

Result:

- `ServiceRequestContext` now returns the correct socket addresses when
  the request is being served via a domain socket in abstract namespace.
- It should be easier to understand the situation when a similar issue
  (unknown address) arises again.
