### PR TITLE
Fix missed overridden methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -290,4 +290,9 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (ClientBuilder) super.contextCustomizer(contextCustomizer);
     }
+
+    @Override
+    public ClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
+        return (ClientBuilder) super.contextHook(contextHook);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -217,4 +217,9 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder {
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (ClientOptionsBuilder) super.contextCustomizer(contextCustomizer);
     }
+
+    @Override
+    public ClientOptionsBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
+        return (ClientOptionsBuilder) super.contextHook(contextHook);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsResolverGroupBuilder.java
@@ -338,4 +338,9 @@ public final class DnsResolverGroupBuilder extends AbstractDnsResolverBuilder {
     public DnsResolverGroupBuilder dnsCache(DnsCache dnsCache) {
         return (DnsResolverGroupBuilder) super.dnsCache(dnsCache);
     }
+
+    @Override
+    public DnsResolverGroupBuilder enableDnsQueryMetrics(boolean enable) {
+        return (DnsResolverGroupBuilder) super.enableDnsQueryMetrics(enable);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -249,4 +249,9 @@ public final class RestClientBuilder extends AbstractWebClientBuilder {
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (RestClientBuilder) super.contextCustomizer(contextCustomizer);
     }
+
+    @Override
+    public RestClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
+        return (RestClientBuilder) super.contextHook(contextHook);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
@@ -263,6 +263,12 @@ public final class CircuitBreakerRuleWithContentBuilder<T extends Response>
         return (CircuitBreakerRuleWithContentBuilder<T>) super.onException();
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public CircuitBreakerRuleWithContentBuilder<T> onTimeoutException() {
+        return (CircuitBreakerRuleWithContentBuilder<T>) super.onTimeoutException();
+    }
+
     /**
      * Reports a {@link Response} as a success or failure to a {@link CircuitBreaker},
      * or ignores it according to the build methods({@link #thenSuccess()}, {@link #thenFailure()} and

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 
+import com.linecorp.armeria.client.AbstractRuleBuilder;
 import com.linecorp.armeria.client.AbstractRuleWithContentBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;
@@ -242,6 +243,12 @@ public final class RetryRuleWithContentBuilder<T extends Response> extends Abstr
     @Override
     public RetryRuleWithContentBuilder<T> onException() {
         return (RetryRuleWithContentBuilder<T>) super.onException();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public RetryRuleWithContentBuilder<T> onTimeoutException() {
+        return (RetryRuleWithContentBuilder<T>) super.onTimeoutException();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 
-import com.linecorp.armeria.client.AbstractRuleBuilder;
 import com.linecorp.armeria.client.AbstractRuleWithContentBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.UnprocessedRequestException;

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
@@ -34,7 +34,6 @@ import java.util.function.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import com.linecorp.armeria.client.AbstractClientOptionsBuilder;
 import com.linecorp.armeria.client.AbstractWebClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOption;

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.client.AbstractClientOptionsBuilder;
 import com.linecorp.armeria.client.AbstractWebClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientOption;
@@ -370,5 +371,10 @@ public final class WebSocketClientBuilder extends AbstractWebClientBuilder {
     public WebSocketClientBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (WebSocketClientBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public WebSocketClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
+        return (WebSocketClientBuilder) super.contextHook(contextHook);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
@@ -154,6 +154,11 @@ public final class HttpRequestBuilder extends AbstractHttpRequestBuilder {
     }
 
     @Override
+    public HttpRequestBuilder trailer(CharSequence name, Object value) {
+        return (HttpRequestBuilder) super.trailer(name, value);
+    }
+
+    @Override
     public HttpRequestBuilder trailers(
             Iterable<? extends Map.Entry<? extends CharSequence, String>> trailers) {
         return (HttpRequestBuilder) super.trailers(trailers);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
@@ -237,6 +237,11 @@ public final class HttpResponseBuilder extends AbstractHttpMessageBuilder {
         return (HttpResponseBuilder) super.headers(headers);
     }
 
+    @Override
+    public HttpResponseBuilder trailer(CharSequence name, Object value) {
+        return (HttpResponseBuilder) super.trailer(name, value);
+    }
+
     /**
      * Adds HTTP trailers to this response.
      */

--- a/it/builders/src/test/java/com/linecorp/armeria/OverriddenBuilderMethodsReturnTypeTest.java
+++ b/it/builders/src/test/java/com/linecorp/armeria/OverriddenBuilderMethodsReturnTypeTest.java
@@ -18,8 +18,10 @@ package com.linecorp.armeria;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -45,20 +47,25 @@ class OverriddenBuilderMethodsReturnTypeTest {
         final String packageName = "com.linecorp.armeria";
         findAllClasses(packageName).stream()
                                    .map(ReflectionUtils::forName)
-                                   .filter(clazz -> clazz.getSimpleName().endsWith("Builder"))
+                                   .filter(clazz -> clazz.getSimpleName().endsWith("Builder") &&
+                                                    Modifier.isFinal(clazz.getModifiers()))
                                    .forEach(clazz -> {
                                        final List<Method> methods = overriddenMethods(clazz);
                                        for (Method m : methods) {
+                                           assertThatNoException().isThrownBy(
+                                                   () -> clazz.getDeclaredMethod(m.getName(),
+                                                                                 m.getParameterTypes()));
+                                           final Method overriddenMethod;
                                            try {
-                                               final Method overriddenMethod =
+                                               overriddenMethod =
                                                        clazz.getDeclaredMethod(m.getName(),
                                                                                m.getParameterTypes());
-                                               assertThat(overriddenMethod.getReturnType())
-                                                       .describedAs("Method name: " + m)
-                                                       .isSameAs(clazz);
                                            } catch (NoSuchMethodException e) {
-                                               // ignored
+                                               throw new RuntimeException(e);
                                            }
+                                           assertThat(overriddenMethod.getReturnType())
+                                                   .describedAs("Method name: " + m)
+                                                   .isSameAs(clazz);
                                        }
                                    });
     }


### PR DESCRIPTION
Motivation:

I found some overridden methods were missed. https://github.com/line/armeria/pull/5107#discussion_r1368090886
While I was at it, I also fixed a test which goes through the entire classpath looking for builders ending with the String `Builder`.

Modifications:

- Fixed `OverriddenBuilderMethodsReturnTypeTest` to not ignore missing methods
- Fixed not overridden methods

Result:

- A more consistent fluent API experience

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
