### PR TITLE
Start HTTP/2 requests when HTTP2-Settings is applied

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -418,12 +418,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             }
         }
 
-        // Do not call fireUserEventTriggered right away because it triggers completing a session promise
-        // in HttpSessionHandler that will make the client to send a request.
-        // However, the HTTP/2 settings frame from the server may not be handled yet at this point.
-        // We need to put the task in the queue so that the promise is complete after the settings
-        // frame is handled.
-        pipeline.channel().eventLoop().execute(() -> pipeline.fireUserEventTriggered(protocol));
+        pipeline.fireUserEventTriggered(protocol);
     }
 
     private static void incrementLocalWindowSize(ChannelPipeline pipeline, int delta) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -460,8 +460,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         }
 
         sessionTimeoutFuture.cancel(false);
-        if (!sessionPromise.trySuccess(channel) && !sessionPromise.isSuccess()) {
-            // Session creation has been failed already; close the connection.
+        if (sessionPromise.trySuccess(channel) || sessionPromise.isSuccess()) {
+            // The session is created successfully or has already been created.
+        } else {
+            // The session creation has been failed already; close the connection.
             ctx.close();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -25,11 +25,13 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
+import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyType;
 import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ClosedSessionException;
@@ -74,12 +76,14 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private final Channel channel;
     private final SocketAddress remoteAddress;
     private final Promise<Channel> sessionPromise;
-    private final ScheduledFuture<?> sessionTimeoutFuture;
+    private final int connectionTimeoutMillis;
     private final SessionProtocol desiredProtocol;
     private final SerializationFormat serializationFormat;
     private final PoolKey poolKey;
     private final HttpClientFactory clientFactory;
 
+    @Nullable
+    private ScheduledFuture<?> sessionTimeoutFuture;
     @Nullable
     private SocketAddress proxyDestinationAddress;
 
@@ -125,18 +129,38 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private boolean isChannelActive;
 
     HttpSessionHandler(HttpChannelPool channelPool, Channel channel,
-                       Promise<Channel> sessionPromise, ScheduledFuture<?> sessionTimeoutFuture,
+                       Promise<Channel> sessionPromise, int connectionTimeoutMillis,
                        SessionProtocol desiredProtocol, SerializationFormat serializationFormat,
                        PoolKey poolKey, HttpClientFactory clientFactory) {
         this.channelPool = requireNonNull(channelPool, "channelPool");
         this.channel = requireNonNull(channel, "channel");
         remoteAddress = channel.remoteAddress();
         this.sessionPromise = requireNonNull(sessionPromise, "sessionPromise");
-        this.sessionTimeoutFuture = requireNonNull(sessionTimeoutFuture, "sessionTimeoutFuture");
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
         this.desiredProtocol = desiredProtocol;
         this.serializationFormat = serializationFormat;
         this.poolKey = poolKey;
         this.clientFactory = clientFactory;
+
+        if (poolKey.proxyConfig == ProxyConfig.direct()) {
+            scheduleSessionTimeout(channel, sessionPromise, connectionTimeoutMillis, desiredProtocol);
+        } else {
+            // A session timeout for a proxied connection may be scheduled when ProxyConnectionEvent is
+            // received.
+        }
+
+    }
+
+    private void scheduleSessionTimeout(Channel channel, Promise<Channel> sessionPromise,
+                                        int connectionTimeoutMillis, SessionProtocol desiredProtocol) {
+        assert sessionTimeoutFuture == null : "sessionTimeoutFuture is scheduled already.";
+        sessionTimeoutFuture = channel.eventLoop().schedule(() -> {
+            if (sessionPromise.tryFailure(new SessionProtocolNegotiationException(
+                    desiredProtocol,
+                    "connection established, but session creation timed out: " + channel))) {
+                channel.close();
+            }
+        }, connectionTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -406,8 +430,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         if (evt instanceof SessionProtocolNegotiationException ||
             evt instanceof ProxyConnectException) {
-            sessionTimeoutFuture.cancel(false);
-            sessionPromise.tryFailure((Throwable) evt);
+            tryFailSessionPromise((Throwable) evt);
             ctx.close();
             return;
         }
@@ -424,8 +447,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                     pendingException.addSuppressed(handshakeException);
                     handshakeException = pendingException;
                 }
-                sessionTimeoutFuture.cancel(false);
-                sessionPromise.tryFailure(handshakeException);
+                tryFailSessionPromise(handshakeException);
                 ctx.close();
             }
             return;
@@ -439,32 +461,54 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
         if (evt instanceof ProxyConnectionEvent) {
             proxyDestinationAddress = ((ProxyConnectionEvent) evt).destinationAddress();
-            tryCompleteSessionPromise(ctx);
+            if (!tryCompleteSessionPromise(ctx)) {
+                // A session has not been created yet. Additional handshakes will be done by HTTP/1 or HTTP/2.
+                assert sessionTimeoutFuture == null;
+                scheduleSessionTimeout(channel, sessionPromise, connectionTimeoutMillis, desiredProtocol);
+            }
             return;
         }
 
         logger.warn("{} Unexpected user event: {}", channel, evt);
     }
 
-    private void tryCompleteSessionPromise(ChannelHandlerContext ctx) {
+    /**
+     * Tries to complete the {@link #sessionPromise} if the session is ready to serve.
+     *
+     * @return {@code true} if the {@link #sessionPromise} has been completed successfully or exceptionally.
+     *         {@code false} if the {@link #sessionPromise} is still incomplete.
+     */
+    private boolean tryCompleteSessionPromise(ChannelHandlerContext ctx) {
         if (protocol == null || !isChannelActive) {
-            return;
+            return false;
         }
         if (poolKey.proxyConfig.proxyType() != ProxyType.DIRECT && proxyDestinationAddress == null) {
             // ProxyConnectionEvent is necessary for a proxied connection.
-            return;
+            return false;
         }
         if (protocol.isExplicitHttp2() && !isSettingsFrameReceived) {
             // Http2Settings should be received for HTTP/2.
-            return;
+            return false;
         }
 
-        sessionTimeoutFuture.cancel(false);
+        if (sessionTimeoutFuture != null) {
+            sessionTimeoutFuture.cancel(false);
+        }
         if (sessionPromise.trySuccess(channel) || sessionPromise.isSuccess()) {
             // The session is created successfully or has already been created.
         } else {
             // The session creation has been failed already; close the connection.
             ctx.close();
+        }
+        return true;
+    }
+
+    private void tryFailSessionPromise(Throwable cause) {
+        if (sessionTimeoutFuture != null) {
+            sessionTimeoutFuture.cancel(false);
+        }
+        if (!sessionPromise.isDone()) {
+            sessionPromise.tryFailure(cause);
         }
     }
 
@@ -475,7 +519,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         // Protocol upgrade has failed, but needs to retry.
         if (retryProtocol != null) {
             assert responseDecoder == null || !responseDecoder.hasUnfinishedResponses();
-            sessionTimeoutFuture.cancel(false);
+            if (sessionTimeoutFuture != null) {
+                sessionTimeoutFuture.cancel(false);
+            }
             if (proxyDestinationAddress != null) {
                 channelPool.connect(proxyDestinationAddress, retryProtocol, serializationFormat,
                                     poolKey, sessionPromise);
@@ -495,11 +541,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
 
             // Cancel the timeout and reject the sessionPromise just in case the connection has been closed
             // even before the session protocol negotiation is done.
-            sessionTimeoutFuture.cancel(false);
-            if (!sessionPromise.isDone()) {
-                sessionPromise.tryFailure(pendingException != null ? pendingException
-                                                                   : maybeGetPendingException(ctx));
-            }
+            tryFailSessionPromise(pendingException != null ? pendingException
+                                                           : maybeGetPendingException(ctx));
         }
     }
 
@@ -509,7 +552,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             final SessionProtocol protocol = this.protocol != null ? this.protocol : desiredProtocol;
             final UnprocessedRequestException wrapped = UnprocessedRequestException.of(cause);
             channelPool.maybeHandleProxyFailure(protocol, poolKey, wrapped);
-            sessionPromise.tryFailure(wrapped);
+            tryFailSessionPromise(wrapped);
             return;
         }
         setPendingException(ctx, new ClosedSessionException(cause));

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -148,7 +148,6 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             // A session timeout for a proxied connection may be scheduled when ProxyConnectionEvent is
             // received.
         }
