### PR TITLE
Don't allocate a route with an empty prefix

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoute.java
@@ -300,6 +300,9 @@ final class DefaultRoute implements Route {
     @Override
     public Route withPrefix(String prefix) {
         requireNonNull(prefix, "prefix");
+        if ("/".equals(prefix)) {
+            return this;
+        }
         return new DefaultRoute(pathMapping.withPrefix(prefix), methods, consumes, produces, paramPredicates,
                                 headerPredicates, isFallback, excludedRoutes);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -451,6 +451,12 @@ class RouteTest {
         assertThatJson(route).node("patternString").isEqualTo("/foo/:id");
     }
 
+    @Test
+    void prefixWithEmptySlash() {
+        final Route route = Route.builder().pathPrefix("/foo").build();
+        assertThat(route.withPrefix("/")).isSameAs(route);
+    }
+
     private static RoutingContext withMethod(HttpMethod method) {
         return DefaultRoutingContext.of(virtualHost(), "example.com",
                                         REQ_TARGET, RequestHeaders.of(method, PATH), RoutingStatus.OK);


### PR DESCRIPTION
Motivation:

Currently, if the `DefaultRoute#withPrefix` API is used with an empty prefix, a new `DefaultRoute` will be allocated.
It has been pointed out that this can be improved on.

Modifications:

- Check if the prefix is a empty path, and return the original route if possible

Result:

- Slightly better memory footprint

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
