### PR TITLE
Add `StreamMessage.endWith(finalizer)`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequest.java
@@ -300,7 +300,7 @@ public interface HttpRequest extends Request, HttpMessage {
         if (trailers.isEmpty()) {
             return of(headers, publisher);
         }
-        return of(headers, new SurroundingPublisher<>(null, publisher, trailers));
+        return of(headers, new SurroundingPublisher<>(null, publisher, unused -> trailers));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -33,17 +33,8 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
 
     static PublisherBasedHttpResponse from(ResponseHeaders headers,
                                            Publisher<? extends HttpData> publisher,
-                                           HttpHeaders trailers) {
-        if (trailers.isEmpty()) {
-            return from(headers, publisher);
-        }
-        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, trailers));
-    }
-
-    static PublisherBasedHttpResponse from(ResponseHeaders headers,
-                                           Publisher<? extends HttpData> publisher,
                                            Function<@Nullable Throwable, HttpHeaders> trailersFunction) {
-        return new PublisherBasedHttpResponse(SurroundingPublisher.from(headers, publisher, trailersFunction));
+        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, trailersFunction));
     }
 
     PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -28,7 +28,7 @@ import com.linecorp.armeria.internal.common.stream.SurroundingPublisher;
 final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpObject> implements HttpResponse {
 
     static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
-        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, null));
+        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, unused -> null));
     }
 
     static PublisherBasedHttpResponse from(ResponseHeaders headers,

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -17,9 +17,11 @@
 package com.linecorp.armeria.common;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import org.reactivestreams.Publisher;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.SurroundingPublisher;
 
@@ -36,6 +38,12 @@ final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpO
             return from(headers, publisher);
         }
         return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, trailers));
+    }
+
+    static PublisherBasedHttpResponse from(ResponseHeaders headers,
+                                           Publisher<? extends HttpData> publisher,
+                                           Function<@Nullable Throwable, HttpHeaders> trailersFunction) {
+        return new PublisherBasedHttpResponse(SurroundingPublisher.from(headers, publisher, trailersFunction));
     }
 
     PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -1076,8 +1076,7 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Emits the last value depending on whether this {@link StreamMessage}