-
     }
 
     private void scheduleSessionTimeout(Channel channel, Promise<Channel> sessionPromise,

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -317,7 +317,7 @@ class ProxyClientIntegrationTest {
                                   .useHttp2Preface(true)
                                   .build()) {
 
-            final WebClient webClient = WebClient.builder(SessionProtocol.H1, backendServer.httpEndpoint())
+            final WebClient webClient = WebClient.builder(SessionProtocol.H1C, backendServer.httpEndpoint())
                                                  .factory(clientFactory)
                                                  .decorator(LoggingClient.newDecorator())
                                                  .build();

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -47,12 +47,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.SessionProtocolNegotiationException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.logging.LoggingClient;
@@ -92,6 +94,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.traffic.ChannelTrafficShapingHandler;
 import io.netty.util.ReferenceCountUtil;
 
 class ProxyClientIntegrationTest {
@@ -118,6 +121,21 @@ class ProxyClientIntegrationTest {
             sb.port(0, SessionProtocol.HTTP);
             sb.port(0, SessionProtocol.HTTPS);
             sb.tlsSelfSigned();
+            sb.service(PROXY_PATH, (ctx, req) -> HttpResponse.of(SUCCESS_RESPONSE));
+        }
+    };
+
+    @RegisterExtension
+    @Order(1)
+    static ServerExtension slowBackendServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.port(0, SessionProtocol.HTTP);
+            sb.port(0, SessionProtocol.HTTPS);
+            sb.tlsSelfSigned();
+            sb.childChannelPipelineCustomizer(pipeline -> {
+                pipeline.addFirst(new ChannelTrafficShapingHandler(128, 0));
+            });
             sb.service(PROXY_PATH, (ctx, req) -> HttpResponse.of(SUCCESS_RESPONSE));
         }
     };
