### PR TITLE
Fix a bug where responseCause is not propagated to `CircuitBreakerRule` from `RetryingClient`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -599,6 +599,15 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     private void propagateResponseSideLog(RequestLog lastChild) {
+        if (lastChild.isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
+            // Update responseCause first if available because callbacks of the other properties may need it
+            // to retry or open circuit breakers.
+            final Throwable responseCause = lastChild.responseCause();
+            if (responseCause != null) {
+                responseCause(responseCause);
+            }
+        }
+
         // Update the available properties without adding a callback if the lastChild already has them.
         if (lastChild.isAvailable(RequestLogProperty.RESPONSE_START_TIME)) {
             startResponse(lastChild.responseStartTimeNanos(), lastChild.responseStartTimeMicros(), true);

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerWithRetryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerWithRetryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.circuitbreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.ConnectException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.client.retry.RetryConfig;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+
+class CircuitBreakerWithRetryTest {
+
+    @Test
+    void shouldPropagateChildResponseCauseToCircuitBreakerRule() {
+        final RetryRule retryRule = RetryRule.builder()
+                                             .onServerErrorStatus()
+                                             .thenBackoff(Backoff.fixed(1));
+        final RetryConfig<HttpResponse> config = RetryConfig.builder(retryRule)
+                                                            .maxTotalAttempts(2)
+                                                            .build();
+        final CircuitBreaker circuitBreaker = CircuitBreaker.ofDefaultName();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final CircuitBreakerRule rule = (ctx, cause) -> {
+            causeRef.set(cause);
+            return UnmodifiableFuture.completedFuture(CircuitBreakerDecision.failure());
+        };
+        final BlockingWebClient client =
+                WebClient.builder("http://127.0.0.1:1")
+                         .decorator(RetryingClient.newDecorator(config))
+                         .decorator(CircuitBreakerClient.newDecorator(circuitBreaker, rule))
+                         .build()
+                         .blocking();
+
+        assertThatThrownBy(() -> client.get("/")).isInstanceOf(UnprocessedRequestException.class)
+                                                 .hasCauseInstanceOf(ConnectException.class);
+        assertThat(causeRef.get()).isInstanceOf(UnprocessedRequestException.class)
+                                  .hasCauseInstanceOf(ConnectException.class);
+    }
+}


### PR DESCRIPTION
…t from RetryingClient

Motivation:

When a child log completes, `responseCause` is propagated as the last property with responseEndTime even if an
`UnprocessedRequestException` occurred before other response properties. 
https://github.com/line/armeria/blob/759bf3b079c0a759d60dc2536fefcefb1cd648d3/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java#L661-L661
`RESPONSE_CAUSE` can not be used when the callbacks that depend on `RequestLogProperty.RESPONSE_HEADERS` or
`RequestLogProperty.RESPONSE_TRAILERS` are executed. 
https://github.com/line/armeria/blob/3a99e6adb00847422f1345d5a7bfa2d7ab1f8e6d/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java#L350-L350
Consequently, `CircuitBreakerRule` can't use the cause to determine the result.

Modifications:

- Set `responseCause` before other response properties if availble.

Result:

- `RequestLog.responseCause()` is correctly propagated to `CircuitBreakerRule` when using `CircuitBreakerClient` with `RetryingClient`.
