### PR TITLE
Allow adding multiple `(Server|Service)ErrorHandler`s

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -274,7 +274,11 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
     @Override
     public ServiceConfigSetters errorHandler(ServiceErrorHandler serviceErrorHandler) {
         requireNonNull(serviceErrorHandler, "serviceErrorHandler");
-        this.serviceErrorHandler = serviceErrorHandler;
+        if (this.serviceErrorHandler == null) {
+            this.serviceErrorHandler = serviceErrorHandler;
+        } else {
+            this.serviceErrorHandler = this.serviceErrorHandler.orElse(serviceErrorHandler);
+        }
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1691,7 +1691,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
 
     /**
      * Adds the {@link ServerErrorHandler} that provides the error responses in case of unexpected exceptions
-     * or protocol errors. If multiple handlers are added, the latter is composed with the former one using
+     * or protocol errors. If multiple handlers are added, the latter is composed with the former using
      * {@link ServerErrorHandler#orElse(ServerErrorHandler)}.
      *
      * <p>Note that the {@link HttpResponseException} is not handled by the {@link ServerErrorHandler}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -1690,8 +1690,9 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     }
 
     /**
-     * Sets the {@link ServerErrorHandler} that provides the error responses in case of unexpected exceptions
-     * or protocol errors.
+     * Adds the {@link ServerErrorHandler} that provides the error responses in case of unexpected exceptions
+     * or protocol errors. If multiple handlers are added, the latter is composed with the former one using
+     * {@link ServerErrorHandler#orElse(ServerErrorHandler)}.
      *
      * <p>Note that the {@link HttpResponseException} is not handled by the {@link ServerErrorHandler}
      * but the {@link HttpResponseException#httpResponse()} is sent as-is.

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -255,7 +255,11 @@ final class ServiceConfigBuilder implements ServiceConfigSetters {
     @Override
     public ServiceConfigBuilder errorHandler(ServiceErrorHandler serviceErrorHandler) {
         requireNonNull(serviceErrorHandler, "serviceErrorHandler");
-        this.serviceErrorHandler = serviceErrorHandler;
+        if (this.serviceErrorHandler == null) {
+            this.serviceErrorHandler = serviceErrorHandler;
+        } else {
+            this.serviceErrorHandler = this.serviceErrorHandler.orElse(serviceErrorHandler);
+        }
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigSetters.java
@@ -259,7 +259,10 @@ interface ServiceConfigSetters {
             Iterable<? extends Entry<? extends CharSequence, ?>> defaultHeaders);
 
     /**
-     * Sets the default {@link ServiceErrorHandler} served by this {@link Service}.
+     * Adds the default {@link ServiceErrorHandler} served by this {@link Service}.
+     * If multiple handlers are added, the latter is composed with the former one using
+     * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)}
+     *
      * @param serviceErrorHandler the default {@link ServiceErrorHandler}
      */
     ServiceConfigSetters errorHandler(ServiceErrorHandler serviceErrorHandler);

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigSetters.java
@@ -260,7 +260,7 @@ interface ServiceConfigSetters {
 
     /**
      * Adds the default {@link ServiceErrorHandler} served by this {@link Service}.
-     * If multiple handlers are added, the latter is composed with the former one using
+     * If multiple handlers are added, the latter is composed with the former using
      * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)}
      *
      * @param serviceErrorHandler the default {@link ServiceErrorHandler}

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -868,7 +868,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
 
     /**
      * Adds the {@link ServiceErrorHandler} that handles exceptions thrown in this virtual host.
-     * If multiple handlers are added, the latter is composed with the former one using
+     * If multiple handlers are added, the latter is composed with the former using
      * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)
      */
     public VirtualHostBuilder errorHandler(ServiceErrorHandler errorHandler) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -726,9 +726,10 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         }
 
         if (!routeDecoratingServices.isEmpty()) {
-            final List<RouteDecoratingService> prefixed = routeDecoratingServices.stream()
-                    .map(service -> service.withRoutePrefix(baseContextPath))
-                    .collect(toImmutableList());
+            final List<RouteDecoratingService> prefixed =
+                    routeDecoratingServices.stream()
+                                           .map(service -> service.withRoutePrefix(baseContextPath))
+                                           .collect(toImmutableList());
             return RouteDecoratingService.newDecorator(Routers.ofRouteDecoratingService(prefixed));
         } else {
             return null;
@@ -869,7 +870,12 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
      * Sets the {@link ServiceErrorHandler} that handles exceptions thrown in this virtual host.
      */
     public VirtualHostBuilder errorHandler(ServiceErrorHandler errorHandler) {
-        this.errorHandler = requireNonNull(errorHandler, "errorHandler");
+        requireNonNull(errorHandler, "errorHandler");
+        if (this.errorHandler == null) {
+            this.errorHandler = errorHandler;
+        } else {
+            this.errorHandler = this.errorHandler.orElse(errorHandler);
+        }
         return this;
     }
 
@@ -1214,7 +1220,8 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
      * added to this builder.
      */
     VirtualHost build(VirtualHostBuilder template, DependencyInjector dependencyInjector,
-                      @Nullable UnhandledExceptionsReporter unhandledExceptionsReporter) {
+                      @Nullable UnhandledExceptionsReporter unhandledExceptionsReporter,
+                      ServerErrorHandler serverErrorHandler) {
         requireNonNull(template, "template");
 
         if (defaultHostname == null) {
@@ -1294,9 +1301,9 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         final Function<? super RoutingContext, ? extends RequestId> requestIdGenerator =
                 this.requestIdGenerator != null ?
                 this.requestIdGenerator : template.requestIdGenerator;
-        final ServiceErrorHandler serverErrorHandler = serverBuilder.errorHandler().asServiceErrorHandler();
+        final ServiceErrorHandler serviceErrorHandler = serverErrorHandler.asServiceErrorHandler();
         final ServiceErrorHandler defaultErrorHandler =
-                errorHandler != null ? errorHandler.orElse(serverErrorHandler) : serverErrorHandler;
+                errorHandler != null ? errorHandler.orElse(serviceErrorHandler) : serviceErrorHandler;
 
         assert defaultServiceNaming != null;
         assert rejectedRouteHandler != null;

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -867,7 +867,9 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     }
 
     /**
-     * Sets the {@link ServiceErrorHandler} that handles exceptions thrown in this virtual host.
+     * Adds the {@link ServiceErrorHandler} that handles exceptions thrown in this virtual host.
+     * If multiple handlers are added, the latter is composed with the former one using
+     * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)
      */
     public VirtualHostBuilder errorHandler(ServiceErrorHandler errorHandler) {
         requireNonNull(errorHandler, "errorHandler");

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -869,7 +869,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     /**
      * Adds the {@link ServiceErrorHandler} that handles exceptions thrown in this virtual host.
      * If multiple handlers are added, the latter is composed with the former using
-     * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)
+     * {@link ServiceErrorHandler#orElse(ServiceErrorHandler)}.
      */
     public VirtualHostBuilder errorHandler(ServiceErrorHandler errorHandler) {
         requireNonNull(errorHandler, "errorHandler");

--- a/core/src/test/java/com/linecorp/armeria/server/ErrorHandlerOrElseTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ErrorHandlerOrElseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ErrorHandlerOrElseTest {
+
+    private static final Queue<String> handlerEvents = new ConcurrentLinkedQueue<>();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> {
+                throw new IllegalStateException();
+            });
+            sb.errorHandler((ctx, cause) -> {
+                handlerEvents.add("Server1");
+                return null;
+            });
+            sb.errorHandler((ctx, cause) -> {
+                handlerEvents.add("Server2");
+                return null;
+            });
+            sb.virtualHost("foo.com")
+              .service("/", (ctx, req) -> {
+                  throw new IllegalStateException();
+              })
+              .errorHandler((ctx, cause) -> {
+                  handlerEvents.add("VirtualHost1");
+                  return null;
+              })
+              .errorHandler((ctx, cause) -> {
+                  handlerEvents.add("VirtualHost2");
+                  return null;
+              })
+              .route()
+              .path("/route")
+              .errorHandler((ctx, cause) -> {
+                  handlerEvents.add("Service1");
+                  return null;
+              })
+              .errorHandler((ctx, cause) -> {
+                  handlerEvents.add("Service2");
+                  return null;
+              })
+              .build((ctx, req) -> {
+                  throw new IllegalStateException();
+              });
+        }
+    };
+
+    @Test
+    void shouldChainErrorHandlerWithOrElse() {
+        final BlockingWebClient client = server.blockingWebClient();
+        assertThat(client.get("/").status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(handlerEvents).containsExactly("Server1", "Server2");
+        handlerEvents.clear();
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .addressResolverGroupFactory(
+                                                          unused -> MockAddressResolverGroup.localhost())
+                                                  .build()) {
+            final BlockingWebClient fooClient = WebClient.builder("http://foo.com:" + server.httpPort())
+                                                         .factory(factory)
+                                                         .build()
+                                                         .blocking();
+            assertThat(fooClient.get("/").status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(handlerEvents).containsExactly(
+                    "VirtualHost1", "VirtualHost2",
+                    "Server1", "Server2");
+
+            handlerEvents.clear();
+            assertThat(fooClient.get("/route").status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(handlerEvents).containsExactly(
+                    "Service1", "Service2",
+                    "VirtualHost1", "VirtualHost2",
+                    "Server1", "Server2");
+            handlerEvents.clear();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostAnnotatedServiceBindingBuilderTest.java
@@ -107,7 +107,7 @@ class VirtualHostAnnotatedServiceBindingBuilderTest {
                 .multipartUploadsLocation(multipartUploadsLocation)
                 .requestIdGenerator(serviceRequestIdGenerator)
                 .build(new TestService())
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
 
         assertThat(virtualHost.serviceConfigs()).hasSize(2);
         final ServiceConfig pathBar = virtualHost.serviceConfigs().get(0);

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
@@ -166,7 +166,7 @@ class VirtualHostBuilderTest {
         final VirtualHost h = new VirtualHostBuilder(Server.builder(), false)
                 .defaultHostname("foo.com")
                 .hostnamePattern("foo.com")
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h.hostnamePattern()).isEqualTo("foo.com");
         assertThat(h.defaultHostname()).isEqualTo("foo.com");
     }
@@ -176,7 +176,7 @@ class VirtualHostBuilderTest {
         final VirtualHost h = new VirtualHostBuilder(Server.builder(), false)
                 .defaultHostname("bar.foo.com")
                 .hostnamePattern("*.foo.com")
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h.hostnamePattern()).isEqualTo("*.foo.com");
         assertThat(h.defaultHostname()).isEqualTo("bar.foo.com");
     }
@@ -187,14 +187,14 @@ class VirtualHostBuilderTest {
                 .defaultHostname("bar.foo.com")
                 .hostnamePattern("*.foo.com")
                 .accessLogger(host -> LoggerFactory.getLogger("customize.test"))
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h1.accessLogger().getName()).isEqualTo("customize.test");
 
         final VirtualHost h2 = new VirtualHostBuilder(Server.builder(), false)
                 .defaultHostname("bar.foo.com")
                 .hostnamePattern("*.foo.com")
                 .accessLogger(LoggerFactory.getLogger("com.foo.test"))
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h2.accessLogger().getName()).isEqualTo("com.foo.test");
     }
 
@@ -256,12 +256,13 @@ class VirtualHostBuilderTest {
         switch (expectedOutcome) {
             case "success":
                 virtualHostBuilder.build(serverBuilder.virtualHostTemplate, noopDependencyInjector,
-                                         null);
+                                         null, ServerErrorHandler.ofDefault());
                 break;
             case "failure":
                 assertThatThrownBy(() -> virtualHostBuilder.build(serverBuilder.virtualHostTemplate,
                                                                   noopDependencyInjector,
-                                                                  null))
+                                                                  null,
+                                                                  ServerErrorHandler.ofDefault()))
                         .isInstanceOf(IllegalStateException.class)
                         .hasMessageContaining("TLS with a bad cipher suite");
                 break;
@@ -302,7 +303,7 @@ class VirtualHostBuilderTest {
             new VirtualHostBuilder(Server.builder(), false)
                     .defaultHostname("bar.com")
                     .hostnamePattern("foo.com")
-                    .build(template, noopDependencyInjector, null);
+                    .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -312,7 +313,7 @@ class VirtualHostBuilderTest {
             new VirtualHostBuilder(Server.builder(), false)
                     .defaultHostname("bar.com")
                     .hostnamePattern("*.foo.com")
-                    .build(template, noopDependencyInjector, null);
+                    .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -326,7 +327,7 @@ class VirtualHostBuilderTest {
         final VirtualHost virtualHost = new VirtualHostBuilder(Server.builder(), true)
                 .service(routeA, (ctx, req) -> HttpResponse.of(200))
                 .service(routeB, (ctx, req) -> HttpResponse.of(201))
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(virtualHost.serviceConfigs().size()).isEqualTo(2);
         final RoutingContext routingContext = new DefaultRoutingContext(virtualHost(), "example.com",
                                                                         RequestHeaders.of(HttpMethod.GET, "/"),
@@ -341,11 +342,11 @@ class VirtualHostBuilderTest {
         final Path multipartUploadsLocation = FileSystems.getDefault().getPath("logs", "access.log");
         final VirtualHost h1 = new VirtualHostBuilder(Server.builder(), false)
                 .multipartUploadsLocation(multipartUploadsLocation)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h1.multipartUploadsLocation()).isEqualTo(multipartUploadsLocation);
 
         final VirtualHost h2 = new VirtualHostBuilder(Server.builder(), false)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h2.multipartUploadsLocation()).isEqualTo(template.multipartUploadsLocation());
     }
 
@@ -354,11 +355,11 @@ class VirtualHostBuilderTest {
         final String defaultLogName = "test";
         final VirtualHost h1 = new VirtualHostBuilder(Server.builder(), false)
                 .defaultLogName(defaultLogName)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h1.defaultLogName()).isEqualTo(defaultLogName);
 
         final VirtualHost h2 = new VirtualHostBuilder(Server.builder(), false)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h2.defaultLogName()).isEqualTo(template.defaultLogName());
     }
 
@@ -367,11 +368,11 @@ class VirtualHostBuilderTest {
         final SuccessFunction successFunction = (ctx, log) -> false;
         final VirtualHost h1 = new VirtualHostBuilder(Server.builder(), false)
                 .successFunction(successFunction)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h1.successFunction()).isEqualTo(successFunction);
 
         final VirtualHost h2 = new VirtualHostBuilder(Server.builder(), false)
-                .build(template, noopDependencyInjector, null);
+                .build(template, noopDependencyInjector, null, ServerErrorHandler.ofDefault());
         assertThat(h2.successFunction()).isEqualTo(template.successFunction());
     }
 }

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
@@ -264,8 +264,8 @@ public final class GraphqlServiceBuilder {
     }
 
     /**
-     * Sets the {@link GraphqlErrorHandler}. If multiple handlers are added, the latter is composed with the
-     * former one using {@link GraphqlErrorHandler#orElse(GraphqlErrorHandler).
+     * Adds the {@link GraphqlErrorHandler}. If multiple handlers are added, the latter is composed with the
+     * former one using {@link GraphqlErrorHandler#orElse(GraphqlErrorHandler)}.
      *
      * <p>If not specified, {@link GraphqlErrorHandler#of()} is used by default.
      */

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
@@ -268,7 +268,12 @@ public final class GraphqlServiceBuilder {
      * If not specified, {@link GraphqlErrorHandler#of()} is used by default.
      */
     public GraphqlServiceBuilder errorHandler(GraphqlErrorHandler errorHandler) {
-        this.errorHandler = requireNonNull(errorHandler, "errorHandler");
+        requireNonNull(errorHandler, "errorHandler");
+        if (this.errorHandler == null) {
+            this.errorHandler = errorHandler;
+        } else {
+            this.errorHandler = this.errorHandler.orElse(errorHandler);
+        }
         return this;
     }
 

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlServiceBuilder.java
@@ -264,8 +264,10 @@ public final class GraphqlServiceBuilder {
     }
 
     /**
-     * Sets the {@link GraphqlErrorHandler}.
-     * If not specified, {@link GraphqlErrorHandler#of()} is used by default.
+     * Sets the {@link GraphqlErrorHandler}. If multiple handlers are added, the latter is composed with the
+     * former one using {@link GraphqlErrorHandler#orElse(GraphqlErrorHandler).
+     *
+     * <p>If not specified, {@link GraphqlErrorHandler#of()} is used by default.
      */
     public GraphqlServiceBuilder errorHandler(GraphqlErrorHandler errorHandler) {
         requireNonNull(errorHandler, "errorHandler");


### PR DESCRIPTION
Motivation:

Some builders use `.orElse()` to allow multiple error handlers, while others allow only one and overwrite the previous value.

For consistency, it would be clear to allow multiple error handlers for all builder methods.

Modifications:

- Fixed `.errorHandler(..)` builder method to compose a new error handler with the old one.

Result:

You can add multiple `(Server|Service)ErrorHandler`s using server and service builder methods.
