### PR TITLE
Fix that `WebSocketService` rejects headers that have multiple values

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceTest.java
@@ -66,8 +66,12 @@ class WebSocketServiceTest {
 
     private static RequestHeaders webSocketUpgradeHeaders() {
         return RequestHeaders.builder(HttpMethod.GET, "/chat")
-                             .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE.toString())
-                             .add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toString())
+                             .add(HttpHeaderNames.CONNECTION,
+                                  HttpHeaderValues.UPGRADE.toString() + ',' +
+                                  // It works even if the header contains multiple values
+                                  HttpHeaderValues.KEEP_ALIVE)
+                             .add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET +
+                                                           ", additional_value")
                              .add(HttpHeaderNames.HOST, "foo.com")
                              .add(HttpHeaderNames.ORIGIN, "http://foo.com")
                              .addInt(HttpHeaderNames.SEC_WEBSOCKET_VERSION, 13)


### PR DESCRIPTION
Motivation:
As described in #5165, `Connection` header for a WebSocket upgrade request can have multiple values.

Modifications:
- Establish a WebSocket session if the `Connection` and `Upgrade` headers contain the required value.

Result:
- Close #5165
- A WebSocket session is correctly established if the `Connection` and `Upgrade` headers contain the required value.

To-do:
- Add IT tests that establish WebSocket from FireFox and Chrome.