### PR TITLE
Do not cache DNS queries that have timed out

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
@@ -78,23 +78,29 @@ final class CachingDnsResolver extends AbstractUnwrappable<DnsResolver> implemen
                     }
 
                     return unwrap().resolve(ctx, key).handle((records, cause) -> {
+                        final String name = question.name();
                         if (records != null) {
                             final List<DnsRecord> copied = records.stream()
                                                                   .map(ByteArrayDnsRecord::copyOf)
                                                                   .collect(toImmutableList());
 
-                            logger.debug("[{}] Caching DNS records: {}", question.name(), copied);
+                            logger.debug("[{}] Caching DNS records: {}", name, copied);
                             dnsCache.cache(key, copied);
                             return copied;
                         } else {
                             cause = Exceptions.peel(cause);
-                            if (DnsUtil.isDnsQueryTimedOut(cause)) {
-                                logger.debug("[{}] Not caching a timed-out DNS query: {}",
-                                             question.name(), question);
+                            if (cause instanceof UnknownHostException) {
+                                if (DnsUtil.isDnsQueryTimedOut(cause)) {
+                                    logger.debug("[{}] Not caching a timed-out DNS query: {}",
+                                                 name, question);
+                                } else {
+                                    logger.debug("[{}] Caching a failed DNS query: {}, cause: {}",
+                                                 name, question, cause.getMessage());
+                                    dnsCache.cache(key, (UnknownHostException) cause);
+                                }
                             } else {
-                                logger.debug("[{}] Caching a failed DNS query: {}, cause: {}",
-                                             question.name(), question, cause.getMessage());
-                                dnsCache.cache(key, (UnknownHostException) cause);
+                                logger.debug("[{}] Not caching a DNS query failed with an unexpected cause: {}",
+                                             name, question, cause);
                             }
                             return Exceptions.throwUnsafely(cause);
                         }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
@@ -88,7 +88,10 @@ final class CachingDnsResolver extends AbstractUnwrappable<DnsResolver> implemen
                             return copied;
                         } else {
                             cause = Exceptions.peel(cause);
-                            if (cause instanceof UnknownHostException) {
+                            if (DnsUtil.isDnsQueryTimedOut(cause)) {
+                                logger.debug("[{}] Not caching a timed-out DNS query: {}",
+                                             question.name(), question);
+                            } else {
                                 logger.debug("[{}] Caching a failed DNS query: {}, cause: {}",
                                              question.name(), question, cause.getMessage());
                                 dnsCache.cache(key, (UnknownHostException) cause);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/CachingDnsResolver.java
@@ -89,17 +89,12 @@ final class CachingDnsResolver extends AbstractUnwrappable<DnsResolver> implemen
                             return copied;
                         } else {
                             cause = Exceptions.peel(cause);
-                            if (cause instanceof UnknownHostException) {
-                                if (DnsUtil.isDnsQueryTimedOut(cause)) {
-                                    logger.debug("[{}] Not caching a timed-out DNS query: {}",
-                                                 name, question);
-                                } else {
-                                    logger.debug("[{}] Caching a failed DNS query: {}, cause: {}",
-                                                 name, question, cause.getMessage());
-                                    dnsCache.cache(key, (UnknownHostException) cause);
-                                }
+                            if (cause instanceof UnknownHostException && !DnsUtil.isDnsQueryTimedOut(cause)) {
+                                logger.debug("[{}] Caching a failed DNS query: {}, cause: {}",
+                                             name, question, cause.getMessage());
+                                dnsCache.cache(key, (UnknownHostException) cause);
                             } else {
-                                logger.debug("[{}] Not caching a DNS query failed with an unexpected cause: {}",
+                                logger.debug("[{}] Not caching an unexpectedly failed DNS query: {}",
                                              name, question, cause);
                             }
                             return Exceptions.throwUnsafely(cause);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/DnsUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/DnsUtil.java
@@ -18,13 +18,16 @@ package com.linecorp.armeria.internal.client.dns;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.UnknownHostException;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.DnsTimeoutException;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.TransportType;
@@ -35,6 +38,7 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.DnsNameResolverTimeoutException;
 
 public final class DnsUtil {
 
@@ -124,6 +128,25 @@ public final class DnsUtil {
 
     public static long defaultDnsQueryTimeoutMillis() {
         return DEFAULT_DNS_QUERY_TIMEOUT_MILLIS;
+    }
+
+    public static boolean isDnsQueryTimedOut(Throwable cause) {
+        final Throwable rootCause = Throwables.getRootCause(cause);
+        if (rootCause instanceof DnsTimeoutException ||
+            rootCause instanceof DnsNameResolverTimeoutException) {
+            return true;
+        }
+
+        if (rootCause instanceof UnknownHostException) {
+            for (Throwable suppressedCause : rootCause.getSuppressed()) {
+                final Throwable suppressedRootCause = Throwables.getRootCause(suppressedCause);
+                if (suppressedRootCause instanceof DnsNameResolverTimeoutException) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private DnsUtil() {}

--- a/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsTimeoutUtil.java
@@ -13,30 +13,19 @@
  * License for the specific language governing permissions and limitations
  * under the License
  */
-
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.UnknownHostException;
-
-import com.google.common.base.Throwables;
-
-import io.netty.resolver.dns.DnsNameResolverTimeoutException;
+import com.linecorp.armeria.internal.client.dns.DnsUtil;
 
 final class DnsTimeoutUtil {
 
     static void assertDnsTimeoutException(Throwable cause) {
-        final Throwable rootCause = Throwables.getRootCause(cause);
-        if (rootCause instanceof UnknownHostException) {
-            final Throwable suppressed = rootCause.getSuppressed()[0];
-            assertThat(suppressed.getClass().getSimpleName())
-                    .isEqualTo("SearchDomainUnknownHostException");
-            assertThat(suppressed.getCause()).isInstanceOf(DnsNameResolverTimeoutException.class);
-        } else {
-            assertThat(rootCause).isInstanceOfAny(DnsTimeoutException.class,
-                                                  DnsNameResolverTimeoutException.class);
-        }
+        assertThat(DnsUtil.isDnsQueryTimedOut(cause))
+                .withFailMessage("Expected the DNS query to fail due to a timeout, " +
+                                 "but it failed with a non-timeout exception: %s", cause)
+                .isTrue();
     }
 
     private DnsTimeoutUtil() {}


### PR DESCRIPTION
Motivation:

`CachingDnsResolver` should not cache any DNS queries that have timed out. However, it currently caches them when the timeout exception is buried in the exception's root cause or suppressed causes.

Modifications:

- Added `DnsUtil.isDnsQueryTimedOut()` to determine whether the DNS query failure was due to a timeout or not precisely
- Changed `DnsTimeoutUtil.assertDnsTimeoutException()` to use `DnsUtil.isDnsQueryTimedOut()`.
- Changed `CachingDnsResolver` to use `DnsUtil.isDnsQueryTimedOut()` in addition to the `instanceof UnknownHostException`.

Result:

- Armeria's DNS resolver doesn't cache a DNS query timeout.