### PR TITLE
Added the "Revved up by Gradle Enterprise" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Visit [the official web site](https://armeria.dev/) for more information.
 <a href="https://github.com/line/armeria/pulse"><img src="https://img.shields.io/github/commit-activity/m/line/armeria.svg?label=commits" /></a>
 <a href="https://search.maven.org/search?q=g:com.linecorp.armeria%20AND%20a:armeria"><img src="https://img.shields.io/maven-central/v/com.linecorp.armeria/armeria.svg?label=version" /></a>
 <a href="https://github.com/line/armeria/commits"><img src="https://img.shields.io/github/release-date/line/armeria.svg?label=release" /></a>
+[![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.armeria.dev/scans)
+
 
 > Build a reactive microservice **at your pace**, not theirs.
 


### PR DESCRIPTION
Added the "Revved up by Gradle Enterprise" badge, which links to https://ge.armeria.dev/

Motivation:

The badge is a standard way for OSS projects that are supported by Gradle Enteprise to have a link to their GE instance in their readme.

Modifications:

- Added the "Revved up by Gradle Enterprise" badge, which links to https://ge.armeria.dev/ to the main `README.md` file.
