### PR TITLE
Disable RST_STREAM frame limitation for HTTP/2 clients

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandlerBuilder.java
@@ -34,6 +34,8 @@ final class Http2ClientConnectionHandlerBuilder
         super(ch);
         this.clientFactory = clientFactory;
         this.protocol = protocol;
+        // Disable RST frames limit for HTTP/2 clients.
+        decoderEnforceMaxRstFramesPerWindow(0, 0);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -78,7 +78,8 @@ final class DefaultFlagsProvider implements FlagsProvider {
     // parameter values, thus anything greater than 0x7FFFFFFF will break them or make them unhappy.
     static final long DEFAULT_HTTP2_MAX_STREAMS_PER_CONNECTION = Integer.MAX_VALUE;
     static final long DEFAULT_HTTP2_MAX_HEADER_LIST_SIZE = 8192L; // from Netty default maxHeaderSize
-    static final int DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE = 400; // Netty default is 200 for 30 seconds
+    // Netty default is 200 for 30 seconds
+    static final int DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE = 400;
     static final String DEFAULT_BACKOFF_SPEC = "exponential=200:10000,jitter=0.2";
     static final int DEFAULT_MAX_TOTAL_ATTEMPTS = 10;
     static final long DEFAULT_REQUEST_AUTO_ABORT_DELAY_MILLIS = 0; // No delay.
@@ -324,8 +325,8 @@ final class DefaultFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Integer defaultHttp2MaxResetFramesPerMinute() {
-        return DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE;
+    public Integer defaultServerHttp2MaxResetFramesPerMinute() {
+        return DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -285,9 +285,9 @@ public final class Flags {
             getValue(FlagsProvider::defaultHttp2MaxHeaderListSize, "defaultHttp2MaxHeaderListSize",
                      value -> value > 0 && value <= 0xFFFFFFFFL);
 
-    private static final int DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE =
-            getValue(FlagsProvider::defaultHttp2MaxResetFramesPerMinute,
-                     "defaultHttp2MaxResetFramesPerMinute", value -> value >= 0);
+    private static final int DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE =
+            getValue(FlagsProvider::defaultServerHttp2MaxResetFramesPerMinute,
+                     "defaultServerHttp2MaxResetFramesPerMinute", value -> value >= 0);
 
     private static final int DEFAULT_MAX_HTTP1_INITIAL_LINE_LENGTH =
             getValue(FlagsProvider::defaultHttp1MaxInitialLineLength, "defaultHttp1MaxInitialLineLength",
@@ -1063,13 +1063,13 @@ public final class Flags {
      * {@link ServerBuilder#http2MaxResetFramesPerWindow(int, int)}.
      *
      * <p>The default value of this flag is
-     * {@value DefaultFlagsProvider#DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE}.
-     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2MaxResetFramesPerMinute=<integer>} JVM option
+     * {@value DefaultFlagsProvider#DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultServerHttp2MaxResetFramesPerMinute=<integer>} JVM option
      * to override the default value. {@code 0} means no protection should be applied.
      */
     @UnstableApi
-    public static int defaultHttp2MaxResetFramesPerMinute() {
-        return DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE;
+    public static int defaultServerHttp2MaxResetFramesPerMinute() {
+        return DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -718,12 +718,12 @@ public interface FlagsProvider {
      * {@link ServerBuilder#http2MaxResetFramesPerWindow(int, int)}.
      *
      * <p>The default value of this flag is
-     * {@value DefaultFlagsProvider#DEFAULT_HTTP2_MAX_RESET_FRAMES_PER_MINUTE}.
-     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2MaxResetFramesPerMinute=<integer>} JVM option
+     * {@value DefaultFlagsProvider#DEFAULT_SERVER_HTTP2_MAX_RESET_FRAMES_PER_MINUTE}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultServerHttp2MaxResetFramesPerMinute=<integer>} JVM option
      * to override the default value. {@code 0} means no protection should be applied.
      */
     @Nullable
-    default Integer defaultHttp2MaxResetFramesPerMinute() {
+    default Integer defaultServerHttp2MaxResetFramesPerMinute() {
         return null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -299,8 +299,8 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     }
 
     @Override
-    public Integer defaultHttp2MaxResetFramesPerMinute() {
-        return getInt("defaultHttp2MaxResetFramesPerMinute");
+    public Integer defaultServerHttp2MaxResetFramesPerMinute() {
+        return getInt("defaultServerHttp2MaxResetFramesPerMinute");
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -232,7 +232,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     private long unhandledExceptionsReportIntervalMillis =
             Flags.defaultUnhandledExceptionsReportIntervalMillis();
     private final List<ShutdownSupport> shutdownSupports = new ArrayList<>();
-    private int http2MaxResetFramesPerWindow = Flags.defaultHttp2MaxResetFramesPerMinute();
+    private int http2MaxResetFramesPerWindow = Flags.defaultServerHttp2MaxResetFramesPerMinute();
     private int http2MaxResetFramesWindowSeconds = 60;
 
     ServerBuilder() {
@@ -778,7 +778,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     /**
      * Sets the maximum number of RST frames that are allowed per window before the connection is closed. This
      * allows to protect against the remote peer flooding us with such frames and using up a lot of CPU.
-     * Defaults to {@link Flags#defaultHttp2MaxResetFramesPerMinute()}.
+     * Defaults to {@link Flags#defaultServerHttp2MaxResetFramesPerMinute()}.
      *
      * <p>Note that {@code 0} for any of the parameters means no protection should be applied.
      */


### PR DESCRIPTION
Motivation:

It is not necessary to limit the maximum number of RST_STREAM frames for clients. https://github.com/netty/netty/pull/13671

Modifications:

- Disable the maximum number of RST_STREAM frames for HTTP/2 clients

Result:

- HTTP/2 clients do not limit the maximum number of RST frames per minute before the connection is closed. Only 1.26.0 is affected.
- Breaking) `Flags.defaultHttp2MaxResetFramesPerMinute()` has been removed and `Flags#defaultServerHttp2MaxResetFramesPerMinute()` is now used instead.
