### PR TITLE
Dynamic decorator of the header for `WebClient`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -16,15 +16,20 @@
 
 package com.linecorp.armeria.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.SuccessFunction;
@@ -181,6 +186,39 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
     @Override
     public WebClientBuilder decorator(DecoratingHttpClientFunction decorator) {
         return (WebClientBuilder) super.decorator(decorator);
+    }
+
+    /**
+     * Adds the decorator that decorates the header of request that name is specified {@code name}.
+     *
+     * @param name  The name of the header.
+     * @param value A supplier that provides a future of the value of the header.
+     */
+    public WebClientBuilder headerDecorator(CharSequence name,
+                                            Supplier<CompletableFuture<Object>> value) {
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+        final DecoratingHttpClientFunction decorator = (client, ctx, req) -> {
+            final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+            value.get().handle((header, cause) -> {
+                if (cause != null) {
+                    future.completeExceptionally(cause);
+                    return null;
+                }
+                try {
+                    final HttpRequest decorated = req.withHeaders(
+                            req.headers().toBuilder().setObject(name, header));
+                    ctx.updateRequest(decorated);
+                    future.complete(client.execute(ctx, decorated));
+                } catch (Exception e) {
+                    future.completeExceptionally(e);
+                }
+                return null;
+            });
+            return HttpResponse.of(future);
+        };
+        decorator(decorator);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

- Currently, `WebClient` can only have static values as default headers. Therefore, whenever the headers need to change, there is an inconvenience of having to create a new request header each time.

Modifications:

- Added a method `WebClientBuilder#headerDecorator(CharSequence, Supplier<CompletableFuture<Object>>)` that takes an argument `name` and modifies the header with a matching name.
- Added test code for the newly added method.

Result:

- Closes #5032.
- Since a decorator for dynamically changing headers is used, there is no need to recreate request headers manually each time.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
