### PR TITLE
Fix a bug where `HttpResponse` can't complete with `CompletionStage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -507,6 +507,18 @@ public interface HttpResponse extends Response, HttpMessage {
 
     /**
      * Creates a new HTTP response that delegates to the {@link HttpResponse} produced by the specified
+     * {@link CompletableFuture}. If the specified {@link CompletableFuture} fails, the returned response will
+     * be closed with the same cause as well.
+     *
+     * @param future the {@link CompletableFuture} which will produce the actual {@link HttpResponse}
+     */
+    static HttpResponse of(CompletableFuture<? extends HttpResponse> future) {
+        requireNonNull(future, "future");
+        return createHttpResponseFrom(future);
+    }
+
+    /**
+     * Creates a new HTTP response that delegates to the {@link HttpResponse} produced by the specified
      * {@link CompletionStage}. If the specified {@link CompletionStage} fails, the returned response will be
      * closed with the same cause as well.
      *
@@ -514,14 +526,9 @@ public interface HttpResponse extends Response, HttpMessage {
      */
     static HttpResponse of(CompletionStage<? extends HttpResponse> stage) {
         requireNonNull(stage, "stage");
-
-        if (stage instanceof CompletableFuture) {
-            return createHttpResponseFrom((CompletableFuture<? extends HttpResponse>) stage);
-        } else {
-            final DeferredHttpResponse res = new DeferredHttpResponse();
-            res.delegateWhenComplete(stage);
-            return res;
-        }
+        final DeferredHttpResponse res = new DeferredHttpResponse();
+        res.delegateWhenComplete(stage);
+        return res;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -480,7 +480,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
                 continue;
             }
 
