### PR TITLE
Added dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+registries:
+    gradle-plugin-portal:
+        type: maven-repository
+        url: https://plugins.gradle.org/m2
+        username: dummy # Required by dependabot
+        password: dummy # Required by dependabot
+updates:
+    - package-ecosystem: "gradle"
+      directory: "/"
+      registries:
+          - gradle-plugin-portal
+      schedule:
+          interval: "daily"
+          time: "02:00"
+          # Use Korea Standard Time (UTC +09:00)
+          timezone: "Asia/Seoul"
+      open-pull-requests-limit: 10
+      allow:
+          - dependency-name: "com.gradle.enterprise"
+            dependency-type: "production"
+          - dependency-name: "com.gradle.common-custom-user-data-gradle-plugin"
+            dependency-type: "production"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "daily"
+          time: "02:00"
+          # Use Korea Standard Time (UTC +09:00)
+          timezone: "Asia/Seoul"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,6 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
-          time: "02:00"
+          time: "10:00"
           # Use Korea Standard Time (UTC +09:00)
           timezone: "Asia/Seoul"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
           - gradle-plugin-portal
       schedule:
           interval: "daily"
-          time: "02:00"
+          time: "10:00"
           # Use Korea Standard Time (UTC +09:00)
           timezone: "Asia/Seoul"
       open-pull-requests-limit: 10


### PR DESCRIPTION
Added dependabot configuration, configured for GE and CCUD plugins, as well as for github actions.

Note: After this is merged, dependabot PRs for dependency version updates will need to be enabled in the repositories settings (if not already). You can enable it in [security settings](https://github.com/line/armeria/settings/security_analysis).

Motivation:

Dependabot will check GE and CCUD plugin versions and open PRs with updates for them. It will also check github action versions and open PRs for that.

Modifications:

- Added dependabot configuration, configured for GE and CCUD plugins, as well as for github actions.

Result:

- It will open PRs for updates to Gradle Enterprise and Common Custom User Data Gradle plugins.
- It will open PRs for updates to Github Actions used.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
