### PR TITLE
Explicitly schedule pending `RequestLogFuture` on `ctx.eventLoop()`

### DIFF
--- a/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/client/brave/BraveClientTest.java
@@ -54,6 +54,7 @@ import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.brave.TestSpanCollector;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 
 import brave.Span.Kind;
 import brave.Tracing;
@@ -241,7 +242,9 @@ class BraveClientTest {
         final RpcRequest rpcReq = RpcRequest.of(TestService.Iface.class, "hello", "Armeria");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, Armeria!");
-        final ClientRequestContext ctx = ClientRequestContext.builder(req).build();
+        final ClientRequestContext ctx = ClientRequestContext.builder(req)
+                                                             .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                             .build();
         // the authority is extracted even when the request doesn't declare an authority
         final RequestHeaders headersWithoutAuthority =
                 req.headers().toBuilder().removeAndThen(HttpHeaderNames.AUTHORITY).build();

--- a/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
+++ b/brave/src/test/java/com/linecorp/armeria/server/brave/BraveServiceTest.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.common.brave.TestSpanCollector;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.TransientHttpService;
@@ -183,6 +184,7 @@ class BraveServiceTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "foo.com"));
         final ServiceRequestContext ctx = ServiceRequestContext.builder(req)
+                                                               .eventLoop(ImmediateEventLoop.INSTANCE)
                                                                .service(transientService)
                                                                .build();
         final RequestLogBuilder logBuilder = ctx.logBuilder();
@@ -220,7 +222,9 @@ class BraveServiceTest {
         final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "foo.com"));
-        final ServiceRequestContext ctx = ServiceRequestContext.builder(req).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(req)
+                                                               .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                               .build();
         final RpcRequest rpcReq = RpcRequest.of(TestService.Iface.class, "hello", "trustin");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, trustin!");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -369,7 +369,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
                 lock.unlock();
             }
             if (satisfiedFutures != null) {
-                completeSatisfiedFutures(satisfiedFutures, partial(flags));
+                completeSatisfiedFutures(satisfiedFutures, partial(flags), ctx);
             }
 
             future = newFuture;
@@ -416,14 +416,19 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
                 }
                 if (satisfiedFutures != null) {
                     final RequestLog log = partial(newFlags);
-                    completeSatisfiedFutures(satisfiedFutures, log);
+                    completeSatisfiedFutures(satisfiedFutures, log, ctx);
                 }
                 break;
             }
         }
     }
 
