### PR TITLE
Exception handler for context aware data structure

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareBiConsumer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareBiConsumer.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
@@ -31,8 +32,20 @@ public interface ContextAwareBiConsumer<T, U> extends BiConsumer<T, U>, ContextH
      * Returns a new {@link ContextAwareBiConsumer} that sets the specified {@link RequestContext}
      * before executing an underlying {@link BiConsumer}.
      */
-    static <T, U> ContextAwareBiConsumer of(RequestContext context, BiConsumer<T, U> action) {
-        return new DefaultContextAwareBiConsumer(context, action);
+    static <T, U> ContextAwareBiConsumer<T, U> of(RequestContext context, BiConsumer<T, U> action) {
+        return new DefaultContextAwareBiConsumer<>(context, action);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareBiConsumer} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link BiConsumer}.
+     *
+     * @param exceptionHandler A consumer function that handles exceptions thrown during the execution of the
+     *                         {@code action}.
+     */
+    static <T, U> ContextAwareBiConsumer<T, U> of(RequestContext context, BiConsumer<T, U> action,
+                                            Consumer<Throwable> exceptionHandler) {
+        return new DefaultContextAwareBiConsumer<>(context, action, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareBiFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareBiFunction.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
@@ -31,8 +32,20 @@ public interface ContextAwareBiFunction<T, U, R> extends BiFunction<T, U, R>, Co
      * Returns a new {@link ContextAwareBiFunction} that sets the specified {@link RequestContext}
      * before executing an underlying {@link BiFunction}.
      */
-    static <T, U, R> ContextAwareBiFunction of(RequestContext context, BiFunction<T, U, R> function) {
-        return new DefaultContextAwareBiFunction(context, function);
+    static <T, U, R> ContextAwareBiFunction<T, U, R> of(RequestContext context, BiFunction<T, U, R> function) {
+        return new DefaultContextAwareBiFunction<>(context, function);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareBiFunction} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link BiFunction}.
+     *
+     * @param exceptionHandler A function that handles exceptions thrown during the execution of the
+     *                         {@code function}.
+     */
+    static <T, U, R> ContextAwareBiFunction<T, U, R> of(RequestContext context, BiFunction<T, U, R> function,
+                                               Function<Throwable, R> exceptionHandler) {
+        return new DefaultContextAwareBiFunction<>(context, function, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareCallable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareCallable.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common;
 
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
@@ -32,7 +33,19 @@ public interface ContextAwareCallable<T> extends Callable<T>, ContextHolder {
      * before executing an underlying {@link Callable}.
      */
     static <T> ContextAwareCallable<T> of(RequestContext context, Callable<T> callable) {
-        return new DefaultContextAwareCallable<T>(context, callable);
+        return new DefaultContextAwareCallable<>(context, callable);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareCallable} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link Callable}.
+     *
+     * @param exceptionHandler A function that handles exceptions thrown during the execution of the
+     *                         {@code callable}.
+     */
+    static <T> ContextAwareCallable<T> of(RequestContext context, Callable<T> callable,
+                                          Function<Throwable, T> exceptionHandler) {
+        return new DefaultContextAwareCallable<>(context, callable, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareConsumer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareConsumer.java
@@ -31,8 +31,20 @@ public interface ContextAwareConsumer<T> extends Consumer<T>, ContextHolder {
      * Returns a new {@link ContextAwareConsumer} that sets the specified {@link RequestContext}
      * before executing an underlying {@link Consumer}.
      */
-    static <T, R> ContextAwareConsumer of(RequestContext context, Consumer<T> action) {
-        return new DefaultContextAwareConsumer(context, action);
+    static <T> ContextAwareConsumer<T> of(RequestContext context, Consumer<T> action) {
+        return new DefaultContextAwareConsumer<>(context, action);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareConsumer} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link Consumer}.
+     *
+     * @param exceptionHandler A consumer function that handles exceptions thrown during the execution of the
+     *                         {@code action}.
+     */
+    static <T> ContextAwareConsumer<T> of(RequestContext context, Consumer<T> action,
+                                          Consumer<Throwable> exceptionHandler) {
+        return new DefaultContextAwareConsumer<>(context, action, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareExecutor.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.internal.common.RequestContextUtil.ensureSame
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 
 /**
  * A delegating {@link Executor} that makes sure all submitted tasks are
@@ -38,6 +39,24 @@ public interface ContextAwareExecutor extends Executor, ContextHolder {
             return (ContextAwareExecutor) executor;
         }
         return new DefaultContextAwareExecutor(context, executor);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareExecutor} that sets the specified
+     * {@link RequestContext} before executing any submitted tasks.
+     *
+     * @param exceptionHandler A consumer function that handles exceptions thrown during task execution.
+     */
+    static ContextAwareExecutor of(RequestContext context, Executor executor,
+                                   Consumer<Throwable> exceptionHandler) {
+        requireNonNull(context, "context");
+        requireNonNull(executor, "executor");
+        requireNonNull(exceptionHandler, "exceptionHandler");
+        if (executor instanceof ContextAwareExecutor) {
+            ensureSameCtx(context, (ContextAwareExecutor) executor, ContextAwareExecutor.class);
+            return (ContextAwareExecutor) executor;
+        }
+        return new DefaultContextAwareExecutor(context, executor, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareFunction.java
@@ -31,8 +31,20 @@ public interface ContextAwareFunction<T, R> extends Function<T, R>, ContextHolde
      * Returns a new {@link ContextAwareFuture} that sets the specified {@link RequestContext}
      * before executing an underlying {@link Function}.
      */
-    static <T, R> ContextAwareFunction of(RequestContext context, Function<T, R> function) {
-        return new DefaultContextAwareFunction(context, function);
+    static <T, R> ContextAwareFunction<T, R> of(RequestContext context, Function<T, R> function) {
+        return new DefaultContextAwareFunction<>(context, function);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareFuture} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link Function}.
+     *
+     * @param exceptionHandler A function that handles exceptions thrown during the execution of the
+     *                         {@code function}.
+     */
+    static <T, R> ContextAwareFunction<T, R> of(RequestContext context, Function<T, R> function,
+                                          Function<Throwable, R> exceptionHandler) {
+        return new DefaultContextAwareFunction<>(context, function, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ContextAwareRunnable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContextAwareRunnable.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.common;
 
+import java.util.function.Consumer;
+
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
@@ -31,6 +33,18 @@ public interface ContextAwareRunnable extends Runnable, ContextHolder {
      */
     static ContextAwareRunnable of(RequestContext context, Runnable runnable) {
         return new DefaultContextAwareRunnable(context, runnable);
+    }
+
+    /**
+     * Returns a new {@link ContextAwareRunnable} that sets the specified {@link RequestContext}
+     * before executing an underlying {@link Runnable}.
+     *
+     * @param exceptionHandler A consumer function that handles exceptions thrown during the execution of the
+     *                         {@code runnable}.
+     */
+    static ContextAwareRunnable of(RequestContext context, Runnable runnable,
+                                   Consumer<Throwable> exceptionHandler) {
+        return new DefaultContextAwareRunnable(context, runnable, exceptionHandler);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultContextAwareExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultContextAwareExecutor.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.common;
 
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +30,12 @@ final class DefaultContextAwareExecutor
 
     DefaultContextAwareExecutor(RequestContext context, Executor executor) {
         super(executor);
+        this.context = context;
+    }
+
+    DefaultContextAwareExecutor(RequestContext context, Executor executor,
+                                Consumer<Throwable> exceptionHandler) {
+        super(executor, exceptionHandler);
         this.context = context;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutor.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.common;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
@@ -33,8 +34,22 @@ final class PropagatingContextAwareExecutor extends AbstractContextAwareExecutor
         }
     }
 
+    static PropagatingContextAwareExecutor of(Executor executor, Consumer<Throwable> exceptionHandler) {
+        requireNonNull(executor, "executor");
+        requireNonNull(exceptionHandler, "exceptionHandler");
+        if (executor instanceof PropagatingContextAwareExecutor) {
+            return (PropagatingContextAwareExecutor) executor;
+        } else {
+            return new PropagatingContextAwareExecutor(executor, exceptionHandler);
+        }
+    }
+
     private PropagatingContextAwareExecutor(Executor executor) {
         super(executor);
+    }
+
+    private PropagatingContextAwareExecutor(Executor executor, Consumer<Throwable> exceptionHandler) {
+        super(executor, exceptionHandler);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

- Armeria provides several context-aware data types. However, in the absence of exception handling logic, if an exception occurs, the error is lost and not propagated to the caller.

Modifications:

- An additional RequestContext#makeContextAware method that accepts an exception handler as an argument has been added.
- Context-aware data types has been enhanced to handle exceptions using the exception handler.

Result:

- Closes #4879
- Users can make their own data types context-aware with a custom exception handler. If an exception occurs, it can be handled with the specified handler.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
