### PR TITLE
Publish `ProxyConnectionEvent` after `HAProxyMessage` is written

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
@@ -93,12 +93,6 @@ final class HAProxyHandler extends ChannelOutboundHandlerAdapter {
         return new ProxyConnectException(e);
     }
 
-    // Call fireUserEventTriggered success/failure in the executor to execute it after the
-    // HttpSessionHandler is added to the pipeline.
-    private static void reschedule(ChannelHandlerContext ctx, Runnable runnable) {
-        ctx.channel().eventLoop().execute(runnable);
-    }
-
     private static HAProxyMessage createMessage(HAProxyConfig haProxyConfig,
                                                 Channel channel, SocketAddress remoteAddress)
             throws ProxyConnectException {

--- a/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
@@ -65,17 +65,18 @@ final class HAProxyHandler extends ChannelOutboundHandlerAdapter {
                 return;
             }
             try {
-                ctx.writeAndFlush(createMessage(haProxyConfig, ctx.channel(), remoteAddress)).addListener(f0 -> {
-                    if (f0.isSuccess()) {
-                        ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
-                        final ProxyConnectionEvent event = new ProxyConnectionEvent(
-                                PROTOCOL, AUTH, proxyAddress, remoteAddress);
-                        ctx.pipeline().fireUserEventTriggered(event);
-                    } else {
-                        ctx.fireExceptionCaught(wrapException(f0.cause()));
-                        ctx.close();
-                    }
-                });
+                ctx.writeAndFlush(createMessage(haProxyConfig, ctx.channel(), remoteAddress))
+                   .addListener(f0 -> {
+                       if (f0.isSuccess()) {
+                           ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
+                           final ProxyConnectionEvent event = new ProxyConnectionEvent(
+                                   PROTOCOL, AUTH, proxyAddress, remoteAddress);
+                           ctx.pipeline().fireUserEventTriggered(event);
+                       } else {
+                           ctx.fireExceptionCaught(wrapException(f0.cause()));
+                           ctx.close();
+                       }
+                   });
             } catch (Exception e) {
                 ctx.pipeline().fireUserEventTriggered(wrapException(e));
                 ctx.close();

--- a/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
@@ -76,6 +76,7 @@ final class HAProxyHandler extends ChannelOutboundHandlerAdapter {
                         ctx.close();
                     }
                 });
+                ctx.flush();
             } catch (Exception e) {
                 ctx.pipeline().fireUserEventTriggered(wrapException(e));
                 ctx.close();

--- a/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HAProxyHandler.java
@@ -65,7 +65,7 @@ final class HAProxyHandler extends ChannelOutboundHandlerAdapter {
                 return;
             }
             try {
-                ctx.write(createMessage(haProxyConfig, ctx.channel(), remoteAddress)).addListener(f0 -> {
+                ctx.writeAndFlush(createMessage(haProxyConfig, ctx.channel(), remoteAddress)).addListener(f0 -> {
                     if (f0.isSuccess()) {
                         ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
                         final ProxyConnectionEvent event = new ProxyConnectionEvent(
@@ -76,7 +76,6 @@ final class HAProxyHandler extends ChannelOutboundHandlerAdapter {
                         ctx.close();
                     }
                 });
-                ctx.flush();
             } catch (Exception e) {
                 ctx.pipeline().fireUserEventTriggered(wrapException(e));
                 ctx.close();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
-import com.linecorp.armeria.client.proxy.ProxyConfig;
 import com.linecorp.armeria.client.proxy.ProxyType;
 import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.ClosedSessionException;
@@ -143,7 +142,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         this.poolKey = poolKey;
         this.clientFactory = clientFactory;
 
-        if (poolKey.proxyConfig == ProxyConfig.direct()) {
+        if (!poolKey.proxyConfig.proxyType().isForwardProxy()) {
             scheduleSessionTimeout(channel, sessionPromise, connectionTimeoutMillis, desiredProtocol);
         } else {
             // A session timeout for a proxied connection may be scheduled when ProxyConnectionEvent is

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -462,8 +462,9 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             proxyDestinationAddress = ((ProxyConnectionEvent) evt).destinationAddress();
             if (!tryCompleteSessionPromise(ctx)) {
                 // A session has not been created yet. Additional handshakes will be done by HTTP/1 or HTTP/2.
-                assert sessionTimeoutFuture == null;
-                scheduleSessionTimeout(channel, sessionPromise, connectionTimeoutMillis, desiredProtocol);
+                if (poolKey.proxyConfig.proxyType().isForwardProxy()) {
+                    scheduleSessionTimeout(channel, sessionPromise, connectionTimeoutMillis, desiredProtocol);
+                }
             }
             return;
         }


### PR DESCRIPTION
Motivation:

1) `HAProxyHandler` is not a subclass of `ProxyHandler` so the whole proxy process is not bound by a connection timeout. https://github.com/line/armeria/pull/5223#discussion_r1372475060 We need to fix to start a session timeout to include HA proxy as a part of the session handshake.

2) A `ProxyConnectionEvent` is published as a connection is established without waiting for the result of `HAProxyMessage`. The event is rescheduled on the premise that the HAProxy message would be written and the HttpSessionHandler would enter the pipeline during the rescheduling.
It has worked well, but it doesn't provide perfect happen-before. Since `HttpSessionHandler` is added as the first listener of `connectionPromise` by #5223, if the connection is successful in the callback of `HAProxyHandler`'s `addListener()`, `HttpSessionHandler` will always exist in the pipeline.
Therefore we don't need to rely on the reschedule to fire a `ProxyConnectionEvent` or `ProxyConnectException`.



Modifications:

- Use `.isForwardProxy()` to determine whether a session timeout should be scheduled as a connection is established.
- Fire `ProxyConnectionEvent` when `HAProxyMessage` is successfully written.
- Remove unnecessary rescheduled jobs.

Result:

`ProxyConnectionEvent` is correctly published after `HAProxyMessage` is successfully written.
