### PR TITLE
Ignore manifest file for jars when computing task inputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -451,7 +451,8 @@ allprojects {
     normalization {
         runtimeClasspath {
             metaInf {
-                ignoreManifest()
+                ignoreAttribute("Ant-Version")
+                ignoreAttribute("Created-By")
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -447,10 +447,12 @@ gradleEnterprise {
     }
 }
 
-normalization {
-    runtimeClasspath {
-        metaInf {
-            ignoreManifest()
+allprojects {
+    normalization {
+        runtimeClasspath {
+            metaInf {
+                ignoreManifest()
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -446,3 +446,11 @@ gradleEnterprise {
         }
     }
 }
+
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreManifest()
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The shaded jar contains a manifest file which contains the build java version including the patch version.
![Screenshot 2023-08-29 at 4 27 16 PM](https://github.com/line/armeria/assets/8510579/559e41ae-2d8e-4c5d-87fc-74dbfd486113)
I propose that we ignore the manifest file for all projects since it doesn't really affect the output.
Note that the `trimShadedJar` is still executed, but I still think this is a big improvement. The `trimShadedJar` task isn't cached because of the `libraryJarFileCollection` input which I'm not sure there's much we can do about
https://ge.armeria.dev/c/vll4rsgncwdai/zawmc5it7jzkw/task-inputs?expanded=WyJkZ3hnY3Zsc2hua3R3LWxpYnJhcnlqYXJmaWxlY29sbGVjdGlvbiJd&task-text=trim

ref: https://ge.armeria.dev/s/coxkiutevscp4

Modifications:

- Added a normalization for all projects which ignores `META-INF/MANIFEST.MF` file

Result:

- Better caching even for different build jdk versions

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
