### PR TITLE
Fix a bug where `CookieClient` does not work with redirects

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -51,13 +51,10 @@ import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.SplitHttpResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.logging.RequestLogAccess;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
-import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
 import com.linecorp.armeria.internal.client.AggregatedHttpRequestDuplicator;
 import com.linecorp.armeria.internal.client.ClientUtil;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
@@ -193,32 +190,28 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
 
         final HttpResponse response = executeWithFallback(unwrap(), derivedCtx,
                                                           (context, cause) -> HttpResponse.ofFailure(cause));
-        // Use split() to allow other decorators to access the response headers via `.mapHeaders()` or
-        // `peekHeaders()`.
-        final SplitHttpResponse splitResponse = response.split(ctx.eventLoop());
-        splitResponse.headers().handle((responseHeaders, cause) -> {
-            final RequestLogAccess log = ctx.log();
-            if (cause != null || log.isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
-                if (cause == null) {
-                    cause = log.ensureAvailable(RequestLogProperty.RESPONSE_CAUSE).responseCause();
+        derivedCtx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).thenAccept(log -> {
+            if (log.isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
+                final Throwable cause = log.responseCause();
+                if (cause != null) {
+                    abortResponse(response, derivedCtx, cause);
+                    handleException(ctx, reqDuplicator, responseFuture, cause, false);
+                    return;
                 }
-                abortResponse(splitResponse, derivedCtx, cause);
-                handleException(ctx, reqDuplicator, responseFuture, cause, false);
-                return null;
             }
 
+            final ResponseHeaders responseHeaders = log.responseHeaders();
             if (!redirectStatuses.contains(responseHeaders.status())) {
-                endRedirect(ctx, reqDuplicator, responseFuture,
-                            HttpResponse.of(responseHeaders, splitResponse.body()));
-                return null;
+                endRedirect(ctx, reqDuplicator, responseFuture, response);
+                return;
             }
             final String location = responseHeaders.get(HttpHeaderNames.LOCATION);
             if (isNullOrEmpty(location)) {
                 endRedirect(ctx, reqDuplicator, responseFuture, response);
-                return null;
+                return;
             }
 
-            final RequestHeaders requestHeaders = ctx.request().headers();
+            final RequestHeaders requestHeaders = log.requestHeaders();
             final URI redirectUri;
             try {
                 redirectUri = URI.create(requestHeaders.path()).resolve(location);
@@ -226,21 +219,21 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
                     final SessionProtocol redirectProtocol = Scheme.parse(redirectUri.getScheme())
                                                                    .sessionProtocol();
                     if (!allowedProtocols.contains(redirectProtocol)) {
-                        handleException(ctx, derivedCtx, reqDuplicator, responseFuture, splitResponse,
+                        handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response,
                                         UnexpectedProtocolRedirectException.of(
                                                 redirectProtocol, allowedProtocols));
-                        return null;
+                        return;
                     }
 
                     if (!domainFilter.test(ctx, redirectUri.getHost())) {
-                        handleException(ctx, derivedCtx, reqDuplicator, responseFuture, splitResponse,
+                        handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response,
                                         UnexpectedDomainRedirectException.of(redirectUri.getHost()));
-                        return null;
+                        return;
                     }
                 }
             } catch (Throwable t) {
-                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, splitResponse, t);
-                return null;
+                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response, t);
+                return;
             }
 
             final HttpRequestDuplicator newReqDuplicator =
@@ -250,30 +243,34 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             try {
                 redirectFullUri = buildFullUri(ctx, redirectUri, newReqDuplicator.headers());
             } catch (Throwable t) {
-                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, splitResponse, t);
-                return null;
+                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response, t);
+                return;
             }
 
             if (isCyclicRedirects(redirectCtx, redirectFullUri, newReqDuplicator.headers())) {
-                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, splitResponse,
+                handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response,
                                 CyclicRedirectsException.of(redirectCtx.originalUri(),
                                                             redirectCtx.redirectUris().values()));
-                return null;
+                return;
             }
 
             final Multimap<HttpMethod, String> redirectUris = redirectCtx.redirectUris();
             if (redirectUris.size() > maxRedirects) {
                 handleException(ctx, derivedCtx, reqDuplicator, responseFuture,
-                                splitResponse,
-                                TooManyRedirectsException.of(maxRedirects, redirectCtx.originalUri(),
-                                                             redirectUris.values()));
-                return null;
+                                response, TooManyRedirectsException.of(maxRedirects, redirectCtx.originalUri(),
+                                                                       redirectUris.values()));
+                return;
             }
 
-            // Cancel the subscription of the response body since we don't need it anymore.
-            abortResponse(splitResponse, derivedCtx, CancelledSubscriptionException.get());
-            ctx.eventLoop().execute(() -> execute0(ctx, redirectCtx, newReqDuplicator, false));
-            return null;
+            // Drain the response to release the pooled objects.
+            response.subscribe().handleAsync((unused, cause) -> {
+                if (cause != null) {
+                    handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response, cause);
+                    return null;
+                }
+                execute0(ctx, redirectCtx, newReqDuplicator, false);
+                return null;
+            }, ctx.eventLoop());
         });
     }
 
