### PR TITLE
Disable request timeout if `grpc-timeout` is omitted while `useClientTimeoutHeader` is enabled.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -243,6 +243,10 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                                     ctx, defaultHeaders.get(serializationFormat).toBuilder(),
                                     GrpcStatus.fromThrowable(statusFunction, ctx, e, metadata), metadata));
                 }
+            } else {
+                // As per gRPC specification, if timeout is omitted a server should assume an infinite timeout.
+                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#protocol
+                ctx.clearRequestTimeout();
             }
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -244,9 +244,14 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                                     GrpcStatus.fromThrowable(statusFunction, ctx, e, metadata), metadata));
                 }
             } else {
-                // As per gRPC specification, if timeout is omitted a server should assume an infinite timeout.
-                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#protocol
-                ctx.clearRequestTimeout();
+                if (Boolean.TRUE.equals(ctx.attr(AbstractUnframedGrpcService.IS_UNFRAMED_GRPC))) {
+                    // For unframed gRPC, we use the default timeout.
+                } else {
+                    // For framed gRPC, as per gRPC specification, if timeout is omitted a server should assume
+                    // an infinite timeout.
+                    // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#protocol
+                    ctx.clearRequestTimeout();
+                }
             }
         }
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTimeoutTest.java
@@ -85,6 +85,18 @@ class GrpcClientTimeoutTest {
         }
     };
 
+    @RegisterExtension
+    static ServerExtension serverWithNoClientTimeout = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.requestTimeoutMillis(2000);
+            sb.service(GrpcService.builder()
+                                  .useClientTimeoutHeader(false)
+                                  .addService(new SlowService())
+                                  .build());
+        }
+    };
+
     @Test
     void clientTimeout() throws InterruptedException {
         final TestServiceBlockingStub client =
@@ -119,7 +131,7 @@ class GrpcClientTimeoutTest {
 
     @Test
     void serverTimeout() throws InterruptedException {
-        final TestServiceBlockingStub client = GrpcClients.builder(server.httpUri())
+        final TestServiceBlockingStub client = GrpcClients.builder(serverWithNoClientTimeout.httpUri())
                                                           .responseTimeoutMillis(0)
                                                           .build(TestServiceBlockingStub.class);
 


### PR DESCRIPTION
Motivation:

gRPC specification says:
> If Timeout is omitted a server should assume an infinite timeout.
> Client implementations are free to send a default minimum timeout
> based on their deployment requirements.

Armeria gRPC implementation does not follow the specification and uses the server's timeout as is.

Modifications:

- Clear a request timeout if no `grpc-timeout` header is set when `useClientTimeoutHeader` enabled

Result:

Armeria gRPC service no longer schedules a timeout if `grpc-timeout` header is omitted when `GrpcServiceBuilder.userClientTimeoutHeader()` is enabled.