### PR TITLE
Fix flaky `GrpcServiceImplErrorTest`

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidGrpcMetadataTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/InvalidGrpcMetadataTest.java
@@ -56,7 +56,7 @@ import testing.grpc.Messages.StreamingOutputCallResponse;
 import testing.grpc.TestServiceGrpc;
 import testing.grpc.TestServiceGrpc.TestServiceBlockingStub;
 
-class GrpcServiceImplErrorTest {
+class InvalidGrpcMetadataTest {
 
     // Valid metadata has even count of binaryValues.
     private static final Metadata validMetadata = InternalMetadata.newMetadata(
@@ -144,7 +144,7 @@ class GrpcServiceImplErrorTest {
             final ServiceRequestContextCaptor serviceCaptor = server.requestContextCaptor();
             assertThat(serviceCaptor.size()).isEqualTo(1);
             final ServiceRequestContext serviceCtx = serviceCaptor.take();
-            assertThat(serviceCtx.log().ensureComplete().responseCause())
+            assertThat(serviceCtx.log().whenComplete().join().responseCause())
                     .isInstanceOf(StatusRuntimeException.class)
                     .satisfies(cause -> {
                         assertThat(Status.fromThrowable(cause).getCode()).isEqualTo(


### PR DESCRIPTION
Motivation:

See #5120

Modifications:

- Used `whenComplete().join()` instead of `ensureComplete()`
- Renamed `GrpcServiceImplErrorTest` to `InvalidGrpcMetadataTest` to easily identify the purpose of the tests

Result:

Closes #5120
