### PR TITLE
Add extension methods in Kotlin for request scoping

### DIFF
--- a/examples/context-propagation/kotlin/build.gradle.kts
+++ b/examples/context-propagation/kotlin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":core"))
+    implementation(project(":kotlin"))
     runtimeOnly(libs.slf4j.simple)
 
     implementation(kotlin("stdlib-jdk8"))

--- a/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
+++ b/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
@@ -23,8 +23,10 @@ import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.AggregatedHttpResponse
 import com.linecorp.armeria.common.HttpRequest
 import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.internal.common.kotlin.ArmeriaRequestCoroutineContext
 import com.linecorp.armeria.server.HttpService
 import com.linecorp.armeria.server.ServiceRequestContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
@@ -32,6 +34,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.future.asDeferred
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
+import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.function.Supplier
@@ -40,7 +43,7 @@ import java.util.stream.Collectors
 class MainService(private val backendClient: WebClient) : HttpService {
     override fun serve(ctx: ServiceRequestContext, req: HttpRequest): HttpResponse {
         val ctxExecutor = ctx.eventLoop()
-        val response = GlobalScope.future(ctxExecutor.asCoroutineDispatcher()) {
+        val response = GlobalScope.future(ctxExecutor.asCoroutineDispatcher() + ArmeriaRequestCoroutineContext(ctx)) {
             val numsFromRequest = async { fetchFromRequest(ctx, req) }
             val numsFromDb = async { fetchFromFakeDb(ctx) }
             val nums = awaitAll(numsFromRequest, numsFromDb).flatten()
@@ -75,24 +78,30 @@ class MainService(private val backendClient: WebClient) : HttpService {
     }
 
     private suspend fun fetchFromRequest(ctx: ServiceRequestContext, req: HttpRequest): List<Long> {
-        // The context is mounted in a thread-local, meaning it is available to all logic such as tracing.
-        require(ServiceRequestContext.current() === ctx)
-        require(ctx.eventLoop().inEventLoop())
+        // Switch to the default dispatcher.
+        val nums = withContext(Dispatchers.Default) {
+            // The thread is switched.
+            require(!ctx.eventLoop().inEventLoop())
+            // The context is still mounted in a thread-local, because it is propagated using
+            // ArmeriaRequestCoroutineContext(ctx).
+            require(ServiceRequestContext.current() === ctx)
 
-        val aggregatedHttpRequest = req.aggregate().await()
+            val aggregatedHttpRequest = req.aggregate().await()
 
-        // The context is kept after resume.
-        require(ServiceRequestContext.current() === ctx)
-        require(ctx.eventLoop().inEventLoop())
+            // The context is kept after resume.
+            require(ServiceRequestContext.current() === ctx)
+            require(!ctx.eventLoop().inEventLoop())
 
-        val nums = mutableListOf<Long>()
-        for (
-        token in Iterables.concat(
-            NUM_SPLITTER.split(aggregatedHttpRequest.path().substring(1)),
-            NUM_SPLITTER.split(aggregatedHttpRequest.contentUtf8())
-        )
-        ) {
-            nums.add(token.toLong())
+            val nums = mutableListOf<Long>()
+            for (
+            token in Iterables.concat(
+                NUM_SPLITTER.split(aggregatedHttpRequest.path().substring(1)),
+                NUM_SPLITTER.split(aggregatedHttpRequest.contentUtf8())
+            )
+            ) {
+                nums.add(token.toLong())
+            }
+            nums
         }
         return nums
     }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.kotlin.coroutines.jdk8)
     implementation(libs.kotlin.reflect)
 
+    testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.reactivestreams.tck)
 }
 

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutor.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutor.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.kotlin
+
+import com.linecorp.armeria.common.ContextAwareExecutor
+import java.util.concurrent.Executor
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+
+/**
+ * Converts an instance of [ContextAwareExecutor] to an implementation of [CoroutineDispatcher].
+ * The returned [CoroutineContext] also contains an [ArmeriaRequestCoroutineContext] that automatically
+ * propagates the [ContextAwareExecutor.context] when the coroutine is resumed on a thread.
+ */
+fun ContextAwareExecutor.asCoroutineDispatcher(): CoroutineContext {
+    return (this as Executor).asCoroutineDispatcher() + context().asCoroutineContext()
+}

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutor.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutor.kt
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common.kotlin
 
 import com.linecorp.armeria.common.ContextAwareExecutor
-import java.util.concurrent.Executor
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -28,5 +27,5 @@ import kotlinx.coroutines.asCoroutineDispatcher
  * propagates the [ContextAwareExecutor.context] when the coroutine is resumed on a thread.
  */
 fun ContextAwareExecutor.asCoroutineDispatcher(): CoroutineContext {
-    return (this as Executor).asCoroutineDispatcher() + context().asCoroutineContext()
+    return this.withoutContext().asCoroutineDispatcher() + context().asCoroutineContext()
 }

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
@@ -34,7 +34,7 @@ fun RequestContext.asCoroutineContext(): ArmeriaRequestCoroutineContext {
 /**
  * Propagates [RequestContext] over coroutines.
  */
-class ArmeriaRequestCoroutineContext internal constructor (
+class ArmeriaRequestCoroutineContext internal constructor(
     private val requestContext: RequestContext
 ) : ThreadContextElement<SafeCloseable>, AbstractCoroutineContextElement(Key) {
 

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,20 +14,25 @@
  * under the License.
  */
 
-package com.linecorp.armeria.internal.common.kotlin
+package com.linecorp.armeria.common.kotlin
 
+import com.linecorp.armeria.common.RequestContext
 import com.linecorp.armeria.common.util.SafeCloseable
-import com.linecorp.armeria.server.ServiceRequestContext
-import kotlinx.coroutines.ThreadContextElement
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.ThreadContextElement
 
 /**
- * Propagates [ServiceRequestContext] over coroutines.
+ * Converts an instance of [RequestContext] to an implementation of [CoroutineContext] that automatically
+ * propagates the [RequestContext]. The propagation is done by [RequestContext.push] when the coroutine is
+ * resumed on a thread.
  */
-@Deprecated("Use RequestContext.asCoroutineContext() instead.", ReplaceWith("RequestContext.asCoroutineContext()"))
+fun RequestContext.asCoroutineContext(): ArmeriaRequestCoroutineContext {
+    return ArmeriaRequestCoroutineContext(this)
+}
+
 class ArmeriaRequestCoroutineContext(
-    private val requestContext: ServiceRequestContext
+    private val requestContext: RequestContext
 ) : ThreadContextElement<SafeCloseable>, AbstractCoroutineContextElement(Key) {
 
     companion object Key : CoroutineContext.Key<ArmeriaRequestCoroutineContext>

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
@@ -34,7 +34,7 @@ fun RequestContext.asCoroutineContext(): ArmeriaRequestCoroutineContext {
 /**
  * Propagates [RequestContext] over coroutines.
  */
-class ArmeriaRequestCoroutineContext(
+class ArmeriaRequestCoroutineContext internal constructor (
     private val requestContext: RequestContext
 ) : ThreadContextElement<SafeCloseable>, AbstractCoroutineContextElement(Key) {
 

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContext.kt
@@ -31,6 +31,9 @@ fun RequestContext.asCoroutineContext(): ArmeriaRequestCoroutineContext {
     return ArmeriaRequestCoroutineContext(this)
 }
 
+/**
+ * Propagates [RequestContext] over coroutines.
+ */
 class ArmeriaRequestCoroutineContext(
     private val requestContext: RequestContext
 ) : ThreadContextElement<SafeCloseable>, AbstractCoroutineContextElement(Key) {

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutorTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutorTest.kt
@@ -31,17 +31,6 @@ import org.junit.jupiter.api.Test
 class CoroutineContextAwareExecutorTest {
 
     @Test
-    fun foo() {
-        val ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
-        runTest(ctx.asCoroutineContext()) {
-            assertThat(ServiceRequestContext.current()).isSameAs(ctx)
-            withContext(Dispatchers.Default) {
-                assertThat(ServiceRequestContext.current()).isSameAs(ctx)
-            }
-        }
-    }
-
-    @Test
     fun serviceRequestContext() {
         val ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
         runTest {

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutorTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineContextAwareExecutorTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.common.kotlin
+
+import com.linecorp.armeria.client.ClientRequestContext
+import com.linecorp.armeria.common.HttpMethod
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.internal.testing.GenerateNativeImageTrace
+import com.linecorp.armeria.server.ServiceRequestContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@GenerateNativeImageTrace
+class CoroutineContextAwareExecutorTest {
+
+    @Test
+    fun foo() {
+        val ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
+        runTest(ctx.asCoroutineContext()) {
+            assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+            withContext(Dispatchers.Default) {
+                assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+            }
+        }
+    }
+
+    @Test
+    fun serviceRequestContext() {
+        val ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
+        runTest {
+            withContext(ctx.eventLoop().asCoroutineDispatcher()) {
+                assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+                assertThat(ctx.eventLoop().inEventLoop()).isTrue()
+                withContext(Dispatchers.Default) {
+                    assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+                    assertThat(ctx.eventLoop().inEventLoop()).isFalse()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun clientRequestContext() {
+        val ctx = ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
+        runTest {
+            withContext(ctx.eventLoop().asCoroutineDispatcher()) {
+                assertThat(ClientRequestContext.current()).isSameAs(ctx)
+                assertThat(ctx.eventLoop().inEventLoop()).isTrue()
+                withContext(Dispatchers.Default) {
+                    assertThat(ClientRequestContext.current()).isSameAs(ctx)
+                    assertThat(ctx.eventLoop().inEventLoop()).isFalse()
+                }
+            }
+        }
+    }
+}

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContextTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/common/kotlin/CoroutineRequestContextTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.common.kotlin
+
+import com.linecorp.armeria.client.ClientRequestContext
+import com.linecorp.armeria.common.HttpMethod
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.internal.testing.GenerateNativeImageTrace
+import com.linecorp.armeria.server.ServiceRequestContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+@GenerateNativeImageTrace
+class CoroutineRequestContextTest {
+
+    @Test
+    fun serviceRequestContext() {
+        val ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
+        runTest(ctx.asCoroutineContext()) {
+            assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+            withContext(Dispatchers.Default) {
+                assertThat(ServiceRequestContext.current()).isSameAs(ctx)
+            }
+        }
+    }
+
+    @Test
+    fun clientRequestContext() {
+        val ctx = ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build()
+        runTest(ctx.asCoroutineContext()) {
+            assertThat(ClientRequestContext.current()).isSameAs(ctx)
+            withContext(Dispatchers.Default) {
+                assertThat(ClientRequestContext.current()).isSameAs(ctx)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
- `ArmeriaRequestCoroutineContext` for Kotlin is an internal API that users shouldn't use. We need to provide a public API for that.
- It would be nice if we could add `ArmeriaRequestCoroutineContext(ctx)` automatically for `ContextAwareExecutor` dispatcher so that the context is automatically propagated even when threads are changed.

Modifications:
- Add `RequestContext.asCoroutineContext()` extension method that replaces the usage of `ArmeriaRequestCoroutineContext(ctx)`
- Add `ContextAwareExecutor.asCoroutineDispatcher()` extension method that returns the dispatcher with `RequestContext.asCoroutineContext()`.

Result:
- You can now easily propagate an Armeria `RequestContext` in kotlin using `ContextAwareExecutor.asCoroutineDispatcher()`.