### PR TITLE
Add metrics for client certificates

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -88,14 +88,12 @@ final class HttpClientFactory implements ClientFactory {
 
     private static void setupTlsMetrics(List<X509Certificate> certificates, MeterRegistry registry) {
         final MeterIdPrefix meterIdPrefix = new MeterIdPrefix("armeria.client");
-        for (X509Certificate certificate : certificates) {
             try {
-                MoreMeterBinders.certificateMetrics(certificate, meterIdPrefix)
+                MoreMeterBinders.certificateMetrics(certificates, meterIdPrefix)
                                 .bindTo(registry);
             } catch (Exception ex) {
-                logger.warn("Failed to set up TLS certificate metrics: {}", certificate, ex);
+                logger.warn("Failed to set up TLS certificate metrics: {}", certificates, ex);
             }
-        }
     }
 
     private final EventLoopGroup workerGroup;

--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import com.linecorp.armeria.client.ClientFactoryBuilder;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MoreMeterBinders;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.EventLoopGroups;
@@ -38,7 +39,7 @@ public final class CommonPools {
     static {
         // Bind EventLoopMetrics for the common worker group.
         MoreMeterBinders
-                .eventLoopMetrics(WORKER_GROUP, "common")
+                .eventLoopMetrics(WORKER_GROUP, new MeterIdPrefix("armeria.netty.common"))
                 .bindTo(Flags.meterRegistry());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -560,7 +560,7 @@ public final class Flags {
                     SslContextBuilder::forClient,
                     /* forceHttp1 */ false,
                     /* tlsAllowUnsafeCiphers */ false,
-                    ImmutableList.of()).newEngine(ByteBufAllocator.DEFAULT);
+                    ImmutableList.of(), null).newEngine(ByteBufAllocator.DEFAULT);
             logger.info("All available SSL protocols: {}",
                         ImmutableList.copyOf(engine.getSupportedProtocols()));
             logger.info("Default enabled SSL protocols: {}", SslContextUtil.DEFAULT_PROTOCOLS);

--- a/core/src/main/java/com/linecorp/armeria/common/metric/CertificateMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/CertificateMetrics.java
@@ -55,6 +55,7 @@ final class CertificateMetrics implements MeterBinder {
              .description("1 if TLS certificate is in validity period, 0 if certificate is not in " +
                           "validity period")
              .tags("common.name", commonName)
+             .tags(meterIdPrefix.tags())
              .register(registry);
 
         Gauge.builder(meterIdPrefix.name("tls.certificate.validity.days"), certificate, x509Cert -> {
@@ -65,6 +66,7 @@ final class CertificateMetrics implements MeterBinder {
              .description("Duration in days before TLS certificate expires, which becomes -1 " +
                           "if certificate is expired")
              .tags("common.name", commonName)
+             .tags(meterIdPrefix.tags())
              .register(registry);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/CertificateMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/CertificateMetrics.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.metric;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.security.cert.CertificateExpiredException;
+import java.security.cert.CertificateNotYetValidException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.linecorp.armeria.internal.common.util.CertificateUtil;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+final class CertificateMetrics implements MeterBinder {
+
+    private final X509Certificate certificate;
+    private final MeterIdPrefix meterIdPrefix;
+
+    CertificateMetrics(X509Certificate certificate, MeterIdPrefix meterIdPrefix) {
+        this.certificate = certificate;
+        this.meterIdPrefix = meterIdPrefix;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        final String commonName = firstNonNull(CertificateUtil.getCommonName(certificate), "");
+
+        Gauge.builder(meterIdPrefix.name("tls.certificate.validity"), certificate, x509Cert -> {
+                 try {
+                     x509Cert.checkValidity();
+                 } catch (CertificateExpiredException | CertificateNotYetValidException e) {
+                     return 0;
+                 }
+                 return 1;
+             })
+             .description("1 if TLS certificate is in validity period, 0 if certificate is not in " +
+                          "validity period")
+             .tags("common.name", commonName)
+             .register(registry);
+
+        Gauge.builder(meterIdPrefix.name("tls.certificate.validity.days"), certificate, x509Cert -> {
+                 final Duration diff = Duration.between(Instant.now(),
+                                                        x509Cert.getNotAfter().toInstant());
+                 return diff.isNegative() ? -1 : diff.toDays();
+             })
+             .description("Duration in days before TLS certificate expires, which becomes -1 " +
+                          "if certificate is expired")
+             .tags("common.name", commonName)
+             .register(registry);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/metric/EventLoopMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/EventLoopMetrics.java
@@ -49,9 +49,9 @@ final class EventLoopMetrics implements MeterBinder {
     /**
      * Creates an instance of {@link EventLoopMetrics}.
      */
-    EventLoopMetrics(EventLoopGroup eventLoopGroup, String name) {
+    EventLoopMetrics(EventLoopGroup eventLoopGroup, MeterIdPrefix idPrefix) {
         this.eventLoopGroup = requireNonNull(eventLoopGroup, "eventLoopGroup");
-        idPrefix = new MeterIdPrefix("armeria.netty").append(requireNonNull(name, "name"));
+        this.idPrefix = idPrefix;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
@@ -102,7 +102,7 @@ public final class MoreMeterBinders {
     @UnstableApi
     public static MeterBinder certificateMetrics(Iterable<? extends X509Certificate> certificates,
                                                  MeterIdPrefix meterIdPrefix) {
-        requireNonNull(certificates, "certificate");
+        requireNonNull(certificates, "certificates");
         requireNonNull(meterIdPrefix, "meterIdPrefix");
         return new CertificateMetrics(ImmutableList.copyOf(certificates), meterIdPrefix);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
@@ -77,6 +77,7 @@ public final class MoreMeterBinders {
      *   <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
      *       becomes -1 if certificate is expired</li>
      * </ul>
+     *
      * @param certificate the certificate to monitor
      * @param meterIdPrefix the prefix to use for all metrics
      */
@@ -90,12 +91,13 @@ public final class MoreMeterBinders {
      * Returns a new {@link MeterBinder} to observe the specified {@link X509Certificate}'s validity.
      * The following stats are currently exported per registered {@link MeterIdPrefix}.
      *
-     *  <ul>
-     *    <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
-     *        is not in validity period</li>
-     *    <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
-     *        becomes -1 if certificate is expired</li>
-     *  </ul>
+     * <ul>
+     *   <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
+     *       is not in validity period</li>
+     *   <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
+     *       becomes -1 if certificate is expired</li>
+     * </ul>
+     *
      * @param certificates the certificates to monitor
      * @param meterIdPrefix the prefix to use for all metrics
      */
@@ -111,12 +113,13 @@ public final class MoreMeterBinders {
      * Returns a new {@link MeterBinder} to observe the {@link X509Certificate}'s validity in the PEM format
      * {@link File}. The following stats are currently exported per registered {@link MeterIdPrefix}.
      *
-     *  <ul>
-     *    <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
-     *        is not in validity period</li>
-     *    <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
-     *        becomes -1 if certificate is expired</li>
-     *  </ul>
+     * <ul>
+     *   <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
+     *       is not in validity period</li>
+     *   <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
+     *       becomes -1 if certificate is expired</li>
+     * </ul>
+     *
      * @param keyCertChainFile the certificates to monitor
      * @param meterIdPrefix the prefix to use for all metrics
      */
@@ -131,12 +134,13 @@ public final class MoreMeterBinders {
      * Returns a new {@link MeterBinder} to observe the {@link X509Certificate}'s validity in the PEM format
      * {@link InputStream}. The following stats are currently exported per registered {@link MeterIdPrefix}.
      *
-     *  <ul>
-     *    <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
-     *        is not in validity period</li>
-     *    <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
-     *        becomes -1 if certificate is expired</li>
-     *  </ul>
+     * <ul>
+     *   <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
+     *       is not in validity period</li>
+     *   <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
+     *       becomes -1 if certificate is expired</li>
+     * </ul>
+     *
      * @param keyCertChainFile the certificates to monitor
      * @param meterIdPrefix the prefix to use for all metrics
      */

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
@@ -69,7 +69,7 @@ public final class MoreMeterBinders {
 
     /**
      * Returns a new {@link MeterBinder} to observe the specified {@link X509Certificate}'s validity.
-     *  The following stats are currently exported per registered {@link MeterIdPrefix}.
+     * The following stats are currently exported per registered {@link MeterIdPrefix}.
      *
      *  <ul>
      *    <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate

--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeterBinders.java
@@ -71,12 +71,12 @@ public final class MoreMeterBinders {
      * Returns a new {@link MeterBinder} to observe the specified {@link X509Certificate}'s validity.
      * The following stats are currently exported per registered {@link MeterIdPrefix}.
      *
-     *  <ul>
-     *    <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
-     *        is not in validity period</li>
-     *    <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
-     *        becomes -1 if certificate is expired</li>
-     *  </ul>
+     * <ul>
+     *   <li>"tls.certificate.validity" (gauge) - 1 if TLS certificate is in validity period, 0 if certificate
+     *       is not in validity period</li>
+     *   <li>"tls.certificate.validity.days" (gauge) - Duration in days before TLS certificate expires, which
+     *       becomes -1 if certificate is expired</li>
+     * </ul>
      * @param certificate the certificate to monitor
      * @param meterIdPrefix the prefix to use for all metrics
      */

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.armeria.server;
+package com.linecorp.armeria.internal.common.util;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -33,7 +33,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 
-final class CertificateUtil {
+public final class CertificateUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(CertificateUtil.class);
 
@@ -52,7 +52,7 @@ final class CertificateUtil {
                     });
 
     @Nullable
-    static String getCommonName(SSLSession session) {
+    public static String getCommonName(SSLSession session) {
         final Certificate[] certs = session.getLocalCertificates();
         if (certs == null || certs.length == 0) {
             return null;
@@ -61,7 +61,7 @@ final class CertificateUtil {
     }
 
     @Nullable
-    static String getCommonName(Certificate certificate) {
+    public static String getCommonName(Certificate certificate) {
         if (!(certificate instanceof X509Certificate)) {
             return null;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
@@ -91,7 +91,7 @@ public final class CertificateUtil {
         return ImmutableList.copyOf(SslContextProtectedAccessHack.toX509CertificateList(in));
     }
 
-    private static class SslContextProtectedAccessHack extends SslContext {
+    private static final class SslContextProtectedAccessHack extends SslContext {
 
         static X509Certificate[] toX509CertificateList(File file) throws CertificateException {
             return SslContext.toX509Certificates(file);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -54,6 +54,7 @@ import com.linecorp.armeria.internal.common.KeepAliveHandler;
 import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 import com.linecorp.armeria.internal.common.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.common.TrafficLoggingHandler;
+import com.linecorp.armeria.internal.common.util.CertificateUtil;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
 
 import io.micrometer.core.instrument.Counter;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerSslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerSslContextUtil.java
@@ -100,7 +100,7 @@ final class ServerSslContextUtil {
             Iterable<? extends Consumer<? super SslContextBuilder>> tlsCustomizers) {
         return SslContextUtil
                 .createSslContext(sslContextBuilderSupplier,
-                        /* forceHttp1 */ false, tlsAllowUnsafeCiphers, tlsCustomizers);
+                        /* forceHttp1 */ false, tlsAllowUnsafeCiphers, tlsCustomizers, null);
     }
 
     private static void unwrap(SSLEngine engine, ByteBuffer packetBuf) throws SSLException {

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -19,23 +19,34 @@ package com.linecorp.armeria.client;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import java.io.InputStream;
+import java.security.cert.CertificateException;
 import java.sql.Date;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
 import java.util.Map;
 
+import org.assertj.core.api.AbstractDoubleAssert;
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.metric.MoreMeterBinders;
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
+import com.linecorp.armeria.server.ServerTlsCertificateMetricsTest;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class ClientCertificateMetricsTest {
 
+    private static final String RESOURCE_PATH_PREFIX =
+            "/testing/core/" + ServerTlsCertificateMetricsTest.class.getSimpleName() + '/';
+
     @Test
-    void shouldMeasureClientCertValidity() {
+    void shouldMeasureClientCertValidityInClientFactory() {
         // If the test runs at 11:59:59 PM, it could fail.
         await().untilAsserted(() -> {
             final Instant now = Instant.now();
@@ -60,5 +71,44 @@ class ClientCertificateMetricsTest {
                 ssc.delete();
             }
         });
+    }
+
+    @Test
+    void measureCertificateChainFile() throws CertificateException {
+        final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        final InputStream certificateChain = getClass()
+                .getResourceAsStream(RESOURCE_PATH_PREFIX + "certificate-chain.pem");
+        MoreMeterBinders.certificateMetrics(certificateChain, new MeterIdPrefix("valid", "tagA", "value"))
+                        .bindTo(registry);
+
+        final String validityName = "valid.tls.certificate.validity";
+        assertThatGauge(registry, validityName, "localhost").isOne();
+        final String validityDaysName = "valid.tls.certificate.validity.days";
+        assertThatGauge(registry, validityDaysName, "localhost").isPositive();
+        assertThatGauge(registry, validityName, "test.root.armeria").isOne();
+        assertThatGauge(registry, validityDaysName, "test.root.armeria").isPositive();
+    }
+
+    @Test
+    void measureExpireCertificate() throws CertificateException {
+        final Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DAY_OF_MONTH, -1);
+        final java.util.Date notAfter = calendar.getTime();
+        calendar.add(Calendar.DAY_OF_MONTH, -1);
+        final java.util.Date notBefore = calendar.getTime();
+        final SelfSignedCertificate ssc = new SelfSignedCertificate("armeria.dev", notBefore, notAfter);
+
+        final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MoreMeterBinders.certificateMetrics(ssc.certificate(), new MeterIdPrefix("expired"))
+                        .bindTo(registry);
+        assertThatGauge(registry, "expired.tls.certificate.validity", "armeria.dev").isZero();
+        assertThatGauge(registry, "expired.tls.certificate.validity.days", "armeria.dev").isEqualTo(-1);
+    }
+
+    private static AbstractDoubleAssert<?> assertThatGauge(MeterRegistry meterRegistry, String gaugeName,
+                                                           String cn, String... tags) {
+        final Gauge gauge = meterRegistry.find(gaugeName).tag("common.name", cn).tags(tags).gauge();
+        assertThat(gauge).isNotNull();
+        return assertThat(gauge.value());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -55,10 +55,11 @@ class ClientCertificateMetricsTest {
                                                                         Date.from(notAfter));
             try {
                 final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-                ClientFactory factory = ClientFactory.builder()
-                                                     .tls(ssc.certificate(), ssc.privateKey())
-                                                     .meterRegistry(meterRegistry)
-                                                     .build();
+                final ClientFactory factory =
+                        ClientFactory.builder()
+                                     .tls(ssc.certificate(), ssc.privateKey())
+                                     .meterRegistry(meterRegistry)
+                                     .build();
                 final Map<String, Double> metrics = MoreMeters.measureAll(meterRegistry);
                 assertThat(metrics)
                         .containsEntry(

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -83,8 +83,8 @@ class ClientCertificateMetricsTest {
                         .bindTo(registry);
 
         final String validityName = "valid.tls.certificate.validity";
-        assertThatGauge(registry, validityName, "localhost").isOne();
         final String validityDaysName = "valid.tls.certificate.validity.days";
+        assertThatGauge(registry, validityName, "localhost").isOne();
         assertThatGauge(registry, validityDaysName, "localhost").isPositive();
         assertThatGauge(registry, validityName, "test.root.armeria").isOne();
         assertThatGauge(registry, validityDaysName, "test.root.armeria").isPositive();

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class ClientCertificateMetricsTest {
+
+    @Test
+    void shouldMeasureClientCertValidity() {
+        // If the test runs at 11:59:59 PM, it could fail.
+        await().untilAsserted(() -> {
+            final Instant now = Instant.now();
+            final Instant notAfter = now.plus(10, ChronoUnit.DAYS);
+            final SelfSignedCertificate ssc = new SelfSignedCertificate("armeria.dev", Date.from(now),
+                                                                        Date.from(notAfter));
+            try {
+                final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+                ClientFactory factory = ClientFactory.builder()
+                                                     .tls(ssc.certificate(), ssc.privateKey())
+                                                     .meterRegistry(meterRegistry)
+                                                     .build();
+                final Map<String, Double> metrics = MoreMeters.measureAll(meterRegistry);
+                assertThat(metrics)
+                        .containsEntry(
+                                "armeria.client.tls.certificate.validity.days#value{common.name=armeria.dev}",
+                                9.0)
+                        .containsEntry("armeria.client.tls.certificate.validity#value{common.name=armeria.dev}",
+                                       1.0);
+                factory.close();
+            } finally {
+                ssc.delete();
+            }
+        });
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -91,7 +91,7 @@ class ClientCertificateMetricsTest {
     }
 
     @Test
-    void measureExpireCertificate() throws CertificateException {
+    void measureExpiredCertificate() throws CertificateException {
         final Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_MONTH, -1);
         final java.util.Date notAfter = calendar.getTime();

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTlsCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTlsCertificateMetricsTest.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
-class ServerTlsCertificateMetricsTest {
+public class ServerTlsCertificateMetricsTest {
 
     private static final String RESOURCE_PATH_PREFIX =
             "/testing/core/" + ServerTlsCertificateMetricsTest.class.getSimpleName() + '/';
@@ -130,7 +130,7 @@ class ServerTlsCertificateMetricsTest {
 
     @Test
     void tlsMetricGivenCertificateChainNotExpired() {
-        final InputStream expiredCertificateChain = getClass().getResourceAsStream(
+        final InputStream certificateChain = getClass().getResourceAsStream(
                 RESOURCE_PATH_PREFIX + "certificate-chain.pem");
         final InputStream pk = getClass().getResourceAsStream(RESOURCE_PATH_PREFIX + "pk.key");
 
@@ -138,7 +138,7 @@ class ServerTlsCertificateMetricsTest {
         Server.builder()
               .service("/", (ctx, req) -> HttpResponse.of(200))
               .meterRegistry(meterRegistry)
-              .tls(expiredCertificateChain, pk)
+              .tls(certificateChain, pk)
               .build();
 
         assertThatGauge(meterRegistry, CERT_VALIDITY_GAUGE_NAME, "localhost").isOne();


### PR DESCRIPTION
Motivation:

Armeria only provides metrics for server certificates. mTLS is also widely used in Kubernetes service mesh or for enhanced security.

If we provide validity metrics for client certificates, users will easily monitor expiration of the certificates.

Modifications:

- Add `CerfiticateMetrics` to easily register metrics for `X509Certificate`
- Set up metrics for client certificates when `HttpClientFactory` is created.
  - Client certificates in `SslContextBuilder` are illegally accessed via reflections.
  - TODO: Open an issue to Netty to expose `keyCertChain` in `SslContextBuilder` or introduce Armeria `SslContextProvider` 
- Move `CertificateUtil` to internal to use in the client modules.
- Fix `EventLoopMetrics` to take `MeterIdPrefix` which makes users easily add additional tags to metrics.
- Refactor `Server.setupTlsMetrics` to use `CerficateMetrics`.

Result:

You can now monitor client certificates in the following metrics:
- `armeria.client.tls.certificates.validity`
- `armeria.client.tls.certificates.validity.days`
