### PR TITLE
CompileThrift task update

### DIFF
--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -101,7 +101,7 @@ class CompileThriftTask extends DefaultTask {
 
     @InputDirectory
     @PathSensitive(PathSensitivity.RELATIVE)
-    String libDir
+    File libDir
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -127,12 +127,12 @@ class CompileThriftTask extends DefaultTask {
     @TaskAction
     def execute() {
         def actualThriftPath
-        if (project.findProperty('thriftPath') != null) {
-            actualThriftPath = project.findProperty('thriftPath')
+        if (thriftBinary != null) {
+            actualThriftPath = thriftBinary.path
         } else {
             actualThriftPath =
                 "${libDir}/thrift" +
-                    "/${project.findProperty('thriftVersion')?: '0.18'}" +
+                    "/${thriftVersion?: '0.18'}" +
                     "/thrift.${project.rootProject.osdetector.classifier}"
         }
 

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -1,4 +1,4 @@
-def libDir = "${buildscript.sourceFile.parentFile}"
+def libDir = buildscript.sourceFile.parentFile
 
 configure(projectsWithFlags('java')) {
     def thriftJsonEnabled = true
@@ -16,12 +16,10 @@ configure(projectsWithFlags('java')) {
         def scope = sourceSet.name
         // Create the task assuming the source directory exists
         // so that subprojects can refer to the task.
-        def task = project.tasks.create([
-                name: sourceSet.getTaskName('compile', 'thrift'),
-                group: 'Build',
-                description: "Compiles the ${sourceSet.name} .thrift files.",
-                type: CompileThriftTask.class,
-        ]) as CompileThriftTask
+        def task = project.tasks.register(
+            (sourceSet.getTaskName('compile', 'thrift')) as String,
+            CompileThriftTask,
+        )
 
         def sourcesJarTask = project.tasks.findByName(sourceSet.getTaskName('sources', 'jar'))
         if (sourcesJarTask) {
@@ -35,7 +33,7 @@ configure(projectsWithFlags('java')) {
                 def defaultSrcDir = "${projectDir}/src/${scope}/thrift"
                 if (!project.file(defaultSrcDir).isDirectory()) {
                     // Disable the compile*Thrift task which turned out to be unnecessary.
-                    task.enabled = false
+                    task.configure { enabled = false }
                     return
                 }
                 srcDirs = [defaultSrcDir]
@@ -50,63 +48,20 @@ configure(projectsWithFlags('java')) {
                 includeDirs = [includeDirs]
             }
             includeDirs = project.files(includeDirs)
-            def javaOutputDir = "${project.ext.genSrcDir}/${scope}/java"
-            def jsonOutputDir = "${project.ext.genSrcDir}/${scope}/resources"
+            def javaOutputDir = project.file("${project.ext.genSrcDir}/${scope}/java")
+            def jsonOutputDir = project.file("${project.ext.genSrcDir}/${scope}/resources")
             task.configure {
-                // configure caching
-                task.thriftDirs.addAll(srcDirs)
-                task.thriftDirs.addAll(includeDirs)
-                task.thriftJsonEnabled = thriftJsonEnabled
-                task.fullCamel = fullCamel
-                outputs.dirs javaOutputDir, jsonOutputDir
+                // configure inputs and outputs
+                it.libDir = libDir
+                it.srcDirs.addAll(srcDirs)
+                it.includeDirs.addAll(includeDirs)
+                it.thriftJsonEnabled = thriftJsonEnabled
+                it.fullCamel = fullCamel
+                it.thriftBinary = project.ext.thriftPath != null ? project.file(project.ext.thriftPath) : null
+                it.thriftVersion = project.ext.thriftVersion
 
-                outputs.cacheIf { true }
-
-                doFirst {
-                    def actualThriftPath
-                    if (project.findProperty('thriftPath') != null) {
-                        actualThriftPath = project.findProperty('thriftPath')
-                    } else {
-                        actualThriftPath =
-                                "${libDir}/thrift" +
-                                "/${project.findProperty('thriftVersion')?: '0.18'}" +
-                                "/thrift.${rootProject.osdetector.classifier}"
-                    }
-
-                    srcDirs.each { srcDir ->
-                        project.fileTree(srcDir) {
-                            include '**/*.thrift'
-                        }.each { sourceFile ->
-                            logger.info("Using ${actualThriftPath} to generate Java sources from ${sourceFile}")
-                            project.mkdir(javaOutputDir)
-                            def javaGenerator = 'java'
-                            if (fullCamel) {
-                                javaGenerator = 'java:fullcamel'
-                            }
-                            project.exec {
-                                commandLine actualThriftPath
-                                args '-gen', javaGenerator, '-out', javaOutputDir
-                                includeDirs.each {
-                                    args '-I', it
-                                }
-                                args sourceFile.absolutePath
-                            }
-                            if (thriftJsonEnabled) {
-                                logger.info("Using ${actualThriftPath} to generate JSON from ${sourceFile}")
-                                def outDir = "${jsonOutputDir}/META-INF/armeria/thrift"
-                                project.mkdir(outDir)
-                                project.exec {
-                                    commandLine actualThriftPath
-                                    args '-gen', 'json', '-out', outDir
-                                    includeDirs.each {
-                                        args '-I', it
-                                    }
-                                    args sourceFile.absolutePath
-                                }
-                            }
-                        }
-                    }
-                }
+                it.javaOutputDir = javaOutputDir
+                it.jsonOutputDir = jsonOutputDir
             }
 
             def processResourcesTask = tasks.findByName(sourceSet.getTaskName('process', 'resources'))
@@ -124,24 +79,95 @@ configure(projectsWithFlags('java')) {
     }
 }
 
+@CacheableTask
 class CompileThriftTask extends DefaultTask {
+    @Override
+    String getGroup() {
+        return 'build'
+    }
+
+    @Override
+    String getDescription() {
+        return "Compiles the ${name} .thrift files."
+    }
 
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
-    def thriftDirs = new ArrayList<File>()
+    def srcDirs = new ArrayList<File>()
 
-    @Input
-    @Optional
-    String thriftVersion = project.ext.thriftVersion
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    def includeDirs = new ArrayList<File>()
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    String libDir
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
-    File thriftBinary = project.ext.thriftPath != null ? project.file(project.ext.thriftPath) : null
+    File thriftBinary
 
     @Input
-    def thriftJsonEnabled
+    @Optional
+    String thriftVersion
 
     @Input
-    def fullCamel
+    Boolean thriftJsonEnabled
+
+    @Input
+    Boolean fullCamel
+
+    @OutputDirectory
+    File javaOutputDir
+
+    @OutputDirectory
+    File jsonOutputDir
+
+    @TaskAction
+    def execute() {
+        def actualThriftPath
+        if (project.findProperty('thriftPath') != null) {
+            actualThriftPath = project.findProperty('thriftPath')
+        } else {
+            actualThriftPath =
+                "${libDir}/thrift" +
+                    "/${project.findProperty('thriftVersion')?: '0.18'}" +
+                    "/thrift.${project.rootProject.osdetector.classifier}"
+        }
+
+        srcDirs.each { srcDir ->
+            project.fileTree(srcDir) {
+                include '**/*.thrift'
+            }.each { sourceFile ->
+                logger.info("Using ${actualThriftPath} to generate Java sources from ${sourceFile}")
+                project.mkdir(javaOutputDir)
+                def javaGenerator = 'java'
+                if (fullCamel) {
+                    javaGenerator = 'java:fullcamel'
+                }
+                project.exec {
+                    commandLine actualThriftPath
+                    args '-gen', javaGenerator, '-out', javaOutputDir
+                    includeDirs.each {
+                        args '-I', it
+                    }
+                    args sourceFile.absolutePath
+                }
+                if (thriftJsonEnabled) {
+                    logger.info("Using ${actualThriftPath} to generate JSON from ${sourceFile}")
+                    def outDir = "${jsonOutputDir}/META-INF/armeria/thrift"
+                    project.mkdir(outDir)
+                    project.exec {
+                        commandLine actualThriftPath
+                        args '-gen', 'json', '-out', outDir
+                        includeDirs.each {
+                            args '-I', it
+                        }
+                        args sourceFile.absolutePath
+                    }
+                }
+            }
+        }
+    }
 }

--- a/gradle/scripts/lib/java-rpc-thrift.gradle
+++ b/gradle/scripts/lib/java-rpc-thrift.gradle
@@ -43,23 +43,22 @@ configure(projectsWithFlags('java')) {
             if (!(srcDirs instanceof Iterable) || srcDirs instanceof CharSequence) {
                 srcDirs = [srcDirs]
             }
+            srcDirs = project.files(srcDirs)
 
             def includeDirs = project.findProperty(sourceSet.getTaskName('', 'thriftIncludeDirs')) ?: []
             if (!(includeDirs instanceof Iterable) || includeDirs instanceof CharSequence) {
                 includeDirs = [includeDirs]
             }
+            includeDirs = project.files(includeDirs)
             def javaOutputDir = "${project.ext.genSrcDir}/${scope}/java"
             def jsonOutputDir = "${project.ext.genSrcDir}/${scope}/resources"
             task.configure {
                 // configure caching
-                srcDirs.each { task.thriftDirs.add(it) }
-                includeDirs.each { task.thriftDirs.add(it) }
-                task.thriftVersion = project.ext.thriftVersion
-                task.thriftBinaryPath = project.ext.thriftPath
+                task.thriftDirs.addAll(srcDirs)
+                task.thriftDirs.addAll(includeDirs)
                 task.thriftJsonEnabled = thriftJsonEnabled
                 task.fullCamel = fullCamel
-                outputs.dir javaOutputDir
-                outputs.dir jsonOutputDir
+                outputs.dirs javaOutputDir, jsonOutputDir
 
                 outputs.cacheIf { true }
 
@@ -127,32 +126,22 @@ configure(projectsWithFlags('java')) {
 
 class CompileThriftTask extends DefaultTask {
 
-    @Internal
-    def thriftDirs = []
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    def thriftDirs = new ArrayList<File>()
 
     @Input
     @Optional
-    def thriftVersion
+    String thriftVersion = project.ext.thriftVersion
 
-    @Internal
-    def thriftBinaryPath
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    @Optional
+    File thriftBinary = project.ext.thriftPath != null ? project.file(project.ext.thriftPath) : null
 
     @Input
     def thriftJsonEnabled
 
     @Input
     def fullCamel
-
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
-    Iterable<File> getInputFiles() {
-        return project.files(thriftDirs)
-    }
-
-    @InputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Optional
-    File getThriftBinary() {
-        return thriftBinaryPath != null ? project.file(thriftBinaryPath) : null
-    }
 }


### PR DESCRIPTION
Motivation:

Cleaned up `CompileThriftTask` implementation, added better code separation between task execution and configuration and prepared for easier possible refactoring away from using `project.ext` block in favor of configuring the task deterministically.

Modifications:

- Moved the execution code of the `CompileThriftTask` to it's task action part.
- Specified all the inputs and outputs of `CompileThriftTask` and removed any external references in task action.
- Removed all the `project.ext` accesses from the task itself (in order not to introduce big changes I left it when configuring the task).

Result:

- Easier to understand the `CompileThriftTask` configuration and execution.
- Better code separation between task configuration and task execution.
- Prepared for easier possible refactoring away from using `project.ext` block in favor of configuring the task deterministically.