-    private static void completeSatisfiedFutures(RequestLogFuture[] satisfiedFutures, RequestLog log) {
+    private static void completeSatisfiedFutures(RequestLogFuture[] satisfiedFutures, RequestLog log,
+                                                 RequestContext ctx) {
+        if (!ctx.eventLoop().inEventLoop()) {
+            ctx.eventLoop().execute(() -> completeSatisfiedFutures(satisfiedFutures, log, ctx));
+            return;
+        }
         for (RequestLogFuture f : satisfiedFutures) {
             if (f == null) {
                 break;

--- a/core/src/test/java/com/linecorp/armeria/client/InitiateConnectionShutdownTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/InitiateConnectionShutdownTest.java
@@ -106,6 +106,7 @@ class InitiateConnectionShutdownTest {
             }
 
             assertNoOpenedConnectionNow(countingListener);
+            await().untilAsserted(() -> assertThat(completedResult.get().completed).isTrue());
             assertThat(completedResult.get().exception).isInstanceOf(UnprocessedRequestException.class);
             assertThat(completedResult.get().exception.getCause()).isSameAs(notAcquiredCause);
         }

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientDefaultLoggerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientDefaultLoggerTest.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -52,7 +53,9 @@ class LoggingClientDefaultLoggerTest {
 
     @Test
     void defaultLoggerUsedIfLogWriterNotSet() throws Exception {
-        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ClientRequestContext ctx = ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                                             .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                             .build();
         final LoggingClient client = LoggingClient.newDecorator().apply(delegate);
         client.execute(ctx, ctx.request());
         assertThat(logAppender.list).hasSize(2);

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -48,6 +48,7 @@ import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RegexBasedSanitizer;
 import com.linecorp.armeria.internal.common.logging.LoggingTestUtil;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 
 class LoggingClientTest {
     static final HttpClient delegate = (ctx, req) -> {
@@ -63,10 +64,16 @@ class LoggingClientTest {
         LoggingTestUtil.throwIfCaptured(capturedCause);
     }
 
+    static ClientRequestContext clientRequestContext(HttpRequest req) {
+        return ClientRequestContext.builder(req)
+                                   .eventLoop(ImmediateEventLoop.INSTANCE)
+                                   .build();
+    }
+
     @Test
     void logger() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
@@ -115,7 +122,7 @@ class LoggingClientTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
@@ -162,7 +169,7 @@ class LoggingClientTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
@@ -206,7 +213,7 @@ class LoggingClientTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         ctx.logBuilder().requestContent("Virginia 333-490-4499", "Virginia 333-490-4499");
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -249,7 +256,7 @@ class LoggingClientTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         ctx.logBuilder().requestContent("Virginia 333-490-4499", "Virginia 333-490-4499");
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -290,7 +297,7 @@ class LoggingClientTest {
     @Test
     void internalServerError() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -318,7 +325,7 @@ class LoggingClientTest {
     @Test
     void defaultsError() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
 
@@ -350,7 +357,7 @@ class LoggingClientTest {
     @Test
     void shouldLogFailedResponseWhenFailureSamplingRateIsAlways() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
 
@@ -382,7 +389,7 @@ class LoggingClientTest {
     @Test
     void shouldNotLogFailedResponseWhenSamplingRateIsZero() throws Exception {
         final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
+        final ClientRequestContext ctx = clientRequestContext(req);
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/DefaultRequestLogTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.ContextAwareEventLoop;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
@@ -46,6 +47,7 @@ import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.AnticipatedException;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceNaming;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -172,6 +174,7 @@ class DefaultRequestLogTest {
     @Test
     void addChild() {
         when(ctx.method()).thenReturn(HttpMethod.GET);
+        when(ctx.eventLoop()).thenReturn(ContextAwareEventLoop.of(ctx, ImmediateEventLoop.INSTANCE));
         final DefaultRequestLog child = new DefaultRequestLog(ctx);
         log.addChild(child);
         child.startRequest();
@@ -253,6 +256,7 @@ class DefaultRequestLogTest {
     void deferContent_setContentAfterEndResponse() {
         when(ctx.sessionProtocol()).thenReturn(SessionProtocol.H2C);
         when(ctx.method()).thenReturn(HttpMethod.GET);
+        when(ctx.eventLoop()).thenReturn(ContextAwareEventLoop.of(ctx, ImmediateEventLoop.INSTANCE));
         final CompletableFuture<RequestLog> completeFuture = log.whenComplete();
         assertThat(completeFuture.isDone()).isFalse();
 
@@ -277,6 +281,7 @@ class DefaultRequestLogTest {
     void deferContent_setContentBeforeEndResponse() {
         when(ctx.sessionProtocol()).thenReturn(SessionProtocol.H2C);
         when(ctx.method()).thenReturn(HttpMethod.GET);
+        when(ctx.eventLoop()).thenReturn(ContextAwareEventLoop.of(ctx, ImmediateEventLoop.INSTANCE));
         final CompletableFuture<RequestLog> completeFuture = log.whenComplete();
         assertThat(completeFuture.isDone()).isFalse();
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.logging.ClientConnectionTimings;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.RequestTimeoutException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
@@ -285,6 +286,7 @@ class RequestMetricSupportTest {
                                     .meterRegistry(registry)
                                     .endpoint(Endpoint.of("example.com", 8080))
                                     .connectionTimings(newConnectionTimings())
+                                    .eventLoop(ImmediateEventLoop.INSTANCE)
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");
@@ -316,6 +318,7 @@ class RequestMetricSupportTest {
         final ServiceRequestContext ctx =
                 ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
                                      .meterRegistry(registry)
+                                     .eventLoop(ImmediateEventLoop.INSTANCE)
                                      .build();
         final String serviceTag = "service=" + ctx.config().service().getClass().getName();
 
@@ -354,6 +357,7 @@ class RequestMetricSupportTest {
         final ClientRequestContext ctx =
                 ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/bar"))
                                     .meterRegistry(registry)
+                                    .eventLoop(ImmediateEventLoop.INSTANCE)
                                     .endpoint(Endpoint.of("example.com", 8080))
                                     .build();
 
@@ -373,6 +377,7 @@ class RequestMetricSupportTest {
         final ServiceRequestContext sctx =
                 ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
                                      .meterRegistry(registry)
+                                     .eventLoop(ImmediateEventLoop.INSTANCE)
                                      .build();
         final String serviceTag = "service=" + sctx.config().service().getClass().getName();
 
@@ -384,6 +389,7 @@ class RequestMetricSupportTest {
             final ClientRequestContext cctx =
                     ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/foo"))
                                         .meterRegistry(registry)
+                                        .eventLoop(ImmediateEventLoop.INSTANCE)
                                         .endpoint(Endpoint.of("example.com", 8080))
                                         .build();
             RequestMetricSupport.setup(cctx, AttributeKey.valueOf("differentKey"),
@@ -430,12 +436,14 @@ class RequestMetricSupportTest {
                                     .meterRegistry(registry)
                                     .endpoint(Endpoint.of("example.com", 8080))
                                     .connectionTimings(newConnectionTimings())
+                                    .eventLoop(ImmediateEventLoop.INSTANCE)
                                     .build();
         final ClientRequestContext ctx2 =
                 ClientRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/bar"))
                                     .meterRegistry(registry)
                                     .endpoint(Endpoint.of("example.com", 8080))
                                     .connectionTimings(newConnectionTimings())
+                                    .eventLoop(ImmediateEventLoop.INSTANCE)
                                     .build();
 
         final MeterIdPrefixFunction meterIdPrefixFunction = MeterIdPrefixFunction.ofDefault("foo");

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLogFormatsTest.java
@@ -60,6 +60,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.ProxiedAddresses;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.logging.AccessLogComponent.AttributeComponent;
@@ -332,11 +333,15 @@ class AccessLogFormatsTest {
         final String fullName = AccessLogFormatsTest.class.getSimpleName() + "/rpcMethod";
         final String expectedLogMessage = "\"GET /armeria/log#" + fullName + " h2c\" 200 1024";
 
-        final ServiceRequestContext ctx = ServiceRequestContext.builder(
-                HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/armeria/log",
-                                                 HttpHeaderNames.USER_AGENT, "armeria/x.y.z",
-                                                 HttpHeaderNames.REFERER, "http://log.example.com",
-                                                 HttpHeaderNames.COOKIE, "a=1;b=2"))).build();
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/armeria/log",
+                                                                 HttpHeaderNames.USER_AGENT, "armeria/x.y.z",
+                                                                 HttpHeaderNames.REFERER,
+                                                                 "http://log.example.com",
+                                                                 HttpHeaderNames.COOKIE, "a=1;b=2"));
+        final ServiceRequestContext ctx =
+                ServiceRequestContext.builder(req)
+                                     .eventLoop(ImmediateEventLoop.INSTANCE)
+                                     .build();
         final RequestLog log = ctx.log().partial();
         final RequestLogBuilder logBuilder = ctx.logBuilder();
 

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceDefaultLoggerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceDefaultLoggerTest.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import ch.qos.logback.classic.Logger;
@@ -52,7 +53,9 @@ class LoggingServiceDefaultLoggerTest {
 
     @Test
     void defaultLoggerUsedIfLogWriterNotSet() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/"))
+                                                               .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                               .build();
         final LoggingService service = LoggingService.newDecorator().apply(delegate);
         service.serve(ctx, ctx.request());
         assertThat(logAppender.list).hasSize(2);

--- a/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/LoggingServiceTest.java
@@ -53,6 +53,7 @@ import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.common.logging.RegexBasedSanitizer;
 import com.linecorp.armeria.internal.common.logging.LoggingTestUtil;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.HttpStatusException;
@@ -81,9 +82,19 @@ class LoggingServiceTest {
         LoggingTestUtil.throwIfCaptured(capturedCause);
     }
 
+    private static ServiceRequestContext serviceRequestContext() {
+        return serviceRequestContext(HttpRequest.of(HttpMethod.GET, "/"));
+    }
+
+    private static ServiceRequestContext serviceRequestContext(HttpRequest req) {
+        return ServiceRequestContext.builder(req)
+                                    .eventLoop(ImmediateEventLoop.INSTANCE)
+                                    .build();
+    }
+
     @Test
     void defaultsSuccess() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         final LoggingService service =
                 LoggingService.builder()
@@ -96,7 +107,7 @@ class LoggingServiceTest {
 
     @Test
     void defaultsError() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -118,7 +129,7 @@ class LoggingServiceTest {
     @MethodSource("expectedException")
     @ParameterizedTest
     void shouldNotLogHttpStatusAndResponseExceptions(Exception exception) throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         final Throwable cause = exception.getCause();
         ctx.logBuilder().endResponse(exception);
@@ -148,7 +159,7 @@ class LoggingServiceTest {
 
     @Test
     void infoLevel() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -173,8 +184,9 @@ class LoggingServiceTest {
 
     @Test
     void mapRequestLogLevelMapper() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(RequestHeaders.of(
-                HttpMethod.GET, "/", "x-req", "test", "x-res", "test")));
+        final HttpRequest req = HttpRequest.of(RequestHeaders.of(
+                HttpMethod.GET, "/", "x-req", "test", "x-res", "test"));
+        final ServiceRequestContext ctx = serviceRequestContext(req);
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isWarnEnabled()).thenReturn(true);
 
@@ -211,7 +223,7 @@ class LoggingServiceTest {
 
     @Test
     void mapRequestLogLevelMapperUnmatched() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         when(logger.isInfoEnabled()).thenReturn(true);
 
@@ -267,7 +279,7 @@ class LoggingServiceTest {
         final BiFunction<RequestContext, HttpHeaders, String> responseTrailersSanitizer =
                 (ctx, trailers) -> sanitizedResponseTrailers;
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         ctx.logBuilder().requestContent(new Object(), new Object());
         ctx.logBuilder().requestTrailers(HttpHeaders.of("foo", "bar"));
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
@@ -327,7 +339,7 @@ class LoggingServiceTest {
         final BiFunction<RequestContext, HttpHeaders, String> responseTrailersSanitizer =
                 (ctx, trailers) -> sanitizedResponseTrailers;
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         ctx.logBuilder().requestContent(new Object(), new Object());
         ctx.logBuilder().requestTrailers(HttpHeaders.of("foo", "bar"));
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(200));
@@ -372,7 +384,7 @@ class LoggingServiceTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final ServiceRequestContext ctx = serviceRequestContext(req);
         final Exception cause = new Exception("not sanitized");
         ctx.logBuilder().endResponse(cause);
 
@@ -424,7 +436,7 @@ class LoggingServiceTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final ServiceRequestContext ctx = serviceRequestContext(req);
         final Exception cause = new Exception("not sanitized");
         ctx.logBuilder().endResponse(cause);
 
@@ -476,7 +488,7 @@ class LoggingServiceTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final ServiceRequestContext ctx = serviceRequestContext(req);
         ctx.logBuilder().requestContent("Virginia 333-490-4499", "Virginia 333-490-4499");
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -518,7 +530,7 @@ class LoggingServiceTest {
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "test.com"));
 
-        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final ServiceRequestContext ctx = serviceRequestContext(req);
         ctx.logBuilder().requestContent("Virginia 333-490-4499", "Virginia 333-490-4499");
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -554,7 +566,7 @@ class LoggingServiceTest {
 
     @Test
     void sample() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
         final LogWriter logWriter = LogWriter.builder()
                                              .logger(logger)
@@ -573,7 +585,7 @@ class LoggingServiceTest {
 
     @Test
     void shouldLogFailedRequestWhenFailureSamplingRateIsAlways() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -596,7 +608,7 @@ class LoggingServiceTest {
 
     @Test
     void shouldNotLogFailedRequestWhenSamplingRateIsZero() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
@@ -613,7 +625,7 @@ class LoggingServiceTest {
 
     @Test
     void responseCauseFilter() throws Exception {
-        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final ServiceRequestContext ctx = serviceRequestContext();
         final IllegalStateException cause = new IllegalStateException("Failed");
         ctx.logBuilder().endResponse(cause);
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);

--- a/core/src/test/java/com/linecorp/armeria/server/observation/ObservationServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/observation/ObservationServiceTest.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.observation.MicrometerObservationRegistryUtils;
 import com.linecorp.armeria.internal.common.observation.SpanCollector;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.TransientHttpService;
@@ -208,7 +209,9 @@ class ObservationServiceTest {
         final HttpRequest req = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/hello/trustin",
                                                                  HttpHeaderNames.SCHEME, "http",
                                                                  HttpHeaderNames.AUTHORITY, "foo.com"));
-        final ServiceRequestContext ctx = ServiceRequestContext.builder(req).build();
+        final ServiceRequestContext ctx = ServiceRequestContext.builder(req)
+                                                               .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                               .build();
         final RpcRequest rpcReq = RpcRequest.of(ObservationServiceTest.class, "hello", "trustin");
         final HttpResponse res = HttpResponse.of(HttpStatus.OK);
         final RpcResponse rpcRes = RpcResponse.of("Hello, trustin!");

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
@@ -30,10 +30,9 @@ import io.netty.channel.EventLoop;
  */
 public final class ImmediateEventLoop extends DefaultEventLoop {
 
-    private ImmediateEventLoop() {
-    }
-
     public static final EventLoop INSTANCE = new ImmediateEventLoop();
+
+    private ImmediateEventLoop() {}
 
     @Override
     public void execute(Runnable command) {

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
@@ -16,10 +16,22 @@
 
 package com.linecorp.armeria.internal.testing;
 
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
 
+/**
+ * A simple {@link EventLoop} implementation which executes tasks immediately
+ * from the caller thread. Note that {@link #invokeAny(Collection)},
+ * {@link #invokeAll(Collection, long, TimeUnit)} and other variants have been
+ * omitted for simplicity.
+ */
 public final class ImmediateEventLoop extends DefaultEventLoop {
+
+    private ImmediateEventLoop() {
+    }
 
     public static final EventLoop INSTANCE = new ImmediateEventLoop();
 

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/ImmediateEventLoop.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.testing;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+
+public final class ImmediateEventLoop extends DefaultEventLoop {
+
+    public static final EventLoop INSTANCE = new ImmediateEventLoop();
+
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+
+    @Override
+    public boolean inEventLoop() {
+        return true;
+    }
+}


### PR DESCRIPTION
Motivation:

Currently the thread which invokes our log callbacks (i.e. `RequestLogFuture`s) are usually from `ctx.eventLoop()`.
This is because most log callbacks are invoked from the encoder/decoder layer which are usually invoked from the channel event loop.

However, while working on https://github.com/line/armeria/pull/4136 now it is possible that `ctx.eventLoop()` is different from `ch.executor()`.
Whether we choose to use `ctx.eventLoop()` or `ch.executor()` when completing callbacks, it is probably important that we are consistent. Therefore, I propose that for now we complete all pending `RequestLogFuture` from `ctx.eventLoop()`

Modifications:

- Reschedule `DefaultRequestLog#completeSatisfiedFutures` to be executed from `ctx.eventLoop()` if not done so already
- Fix failing tests

Result:

- More consistent behavior
- It is easier to review https://github.com/line/armeria/pull/4136


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
