### PR TITLE
Ignore empty Gradle build scans and continue to upload

### DIFF
--- a/.github/actions/comment-build-scan.ts
+++ b/.github/actions/comment-build-scan.ts
@@ -42,9 +42,9 @@ async function main(): Promise<void> {
     const [jobName, scanUrl]= scan.split(" ");
     const job = jobs.find(job => job.name === jobName);
     if (job.conclusion === 'success') {
-      commentBody += `| [${job.name}](${job.url}) | ✅ | ${scanUrl} |\n`;
+      commentBody += `| [${job.name}](${job.html_url}) | ✅ | ${scanUrl} |\n`;
     } else {
-      commentBody += `| [${job.name}](${job.url}) | ❌ (${job.conclusion}) | ${scanUrl} |\n`;
+      commentBody += `| [${job.name}](${job.html_url}) | ❌ (${job.conclusion}) | ${scanUrl} |\n`;
     }
   }
 

--- a/.github/workflows/gradle-build-scan.yml
+++ b/.github/workflows/gradle-build-scan.yml
@@ -66,6 +66,7 @@ jobs:
           echo "## Build Scan®" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
+          rm -rf $BUILD_SCAN_DIR
           for SCAN in $(ls $DOWNLOAD_DIR) ; do
             mkdir -p $BUILD_SCAN_DIR
             echo "🚚 Copying build scan: ${DOWNLOAD_DIR}${SCAN}/ to $BUILD_SCAN_DIR ..."

--- a/.github/workflows/gradle-build-scan.yml
+++ b/.github/workflows/gradle-build-scan.yml
@@ -73,11 +73,14 @@ jobs:
 
             JOB_NAME=$(echo ${SCAN} | sed 's/.*build-scan-\(.*\)/\1/')
             echo "📤 Uploading build scan for job ${JOB_NAME} ..."
-            ./gradlew --no-daemon --stacktrace clean buildScanPublishPrevious
-            echo "✅ Published build scan: ${JOB_NAME}"
-
-            BUILD_SCANS="${JOB_NAME} $(cat build/build-scan-url.txt),${BUILD_SCANS}"
-            echo "- [${JOB_NAME}]($(cat build/build-scan-url.txt))" >> "$GITHUB_STEP_SUMMARY"
+          
+            if ./gradlew --no-daemon --stacktrace clean buildScanPublishPrevious; then
+              echo "✅ Published build scan: ${JOB_NAME}"
+              BUILD_SCANS="${JOB_NAME} $(cat build/build-scan-url.txt),${BUILD_SCANS}"
+              echo "- [${JOB_NAME}]($(cat build/build-scan-url.txt))" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "❌ Failed to upload build scan: ${JOB_NAME}"
+            fi
 
             rm -rf $BUILD_SCAN_DIR
           done


### PR DESCRIPTION
Motivation:

A build scan may fail to upload if a Gradle build is corrupted somehow.
If there is no scan data in `.gradle/build-scan-data`, `./gradlew buildScanPublishPrevious` exits with 1, and then the subsequent commands will be halted.

Modifications:

- Ignore failed upload build scan and continue to upload the next data
- Use html_url for the workflow job 