### PR TITLE
Fix NPE from `HttpSessionHander.isAcquirable()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -165,7 +165,8 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
                         " in one connection. ID: " + id);
             } else {
                 exception = new ClosedSessionException(
-                        "Can't send requests. ID: " + id + ", session active: " + session.isAcquirable());
+                        "Can't send requests. ID: " + id + ", session active: " +
+                        session.isAcquirable(responseDecoder.keepAliveHandler()));
             }
             session.deactivate();
             // No need to send RST because we didn't send any packet and this will be disconnected anyway.

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpResponseDecoder.java
@@ -144,11 +144,6 @@ abstract class AbstractHttpResponseDecoder implements HttpResponseDecoder {
         return httpSession = HttpSession.get(channel);
     }
 
-    @Override
-    public boolean needsToDisconnectNow() {
-        return !session().isAcquirable() && !hasUnfinishedResponses();
-    }
-
     static ContentTooLargeException contentTooLargeException(HttpResponseWrapper res, long transferred) {
         final ContentTooLargeExceptionBuilder builder =
                 ContentTooLargeException.builder()

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpResponseDecoder.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.client.DecodedHttpResponse;
 import com.linecorp.armeria.internal.client.HttpSession;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
-import com.linecorp.armeria.internal.common.KeepAliveHandler;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
@@ -65,10 +64,7 @@ abstract class AbstractHttpResponseDecoder implements HttpResponseDecoder {
                 new HttpResponseWrapper(res, eventLoop, ctx,
                                         ctx.responseTimeoutMillis(), ctx.maxResponseLength());
         final HttpResponseWrapper oldRes = responses.put(id, newRes);
-        final KeepAliveHandler keepAliveHandler = keepAliveHandler();
-        if (keepAliveHandler != null) {
-            keepAliveHandler.increaseNumRequests();
-        }
+        keepAliveHandler().increaseNumRequests();
 
         assert oldRes == null : "addResponse(" + id + ", " + res + ", " + ctx + "): " + oldRes;
         onResponseAdded(id, eventLoop, newRes);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -418,6 +418,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             }
         }
 
+        // Do not call fireUserEventTriggered right away because it triggers completing a session promise
+        // in HttpSessionHandler that will make the client to send a request.
+        // However, the HTTP/2 settings frame from the server may not be handled yet at this point.
+        // We need to put the task in the queue so that the promise is complete after the settings
+        // frame is handled.
         pipeline.channel().eventLoop().execute(() -> pipeline.fireUserEventTriggered(protocol));
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseDecoder.java
@@ -53,6 +53,6 @@ interface HttpResponseDecoder {
     KeepAliveHandler keepAliveHandler();
 
     default boolean needsToDisconnectNow() {
-        return !session().isAcquirable() && !hasUnfinishedResponses();
+        return !session().isAcquirable(keepAliveHandler()) && !hasUnfinishedResponses();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -283,15 +283,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
     @Override
     public boolean isAcquirable() {
-        if (!isAcquirable) {
-            return false;
-        }
         // responseDecoder and keepAliveHandler are set before this session is added to the pool.
         assert responseDecoder != null;
-        final KeepAliveHandler keepAliveHandler = responseDecoder.keepAliveHandler();
-        assert keepAliveHandler != null;
-        // Do no call isAcquirable(keepAliveHandler) to avoid accessing the volatile field once more.
-        return !keepAliveHandler.needsDisconnection();
+        return isAcquirable(responseDecoder.keepAliveHandler());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/HttpSession.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.internal.common.KeepAliveHandler;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -84,6 +85,11 @@ public interface HttpSession {
         }
 
         @Override
+        public boolean isAcquirable(KeepAliveHandler keepAliveHandler) {
+            return false;
+        }
+
+        @Override
         public void deactivate() {}
 
         @Override
@@ -115,6 +121,14 @@ public interface HttpSession {
      * session from {@code com.linecorp.armeria.client.HttpChannelPool}.
      */
     boolean isAcquirable();
+
+    /**
+     * Returns whether this {@link HttpSession} is healthy using the {@link KeepAliveHandler}.
+     * {@code true} if a new request can acquire this session from
+     * {@code com.linecorp.armeria.client.HttpChannelPool}. {@link KeepAliveHandler#needsDisconnection()}
+     * is also used to determine whether this {@link HttpSession} is healthy.
+     */
+    boolean isAcquirable(KeepAliveHandler keepAliveHandler);
 
     /**
      * Deactivates this {@link HttpSession} to prevent new requests from acquiring this {@link HttpSession}.

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUpgradeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUpgradeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class HttpClientUpgradeTest {
+
+    @RegisterExtension
+    public static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void numConnections() {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                        .useHttp2Preface(false)
+                                                        .build()) {
+            final WebClient client = WebClient.builder(server.httpUri()).factory(factory).build();
+            // Previously the following exception was raised and caught by DefaultHttp2Connection:
+            //
+            // ERROR i.n.h.c.http2.DefaultHttp2Connection - Caught Throwable from listener onStreamClosed.
+            // java.lang.AssertionError: null
+            //  at com.linecorp.armeria.client.HttpSessionHandler.isAcquirable(HttpSessionHandler.java:290)
+            //  at com.linecorp.armeria.client.AbstractHttpResponseDecoder.needsToDisconnectNow(Abstract...)
+            //  at com.linecorp.armeria.client.Http2ResponseDecoder.shouldSendGoAway(Http2ResponseDecoder...)
+            //  ..
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientUpgradeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientUpgradeTest.java
@@ -41,7 +41,8 @@ class HttpClientUpgradeTest {
                                                         .useHttp2Preface(false)
                                                         .build()) {
             final WebClient client = WebClient.builder(server.httpUri()).factory(factory).build();
-            // Previously the following exception was raised and caught by DefaultHttp2Connection:
+            // Before https://github.com/line/armeria/pull/5162 is applied,
+            // the following exception was raised and caught by DefaultHttp2Connection:
             //
             // ERROR i.n.h.c.http2.DefaultHttp2Connection - Caught Throwable from listener onStreamClosed.
             // java.lang.AssertionError: null


### PR DESCRIPTION
Motivation:
When the client sends an options request for upgrade, the server can respond with the following data in the order:
- 101 switching protocol
- HTTP/2 settings frame
- HTTP/2 response for the options request

When the client process the HTTP/2 response, an NPE is raised because:
- the end of stream of the response for options request is set to true and it triggers `Http2ResponseDecoder.onStreamClosed()`
- [HttpSessionHandler.isAcquirable()](https://github.com/line/armeria/blob/main/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java#L285) is also called but NPE is raised because `responseDecoder` isn't set.
- The task for setting the response decoder is in the event loop queue: https://github.com/line/armeria/blob/863e27c5268631360c14e50e13cd3e38d84c9db5/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java#L421

Modifications:
- Add `HttpSessionHandler.isAcquirable(KeepAliveHandler)` method so that we can check the healthiness when the response decoder isn't set.

Result:
- No more `NullPointerException` from `HttpSessionHander.isAcquirable()`.