### PR TITLE
Do not add protocol-gRPC when sending a request from docs client

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -473,6 +473,7 @@ const App: React.FunctionComponent<Props> = (props) => {
         });
         setSpecification(initialSpecification);
       } catch (e) {
+        console.log(e);
         setSpecLoadingStatus(SpecLoadingStatus.FAILED);
         return;
       }

--- a/docs-client/src/lib/transports/grpc-unframed.ts
+++ b/docs-client/src/lib/transports/grpc-unframed.ts
@@ -41,7 +41,11 @@ export default class GrpcUnframedTransport extends Transport {
     const endpoint = this.getDebugMimeTypeEndpoint(method, endpointPath);
 
     const hdrs = new Headers();
-    hdrs.set('content-type', GRPC_UNFRAMED_MIME_TYPE);
+    // protocol=gRPC is added to mime types for the purpose of endpoint detection
+    // but is not actually used by unframed gRPC services. We use a simpler mime
+    // type when actually sending the request to better represent what a real client
+    // would do.
+    hdrs.set('content-type', 'application/json; charset=utf-8');
     for (const [name, value] of Object.entries(headers)) {
       hdrs.set(name, value);
     }


### PR DESCRIPTION
Motivation:

I miss Armeria docs service a lot. So I am working on an implementation of the server side in Go to be able to reuse the excellent client :)

https://github.com/curioswitch/go-docs-handler/blob/main/examples/connect/main.go

Currently still WIP, the features of simple GreetService are implemented but still just a bit more work to finish it up. Normally I would wait until more completeness but I saw the "Update dependencies" PR :P

`protocol=gRPC` is added for better differentiation within the docs UI but is not necessary for actually making requests. Coincidentally, not including it provides compatibility with this Go gRPC server implementation called connect. While I doubt Armeria could officially implement servers in other languages / frameworks like this, may small best effort tweaks are still ok?

Modifications:

- Don't send gRPC=protocol in the actual request to a gRPC service
- Also added a logging statement when parsing a specification fails, currently it is completely squashed and hard to debug server side issues

Result:

Go API developers (and maybe other languages that take a similar approach) can take advantage of some of Armeria's awesomeness.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