-     * completes successfully or exceptionally.
+     * Emits the last value whether this {@link StreamMessage} completes successfully or exceptionally.
      *
      * <p>For example:<pre>{@code
      * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -1100,7 +1100,8 @@ public interface StreamMessage<T> extends Publisher<T> {
      * }</pre>
      *
      * <p>Note that if {@code null} is returned by the {@link Function}, the {@link StreamMessage} will complete
-     * successfully without emitting an additional value.
+     * successfully without emitting an additional value when this stream is complete successfully,
+     * or complete exceptionally when this stream is complete exceptionally.
      */
     @UnstableApi
     default StreamMessage<T> endWith(Function<@Nullable Throwable, ? extends @Nullable T> finalizer) {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -1076,7 +1076,8 @@ public interface StreamMessage<T> extends Publisher<T> {
     }
 
     /**
-     * Emits the last value whether this {@link StreamMessage} completes successfully or exceptionally.
+     * Dynamically emits the last value depending on whether this {@link StreamMessage} completes successfully
+     * or exceptionally.
      *
      * <p>For example:<pre>{@code
      * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1097,9 +1098,12 @@ public interface StreamMessage<T> extends Publisher<T> {
      *
      * assert collected.equals(List.of(1, 2, 3, 4, 5, 100));
      * }</pre>
+     *
+     * <p>Note that if {@code null} is returned by the {@link Function}, the {@link StreamMessage} will complete
+     * successfully without emitting an additional value.
      */
     @UnstableApi
-    default StreamMessage<T> endWith(Function<@Nullable Throwable, ? extends T> finalizer) {
-        return SurroundingPublisher.from(null, this, finalizer);
+    default StreamMessage<T> endWith(Function<@Nullable Throwable, ? extends @Nullable T> finalizer) {
+        return new SurroundingPublisher<>(null, this, finalizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.internal.common.stream.InternalStreamMessageUtil;
 import com.linecorp.armeria.internal.common.stream.OneElementFixedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.RecoverableStreamMessage;
 import com.linecorp.armeria.internal.common.stream.RegularFixedStreamMessage;
+import com.linecorp.armeria.internal.common.stream.SurroundingPublisher;
 import com.linecorp.armeria.internal.common.stream.ThreeElementFixedStreamMessage;
 import com.linecorp.armeria.internal.common.stream.TwoElementFixedStreamMessage;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -1072,5 +1073,34 @@ public interface StreamMessage<T> extends Publisher<T> {
         requireNonNull(httpDataConverter, "httpDataConverter");
         requireNonNull(executor, "executor");
         return new StreamMessageInputStream<>(this, httpDataConverter, executor);
+    }
+
+    /**
+     * Emits the last value depending on whether this {@link StreamMessage}
+     * completes successfully or exceptionally.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+     * StreamMessage<Integer> aborted = source
+     *     .peek(i -> {
+     *         if (i > 5) {
+     *             source.abort();
+     *         }
+     *     });
+     * StreamMessage<Integer> endWith = aborted
+     *     .endWith(th -> {
+     *          if (th instanceof AbortedStreamException) {
+     *              return 100;
+     *          }
+     *          return -1;
+     *     });
+     * List<Integer> collected = endWith.collect().join();
+     *
+     * assert collected.equals(List.of(1, 2, 3, 4, 5, 100));
+     * }</pre>
+     */
+    @UnstableApi
+    default StreamMessage<T> endWith(Function<@Nullable Throwable, ? extends T> finalizer) {
+        return SurroundingPublisher.from(null, this, finalizer);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
@@ -67,29 +67,26 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
 
     @SuppressWarnings("unchecked")
     public SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher, @Nullable T tail) {
-        requireNonNull(publisher, "publisher");
-        this.head = head;
-        if (publisher instanceof StreamMessage) {
-            this.publisher = (StreamMessage<T>) publisher;
-        } else {
-            this.publisher = new PublisherBasedStreamMessage<>(publisher);
-        }
-        this.tail = tail;
-        finalizer = null;
+        this(head, publisher, tail, null);
     }
 
     @SuppressWarnings("unchecked")
     private SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher,
                                  Function<@Nullable Throwable, ? extends T> finalizer) {
+        this(head, publisher, null, requireNonNull(finalizer, "finalizer"));
+    }
+
+    private SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher, @Nullable T tail,
+                                 @Nullable Function<@Nullable Throwable, ? extends T> finalizer) {
         requireNonNull(publisher, "publisher");
-        requireNonNull(finalizer, "finalizer");
         this.head = head;
         if (publisher instanceof StreamMessage) {
+            //noinspection unchecked
             this.publisher = (StreamMessage<T>) publisher;
         } else {
             this.publisher = new PublisherBasedStreamMessage<>(publisher);
         }
-        tail = null;
+        this.tail = tail;
         this.finalizer = finalizer;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
@@ -65,12 +65,10 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
     @Nullable
     private volatile SurroundingSubscriber<T> surroundingSubscriber;
 
-    @SuppressWarnings("unchecked")
     public SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher, @Nullable T tail) {
         this(head, publisher, tail, null);
     }
 
-    @SuppressWarnings("unchecked")
     private SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher,
                                  Function<@Nullable Throwable, ? extends T> finalizer) {
         this(head, publisher, null, requireNonNull(finalizer, "finalizer"));

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
@@ -400,7 +400,7 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
                 downstream.onNext(finalizer.apply(cause));
                 close0(null);
             } else {
-                close(cause);
+                close0(cause);
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageEndWithTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageEndWithTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.stream;
+
+import org.junit.jupiter.api.Test;
+
+import reactor.test.StepVerifier;
+
+class StreamMessageEndWithTest {
+
+    @Test
+    void endWith() {
+        final StreamMessage<Integer> endWith = StreamMessage
+                .of(1, 2, 3, 4, 5)
+                .endWith(th -> 100);
+
+        StepVerifier.create(endWith)
+                    .expectNext(1, 2, 3, 4, 5, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void endWith_aborted() {
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final StreamMessage<Integer> aborted = source
+                .peek(i -> {
+                    if (i > 5) {
+                        source.abort();
+                    }
+                });
+        final StreamMessage<Integer> endWith = aborted
+                .endWith(th -> {
+                   if (th instanceof AbortedStreamException) {
+                       return 100;
+                   }
+                   return -1;
+                });
+
+        StepVerifier.create(endWith)
+                    .expectNext(1, 2, 3, 4, 5, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void endWith_thrown() {
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        final StreamMessage<Integer> thrown = source
+                .map(i -> {
+                    if (i > 5) {
+                        throw new RuntimeException();
+                    }
+                    return i;
+                });
+        final StreamMessage<Integer> endWith = thrown
+                .endWith(th -> {
+                    if (th instanceof AbortedStreamException) {
+                        return 100;
+                    }
+                    return -1;
+                });
+
+        StepVerifier.create(endWith)
+                    .expectNext(1, 2, 3, 4, 5, -1)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void endWith_not_thrown() {
+        final StreamMessage<Integer> source = StreamMessage.of(1, 2, 3, 4, 5);
+        final StreamMessage<Integer> endWith = source
+                .endWith(th -> {
+                    if (th instanceof AbortedStreamException) {
+                        return 999;
+                    }
+                    if (th == null) {
+                        return 100;
+                    }
+                    return -1;
+                });
+
+        StepVerifier.create(endWith)
+                    .expectNext(1, 2, 3, 4, 5, 100)
+                    .expectComplete()
+                    .verify();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTckTest.java
@@ -44,18 +44,18 @@ public class SurroundingPublisherTckTest extends StreamMessageVerification<Objec
     @Override
     public StreamMessage<Object> createPublisher(long elements) {
         if (elements == 0) {
-            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), null);
+            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), unused -> null);
             // `SurroundingPublisher` doesn't check head, tail, publisher's availability before subscribed so manually set complete.
             publisher.whenComplete().complete(null);
             return publisher;
         }
         if (elements == 1) {
-            return new SurroundingPublisher<>("head", Mono.empty(), null);
+            return new SurroundingPublisher<>("head", Mono.empty(), unused -> null);
         }
         if (elements == 2) {
-            return new SurroundingPublisher<>(null, Mono.just(1), "tail");
+            return new SurroundingPublisher<>(null, Mono.just(1), unused -> "tail");
         }
-        return new SurroundingPublisher<>("head", Flux.fromStream(LongStream.range(0, elements - 2).boxed()), "tail");
+        return new SurroundingPublisher<>("head", Flux.fromStream(LongStream.range(0, elements - 2).boxed()), unused -> "tail");
     }
 
     /**
@@ -71,13 +71,13 @@ public class SurroundingPublisherTckTest extends StreamMessageVerification<Objec
      */
     @Override
     public StreamMessage<Object> createFailedPublisher() {
-        return new SurroundingPublisher<>(null, Mono.error(new RuntimeException()), "tail");
+        return new SurroundingPublisher<>(null, Mono.error(new RuntimeException()), unused -> null);
     }
 
     @Override
     public @Nullable StreamMessage<Object> createAbortedPublisher(long elements) {
         if (elements == 0) {
-            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), null);
+            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), unused -> null);
             publisher.abort();
             return publisher;
         }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.internal.common.stream;
 
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -26,6 +27,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.StreamMessage;
 
 import reactor.core.publisher.Flux;
@@ -255,13 +257,133 @@ class SurroundingPublisherTest {
                     .verify();
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(FiveElementsFinalizedSurroundingPublisherProvider.class)
+    void fiveElementsSurroundingPublisher_finalized100(StreamMessage<Integer> surroundingPublisher) {
+        // when & then
+        StepVerifier.create(surroundingPublisher, 5)
+                    .expectNext(1, 2, 3, 4, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FiveElementsFinalizedSurroundingPublisherProvider.class)
+    void fiveElementsSurroundingPublisher_finalized100_requestAll(
+            StreamMessage<Integer> surroundingPublisher) {
+        // when & then
+        StepVerifier.create(surroundingPublisher)
+                    .expectNext(1, 2, 3, 4, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FiveElementsFinalizedSurroundingPublisherProvider.class)
+    void fiveElementsSurroundingPublisher_finalized100_request1BeforeAborted(
+            StreamMessage<Integer> surroundingPublisher) {
+        // when & then
+        StepVerifier.create(surroundingPublisher, 4)
+                    .expectNext(1, 2, 3, 4)
+                    .thenRequest(1)
+                    .expectNext(100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FiveElementsFinalizedSurroundingPublisherProvider.class)
+    void fiveElementsSurroundingPublisher_finalized100_requestAllBeforeAborted(
+            StreamMessage<Integer> surroundingPublisher) {
+        // when & then
+        StepVerifier.create(surroundingPublisher, 4)
+                    .expectNext(1, 2, 3, 4)
+                    .thenRequest(Integer.MAX_VALUE)
+                    .expectNext(100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void finalizer_aborted() {
+        // given
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(2, 3, 4, 5);
+        final StreamMessage<Integer> aborted = streamMessage
+                .peek(val -> {
+                    if (val == 5) {
+                        streamMessage.abort();
+                    }
+                });
+        final Function<Throwable, Integer> finalizer = th -> {
+            if (th instanceof AbortedStreamException) {
+                return 100;
+            }
+            return -1;
+        };
+        final StreamMessage<Integer> publisher = SurroundingPublisher.from(1, aborted, finalizer);
+
+        // when & then
+        StepVerifier.create(publisher)
+                    .expectNext(1, 2, 3, 4, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void finalizer_thrown() {
+        // given
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(2, 3, 4, 5);
+        final StreamMessage<Integer> aborted = streamMessage
+                .peek(val -> {
+                    if (val == 5) {
+                        throw new RuntimeException();
+                    }
+                });
+        final Function<Throwable, Integer> finalizer = th -> {
+            if (th instanceof AbortedStreamException) {
+                return 100;
+            }
+            return -1;
+        };
+        final StreamMessage<Integer> publisher = SurroundingPublisher.from(1, aborted, finalizer);
+
+        // when & then
+        StepVerifier.create(publisher)
+                    .expectNext(1, 2, 3, 4, -1)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void finalizer_not_thrown() {
+        // given
+        final StreamMessage<Integer> streamMessage = StreamMessage.of(2, 3, 4);
+        final Function<Throwable, Integer> finalizer = th -> {
+            if (th instanceof AbortedStreamException) {
+                return 999;
+            }
+            if (th == null) {
+                return 100;
+            }
+            return -1;
+        };
+        final StreamMessage<Integer> publisher = SurroundingPublisher.from(1, streamMessage, finalizer);
+
+        // when & then
+        StepVerifier.create(publisher)
+                    .expectNext(1, 2, 3, 4, 100)
+                    .expectComplete()
+                    .verify();
+    }
+
     private static class OneElementSurroundingPublisherProvider implements ArgumentsProvider {
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             return Stream.of(new SurroundingPublisher<>(1, Mono.empty(), null),
                              new SurroundingPublisher<>(null, Mono.just(1), null),
-                             new SurroundingPublisher<>(null, Mono.empty(), 1))
+                             new SurroundingPublisher<>(null, Mono.empty(), 1),
+                             SurroundingPublisher.from(null, Mono.empty(), th -> 1))
                          .map(Arguments::of);
         }
     }
@@ -273,6 +395,8 @@ class SurroundingPublisherTest {
             return Stream.of(new SurroundingPublisher<>(1, Mono.just(2), null),
                              new SurroundingPublisher<>(1, Mono.empty(), 2),
                              new SurroundingPublisher<>(null, Mono.just(1), 2),
+                             SurroundingPublisher.from(1, Mono.empty(), th -> 2),
+                             SurroundingPublisher.from(null, Mono.just(1), th -> 2),
                              new SurroundingPublisher<>(null, Flux.just(1, 2), null))
                          .map(Arguments::of);
         }
@@ -285,6 +409,8 @@ class SurroundingPublisherTest {
             return Stream.of(new SurroundingPublisher<>(1, Flux.just(2, 3), null),
                              new SurroundingPublisher<>(1, Mono.just(2), 3),
                              new SurroundingPublisher<>(null, Flux.just(1, 2), 3),
+                             SurroundingPublisher.from(1, Mono.just(2), th -> 3),
+                             SurroundingPublisher.from(null, Flux.just(1, 2), th -> 3),
                              new SurroundingPublisher<>(null, Flux.just(1, 2, 3), null))
                          .map(Arguments::of);
         }
@@ -301,8 +427,51 @@ class SurroundingPublisherTest {
                             1, Flux.fromStream(IntStream.range(2, 5).boxed()), 5),
                     new SurroundingPublisher<>(
                             null, Flux.fromStream(IntStream.range(1, 5).boxed()), 5),
+                    SurroundingPublisher.from(
+                            1, Flux.fromStream(IntStream.range(2, 5).boxed()), th -> 5),
+                    SurroundingPublisher.from(
+                            null, Flux.fromStream(IntStream.range(1, 5).boxed()), th -> 5),
                     new SurroundingPublisher<>(
                             null, Flux.fromStream(IntStream.range(1, 6).boxed()), null))
+                         .map(Arguments::of);
+        }
+    }
+
+    private static class FiveElementsFinalizedSurroundingPublisherProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            return Stream.of(
+                    SurroundingPublisher.from(
+                            1,
+                            Flux.fromStream(IntStream.range(2, 10).boxed())
+                                .map(i -> {
+                                    if (i >= 5) {
+                                        throw new RuntimeException();
+                                    }
+                                    return i;
+                                }),
+                            th -> {
+                                if (th instanceof RuntimeException) {
+                                    return 100;
+                                }
+                                return -1;
+                            }),
+                    SurroundingPublisher.from(
+                            null,
+                            Flux.fromStream(IntStream.range(1, 10).boxed())
+                                .map(i -> {
+                                    if (i >= 5) {
+                                        throw new RuntimeException();
+                                    }
+                                    return i;
+                                }),
+                            th -> {
+                                if (th instanceof RuntimeException) {
+                                    return 100;
+                                }
+                                return -1;
+                            }))
                          .map(Arguments::of);
         }
     }


### PR DESCRIPTION
Related issue #4816 

### Motivation:
> As a future work of https://github.com/line/armeria/pull/4727,
users might want to dynamically emit the last message depending on whether the upstream publisher completes successfully or exceptionally.

- On #4816, it's good to add `StreamMessage.endWith(finalizer)`

### Modifications:

- Add `StreamMessage.endWith(finalizer)`

### Result:

- Closes #4816 
- Now user can dynamically emit the last value depending on whether the `StreamMessage` completes successfully or exceptionally by using `StreamMessage.endWith(finalizer)`
