### PR TITLE
Allow zero TTL for DNS cache

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
@@ -121,6 +121,11 @@ final class DefaultDnsCache implements DnsCache {
     public void cache(DnsQuestion question, Iterable<? extends DnsRecord> records) {
         requireNonNull(question, "question");
         requireNonNull(records, "records");
+        if (maxTtl == 0) {
+            // DNS records cache is disabled.
+            return;
+        }
+
         final List<DnsRecord> copied = ImmutableList.copyOf(records);
 
         final long ttl = copied.stream()

--- a/core/src/main/java/com/linecorp/armeria/client/DnsCacheBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsCacheBuilder.java
@@ -85,10 +85,12 @@ public final class DnsCacheBuilder {
      * respectively.
      * The default value is {@code 1} and {@link Integer#MAX_VALUE}, which practically tells this resolver to
      * respect the TTL from the DNS server.
+     *
+     * <p>Note that if {@code maxTtl} is set to {@code 0}, the resolved DNS records are not cached.
      */
     public DnsCacheBuilder ttl(int minTtl, int maxTtl) {
-        checkArgument(minTtl > 0 && minTtl <= maxTtl,
-                      "minTtl: %s, maxTtl: %s (expected: 1 <= minTtl <= maxTtl)", minTtl, maxTtl);
+        checkArgument(minTtl >= 0 && minTtl <= maxTtl,
+                      "minTtl: %s, maxTtl: %s (expected: 0 <= minTtl <= maxTtl)", minTtl, maxTtl);
         this.minTtl = minTtl;
         this.maxTtl = maxTtl;
         return this;

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultDnsCacheTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultDnsCacheTest.java
@@ -293,4 +293,22 @@ class DefaultDnsCacheTest {
         await().untilTrue(evicted);
         assertThat(removed).isFalse();
     }
+
+    @Test
+    void zeroTtl() throws UnknownHostException {
+        final DnsCache dnsCache = DnsCache.builder()
+                                          .ttl(0, 0)
+                                          .negativeTtl(1000)
+                                          .build();
+
+        final DnsQuestionWithoutTrailingDot query =
+                DnsQuestionWithoutTrailingDot.of("foo.com.", DnsRecordType.A);
+        final DnsRecord record = newRecord("foo.com.", "1.1.1.0", 20);
+        dnsCache.cache(query, ImmutableList.of(record));
+        assertThat(dnsCache.get(query)).isNull();
+
+        final UnknownHostException unknownHostException = new UnknownHostException("not found");
+        dnsCache.cache(query, unknownHostException);
+        assertThatThrownBy(() -> dnsCache.get(query)).isEqualTo(unknownHostException);
+    }
 }


### PR DESCRIPTION
Motivation:

When creating a new connection, the DNS records cache is disabled to obtain a new IP address, but there may be a need to cache NXDOMAIN. The default `DnsCache` shares a cache for positive and negative results and does not allow zero TTL, so it is difficult to configure the desired settings with `DnsCacheBuilder`.

Modifications:

- Allow zero TTL for successful DNS records.

Result:

`DnsCache` now allows zero TTL for the resolved DNS records.

