### PR TITLE
Update jmh configuration for async profiler

### DIFF
--- a/benchmarks/jmh/README.md
+++ b/benchmarks/jmh/README.md
@@ -34,15 +34,13 @@ A collection of JMH benchmarks which may be useful for measuring Armeria perform
 ## Retrieving flame graph using async-profiler
 
 - Allow running `perf` as a normal user on Linux:
-  - MacOS profiling is limited to user space code only, thus this does not work with MacOS.
-
   ```
   # echo 1 > /proc/sys/kernel/perf_event_paranoid
   # echo 0 > /proc/sys/kernel/kptr_restrict
   ```
+  - MacOS profiling is limited to user space code only, thus this does not work with MacOS.
 
 - Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler):
-
   ```
   $ cd "$HOME"
   $ git clone https://github.com/jvm-profiling-tools/async-profiler.git

--- a/benchmarks/jmh/README.md
+++ b/benchmarks/jmh/README.md
@@ -2,14 +2,9 @@
 
 A collection of JMH benchmarks which may be useful for measuring Armeria performance.
 
-## Always prepend `--no-daemon` and `clean`
+## Limitation
 
-You must prepend `--no-daemon` and `clean` to your benchmark command due to
-[a known bug in jmh-gradle-plugin](https://github.com/melix/jmh-gradle-plugin/issues/132):
-
-```
-$ ./gradlew --no-daemon :benchmarks:jmh:clean :benchmarks:jmh:jmh ...
-```
+- MacOS profiling is limited to user space code only, thus this guide does not cover profiling on MacOS.
 
 ## Options
 
@@ -29,7 +24,7 @@ $ ./gradlew --no-daemon :benchmarks:jmh:clean :benchmarks:jmh:jmh ...
   - The number of iterations. Uses the value of `jmh.iterations` if unspecified.
 - `-Pjmh.profilers=<spec>`
   - The profiler settings. Profiler disabled if unspecified.
-    - `jmh.extras.Async:asyncProfilerDir=...;flameGraphDir=...`
+    - `async:libPath=...;output=flamegraph`
 - `-Pjmh.threads=<integer>`
   - The number of threads. JMH default if unspecified.
 - `-Pjmh.verbose`
@@ -49,13 +44,11 @@ Allow running `perf` as a normal user:
 # echo 0 > /proc/sys/kernel/kptr_restrict
 ```
 
-Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) and
-[FlameGraph](https://github.com/brendangregg/FlameGraph):
+Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler):
 
 ```
 $ cd "$HOME"
 $ git clone https://github.com/jvm-profiling-tools/async-profiler.git
-$ git clone https://github.com/brendangregg/FlameGraph.git
 $ cd async-profiler
 $ make
 ```
@@ -63,12 +56,12 @@ $ make
 When running a benchmark, specify `-Pjmh.profilers` option:
 
 ```
-$ ./gradlew --no-daemon :benchmarks:jmh:clean :benchmarks:jmh:jmh \
-  "-Pjmh.profilers=jmh.extras.Async:asyncProfilerDir=$HOME/async-profiler;flameGraphDir=$HOME/FlameGraph"
+$ ./gradlew :benchmarks:jmh:jmh \
+  "-Pjmh.profilers=async:libPath=$HOME/async-profiler/build/lib/libasyncProfiler.so;output=flamegraph;dir=$HOME/result"
 ```
 
 ## Notes
 
 - Do not forget to wrap `-Pjmh.params` and `-Pjmh.profilers` option with double quotes, because otherwise your
   shell will interpret `;` as the end of the command.
