### PR TITLE
Enable local cache by default

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -61,7 +61,7 @@ gradleEnterprise {
 
 buildCache {
     local {
-        enabled = false
+        enabled = true
     }
     remote(gradleEnterprise.buildCache) {
         enabled = true


### PR DESCRIPTION
Motivation:

This pull request attempts to enable local caching by default.
Doing so should be safe since this only adds an extra layer of caching on top of remote caching.

Modifications:

- Enable local caching by default

Result:

- Local caching is now available

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