@@ -299,7 +317,7 @@ class ProxyClientIntegrationTest {
                                   .useHttp2Preface(true)
                                   .build()) {
 
-            final WebClient webClient = WebClient.builder(SessionProtocol.H1C, backendServer.httpEndpoint())
+            final WebClient webClient = WebClient.builder(SessionProtocol.H1, backendServer.httpEndpoint())
                                                  .factory(clientFactory)
                                                  .decorator(LoggingClient.newDecorator())
                                                  .build();
@@ -646,6 +664,36 @@ class ProxyClientIntegrationTest {
                                                     .hasRootCauseInstanceOf(ProxyConnectException.class);
             assertThat(failedAttempts).hasValue(1);
             assertThat(selector.result()).isTrue();
+        }
+    }
+
+    /**
+     * Tests if a request is failed with {@link SessionProtocolNegotiationException} if a session negotiation
+     * with the backend server takes longer than a connection timeout.
+     *
+     * <p>Cleartext protocol are not used because the session could immediately complete when a connection is
+     * established with the proxy server.
+     */
+    @CsvSource({ "H1", "H2", "HTTPS" })
+    @ParameterizedTest
+    void testProxy_sessionTimeout(SessionProtocol protocol) {
+        try (ClientFactory clientFactory =
+                     ClientFactory.builder()
+                                  .proxyConfig(ProxyConfig.socks4(socksProxyServer.address()))
+                                  .connectTimeoutMillis(1000)
+                                  .tlsNoVerify()
+                                  .build()) {
+
+            final WebClient webClient = WebClient.builder(slowBackendServer.uri(protocol))
+                                                 .factory(clientFactory)
+                                                 .decorator(LoggingClient.newDecorator())
+                                                 .build();
+            final CompletableFuture<AggregatedHttpResponse> responseFuture =
+                    webClient.get(PROXY_PATH).aggregate();
+            assertThatThrownBy(responseFuture::join).isInstanceOf(CompletionException.class)
+                                                    .hasCauseInstanceOf(UnprocessedRequestException.class)
+                                                    .hasRootCauseInstanceOf(
+                                                            SessionProtocolNegotiationException.class);
         }
     }
 


### PR DESCRIPTION
Motivation:

The `SessionProtocol` event is rescheduled to fire it after `Http2Settings` is applied to `HttpSessionHandler`. 
https://github.com/line/armeria/blob/f93ccca0ea955b6e1858f2b7d95974b561a98423/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java#L423-L426

This strategy relying on executors does not provide 100% correct order. We also got a report LINE internally that requests start before `Http2Settings` is applied to `HttpSessionHandler` which results in `RST_STREAM` due to a violation of the max concurrent stream.

Modifications:

- Remove the rescheduler for `SessionProcotol` and refactor `HttpSessionHandler` so that `sessionPromise` is completed when both `SessionProtocol` and `Http2Settings` are applied.

Result:

Armeria client no longer violates max concurrent streams.