-            if (e instanceof CompletableFuture) {
+            if (e instanceof AwaitDemandFuture) {
                 if (cause == null) {
                     cause = ClosedStreamException.get();
                 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -999,8 +999,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      * }</pre>
      */
     @UnstableApi
-    default <E extends Throwable> StreamMessage<T> recoverAndResume(Class<E> causeClass,
-                                                                    Function<? super E, ? extends StreamMessage<T>> function) {
+    default <E extends Throwable> StreamMessage<T> recoverAndResume(
+            Class<E> causeClass, Function<? super E, ? extends StreamMessage<T>> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recoverAndResume(cause -> {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -188,6 +188,19 @@ public interface StreamMessage<T> extends Publisher<T> {
 
     /**
      * Creates a new {@link StreamMessage} that delegates to the {@link StreamMessage} produced by the specified
+     * {@link CompletableFuture}. If the specified {@link CompletableFuture} fails, the returned
+     * {@link StreamMessage} will be closed with the same cause as well.
+     *
+     * @param future the {@link CompletableFuture} which will produce the actual {@link StreamMessage}
+     */
+    @UnstableApi
+    static <T> StreamMessage<T> of(CompletableFuture<? extends Publisher<? extends T>> future) {
+        requireNonNull(future, "stage");
+        return createStreamMessageFrom(future);
+    }
+
+    /**
+     * Creates a new {@link StreamMessage} that delegates to the {@link StreamMessage} produced by the specified
      * {@link CompletionStage}. If the specified {@link CompletionStage} fails, the returned
      * {@link StreamMessage} will be closed with the same cause as well.
      *
@@ -197,14 +210,10 @@ public interface StreamMessage<T> extends Publisher<T> {
     static <T> StreamMessage<T> of(CompletionStage<? extends Publisher<? extends T>> stage) {
         requireNonNull(stage, "stage");
 
-        if (stage instanceof CompletableFuture) {
-            return createStreamMessageFrom((CompletableFuture<? extends Publisher<? extends T>>) stage);
-        } else {
-            final DeferredStreamMessage<T> deferred = new DeferredStreamMessage<>();
-            //noinspection unchecked
-            deferred.delegateOnCompletion((CompletionStage<? extends Publisher<T>>) stage);
-            return deferred;
-        }
+        final DeferredStreamMessage<T> deferred = new DeferredStreamMessage<>();
+        //noinspection unchecked
+        deferred.delegateOnCompletion((CompletionStage<? extends Publisher<T>>) stage);
+        return deferred;
     }
 
     /**
@@ -991,7 +1000,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     @UnstableApi
     default <E extends Throwable> StreamMessage<T> recoverAndResume(Class<E> causeClass,
-            Function<? super E, ? extends StreamMessage<T>> function) {
+                                                                    Function<? super E, ? extends StreamMessage<T>> function) {
         requireNonNull(causeClass, "causeClass");
         requireNonNull(function, "function");
         return recoverAndResume(cause -> {

--- a/core/src/test/java/com/linecorp/armeria/common/DeferredHttpResponseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/DeferredHttpResponseTest.java
@@ -73,7 +73,8 @@ class DeferredHttpResponseTest {
         final HttpResponse res1 = HttpResponse.of(completedFuture);
         final HttpResponse res2 = HttpResponse.of((CompletionStage<? extends HttpResponse>) completedFuture);
         assertThat(res1).isSameAs(originalRes);
-        assertThat(res2).isSameAs(originalRes);
+        // CompletionStage does not provide the current state.
+        assertThat(res2).isNotSameAs(originalRes);
     }
 
     /**
@@ -90,7 +91,8 @@ class DeferredHttpResponseTest {
         final HttpResponse res1 = HttpResponse.of(completedFuture);
         final HttpResponse res2 = HttpResponse.of((CompletionStage<? extends HttpResponse>) completedFuture);
         assertThat(res1).isInstanceOf(AbortedHttpResponse.class);
-        assertThat(res2).isInstanceOf(AbortedHttpResponse.class);
+        // CompletionStage does not provide the current state.
+        assertThat(res2).isNotInstanceOf(AbortedHttpResponse.class);
         assertThatThrownBy(() -> res1.collect().join()).hasCause(originalCause);
         assertThatThrownBy(() -> res2.collect().join()).hasCause(originalCause);
     }

--- a/core/src/test/java9/com/linecorp/armeria/internal/common/HttpResponseCompletionStageTest.java
+++ b/core/src/test/java9/com/linecorp/armeria/internal/common/HttpResponseCompletionStageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.stream.StreamMessage;
+
+class HttpResponseCompletionStageTest {
+
+    @Test
+    void shouldCompleteHttpResponseWithCompletionStage() {
+        final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+        final HttpResponse response = HttpResponse.of(future.minimalCompletionStage());
+        future.complete(HttpResponse.of(200));
+        assertThat(response.aggregate().join().status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void shouldCompleteStreamMessageWithCompletionStage() {
+        final CompletableFuture<StreamMessage<Integer>> future = new CompletableFuture<>();
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(future.minimalCompletionStage());
+        future.complete(StreamMessage.of(1));
+        assertThat(streamMessage.collect().join()).containsExactly(1);
+    }
+}


### PR DESCRIPTION
Motivation:

`CompletionStage<T> CompletableFuture.minimalCompletionStage()` returns a `MinimalStage` which implements `CompletionFuture` and raises `UnsupportedOperationException` if the methods only in `CompletionFuture` are called.

`HttpResponse.of(CompletionStage<HttpResponse>)` checks if the given value is an instance of `CompletableFuture` to use an optimized path for `CompletableFuture`. It is not working because `MinimalStage` can be set to the method parameter easily.
```java
CompletableFuture<HttpResponse> future = new CompletableFuture<>();
HttpResponse.of(future.minimalCompletionStage());
```

Discord discussion: https://discord.com/channels/1087271586832318494/1087272728177942629/1153277808630566942

Modifications:

- Do not check if a `CompletationStage` is an instance of `CompletableFuture` in `HttpResponse` and `StreamMessage`.

Result:

You no longer see `UnsupportedOperationException` when creating an `HttpResposne` with `CompletationStage`.
