### PR TITLE
Try making `buildWeb` cacheable

### DIFF
--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -1,3 +1,6 @@
+import static org.gradle.internal.os.OperatingSystem.LINUX
+import static org.gradle.internal.os.OperatingSystem.current
+
 plugins {
     id 'base'
     alias(libs.plugins.node.gradle)
@@ -35,7 +38,8 @@ task buildWeb(type: NpmTask) {
                  'webpack.config.ts').withPathSensitivity(PathSensitivity.RELATIVE)
 
     outputs.dir('build/web')
-    outputs.cacheIf { true }
+    // cache the result from linux builds only to preserve previous behavior
+    outputs.cacheIf { current() == LINUX }
 }
 
 task copyWeb(type: Copy) {

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -30,8 +30,9 @@ task buildWeb(type: NpmTask) {
 
     args = ['run', 'build']
 
+    // note that node_modules isn't cached due to potential cache misses per architecture
     inputs.property("node.version", node.version)
-    // cache built web per OS type
+    // build per OS type to preserve behavior of packaging jar from linux
     inputs.property("os.familyName", current().getFamilyName())
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
             .withPropertyName("sources files")
@@ -42,7 +43,7 @@ task buildWeb(type: NpmTask) {
 
     outputs.dir('build/web')
 
-    // FIXME: consider disabling cacheability once arm actions runners are available
+    // TODO: consider disabling cacheability once arm actions runners are available
     outputs.cacheIf { true }
 }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -33,12 +33,15 @@ task buildWeb(type: NpmTask) {
 
     inputs.property("node.version", node.version)
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
+            .withPropertyName("sources files")
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
                  'webpack.config.ts')
-          .withPathSensitivity(PathSensitivity.RELATIVE)
-          .withPropertyName("npm configuration files")
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+            .withPropertyName("npm configuration files")
 
     outputs.dir('build/web')
+
+    // FIXME: consider disabling cacheability once arm actions runners are available
     outputs.cacheIf { true }
 }
 
@@ -58,8 +61,11 @@ if (!rootProject.hasProperty('noLint')) {
         args = ['run', 'lint']
 
         inputs.dir('src')
+                .withPropertyName("sources files")
         inputs.files('package.json', 'package-lock.json', '.prettierrc.js', '.eslintrc.js')
+                .withPropertyName("configuration files")
         inputs.dir('../settings/')
+                .withPropertyName("settings files")
 
         outputs.upToDateWhen { true }
     }

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -33,7 +33,6 @@ task buildWeb(type: NpmTask) {
 
     inputs.property("node.version", node.version)
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir('node_modules').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
                  'webpack.config.ts')
           .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -35,11 +35,11 @@ task buildWeb(type: NpmTask) {
     // build per OS type to preserve behavior of packaging jar from linux
     inputs.property("os.familyName", current().getFamilyName())
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
-            .withPropertyName("sources files")
+          .withPropertyName("sources files")
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
                  'webpack.config.ts')
-            .withPathSensitivity(PathSensitivity.RELATIVE)
-            .withPropertyName("npm configuration files")
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+          .withPropertyName("npm configuration files")
 
     outputs.dir('build/web')
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -34,10 +34,6 @@ task buildWeb(type: NpmTask) {
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
                  'webpack.config.ts').withPathSensitivity(PathSensitivity.RELATIVE)
 
-    // lint options
-    inputs.files('.npmrc', '.prettierrc.js', '.eslintrc.js').withPathSensitivity(PathSensitivity.RELATIVE)
-    inputs.dir('../settings/').withPathSensitivity(PathSensitivity.RELATIVE)
-
     outputs.dir('build/web')
     outputs.cacheIf { true }
 }
@@ -58,8 +54,9 @@ if (!rootProject.hasProperty('noLint')) {
         args = ['run', 'lint']
 
         inputs.dir('src')
-        inputs.file('package.json')
-        inputs.file('package-lock.json')
+        inputs.files('package.json', 'package-lock.json', '.prettierrc.js', '.eslintrc.js')
+        inputs.dir('../settings/')
+
         outputs.upToDateWhen { true }
     }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -35,11 +35,12 @@ task buildWeb(type: NpmTask) {
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir('node_modules').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
-                 'webpack.config.ts').withPathSensitivity(PathSensitivity.RELATIVE)
+                 'webpack.config.ts')
+          .withPathSensitivity(PathSensitivity.RELATIVE)
+          .withPropertyName("npm configuration files")
 
     outputs.dir('build/web')
-    // cache the result from linux builds only to preserve previous behavior
-    outputs.cacheIf { current() == LINUX }
+    outputs.cacheIf { true }
 }
 
 task copyWeb(type: Copy) {

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -28,12 +28,17 @@ task buildWeb(type: NpmTask) {
 
     args = ['run', 'build']
 
-    inputs.dir('src')
-    inputs.dir('node_modules')
+    inputs.property("node.version", node.version)
+    inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir('node_modules').withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
-                 'webpack.config.ts')
-    outputs.dir('build/web')
+                 'webpack.config.ts').withPathSensitivity(PathSensitivity.RELATIVE)
 
+    // lint options
+    inputs.files('.npmrc', '.prettierrc.js', '.eslintrc.js').withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir('../settings/').withPathSensitivity(PathSensitivity.RELATIVE)
+
+    outputs.dir('build/web')
     outputs.cacheIf { true }
 }
 

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -29,8 +29,12 @@ task buildWeb(type: NpmTask) {
     args = ['run', 'build']
 
     inputs.dir('src')
-    inputs.files('package.json', 'package-lock.json')
+    inputs.dir('node_modules')
+    inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',
+                 'webpack.config.ts')
     outputs.dir('build/web')
+
+    outputs.cacheIf { true }
 }
 
 task copyWeb(type: Copy) {

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -1,4 +1,3 @@
-import static org.gradle.internal.os.OperatingSystem.LINUX
 import static org.gradle.internal.os.OperatingSystem.current
 
 plugins {

--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -32,6 +32,8 @@ task buildWeb(type: NpmTask) {
     args = ['run', 'build']
 
     inputs.property("node.version", node.version)
+    // cache built web per OS type
+    inputs.property("os.familyName", current().getFamilyName())
     inputs.dir('src').withPathSensitivity(PathSensitivity.RELATIVE)
             .withPropertyName("sources files")
     inputs.files('package.json', 'package-lock.json', 'tsconfig.json', 'tsconfig-webpack.json',


### PR DESCRIPTION
Motivation:

The output of `npm run build` is inconsistent across builds at the moment.
As a result, our jars are slightly different causing cache misses downstream.
It has been suggested that we can make the npm task cacheable.
To keep the current behavior, I also propose that we upload caches only on linux machines (like we've been doing so far) by adding an input to the current os family.

local run: https://ge.armeria.dev/c/y4by6h2mrop3u/gt25suskafqek/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure
run: https://ge.armeria.dev/s/zpv5sbkn6i6f2

Modifications:

- Added inputs/outputs with relative directories for the npm run task
- Added a `cacheIf` condition which caches the output of `buildWeb` per OS family type
- I also noticed that the lint task may not be run even if lint related properties are changed. I've added inputs for consistent runs.

Result:

- Less cache misses for our builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
