### PR TITLE
Fix a bug where an idle connection could not be reused and a new connection is created

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/client/EventLoopStateBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/client/EventLoopStateBenchmark.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -51,7 +52,8 @@ public class EventLoopStateBenchmark {
 
         eventLoopGroup = EventLoopGroups.newEventLoopGroup(maxNumEventLoops);
         final DefaultEventLoopScheduler scheduler = new DefaultEventLoopScheduler(
-                eventLoopGroup, maxNumEventLoops, maxNumEventLoops, ImmutableList.of());
+                eventLoopGroup, maxNumEventLoops, maxNumEventLoops, ImmutableList.of(),
+                Duration.ofMinutes(1).toMillis());
         final List<EventLoop> eventLoops = Streams.stream(eventLoopGroup)
                                                   .map(EventLoop.class::cast)
                                                   .collect(toImmutableList());

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -72,7 +72,8 @@ public final class ClientFactoryOptions
     public static final ClientFactoryOption<Function<? super EventLoopGroup, ? extends EventLoopScheduler>>
             EVENT_LOOP_SCHEDULER_FACTORY = ClientFactoryOption.define(
             "EVENT_LOOP_SCHEDULER_FACTORY",
-            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of()));
+            eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of(),
+                                                            Flags.defaultClientIdleTimeoutMillis()));
 
     /**
      * The {@link Consumer} which can arbitrarily configure the {@link SslContextBuilder} that will be

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
@@ -256,8 +256,9 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
     }
 
     /**
-     * Cleans up empty entries with no activity for more than 1 minute. For reduced overhead, we perform this
-     * only when 1) the last clean-up was more than 1 minute ago and 2) the number of acquisitions % 256 is 0.
+     * Cleans up empty entries with no activity for more than {@code cleanupIntervalNanos}. For reduced
+     * overhead, we perform this only when 1) the last clean-up was more than {@code cleanupIntervalNanos} ago
+     * and 2) the number of acquisitions % 256 is 0.
      */
     private void cleanup() {
         if ((++cleanupCounter & 0xFF) != 0) { // (++counter % 256) != 0

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryOptionsTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -98,7 +99,8 @@ class ClientFactoryOptionsTest {
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             final Function<? super EventLoopGroup, ? extends EventLoopScheduler> schedulerFactory =
-                    eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of());
+                    eventLoopGroup -> new DefaultEventLoopScheduler(eventLoopGroup, 0, 0, ImmutableList.of(),
+                                                                    Duration.ofMinutes(1).toMillis());
             final Function<? super EventLoopGroup,
                     ? extends AddressResolverGroup<? extends InetSocketAddress>> addressResolverGroupFactory =
                     eventLoopGroup -> new DnsResolverGroupBuilder().build(eventLoopGroup);

--- a/core/src/test/java/com/linecorp/armeria/client/DefaultEventLoopSchedulerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultEventLoopSchedulerTest.java
@@ -319,8 +319,8 @@ class DefaultEventLoopSchedulerTest {
 
     @Test
     void cleanUpInactiveEndpointsAfterIdleTimeout() throws InterruptedException {
-        Endpoint endpointA = Endpoint.of("a.com");
-        Endpoint endpointB = Endpoint.of("b.com");
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
         final EventLoopGroup group = new DefaultEventLoopGroup(1024);
         final DefaultEventLoopScheduler s = new DefaultEventLoopScheduler(
                 group, 1, GROUP_SIZE,

--- a/core/src/test/java/com/linecorp/armeria/client/MaxNumEventLoopsPerEndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/MaxNumEventLoopsPerEndpointTest.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.client.DefaultEventLoopSchedulerTest.acquireEntry;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -51,7 +52,8 @@ class MaxNumEventLoopsPerEndpointTest {
     @Test
     void defaultMaxNumEventLoopsEqualsOne() {
         final EventLoopGroup group = new DefaultEventLoopGroup(7);
-        final DefaultEventLoopScheduler s = new DefaultEventLoopScheduler(group, 0, 0, ImmutableList.of());
+        final DefaultEventLoopScheduler s = new DefaultEventLoopScheduler(group, 0, 0, ImmutableList.of(),
+                                                                          Duration.ofMinutes(1).toMillis());
         final AbstractEventLoopEntry[] entries1 = s.entries(SessionProtocol.H1C, endpointA, endpointA);
         assertThat(removeNullOrInactiveElements(entries1)).hasSize(1);
     }
@@ -84,7 +86,7 @@ class MaxNumEventLoopsPerEndpointTest {
             } else {
                 return -1;
             }
-        }));
+        }), Duration.ofMinutes(1).toMillis());
         checkMaxNumEventLoops(s, endpointA, endpointB);
     }
 
@@ -148,7 +150,8 @@ class MaxNumEventLoopsPerEndpointTest {
                     return -1;
                 });
         final DefaultEventLoopScheduler s = new DefaultEventLoopScheduler(group, 7, 7,
-                                                                          maxNumEventLoopsFunctions);
+                                                                          maxNumEventLoopsFunctions,
+                                                                          Duration.ofMinutes(1).toMillis());
         final AbstractEventLoopEntry[] entries1 = s.entries(SessionProtocol.H1C, endpointA, endpointA);
         assertThat(removeNullOrInactiveElements(entries1)).hasSize(0);
         acquireTenEntries(s, SessionProtocol.H1C, endpointA, endpointA);
@@ -281,7 +284,8 @@ class MaxNumEventLoopsPerEndpointTest {
         final EventLoopGroup group = new DefaultEventLoopGroup(7);
         final DefaultEventLoopScheduler s = new DefaultEventLoopScheduler(group, maxNumEventLoops,
                                                                           maxNumEventLoops,
-                                                                          maxNumEventLoopsFunctions);
+                                                                          maxNumEventLoopsFunctions,
+                                                                          Duration.ofMinutes(1).toMillis());
 
         // endpointA
 


### PR DESCRIPTION
Motivation:

For HTTP/2, we expect only as many connections as
`ClientFactoryBuilder.maxNumEventLoopsPerEndpoint()` to be created and reused. This is working as expected when the connection is actively used.

`DefaultEventLoopScheduler` removes `EndpointLoopState`s that are inactive for 1 minute. A different event loop may be assigned for new requests.

Because of this, active connections (idle timeout > 1 minute) allocated to the old EventLoop` cannot be reused and a new connection is created instead.

Modifications:

- Set an idle timeout + 5 seconds as the cleanup interval of `DefaultEventLoopScheduler`

Result:

HTTP/2 clients no longer allocate more `EventLoop`s than `ClientFactoryBuilder.maxNumEventLoopsPerEndpoint()`.