-- See [sbt-jmh documentation](https://github.com/ktoso/sbt-jmh#using-async-profiler) for more profiler options.
+- Run `$ ./gradlew :benchmarks:jmh:jmh "-Pjmh.profilers=async"` for more profiler options.

--- a/benchmarks/jmh/README.md
+++ b/benchmarks/jmh/README.md
@@ -40,10 +40,10 @@ A collection of JMH benchmarks which may be useful for measuring Armeria perform
   ```
   - MacOS profiling is limited to user space code only, thus this does not work with MacOS.
 
-- Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler):
+- Install [async-profiler](https://github.com/async-profiler/async-profiler):
   ```
   $ cd "$HOME"
-  $ git clone https://github.com/jvm-profiling-tools/async-profiler.git
+  $ git clone https://github.com/async-profiler/async-profiler.git
   $ cd async-profiler
   $ make
   ```
@@ -64,4 +64,4 @@ A collection of JMH benchmarks which may be useful for measuring Armeria perform
 
 - Do not forget to wrap `-Pjmh.params` and `-Pjmh.profilers` option with double quotes, because otherwise your
   shell will interpret `;` as the end of the command.
-- Run `$ ./gradlew :benchmarks:jmh:jmh "-Pjmh.profilers=async"` for more profiler options.
+- Run `$ ./gradlew :benchmarks:jmh:jmh "-Pjmh.profilers=async:help"` for more profiler options.

--- a/benchmarks/jmh/README.md
+++ b/benchmarks/jmh/README.md
@@ -2,10 +2,6 @@
 
 A collection of JMH benchmarks which may be useful for measuring Armeria performance.
 
-## Limitation
-
-- MacOS profiling is limited to user space code only, thus this guide does not cover profiling on MacOS.
-
 ## Options
 
 - `-Pjmh.includes=<pattern>`
@@ -37,28 +33,34 @@ A collection of JMH benchmarks which may be useful for measuring Armeria perform
 
 ## Retrieving flame graph using async-profiler
 
-Allow running `perf` as a normal user:
+- Allow running `perf` as a normal user on Linux:
+  - MacOS profiling is limited to user space code only, thus this does not work with MacOS.
 
-```
-# echo 1 > /proc/sys/kernel/perf_event_paranoid
-# echo 0 > /proc/sys/kernel/kptr_restrict
-```
+  ```
+  # echo 1 > /proc/sys/kernel/perf_event_paranoid
+  # echo 0 > /proc/sys/kernel/kptr_restrict
+  ```
 
-Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler):
+- Install [async-profiler](https://github.com/jvm-profiling-tools/async-profiler):
 
-```
-$ cd "$HOME"
-$ git clone https://github.com/jvm-profiling-tools/async-profiler.git
-$ cd async-profiler
-$ make
-```
+  ```
+  $ cd "$HOME"
+  $ git clone https://github.com/jvm-profiling-tools/async-profiler.git
+  $ cd async-profiler
+  $ make
+  ```
 
-When running a benchmark, specify `-Pjmh.profilers` option:
-
-```
-$ ./gradlew :benchmarks:jmh:jmh \
-  "-Pjmh.profilers=async:libPath=$HOME/async-profiler/build/lib/libasyncProfiler.so;output=flamegraph;dir=$HOME/result"
-```
+- When running a benchmark, specify `-Pjmh.profilers` option:
+  - On Linux
+    ```
+    $ ./gradlew :benchmarks:jmh:jmh \
+      "-Pjmh.profilers=async:libPath=$HOME/async-profiler/build/lib/libasyncProfiler.so;output=flamegraph;dir=$HOME/result"
+    ```
+  - On MacOS
+    ```
+    $ ./gradlew :benchmarks:jmh:jmh \
+      "-Pjmh.profilers=async:libPath=$HOME/async-profiler/build/lib/libasyncProfiler.dylib;output=flamegraph;dir=$HOME/result"
+    ```
 
 ## Notes
 

--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -20,8 +20,6 @@ dependencies {
     implementation libs.awaitility
     implementation libs.kotlin.coroutines.core
 
-    jmh libs.jmh.extras
-
     implementation project(':testing-internal')
 }
 

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -61,7 +61,6 @@ jetty93 = "9.3.30.v20211001"
 jetty94 = "9.4.51.v20230217"
 jetty-alpn-api = "1.1.3.v20160715"
 jmh-core = "1.37"
-jmh-extras = "0.3.7"
 jmh-gradle-plugin = "0.7.1"
 joor = "0.9.14"
 json-unit = "2.38.0"
@@ -669,10 +668,6 @@ version.ref = "jetty94"
 [libraries.jetty-alpn-api]
 module = "org.eclipse.jetty.alpn:alpn-api"
 version.ref = "jetty-alpn-api"
-
-[libraries.jmh-extras]
-module = "pl.project13.scala:sbt-jmh-extras"
-version.ref = "jmh-extras"
 
 [libraries.joor]
 module = "org.jooq:joor"


### PR DESCRIPTION
Motivation:
We don't have to use sbt-jmh-extras because the integration with async-profiler and JFR are merged to the JMH. https://github.com/sbt/sbt-jmh#using-java-flight-recorder--async-profiler

Modification:
- Remove `sbt-jmh-extras` dependency
- Update README.md and build.gradle

Result:
- Correct guide for JMH async profiler