### PR TITLE
Do not expose Guava's `ToStringHelper` from the public API

### DIFF
--- a/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
+++ b/consul/src/main/java/com/linecorp/armeria/client/consul/ConsulEndpointGroup.java
@@ -142,10 +142,14 @@ public final class ConsulEndpointGroup extends DynamicEndpointGroup {
 
     @Override
     public String toString() {
-        return toStringHelper()
-                .add("serviceName", serviceName)
-                .add("datacenter", datacenter)
-                .add("filter", filter)
-                .toString();
+        return toString(buf -> {
+            buf.append(", serviceName=").append(serviceName);
+            if (datacenter != null) {
+                buf.append(", datacenter=").append(datacenter);
+            }
+            if (filter != null) {
+                buf.append(", filter=").append(filter);
+            }
+        });
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
+import java.util.function.Consumer;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -340,20 +341,36 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
 
     @Override
     public String toString() {
-        return toStringHelper().toString();
+        return toString(unused -> {});
     }
 
     /**
-     * Returns {@link ToStringHelper} that contains fields information.
+     * Returns the string representation of this {@link DynamicEndpointGroup}. Specify a {@link Consumer}
+     * to add more fields to the returned string, e.g.
+     * <pre>{@code
+     * > @Override
+     * > public String toString() {
+     * >     return toString(buf -> {
+     * >         buf.append(", foo=").append(foo);
+     * >         buf.append(", bar=").append(bar);
+     * >     });
+     * > }
+     * }</pre>
+     *
+     * @param builderMutator the {@link Consumer} that appends the additional fields into the given
+     *                       {@link StringBuilder}.
      */
-    protected ToStringHelper toStringHelper() {
-        return MoreObjects.toStringHelper(this)
-                          .omitNullValues()
-                          .add("selectionStrategy", selectionStrategy.getClass())
-                          .add("allowsEmptyEndpoints", allowEmptyEndpoints)
-                          .add("endpoints", truncate(endpoints, 10))
-                          .add("numEndpoints", endpoints.size())
-                          .add("initialized", initialEndpointsFuture.isDone());
+    @UnstableApi
+    protected final String toString(Consumer<? super StringBuilder> builderMutator) {
+        final StringBuilder buf = new StringBuilder();
+        buf.append(getClass().getSimpleName());
+        buf.append("{selectionStrategy=").append(selectionStrategy.getClass());
+        buf.append(", allowsEmptyEndpoints=").append(allowEmptyEndpoints);
+        buf.append(", initialized=").append(initialEndpointsFuture.isDone());
+        buf.append(", numEndpoints=").append(endpoints.size());
+        buf.append(", endpoints=").append(truncate(endpoints, 10));
+        builderMutator.accept(buf);
+        return buf.append('}').toString();
     }
 
     private class InitialEndpointsFuture extends EventLoopCheckingFuture<List<Endpoint>> {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -32,8 +32,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/PropertiesEndpointGroup.java
@@ -233,8 +233,6 @@ public final class PropertiesEndpointGroup extends DynamicEndpointGroup {
 
     @Override
     public String toString() {
-        return toStringHelper()
-                .add("watchRegisterKey", watchRegisterKey)
-                .toString();
+        return toString(buf -> buf.append(", watchRegisterKey=").append(watchRegisterKey));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -242,10 +242,10 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup implements DnsCache
 
     @Override
     public String toString() {
-        return toStringHelper()
-                .add("questions", questions)
-                .add("logPrefix", logPrefix)
-                .add("attemptsSoFar", attemptsSoFar)
-                .toString();
+        return toString(buf -> {
+            buf.append(", questions=").append(questions);
+            buf.append(", logPrefix=").append(logPrefix);
+            buf.append(", attemptsSoFar=").append(attemptsSoFar);
+        });
     }
 }

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroup.java
@@ -419,8 +419,6 @@ public final class EurekaEndpointGroup extends DynamicEndpointGroup {
 
     @Override
     public String toString() {
-        return toStringHelper()
-                .add("requestHeaders", requestHeaders)
-                .toString();
+        return toString(buf -> buf.append(", requestHeaders=").append(requestHeaders));
     }
 }

--- a/javadoc/build.gradle
+++ b/javadoc/build.gradle
@@ -31,8 +31,13 @@ task checkJavadoc(
                 'nested.classes.inherited.from.class.'
         ]
         def allowedListPrefixes = ['java.', 'javax.']
-        def disallowedListPrefixes = [ 'com.linecorp.armeria.internal.' ] +
-                rootProject.ext.relocations.collect { it[1] + '.' }
+        def disallowedListPrefixes = ['com.linecorp.armeria.internal.']
+        disallowedListPrefixes.addAll(rootProject.ext.relocations.collect {
+            def packageName = it["from"]
+            assert packageName != null
+            packageName + '.'
+        })
+
         def errors = []
 
         reportFile.parentFile.mkdirs()


### PR DESCRIPTION
Motivation:

It's a bad idea to expose Guava classes from our public API because all
Guava classes are shaded into `com.linecorp.armeria.internal.shaded.guava`,
exposing the internal classes in the public API.

Modifications:

- Fixed the broken test in `javadoc/build.gradle`.
- Replaced `DynamicEndpointGroup.toStringHelper()` with `toString(Consumer)`.

Result:

- We do not leak internal classes in our public API anymore.
