### PR TITLE
Update `FlowResponseConverterFunctionProvider` Type Extension functions toClass()

### DIFF
--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/FlowResponseConverterFunctionProvider.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/FlowResponseConverterFunctionProvider.kt
@@ -34,7 +34,7 @@ class FlowResponseConverterFunctionProvider : DelegatingResponseConverterFunctio
         returnType
             .toClassOrNull()
             ?.let {
-                if (Flow::class.java.isAssignableFrom(clazz)) {
+                if (Flow::class.java.isAssignableFrom(it)) {
                     FlowResponseConverterFunction(responseConverter)
                 } else {
                     null

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/FlowResponseConverterFunctionProvider.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/FlowResponseConverterFunctionProvider.kt
@@ -32,16 +32,16 @@ class FlowResponseConverterFunctionProvider : DelegatingResponseConverterFunctio
         responseConverter: ResponseConverterFunction
     ): ResponseConverterFunction? =
         returnType
-            .toClass()
+            .toClassOrNull()
             ?.let {
-                if (Flow::class.java.isAssignableFrom(it)) {
+                if (Flow::class.java.isAssignableFrom(clazz)) {
                     FlowResponseConverterFunction(responseConverter)
                 } else {
                     null
                 }
             }
 
-    private fun Type.toClass(): Class<*>? =
+    private fun Type.toClassOrNull(): Class<*>? =
         when (this) {
             is ParameterizedType -> this.rawType as Class<*>
             is Class<*> -> this


### PR DESCRIPTION
<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->

안녕하세요 Armeria kotlin 부분중 FlowResponseConverterFucntionProvider라는 클래스에서 Type의 확장 함수를 만들어 
DelegatingResponseConverterFunctionProvider의 createResponseConverterFunction() 함수를 구현하는 부분에 적용하는 곳을 보던중 toClass()의 반환타입이 `Class<*>?` 인 것을 확인하였습니다.

과거 코틀린으로 개발을 하던중 nullable를 반환하는 확장함수를 만들었던 중 `toXXXOrNull()` 형식의 코드로 작성했던 적이 있었습니다. 유지보수하는 입장에서 함수의 이름이 더욱 명확히 들어나기 때문에 팀원들의 코드 이해가 빨라서 좋았던 경험이 있었습니다.

확장함수는 createResponseConverterFunction()의 아래에 정의가 되어있기 때문에 Armeria의 코드를 분석하던 도중 "toClass()?.let 을 사용하는 이유가 무엇이지? 아 아래에 확장함수를 정의하였구나?" 이런식의 코드 이해가 진행이 되는데 OrNull을 붙여주면 좀 더 읽기 쉬운 코드가 될 것 같습니다.

> 네이밍 컨벤션은 물론 기업마다 전부 다르고 private 으로 정의된 함수라서 그렇게 중요하다고는 생각하지 않습니다.
> 그러나 저의 제안이 마음에 드신다면 변경을 적용해 주시면 감사하겠습니다.

---

```kt
 private fun Type.toClassOrNull(): Class<*>? =
        when (this) {
            is ParameterizedType -> this.rawType as Class<*>
            is Class<*> -> this
            else -> null
        }
```

```