### PR TITLE
Sort jmods before adding to proguard jars for easier caching

### DIFF
--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -137,7 +137,7 @@ configure(relocatedProjects) {
             if (jmodDir.isDirectory()) {
                 jmodDir.listFiles().findAll { File f ->
                     f.isFile() && f.name.toLowerCase(Locale.ENGLISH).endsWith(".jmod")
-                }.each { libraryjars it }
+                }.sort().each { libraryjars it }
             } else {
                 libraryjars file("${System.getProperty('java.home')}/lib/rt.jar")
             }


### PR DESCRIPTION
Motivation:

`trimShadedJar` may induce a build-cache miss due to a different file order. It may be worth sorting the libraryjars before adding them to avoid such cache misses.
ref: https://ge.armeria.dev/c/klccgbghrflqk/zbz73bzpwscrg/task-inputs?expanded=WyJkZ3hnY3Zsc2hua3R3LWluamFyZmlsZWNvbGxlY3Rpb24iLCJkZ3hnY3Zsc2hua3R3LWxpYnJhcnlqYXJmaWxlY29sbGVjdGlvbiIsImRneGdjdmxzaG5rdHctbGlicmFyeUphckZpbGVDb2xsZWN0aW9uLTEtZmlsZS1vcmRlciJd&task-text=trim
![Screenshot 2023-08-16 at 1 23 28 PM](https://github.com/line/armeria/assets/8510579/da708ab2-142f-49dc-90d9-7851c7f07eba)


Modifications:

- Sort each jmod before adding to `libraryjars` for proguard

Result:

- More stability for build cache hits

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
