### PR TITLE
Add more factory methods to `PrometheusExpositionService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/metric/PrometheusExpositionService.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.armeria.server.metric;
 
 import static java.util.Objects.requireNonNull;
@@ -47,11 +46,27 @@ import io.prometheus.client.exporter.common.TextFormat;
 public final class PrometheusExpositionService extends AbstractHttpService implements TransientHttpService {
 
     /**
+     * Returns a new {@link PrometheusExpositionService} that exposes Prometheus metrics from
+     * {@link CollectorRegistry#defaultRegistry}.
+     */
+    public static PrometheusExpositionService of() {
+        return of(CollectorRegistry.defaultRegistry);
+    }
+
+    /**
      * Returns a new {@link PrometheusExpositionService} that exposes Prometheus metrics from the specified
      * {@link CollectorRegistry}.
      */
     public static PrometheusExpositionService of(CollectorRegistry collectorRegistry) {
         return new PrometheusExpositionService(collectorRegistry, Flags.transientServiceOptions());
+    }
+
+    /**
+     * Returns a new {@link PrometheusExpositionServiceBuilder} created with
+     * {@link CollectorRegistry#defaultRegistry}.
+     */
+    public static PrometheusExpositionServiceBuilder builder() {
+        return builder(CollectorRegistry.defaultRegistry);
     }
 
     /**


### PR DESCRIPTION
Motivation:

It is very common for users to specify `CollectorRegistry.defaultRegistry` when creating a `PrometheusExpositionService` or its builder.

Modifications:

- Added two shortcut methods:
  - `of()` -> `of(CollectorRegistry.defaultRegistry)`
  - `builder()` -> `builder(CollectorRegistry.defaultRegistry)`

Result:

- Much more convenient and less verbose when creating a `PrometheusExpositionService`