@@ -313,7 +310,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
 
     private static void handleException(ClientRequestContext ctx, ClientRequestContext derivedCtx,
                                         HttpRequestDuplicator reqDuplicator,
-                                        CompletableFuture<HttpResponse> future, SplitHttpResponse originalRes,
+                                        CompletableFuture<HttpResponse> future, HttpResponse originalRes,
                                         Throwable cause) {
         abortResponse(originalRes, derivedCtx, cause);
         handleException(ctx, reqDuplicator, future, cause, false);
@@ -332,7 +329,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
         ctx.logBuilder().endResponse(cause);
     }
 
-    private static void abortResponse(SplitHttpResponse originalRes, ClientRequestContext derivedCtx,
+    private static void abortResponse(HttpResponse originalRes, ClientRequestContext derivedCtx,
                                       @Nullable Throwable cause) {
         // Set response content with null to make sure that the log is complete.
         final RequestLogBuilder logBuilder = derivedCtx.logBuilder();
@@ -340,9 +337,9 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
         logBuilder.responseContentPreview(null);
 
         if (cause != null) {
-            originalRes.body().abort(cause);
+            originalRes.abort(cause);
         } else {
-            originalRes.body().abort();
+            originalRes.abort();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -263,7 +263,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             }
 
             // Drain the response to release the pooled objects.
-            response.subscribe().handleAsync((unused, cause) -> {
+            response.subscribe(ctx.eventLoop()).handleAsync((unused, cause) -> {
                 if (cause != null) {
                     handleException(ctx, derivedCtx, reqDuplicator, responseFuture, response, cause);
                     return null;

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -542,7 +542,27 @@ public interface StreamMessage<T> extends Publisher<T> {
      * }</pre>
      */
     default CompletableFuture<Void> subscribe() {
-        subscribe(NoopSubscriber.get());
+        return subscribe(defaultSubscriberExecutor());
+    }
+
+    /**
+     * Drains and discards all objects in this {@link StreamMessage}.
+     *
+     * <p>For example:<pre>{@code
+     * StreamMessage<Integer> source = StreamMessage.of(1, 2, 3);
+     * List<Integer> collected = new ArrayList<>();
+     * CompletableFuture<Void> future = source.peek(collected::add).subscribe();
+     * future.join();
+     * assert collected.equals(List.of(1, 2, 3));
+     * assert future.isDone();
+     * }</pre>
+     *
+     * @param executor the executor to subscribe
+     */
+    @UnstableApi
+    default CompletableFuture<Void> subscribe(EventExecutor executor) {
+        requireNonNull(executor, "executor");
+        subscribe(NoopSubscriber.get(), executor);
         return whenComplete();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RedirectWithCookieClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RedirectWithCookieClientTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.cookie.CookieClient;
+import com.linecorp.armeria.client.cookie.CookiePolicy;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.Cookie;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RedirectWithCookieClientTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+
+            sb.service("/old", (ctx, req) -> {
+                final ResponseHeaders headers = ResponseHeaders.builder()
+                                                               .status(HttpStatus.SEE_OTHER)
+                                                               .add(HttpHeaderNames.LOCATION, "/new")
+                                                               .cookie(Cookie.builder("foo", "bar")
+                                                                             .path("/")
+                                                                             .build())
+                                                               .build();
+                return HttpResponse.of(headers);
+            });
+            sb.service("/new", (ctx, req) -> {
+                final Cookie cookie = req.headers().cookies().stream().findFirst().get();
+                return HttpResponse.of(cookie.name() + '=' + cookie.value());
+            });
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @Test
+    void shouldWorkCookieClientWithRedirection() {
+        final BlockingWebClient client =
+                WebClient.builder(server.httpUri())
+                         .followRedirects()
+                         .decorator(LoggingClient.newDecorator())
+                         .decorator(CookieClient.newDecorator(CookiePolicy.acceptAll()))
+                         .build()
+                         .blocking();
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            assertThat(client.get("/old").contentUtf8()).isEqualTo("foo=bar");
+            final ClientRequestContext context = captor.get();
+            final RequestLog log = context.log().whenComplete().join();
+            assertThat(log.children().size()).isEqualTo(2);
+            for (RequestLogAccess childLog : log.children()) {
+                // Should not raise an exception.
+                assertThat(childLog.whenComplete().join().responseCause()).isNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

When `CookieClient` is used while enabling `followRedirects` option, `CookieClient` fails to relay the cookies of the redirection request.

`CookieClient` uses `peekHeaders(callback)` to see the response headers. `RedirectingClient` uses `log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS)` to see response headers.  The key difference is that `peekHeaders()` is invoked when HttpResponse is subscribed or aggregated and `RequestLogProperty.RESPONSE_HEADERS` is immediately invoked when the response headers is received by the response decoder.

As `RedirectingClient` aborts the response after checking the response headers via the request log, the response is not subscribed at all which results in `CookieClient` not working.

Modifications:

- Split the redirect response to access the response headers instead of using `RequestLogProperty.RESPONSE_HEADERS`.
- Used `CancelledSubscriptionException` to silently abort redirect responses and not to log the exception because the response is correctly sent by the server.

Result:

`CookieClient` is now correctly working with redirects.
