### PR TITLE
Fix a bug where tests did not work for MRJAR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,6 +35,7 @@ mrJarVersions.each { version->
         testClassesDirs = sourceSets."java${version}Test".output.classesDirs
         classpath = sourceSets."java${version}Test".runtimeClasspath
 
+        useJUnitPlatform()
         project.ext.configureCommonTestSettings(it)
         enabled = project.ext.testJavaVersion >= targetJavaVersion
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
@@ -54,10 +54,11 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
     @Override
     public ChannelFuture doWriteHeaders(int id, int streamId, ResponseHeaders headers, boolean endStream,
                                         boolean isTrailersEmpty) {
-        if (!isStreamPresentAndWritable(streamId)) {
+        if (!isStreamPresentAndWritable(streamId) || isResponseHeadersSent(id, streamId)) {
             // One of the following cases:
             // - Stream has been closed already.
             // - (bug) Server tried to send a response HEADERS frame before receiving a request HEADERS frame.
+            // - Server tried to send a response HEADERS frame twice.
             return newFailedFuture(ClosedStreamException.get());
         }
 


### PR DESCRIPTION
Motivation:

- Tests did not work for MRJAR because JUnit 5 was not set for `testJava9` or `testJava12`
- While fixing the issue, I found out that `JavaHttpClientUpgradeTest` for HTTP/2 fails to pass due to double write of headers.
  - One is sent by `fail()`
  - The other one is sent by the callback of `.abortResponse()` https://github.com/line/armeria/blob/de80c40588b9d3c4fb1d1791a2e798de0295f013/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java#L309-L314

Modifications:

- Set `useJUnitPlatform()` to `testJava{version}` test tasks.
- Check if a response headers was sent already before writing headers.

Result:

- Tests for Multi-release JAR now correctly run with `testJava9` and `testJava12` tasks.
- Fixed a bug where headers could be written twice if `content-length` was exceeded during HTTP/2 cleartext upgrade.

