### PR TITLE
Fixed bug where a null endpoint is returned

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -87,9 +87,17 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         final ListeningFuture listeningFuture = new ListeningFuture(ctx, executor);
         addPendingFuture(listeningFuture);
 
-        // The EndpointGroup have just been updated.
+        // The EndpointGroup have just been updated after adding ListeningFuture.
         if (listeningFuture.isDone()) {
             return listeningFuture;
+        }
+        if (endpointGroup.whenReady().isDone()) {
+            final Endpoint endpoint0 = selectNow(ctx);
+            if (endpoint0 != null) {
+                // The EndpointGroup have just been updated before adding ListeningFuture.
+                listeningFuture.complete(endpoint0);
+                return listeningFuture;
+            }
         }
 
         final long selectionTimeoutMillis = endpointGroup.selectionTimeoutMillis();


### PR DESCRIPTION
Motivation:

While fixing #5163, I made a bug that `EndpointSelector` returns a null endpoint due to a race condition between an EndpointGroup initialization event and `EndpointSelector.select()`.
```
Caused by:
com.linecorp.armeria.client.endpoint.EndpointSelectionTimeoutException: Failed to select within 3200 ms an endpoint from: HealthCheckedEndpointGroup{endpoints=[Endpoint{127.0.0.1:46843, weight=1000}], numEndpoints=1, candidates=[Endpoint{127.0.0.1:46843, weight=1000}], numCandidates=1, selectionStrategy=class com.linecorp.armeria.client.endpoint.WeightedRoundRobinStrategy, initialized=true, initialSelectionTimeoutMillis=15000, selectionTimeoutMillis=3200, contextGroupChain=[HealthCheckContextGroup{contexts={Endpoint{127.0.0.1:46843, weight=1000}=DefaultHealthCheckerContext{originalEndpoint=Endpoint{127.0.0.1:46843, weight=1000}, endpoint=Endpoint{127.0.0.1:46843, weight=1000}, initializationStarted=true, initialized=true, destroyed=false, refCnt=1}}, candidates=[Endpoint{127.0.0.1:46843, weight=1000}], initialized=true}]}
    at app//com.linecorp.armeria.client.endpoint.EndpointSelectionTimeoutException.get(EndpointSelectionTimeoutException.java:48)
    at app//com.linecorp.armeria.client.endpoint.AbstractEndpointSelector.lambda$select$0(AbstractEndpointSelector.java:105)
```

If a `ListeningFuture` is added to `pendingFutures` after an `EndpointGroup` update event is delivered, `listeningFuture` may not be completed within a selection timeout.

Modifications:

- Check if an `EndpointGroup` completes after adding `ListeningFuture` to `pendingFutures`.

Result:

You no longer see `EndpointSelectionTimeoutException` when selecting an `Endpoint` from an `EndpointGroup`.