### PR TITLE
throw ISE when gRPC HTTP JSON transcoding is enabled but serialization format JSON is missing

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -637,7 +637,10 @@ public final class GrpcServiceBuilder {
     /**
      * Sets whether the service handles HTTP/JSON requests using the gRPC wire protocol.
      *
-     * <p>Limitations:
+     * <p><b>Limitations:</b>
+     * Make sure {@code GrpcSerializationFormats.JSON} is supported by the service by calling
+     * {@code this#supportedSerializationFormats(GrpcSerializationFormats.JSON)}. Otherwise, service builder
+     * will throw {@code IllegalStateException} when building the service.
      * <ul>
      *     <li>Only unary methods (single request, single response) are supported.</li>
      *     <li>
@@ -974,6 +977,12 @@ public final class GrpcServiceBuilder {
             throw new IllegalStateException(
                     "'httpJsonTranscodingErrorHandler' can only be set if HTTP/JSON transcoding feature " +
                     "is enabled");
+        }
+        if (enableHttpJsonTranscoding
+            && !supportedSerializationFormats.contains(GrpcSerializationFormats.JSON)) {
+            throw new IllegalStateException(
+                    "'GrpcSerializationFormats.JSON' must be set if 'enableHttpJsonTranscoding' is set"
+            );
         }
         if (enableHealthCheckService) {
             grpcHealthCheckService = GrpcHealthCheckService.builder().build();

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -651,8 +651,8 @@ public final class GrpcServiceBuilder {
      *     </li>
      * </ul>
      *
-     * <p>{@link GrpcSerializationFormats#JSON} must be supported via
-     * {@link #supportedSerializationFormats(SerializationFormat...)} to enable HTTP/JSON transcoding.
+     * <p>When custom {@link #supportedSerializationFormats(SerializationFormat...)} are used,
+     * {@link GrpcSerializationFormats#JSON} must be included to enable HTTP/JSON transcoding.
      * Otherwise, service builder will throw {@link IllegalStateException} when building the service.
      *
      * @see <a href="https://cloud.google.com/endpoints/docs/grpc/transcoding">Transcoding HTTP/JSON to gRPC</a>

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -638,9 +638,6 @@ public final class GrpcServiceBuilder {
      * Sets whether the service handles HTTP/JSON requests using the gRPC wire protocol.
      *
      * <p><b>Limitations:</b>
-     * Make sure {@code GrpcSerializationFormats.JSON} is supported by the service by calling
-     * {@code this#supportedSerializationFormats(GrpcSerializationFormats.JSON)}. Otherwise, service builder
-     * will throw {@code IllegalStateException} when building the service.
      * <ul>
      *     <li>Only unary methods (single request, single response) are supported.</li>
      *     <li>
@@ -653,6 +650,10 @@ public final class GrpcServiceBuilder {
      *         {@link ServerBuilder#serviceUnder(String, HttpService)}.
      *     </li>
      * </ul>
+     *
+     * <p>{@link GrpcSerializationFormats#JSON} must be supported via
+     * {@link #supportedSerializationFormats(SerializationFormat...)} to enable HTTP/JSON transcoding.
+     * Otherwise, service builder will throw {@link IllegalStateException} when building the service.
      *
      * @see <a href="https://cloud.google.com/endpoints/docs/grpc/transcoding">Transcoding HTTP/JSON to gRPC</a>
      */
@@ -978,8 +979,8 @@ public final class GrpcServiceBuilder {
                     "'httpJsonTranscodingErrorHandler' can only be set if HTTP/JSON transcoding feature " +
                     "is enabled");
         }
-        if (enableHttpJsonTranscoding
-            && !supportedSerializationFormats.contains(GrpcSerializationFormats.JSON)) {
+        if (enableHttpJsonTranscoding && !supportedSerializationFormats.contains(
+                GrpcSerializationFormats.JSON)) {
             throw new IllegalStateException(
                     "'GrpcSerializationFormats.JSON' must be set if 'enableHttpJsonTranscoding' is set"
             );

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -394,10 +394,10 @@ class GrpcServiceBuilderTest {
 
     @Test
     void enableHttpJsonTranscodingWithoutJsonSupport() {
-        GrpcServiceBuilder builder = GrpcService.builder()
-                                                .enableHttpJsonTranscoding(true)
-                                                .supportedSerializationFormats(GrpcSerializationFormats.PROTO);
-        assertThatThrownBy(builder::build)
+        assertThatThrownBy(() -> GrpcService.builder()
+                                            .enableHttpJsonTranscoding(true)
+                                            .supportedSerializationFormats(GrpcSerializationFormats.PROTO)
+                                            .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("GrpcSerializationFormats.JSON")
                 .hasMessageContaining("must be set")

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.server.grpc.GrpcServiceBuilder.toGrpcStatusFunction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.internal.common.grpc.GrpcStatus;
@@ -380,6 +382,26 @@ class GrpcServiceBuilderTest {
                                             .enableHealthCheckService(true)
                                             .build())
                 .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void enableHttpJsonTranscodingWithJsonSupport() {
+        assertDoesNotThrow(() -> GrpcService.builder()
+                                            .enableHttpJsonTranscoding(true)
+                                            .supportedSerializationFormats(GrpcSerializationFormats.JSON)
+                                            .build());
+    }
+
+    @Test
+    void enableHttpJsonTranscodingWithoutJsonSupport() {
+        GrpcServiceBuilder builder = GrpcService.builder()
+                                                .enableHttpJsonTranscoding(true)
+                                                .supportedSerializationFormats(GrpcSerializationFormats.PROTO);
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("GrpcSerializationFormats.JSON")
+                .hasMessageContaining("must be set")
+                .hasMessageContaining("enableHttpJsonTranscoding");
     }
 
     private static class MetricsServiceImpl extends MetricsServiceImplBase {}


### PR DESCRIPTION
Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- Throw ISE in `GrpcServiceBuilder.build()` if transcoding is enabled but serialization format `JSON` is not set.

Result:

- Closes https://github.com/line/armeria/issues/5176

The detailed description on why this is an annoying issue is discussed in the issue.
