### PR TITLE
Add params for benchmarking blocking grpc services

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/grpc/downstream/DownstreamSimpleBenchmark.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.grpc.downstream;
 import java.time.Duration;
 
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
@@ -41,6 +42,9 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
     private GithubServiceBlockingStub githubApiClient;
     private GithubServiceFutureStub githubApiFutureClient;
 
+    @Param(value = {"false"})
+    private Boolean useBlockingTaskExecutor;
+
     @Override
     protected int port() {
         return server.activeLocalPort(SessionProtocol.HTTP);
@@ -61,6 +65,7 @@ public class DownstreamSimpleBenchmark extends SimpleBenchmarkBase {
         server = Server.builder()
                        .serviceUnder("/",
                                      GrpcService.builder()
+                                                .useBlockingTaskExecutor(useBlockingTaskExecutor)
                                                 .addService(new GithubApiService()).build())
                                                 .requestTimeout(Duration.ZERO)
                                                 .meterRegistry(NoopMeterRegistry.get())


### PR DESCRIPTION
Motivation:

While reviewing the following pull request, I found that we don't have an easy way to benchmark blocking gRPC services.

ref: https://github.com/line/armeria/pull/5169

Modifications:

- Added a parameter to gRPC benchmarks

Result:

- Users can now benchmark gRPC blocking services more easily
<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
