### PR TITLE
Change the retention policy of `@UnstableApi` to `CLASS`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/annotation/UnstableApi.java
+++ b/core/src/main/java/com/linecorp/armeria/common/annotation/UnstableApi.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  * Indicates the API of the target is not mature enough to guarantee the compatibility between releases.
  * Its behavior, signature or even existence might change without a prior notice at any point.
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target({
         ElementType.ANNOTATION_TYPE,
         ElementType.CONSTRUCTOR,


### PR DESCRIPTION
Motivation:

The retention policy of the `@UnstableApi` annotation is currently
`SOURCE`, which means `.class` files in our JAR will not be able to tell
bytecode-level analysis tools about whether a certain class or method is
unstable or not. Therefore, we cannot exclude the unstable API elements
from the API backward compatibility checks we'd like to introduce in the
future.

Modifications:

- Change the retention policy from `SOURCE` to `CLASS` so that our
  `.class` files contains enough metadata about the stability of our
  API.

Result:

- We can exclude the unstable API elements from our future API backward
  compatibility tests.
