### PR TITLE
Fix a bug where `ClientOptions` of derived clients is duplicated

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Clients.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Clients.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.MustBeClosed;
 
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -259,11 +260,8 @@ public final class Clients {
      *                    additional options are merged when a derived client is created.
      */
     public static <T> T newDerivedClient(T client, ClientOptionValue<?>... additionalOptions) {
-        final ClientBuilderParams params = builderParams(client);
-        final ClientBuilder builder = newDerivedBuilder(params);
-        builder.options(additionalOptions);
-
-        return newDerivedClient(builder, params.clientType());
+        requireNonNull(additionalOptions, "additionalOptions");
+        return newDerivedClient(client, ImmutableList.copyOf(additionalOptions));
     }
 
     /**
@@ -275,7 +273,7 @@ public final class Clients {
      */
     public static <T> T newDerivedClient(T client, Iterable<ClientOptionValue<?>> additionalOptions) {
         final ClientBuilderParams params = builderParams(client);
-        final ClientBuilder builder = newDerivedBuilder(params);
+        final ClientBuilder builder = newDerivedBuilder(params, true);
         builder.options(additionalOptions);
 
         return newDerivedClient(builder, params.clientType());
@@ -305,7 +303,7 @@ public final class Clients {
     public static <T> T newDerivedClient(
             T client, Function<? super ClientOptions, ClientOptions> configurator) {
         final ClientBuilderParams params = builderParams(client);
-        final ClientBuilder builder = newDerivedBuilder(params);
+        final ClientBuilder builder = newDerivedBuilder(params, false);
         builder.options(configurator.apply(params.options()));
 
         return newDerivedClient(builder, params.clientType());
@@ -316,10 +314,12 @@ public final class Clients {
         return builder.build((Class<T>) clientType);
     }
 
-    private static ClientBuilder newDerivedBuilder(ClientBuilderParams params) {
+    private static ClientBuilder newDerivedBuilder(ClientBuilderParams params, boolean setOptions) {
         final ClientBuilder builder = builder(params.scheme(), params.endpointGroup(),
                                               params.absolutePathRef());
-        builder.options(params.options());
+        if (setOptions) {
+            builder.options(params.options());
+        }
         return builder;
     }
 

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientDerivedClientTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientDerivedClientTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientBuilderParams;
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRpcClient;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
+import com.linecorp.armeria.client.limit.ConcurrencyLimitingClient;
+import com.linecorp.armeria.client.logging.LoggingRpcClient;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import testing.thrift.main.HelloService;
+
+class ThriftClientDerivedClientTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", THttpService.of((HelloService.AsyncIface) (name, resultHandler)
+                    -> resultHandler.onComplete("Hello, " + name + '!')));
+        }
+    };
+
+    @Test
+    void shouldPreserveOriginalDecorators() {
+        final HelloService.Iface client =
+                ThriftClients.builder(server.httpUri())
+                             .rpcDecorator(LoggingRpcClient.newDecorator())
+                             .rpcDecorator(
+                                     CircuitBreakerRpcClient.newDecorator(
+                                             CircuitBreaker.ofDefaultName(),
+                                             CircuitBreakerRuleWithContent.<RpcResponse>builder()
+                                                                          .onServerErrorStatus()
+                                                                          .thenFailure()))
+                             .build(HelloService.Iface.class);
+        final HelloService.Iface derivedClient0 = Clients.newDerivedClient(client, options -> {
+            return options.toBuilder()
+                          .decorator(ConcurrencyLimitingClient.newDecorator(10))
+                          .build();
+        });
+
+        final HelloService.Iface derivedClient1 =
+                Clients.newDerivedClient(client,
+                                         ClientOptions.DECORATION.newValue(ClientDecoration.of(
+                                                 ConcurrencyLimitingClient.newDecorator(10))));
+
+        final ClientBuilderParams originalParams = Clients.unwrap(client, ClientBuilderParams.class);
+        final ClientBuilderParams derivedParams0 = Clients.unwrap(derivedClient0, ClientBuilderParams.class);
+        assertThat(derivedParams0.options().decoration().rpcDecorators())
+                .isEqualTo(originalParams.options().decoration().rpcDecorators());
+        assertThat(derivedParams0.options().decoration().decorators()).hasSize(1);
+
+        final ClientBuilderParams derivedParams1 = Clients.unwrap(derivedClient1, ClientBuilderParams.class);
+        assertThat(derivedParams1.options().decoration().rpcDecorators())
+                .isEqualTo(originalParams.options().decoration().rpcDecorators());
+        assertThat(derivedParams1.options().decoration().decorators()).hasSize(1);
+    }
+}

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientDerivedClientTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftClientDerivedClientTest.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.client.thrift;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientDecoration;
@@ -31,27 +30,15 @@ import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRuleWithContent;
 import com.linecorp.armeria.client.limit.ConcurrencyLimitingClient;
 import com.linecorp.armeria.client.logging.LoggingRpcClient;
 import com.linecorp.armeria.common.RpcResponse;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.thrift.THttpService;
-import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import testing.thrift.main.HelloService;
 
 class ThriftClientDerivedClientTest {
 
-    @RegisterExtension
-    static ServerExtension server = new ServerExtension() {
-        @Override
-        protected void configure(ServerBuilder sb) {
-            sb.service("/", THttpService.of((HelloService.AsyncIface) (name, resultHandler)
-                    -> resultHandler.onComplete("Hello, " + name + '!')));
-        }
-    };
-
     @Test
     void shouldPreserveOriginalDecorators() {
         final HelloService.Iface client =
-                ThriftClients.builder(server.httpUri())
+                ThriftClients.builder("http://127.0.0.1:8080/")
                              .rpcDecorator(LoggingRpcClient.newDecorator())
                              .rpcDecorator(
                                      CircuitBreakerRpcClient.newDecorator(


### PR DESCRIPTION
Motivation:

If a client is derived with `ClientOptions` configurator, client options containing collection values such as `decorators`, `rpcDecorators` are duplicated. For example, the original client has `LoggingClient -> CircuitBreakerClient` decorators, and the derived client will have `LoggingClient -> CircuitBreakerClient -> LoggingClient -> CircuitBreakerClient`.

Because `configurator` builds a new `ClientOptions` and appends it to the existing `ClientOptions`.

Modifications:

- Do not set the existing client options when using `ClientOptions` configurator.

Result:

You no longer see duplicate `ClientOptions` when creating a derived client with `<type://Clients#newDerivedClient(T,Function)>`.
