### PR TITLE
Specify Node.js version to GitHub Actions

### DIFF
--- a/.github/workflows/gradle-build-scan.yml
+++ b/.github/workflows/gradle-build-scan.yml
@@ -43,14 +43,14 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - id: get-pr-number-by-sha
         name: Get PR number by SHA
         working-directory: .github/actions
         run: |
-          export NVM_DIR=~/.nvm
-          source ~/.nvm/nvm.sh
-          npm install
+          npm ci
           npm run get-pr-number-by-sha
 
       - name: Setup Gradle
@@ -89,10 +89,7 @@ jobs:
         name: Create or update comment
         if: steps.get-pr-number-by-sha.outputs.pr_number
         working-directory: .github/actions
-        run: |
-          export NVM_DIR=~/.nvm
-          source ~/.nvm/nvm.sh
-          npm run comment-build-scan
+        run: npm run comment-build-scan
         env:
           BUILD_SCANS: ${{ steps.upload-build-scans.outputs.BUILD_SCANS }}
           PR_NUMBER: ${{ steps.get-pr-number-by-sha.outputs.pr_number }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,13 +46,13 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - name: Perform post-release process
         working-directory: .github/actions
         run: |
-          export NVM_DIR=~/.nvm
-          source ~/.nvm/nvm.sh
-          npm install
+          npm ci
           npm run post-release ${{ github.ref_name }}
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
Motivation:

The GitHub Actions job for Gradle scan failed due to `.nvm/nvm.sh: No such file or directory`.
https://github.com/line/armeria/actions/runs/5899610915/job/16002384391

Node.js version wasn't specified in `actions/setup-node@v3` workflow, so the node version in `PATH` could be used. https://github.com/actions/setup-node#usage It can't make our CI portable to other systems.

Modifications:

- Specify Node.js 18 to `setup-node` workflow
- Remove curruped code related to `nvm`
- Use `npm ci` instead of `npm install`
  - npm ci is a recommended way to install dependencies https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#npm

Result:

Hopely fix `.nvm/nvm.sh: No such file or directory` issue

