### PR TITLE
Support context-path for Spring integration

### DIFF
--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationSettingsUtil.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationSettingsUtil.java
@@ -38,6 +38,7 @@ public final class ArmeriaConfigurationSettingsUtil {
      * Configures the {@link ServerBuilder} using the specified {@link ArmeriaSettings}.
      */
     public static void configureSettings(ServerBuilder server, ArmeriaSettings settings) {
+        configureIfNonNull(settings.getContextPath(), server::baseContextPath);
         configureIfNonNull(settings.getWorkerGroup(), server::workerGroup);
         configureIfNonNull(settings.getBlockingTaskExecutor(), server::blockingTaskExecutor);
 

--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -431,6 +431,12 @@ public class ArmeriaSettings {
     private List<Port> ports = new ArrayList<>();
 
     /**
+     * The context path to serve the requests on. If not set, will serve requests on the root context path.
+     */
+    @Nullable
+    private String contextPath;
+
+    /**
      * The path to serve health check requests on. Should correspond to what is
      * registered in the load balancer. If not set, health check service will not
      * be registered.
@@ -635,6 +641,21 @@ public class ArmeriaSettings {
      */
     public void setPorts(List<Port> ports) {
         this.ports = ports;
+    }
+
+    /**
+     * Returns the context path of the {@link Server}.
+     */
+    @Nullable
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    /**
+     * Sets the context path to serve the requests on. If not set, will serve requests on the root context path.
+     */
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
     }
 
     /**

--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaSettings.java
@@ -431,7 +431,7 @@ public class ArmeriaSettings {
     private List<Port> ports = new ArrayList<>();
 
     /**
-     * The context path to serve the requests on. If not set, will serve requests on the root context path.
+     * The context path to serve the requests on. If not set, requests will be served on the root context path.
      */
     @Nullable
     private String contextPath;
@@ -652,7 +652,8 @@ public class ArmeriaSettings {
     }
 
     /**
-     * Sets the context path to serve the requests on. If not set, will serve requests on the root context path.
+     * Sets the context path to serve the requests on. If not set, requests will be served on the root context
+     * path.
      */
     public void setContextPath(String contextPath) {
         this.contextPath = contextPath;

--- a/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsBaseContextPathTest.java
+++ b/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsBaseContextPathTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.spring.ArmeriaSettingsBaseContextPathTest.TestConfiguration;
+
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "baseContextPathTest" })
+@DirtiesContext
+class ArmeriaSettingsBaseContextPathTest {
+
+    @SpringBootApplication
+    static class TestConfiguration {
+        @Bean
+        ArmeriaServerConfigurator armeriaServerConfigurator() {
+            return server -> {
+                server.service("/hello", (ctx, req) -> {
+                    return HttpResponse.of("Hello, world!");
+                });
+            };
+        }
+    }
+
+    @LocalArmeriaPort
+    int port;
+
+    @Test
+    void shouldServiceRequestsOnBaseContextPath() {
+        final BlockingWebClient client = BlockingWebClient.of("http://127.0.0.1:" + port);
+        assertThat(client.get("/hello").status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(client.get("/foo/hello").status()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/spring/boot3-autoconfigure/src/test/resources/config/application-baseContextPathTest.yml
+++ b/spring/boot3-autoconfigure/src/test/resources/config/application-baseContextPathTest.yml
@@ -1,0 +1,4 @@
+armeria:
+  ports:
+  - port: 0
+  context-path: /foo


### PR DESCRIPTION
Motivation:

The final task of context-path support is to configure the value with Spring auto-configuration.

Modifications:

- `context-path` properties to Armeria settings
  - If set, the value is set to `ServerBuilder.baseContextPath()`

Result:

You can now set a base context path of a server via Spring auto-configuration.
```yml
armeria:
  context-path: /api/v1
```