### PR TITLE
Remove AutoConfiguration.imports and revert spring.factories for Spring Boot 2

### DIFF
--- a/spring/boot2-actuator-autoconfigure/build.gradle
+++ b/spring/boot2-actuator-autoconfigure/build.gradle
@@ -25,7 +25,6 @@ tasks.sourcesJar.dependsOn(project(":spring:$boot3Actuator").tasks.sourcesJar)
 
 tasks.compileJava.source "${boot3ActuatorProjectDir}/src/main/java",
         "${boot3ActuatorProjectDir}/gen-src/main/java"
-tasks.processResources.from "${boot3ActuatorProjectDir}/src/main/resources"
 tasks.compileTestJava.source "${boot3ActuatorProjectDir}/src/test/java",
         "${boot3ActuatorProjectDir}/gen-src/test/java"
 tasks.processTestResources.from "${boot3ActuatorProjectDir}/src/test/resources"

--- a/spring/boot2-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring/boot2-actuator-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfiguration

--- a/spring/boot2-autoconfigure/build.gradle
+++ b/spring/boot2-autoconfigure/build.gradle
@@ -38,7 +38,6 @@ tasks.compileJava.dependsOn(project(":spring:$boot3Autoconfigure").tasks.compile
 tasks.compileTestJava.dependsOn(project(":spring:$boot3Autoconfigure").tasks.compileTestJava)
 
 tasks.compileJava.source "${boot3AutoconfigureProjectDir}/src/main/java"
-tasks.processResources.from "${boot3AutoconfigureProjectDir}/src/main/resources"
 tasks.compileTestJava.source "${projectDir}/src/test/java",
         "${boot3AutoconfigureProjectDir}/src/test/java",
         "${boot3AutoconfigureProjectDir}/gen-src/test/grpc",

--- a/spring/boot2-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring/boot2-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.linecorp.armeria.spring.ArmeriaAutoConfiguration,\
+  com.linecorp.armeria.spring.ArmeriaBeanPostProcessorConfiguration

--- a/spring/boot2-webflux-autoconfigure/build.gradle
+++ b/spring/boot2-webflux-autoconfigure/build.gradle
@@ -70,6 +70,7 @@ task generateSources(type: Copy) {
     from("${"${rootProject.projectDir}/spring/boot3-webflux-autoconfigure"}/src") {
         exclude '**/AbstractServerHttpResponseVersionSpecific.java'
         exclude '**/package-info.java'
+        exclude '**/org.springframework.boot.autoconfigure.AutoConfiguration.imports'
     }
 
     into "${project.ext.genSrcDir}"

--- a/spring/boot2-webflux-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/spring/boot2-webflux-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  com.linecorp.armeria.spring.web.reactive.ArmeriaReactiveWebServerFactoryAutoConfiguration,\
+  com.linecorp.armeria.spring.web.reactive.ArmeriaClientAutoConfiguration


### PR DESCRIPTION
Motivation:

`org.springframework.boot.autoconfigure.AutoConfiguration.imports` was introduced in Spring Boot 2.7. The legacy `spring.factories` files in Spring integration modules have been migrated to
`AutoConfiguration.imports` to share the same files between Spring Boot 2 and 3.

Some uses are still using old Spring Boot versions (< 2.7) so they are having trouble upgrading Armeria version due to the removal of `spring.factories`. `spring.factories` is still supported in 2.7. For backward compatibility, the legacy `spring.factories` is a better to provide auto-configuration in the Spring Boot 2 modules.

Modifications:

- Revive `spring.factories` and do not copy `AutoConfiguration.imports` from Spring Boot 3 modules.

Result:

Fixed a bug where Armeria Spring integration is not compatible with Spring Boot 2.6 and lower.
