### PR TITLE
Refactor bootstrap retrieval in `HttpChannelPool`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.common.SessionProtocol.httpAndHttpsValues;
+
+import java.lang.reflect.Array;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Set;
+
+import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.handler.ssl.SslContext;
+
+final class Bootstraps {
+    private final Bootstrap[][] inetBootstraps;
+    @Nullable
+    private final Bootstrap[][] unixBootstraps;
+
+    private final int connectTimeoutMillis;
+
+    private final EventLoop eventLoop;
+
+    private final SslContext sslCtxHttp1Only;
+
+    private final SslContext sslCtxHttp1Or2;
+
+    Bootstraps(HttpClientFactory clientFactory, EventLoop eventLoop, SslContext sslCtxHttp1Only,
+               SslContext sslCtxHttp1Or2) {
+        this.eventLoop = eventLoop;
+        this.sslCtxHttp1Only = sslCtxHttp1Only;
+        this.sslCtxHttp1Or2 = sslCtxHttp1Or2;
+        final Bootstrap inetBaseBootstrap = clientFactory.newInetBootstrap();
+        final Bootstrap unixBaseBootstrap = clientFactory.newUnixBootstrap();
+        inetBootstraps = newBootstrapMap(inetBaseBootstrap, clientFactory, eventLoop);
+        if (unixBaseBootstrap != null) {
+            unixBootstraps = newBootstrapMap(unixBaseBootstrap, clientFactory, eventLoop);
+        } else {
+            unixBootstraps = null;
+        }
+        connectTimeoutMillis = (Integer) inetBaseBootstrap.config().options()
+                                                          .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+    }
+
+    Bootstrap get(SocketAddress remoteAddress, SessionProtocol desiredProtocol,
+                  SerializationFormat serializationFormat) {
+        if (!httpAndHttpsValues().contains(desiredProtocol)) {
+            throw new NullPointerException("Unsupported session protocol: " + desiredProtocol);
+        }
+
+        if (remoteAddress instanceof InetSocketAddress) {
+            return select(inetBootstraps, desiredProtocol, serializationFormat);
+        }
+
+        assert remoteAddress instanceof DomainSocketAddress : remoteAddress;
+
+        if (unixBootstraps == null) {
+            throw new IllegalArgumentException("Domain sockets are not supported by " +
+                                               eventLoop.getClass().getName());
+        }
+
+        return select(unixBootstraps, desiredProtocol, serializationFormat);
+    }
+
+    int getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    private Bootstrap select(Bootstrap[][] bootstraps, SessionProtocol desiredProtocol, SerializationFormat serializationFormat) {
+        return bootstraps[desiredProtocol.ordinal()][toIndex(serializationFormat)];
+    }
+
+    private Bootstrap[][] newBootstrapMap(Bootstrap baseBootstrap,
+                                          HttpClientFactory clientFactory,
+                                          EventLoop eventLoop) {
+        baseBootstrap.group(eventLoop);
+        final Set<SessionProtocol> sessionProtocols = httpAndHttpsValues();
+        final Bootstrap[][] maps = (Bootstrap[][]) Array.newInstance(
+                Bootstrap.class, SessionProtocol.values().length, 2);
+        // Attempting to access the array with an unallowed protocol will trigger NPE,
+        // which will help us find a bug.
+        for (SessionProtocol p : sessionProtocols) {
+            final SslContext sslCtx = determineSslContext(p);
+            setBootstrap(baseBootstrap.clone(), clientFactory, maps, p, sslCtx, true);
+            setBootstrap(baseBootstrap.clone(), clientFactory, maps, p, sslCtx, false);
+        }
+        return maps;
+    }
+    private void setBootstrap(Bootstrap bootstrap, HttpClientFactory clientFactory, Bootstrap[][] maps,
+                              SessionProtocol p, SslContext sslCtx, boolean webSocket) {
+        bootstrap.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(
+                        new HttpClientPipelineConfigurator(clientFactory, webSocket, p, sslCtx));
+            }
+        });
+        maps[p.ordinal()][toIndex(webSocket)] = bootstrap;
+    }
+
+    private int toIndex(boolean webSocket) {
+        return webSocket ? 1 : 0;
+    }
+
+    private int toIndex(SerializationFormat serializationFormat) {
+        return toIndex(serializationFormat == SerializationFormat.WS);
+    }
+
+    private SslContext determineSslContext(SessionProtocol desiredProtocol) {
+        return desiredProtocol == SessionProtocol.H1 || desiredProtocol == SessionProtocol.H1C ?
+               sslCtxHttp1Only : sslCtxHttp1Or2;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -103,8 +103,7 @@ final class Bootstraps {
      * Determine {@link SslContext} by the specified {@link SessionProtocol}.
      */
     SslContext determineSslContext(SessionProtocol desiredProtocol) {
-        return desiredProtocol == SessionProtocol.H1 || desiredProtocol == SessionProtocol.H1C ?
-               sslCtxHttp1Only : sslCtxHttp1Or2;
+        return desiredProtocol.isExplicitHttp1() ? sslCtxHttp1Only : sslCtxHttp1Or2;
     }
 
     private static Bootstrap select(Bootstrap[][] bootstraps, SessionProtocol desiredProtocol,

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -35,6 +35,7 @@ import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.handler.ssl.SslContext;
 
 final class Bootstraps {
+
     private final Bootstrap[][] inetBootstraps;
     @Nullable
     private final Bootstrap[][] unixBootstraps;

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -43,7 +43,7 @@ final class Bootstraps {
     private final SslContext sslCtxHttp1Or2;
 
     Bootstraps(HttpClientFactory clientFactory, EventLoop eventLoop, SslContext sslCtxHttp1Or2,
-               SslContext sslCtxHttp1Only, Bootstrap inetBaseBootstrap, Bootstrap unixBaseBootstrap) {
+               SslContext sslCtxHttp1Only, Bootstrap inetBaseBootstrap, @Nullable Bootstrap unixBaseBootstrap) {
         this.eventLoop = eventLoop;
         this.sslCtxHttp1Or2 = sslCtxHttp1Or2;
         this.sslCtxHttp1Only = sslCtxHttp1Only;

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -114,12 +114,15 @@ final class Bootstraps {
     private static void setBootstrap(Bootstrap bootstrap, HttpClientFactory clientFactory, Bootstrap[][] maps,
                                      SessionProtocol p, SslContext sslCtx, boolean webSocket) {
         bootstrap.handler(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) throws Exception {
-                ch.pipeline().addLast(
-                        new HttpClientPipelineConfigurator(clientFactory, webSocket, p, sslCtx));
-            }
-        });
+                              @Override
+                              protected void initChannel(Channel ch) throws Exception {
+                                  ch.pipeline().addLast(new HttpClientPipelineConfigurator(clientFactory,
+                                          webSocket,
+                                          p,
+                                          sslCtx));
+                              }
+                          }
+        );
         maps[p.ordinal()][toIndex(webSocket)] = bootstrap;
     }
 
@@ -130,5 +133,4 @@ final class Bootstraps {
     private static int toIndex(SerializationFormat serializationFormat) {
         return toIndex(serializationFormat == SerializationFormat.WS);
     }
-
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -51,9 +51,7 @@ final class Bootstraps {
 
         final Bootstrap inetBaseBootstrap = clientFactory.newInetBootstrap();
         final Bootstrap unixBaseBootstrap = clientFactory.newUnixBootstrap();
-
         inetBootstraps = newBootstrapMap(inetBaseBootstrap, clientFactory, eventLoop);
-
         if (unixBaseBootstrap != null) {
             unixBootstraps = newBootstrapMap(unixBaseBootstrap, clientFactory, eventLoop);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -44,10 +44,13 @@ final class Bootstraps {
     private final SslContext sslCtxHttp1Or2;
 
     Bootstraps(HttpClientFactory clientFactory, EventLoop eventLoop, SslContext sslCtxHttp1Or2,
-               SslContext sslCtxHttp1Only, Bootstrap inetBaseBootstrap, @Nullable Bootstrap unixBaseBootstrap) {
+               SslContext sslCtxHttp1Only) {
         this.eventLoop = eventLoop;
         this.sslCtxHttp1Or2 = sslCtxHttp1Or2;
         this.sslCtxHttp1Only = sslCtxHttp1Only;
+
+        final Bootstrap inetBaseBootstrap = clientFactory.newInetBootstrap();
+        final Bootstrap unixBaseBootstrap = clientFactory.newUnixBootstrap();
 
         inetBootstraps = newBootstrapMap(inetBaseBootstrap, clientFactory, eventLoop);
 

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -37,8 +37,7 @@ import io.netty.handler.ssl.SslContext;
 final class Bootstraps {
 
     private final Bootstrap[][] inetBootstraps;
-    @Nullable
-    private final Bootstrap[][] unixBootstraps;
+    private final Bootstrap @Nullable [][] unixBootstraps;
     private final EventLoop eventLoop;
     private final SslContext sslCtxHttp1Only;
     private final SslContext sslCtxHttp1Or2;
@@ -118,10 +117,8 @@ final class Bootstraps {
         bootstrap.handler(new ChannelInitializer<Channel>() {
                               @Override
                               protected void initChannel(Channel ch) throws Exception {
-                                  ch.pipeline().addLast(new HttpClientPipelineConfigurator(clientFactory,
-                                          webSocket,
-                                          p,
-                                          sslCtx));
+                                  ch.pipeline().addLast(new HttpClientPipelineConfigurator(
+                                          clientFactory, webSocket, p, sslCtx));
                               }
                           }
         );

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -506,7 +506,7 @@ final class HttpChannelPool implements AsyncCloseable {
                     // Clean up old unhealthy channels by iterating from the beginning of the queue.
                     final Deque<PooledChannel> queue = getPool(protocol, key);
                     if (queue != null) {
-                        for (; ; ) {
+                        for (;;) {
                             final PooledChannel pooledChannel = queue.peekFirst();
                             if (pooledChannel == null || isHealthy(pooledChannel)) {
                                 break;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -105,14 +105,11 @@ final class HttpChannelPool implements AsyncCloseable {
         allChannels = new IdentityHashMap<>();
         this.listener = listener;
 
-        final Bootstrap inetBaseBootstrap = clientFactory.newInetBootstrap();
-        final Bootstrap unixBaseBootstrap = clientFactory.newUnixBootstrap();
+        connectTimeoutMillis = (Integer) clientFactory.options()
+                .channelOptions()
+                .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
 
-        connectTimeoutMillis = (Integer) inetBaseBootstrap.config().options()
-                                                          .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
-
-        bootstraps = new Bootstraps(clientFactory, eventLoop, sslCtxHttp1Or2, sslCtxHttp1Only,
-                                    inetBaseBootstrap, unixBaseBootstrap);
+        bootstraps = new Bootstraps(clientFactory, eventLoop, sslCtxHttp1Or2, sslCtxHttp1Only);
     }
 
     private void configureProxy(Channel ch, ProxyConfig proxyConfig, SessionProtocol desiredProtocol) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -99,16 +99,15 @@ final class HttpChannelPool implements AsyncCloseable {
                     ConnectionPoolListener listener) {
         this.clientFactory = clientFactory;
         this.eventLoop = eventLoop;
+        this.listener = listener;
+
         pool = newEnumMap(ImmutableSet.of(SessionProtocol.H1, SessionProtocol.H1C,
                                           SessionProtocol.H2, SessionProtocol.H2C));
         pendingAcquisitions = newEnumMap(httpAndHttpsValues());
         allChannels = new IdentityHashMap<>();
-        this.listener = listener;
-
         connectTimeoutMillis = (Integer) clientFactory.options()
                 .channelOptions()
                 .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
-
         bootstraps = new Bootstraps(clientFactory, eventLoop, sslCtxHttp1Or2, sslCtxHttp1Only);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -506,7 +506,7 @@ final class HttpChannelPool implements AsyncCloseable {
                     // Clean up old unhealthy channels by iterating from the beginning of the queue.
                     final Deque<PooledChannel> queue = getPool(protocol, key);
                     if (queue != null) {
-                        while (true) {
+                        for (; ; ) {
                             final PooledChannel pooledChannel = queue.peekFirst();
                             if (pooledChannel == null || isHealthy(pooledChannel)) {
                                 break;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -168,11 +168,6 @@ final class HttpChannelPool implements AsyncCloseable {
         return maps;
     }
 
-    private Bootstrap getBootstrap(SessionProtocol desiredProtocol, SocketAddress remoteAddress,
-                                   SerializationFormat serializationFormat) {
-        return bootstraps.get(remoteAddress, desiredProtocol, serializationFormat);
-    }
-
     @Nullable
     private Deque<PooledChannel> getPool(SessionProtocol protocol, PoolKey key) {
         return pool[protocol.ordinal()].get(key);
@@ -367,7 +362,7 @@ final class HttpChannelPool implements AsyncCloseable {
 
         final Bootstrap bootstrap;
         try {
-            bootstrap = getBootstrap(desiredProtocol, remoteAddress, serializationFormat);
+            bootstrap = bootstraps.get(remoteAddress, desiredProtocol, serializationFormat);
         } catch (Exception e) {
             sessionPromise.tryFailure(e);
             return;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -506,7 +506,7 @@ final class HttpChannelPool implements AsyncCloseable {
                     // Clean up old unhealthy channels by iterating from the beginning of the queue.
                     final Deque<PooledChannel> queue = getPool(protocol, key);
                     if (queue != null) {
-                        for (; ; ) {
+                        while (true) {
                             final PooledChannel pooledChannel = queue.peekFirst();
                             if (pooledChannel == null || isHealthy(pooledChannel)) {
                                 break;
@@ -878,5 +878,4 @@ final class HttpChannelPool implements AsyncCloseable {
             }
         }
     }
-
 }


### PR DESCRIPTION
Related: #5129

Motivation:
The `bootstrap` creation logic in the `HttpChannelPool`  is fairly complex. We want to simplify it by making it a separate class and data structure. from @minwoox 


Modifications:
- `inetBootstraps` and `unixBootstraps` were fields in `HttpChannelPool`, but have now been changed to fields in the own class `Bootstraps`.


Result:
- Closes #5129. (If this resolves the issue.)
- We've separate the bootstrap retrieval logic from `HttpChannelPool` to make it simple.


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
