### PR TITLE
Add metrics for active connections on the client side

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
@@ -70,6 +70,10 @@ public interface ConnectionPoolListener extends Unwrappable {
      *   <td>{@code armeria.client.connections#count{state="closed"}}</td>
      *   <td>The number of closed connections.</td>
      * </tr>
+     * <tr>
+     *   <td>{@code armeria.client.connections#value{state="active"}}</td>
+     *   <td>The number of active connections.</td>
+     * </tr>
      * </table>
      */
     @UnstableApi
@@ -96,6 +100,10 @@ public interface ConnectionPoolListener extends Unwrappable {
      *   <td>The number of closed connections.</td>
      * </tr>
      * </table>
+     * <tr>
+     *   <td>{@code #value{state="active"}}</td>
+     *   <td>The number of active connections.</td>
+     * </tr>
      */
     @UnstableApi
     static ConnectionPoolListener metricCollecting(MeterRegistry registry, MeterIdPrefix meterIdPrefix) {

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
@@ -100,7 +100,7 @@ public interface ConnectionPoolListener extends Unwrappable {
      *   <td>The number of closed connections.</td>
      * </tr>
      * <tr>
-     *   <td>{@code #value{state="active"}}</td>
+     *   <td>{@code <name>#value{state="active"}}</td>
      *   <td>The number of active connections.</td>
      * </tr>
      * </table>

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolListener.java
@@ -99,11 +99,11 @@ public interface ConnectionPoolListener extends Unwrappable {
      *   <td>{@code <name>#count{state="closed"}}</td>
      *   <td>The number of closed connections.</td>
      * </tr>
-     * </table>
      * <tr>
      *   <td>{@code #value{state="active"}}</td>
      *   <td>The number of active connections.</td>
      * </tr>
+     * </table>
      */
     @UnstableApi
     static ConnectionPoolListener metricCollecting(MeterRegistry registry, MeterIdPrefix meterIdPrefix) {

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
@@ -15,50 +15,81 @@
  */
 package com.linecorp.armeria.client;
 
-import static java.util.Objects.requireNonNull;
-
 import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 
 final class ConnectionPoolMetrics {
     private static final String PROTOCOL = "protocol";
     private static final String REMOTE_IP = "remote.ip";
     private static final String LOCAL_IP = "local.ip";
     private static final String STATE = "state";
+
     private final MeterRegistry meterRegistry;
     private final MeterIdPrefix idPrefix;
+    private final Map<List<Tag>, Integer> activeConnections = new ConcurrentHashMap<>();
 
     /**
      * Creates a new instance with the specified {@link Meter} name.
      */
     ConnectionPoolMetrics(MeterRegistry meterRegistry, MeterIdPrefix idPrefix) {
-        this.idPrefix = requireNonNull(idPrefix, "idPrefix");
-        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
+        this.idPrefix = idPrefix;
+        this.meterRegistry = meterRegistry;
     }
 
     void increaseConnOpened(SessionProtocol protocol, InetSocketAddress remoteAddr,
                             InetSocketAddress localAddr) {
-        meterRegistry.counter(idPrefix.name(),
-                              idPrefix.tags(PROTOCOL, protocol.name(),
-                                            REMOTE_IP, remoteAddr.getAddress().getHostAddress(),
-                                            LOCAL_IP, localAddr.getAddress().getHostAddress(),
-                                            STATE, "opened"))
-                     .increment();
+        final List<Tag> commonTags = commonTags(protocol, remoteAddr, localAddr);
+        Counter.builder(idPrefix.name())
+               .tags(commonTags)
+               .tag(STATE, "opened")
+               .register(meterRegistry)
+               .increment();
+
+        final int numConnections = activeConnections.compute(commonTags, (k, v) -> v == null ? 1 : v + 1);
+        if (numConnections == 1) {
+            Gauge.builder(idPrefix.name(),
+                          activeConnections,
+                          activeConnections -> activeConnections.getOrDefault(commonTags, 0))
+                 .tags(commonTags)
+                 .tag(STATE, "active")
+                 .register(meterRegistry);
+        }
+    }
+
+    @Nonnull
+    private List<Tag> commonTags(SessionProtocol protocol, InetSocketAddress remoteAddr,
+                                 InetSocketAddress localAddr) {
+        return idPrefix.tags(PROTOCOL, protocol.name(),
+                             REMOTE_IP, remoteAddr.getAddress().getHostAddress(),
+                             LOCAL_IP, localAddr.getAddress().getHostAddress());
     }
 
     void increaseConnClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
                             InetSocketAddress localAddr) {
-        meterRegistry.counter(idPrefix.name(),
-                              idPrefix.tags(
-                                      PROTOCOL, protocol.name(),
-                                      REMOTE_IP, remoteAddr.getAddress().getHostAddress(),
-                                      LOCAL_IP, localAddr.getAddress().getHostAddress(),
-                                      STATE, "closed"))
-                     .increment();
+        final List<Tag> commonTags = commonTags(protocol, remoteAddr, localAddr);
+        Counter.builder(idPrefix.name())
+               .tags(commonTags)
+               .tag(STATE, "closed")
+               .register(meterRegistry)
+               .increment();
+
+        activeConnections.computeIfPresent(commonTags, (k, v) -> v - 1);
+        if (activeConnections.getOrDefault(commonTags, 0) <= 0) {
+            // Remove the gauge to be garbage collected.
+            activeConnections.remove(commonTags);
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
@@ -81,7 +81,7 @@ final class ConnectionPoolMetrics {
             final Meters meters = metersMap.get(commonTags);
             if (meters != null) {
                 meters.decrement();
-                assert meters.activeConnections() >= 0 : "active connections should not be negative" + meters;
+                assert meters.activeConnections() >= 0 : "active connections should not be negative. " + meters;
                 if (meters.activeConnections() == 0) {
                     // XXX(ikhoon): Should we consider to remove the gauge lazily so that collectors can get the
                     //              value.

--- a/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ConnectionPoolMetrics.java
@@ -16,14 +16,15 @@
 package com.linecorp.armeria.client;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nonnull;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
@@ -39,7 +40,9 @@ final class ConnectionPoolMetrics {
 
     private final MeterRegistry meterRegistry;
     private final MeterIdPrefix idPrefix;
-    private final Map<List<Tag>, IntHolder> activeConnections = new ConcurrentHashMap<>();
+    @GuardedBy("lock")
+    private final Map<List<Tag>, Meters> metersMap = new HashMap<>();
+    private final ReentrantShortLock lock = new ReentrantShortLock();
 
     /**
      * Creates a new instance with the specified {@link Meter} name.
@@ -52,24 +55,16 @@ final class ConnectionPoolMetrics {
     void increaseConnOpened(SessionProtocol protocol, InetSocketAddress remoteAddr,
                             InetSocketAddress localAddr) {
         final List<Tag> commonTags = commonTags(protocol, remoteAddr, localAddr);
-        Counter.builder(idPrefix.name())
-               .tags(commonTags)
-               .tag(STATE, "opened")
-               .register(meterRegistry)
-               .increment();
-
-        final IntHolder numConnections = activeConnections.compute(commonTags, (k, v) -> {
-            return v == null ? new IntHolder(1) : v.increment();
-        });
-        if (numConnections.value == 1) {
-            Gauge.builder(idPrefix.name(), numConnections, self -> self.value)
-                 .tags(commonTags)
-                 .tag(STATE, "active")
-                 .register(meterRegistry);
+        lock.lock();
+        try {
+            final Meters meters = metersMap.computeIfAbsent(commonTags,
+                                                            key -> new Meters(idPrefix, key, meterRegistry));
+            meters.increment();
+        } finally {
+            lock.unlock();
         }
     }
 
-    @Nonnull
     private List<Tag> commonTags(SessionProtocol protocol, InetSocketAddress remoteAddr,
                                  InetSocketAddress localAddr) {
         return idPrefix.tags(PROTOCOL, protocol.name(),
@@ -79,38 +74,70 @@ final class ConnectionPoolMetrics {
 
     void increaseConnClosed(SessionProtocol protocol, InetSocketAddress remoteAddr,
                             InetSocketAddress localAddr) {
-        final List<Tag> commonTags = commonTags(protocol, remoteAddr, localAddr);
-        Counter.builder(idPrefix.name())
-               .tags(commonTags)
-               .tag(STATE, "closed")
-               .register(meterRegistry)
-               .increment();
 
-        final IntHolder numConnections = activeConnections.computeIfPresent(commonTags,
-                                                                            (k, v) -> v.decrement());
-        if (numConnections != null && numConnections.value <= 0) {
-            // Remove the gauge to be garbage collected.
-            activeConnections.remove(commonTags);
+        final List<Tag> commonTags = commonTags(protocol, remoteAddr, localAddr);
+        lock.lock();
+        try {
+            final Meters meters = metersMap.get(commonTags);
+            if (meters != null) {
+                meters.decrement();
+                assert meters.activeConnections() >= 0 : "active connections should not be negative" + meters;
+                if (meters.activeConnections() == 0) {
+                    // XXX(ikhoon): Should we consider to remove the gauge lazily so that collectors can get the
+                    //              value.
+                    // Remove gauges to be garbage collected because the cardinality of remoteAddr could be
+                    // high.
+                    metersMap.remove(commonTags);
+                    meters.remove(meterRegistry);
+                }
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
-    private static class IntHolder {
+    private static final class Meters {
 
-        int value;
+        private final Counter opened;
+        private final Counter closed;
+        private final Gauge active;
+        private int activeConnections;
 
-        IntHolder(int value) {
-            this.value = value;
+        Meters(MeterIdPrefix idPrefix, List<Tag> commonTags, MeterRegistry registry) {
+            opened = Counter.builder(idPrefix.name())
+                            .tags(commonTags)
+                            .tag(STATE, "opened")
+                            .register(registry);
+            closed = Counter.builder(idPrefix.name())
+                            .tags(commonTags)
+                            .tag(STATE, "closed")
+                            .register(registry);
+            active = Gauge.builder(idPrefix.name(), this, Meters::activeConnections)
+                          .tags(commonTags)
+                          .tag(STATE, "active")
+                          .register(registry);
         }
 
-        IntHolder increment() {
-            value++;
+        Meters increment() {
+            activeConnections++;
+            opened.increment();
             return this;
         }
 
-        IntHolder decrement() {
-            value--;
+        Meters decrement() {
+            activeConnections--;
+            closed.increment();
             return this;
         }
 
+        int activeConnections() {
+            return activeConnections;
+        }
+
+        void remove(MeterRegistry registry) {
+            registry.remove(opened);
+            registry.remove(closed);
+            registry.remove(active);
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -475,7 +475,7 @@ final class HttpChannelPool implements AsyncCloseable {
                         : "raddr: " + remoteAddr + ", laddr: " + localAddr;
                 try {
                     listener.connectionOpen(protocol, remoteAddr, localAddr, channel);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     if (logger.isWarnEnabled()) {
                         logger.warn("{} Exception handling {}.connectionOpen()",
                                     channel, listener.getClass().getName(), e);
@@ -515,7 +515,7 @@ final class HttpChannelPool implements AsyncCloseable {
 
                     try {
                         listener.connectionClosed(protocol, remoteAddr, localAddr, channel);
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         if (logger.isWarnEnabled()) {
                             logger.warn("{} Exception handling {}.connectionClosed()",
                                         channel, listener.getClass().getName(), e);

--- a/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolCollectingMetricTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolCollectingMetricTest.java
@@ -49,38 +49,51 @@ class ConnectionPoolCollectingMetricTest {
                                        "protocol=H1,remote.ip=10.10.10.10,state=opened}";
         final String closedABMetricKey = "armeria.client.connections#count{local.ip=10.10.10.11," +
                                          "protocol=H1,remote.ip=10.10.10.10,state=closed}";
+        final String activeABMetricKey = "armeria.client.connections#value{local.ip=10.10.10.11," +
+                                         "protocol=H1,remote.ip=10.10.10.10,state=active}";
         final String openBAMetricKey = "armeria.client.connections#count{local.ip=10.10.10.10," +
                                        "protocol=H1,remote.ip=10.10.10.11,state=opened}";
         final String closedBAMetricKey = "armeria.client.connections#count{local.ip=10.10.10.10," +
                                          "protocol=H1,remote.ip=10.10.10.11,state=closed}";
+        final String activeBAMetricKey = "armeria.client.connections#value{local.ip=10.10.10.10," +
+                                         "protocol=H1,remote.ip=10.10.10.11,state=active}";
 
         final AttributeMap attributeMap = new DefaultAttributeMap();
 
         connectionPoolListener.connectionOpen(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry)).containsEntry(openABMetricKey, 1.0);
+        assertThat(MoreMeters.measureAll(registry)).containsEntry(activeABMetricKey, 1.0);
 
         connectionPoolListener.connectionClosed(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 1.0)
-                .containsEntry(closedABMetricKey, 1.0);
-
+                .containsEntry(closedABMetricKey, 1.0)
+                .containsEntry(activeABMetricKey, 0.0);
         connectionPoolListener.connectionOpen(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
-                .containsEntry(closedABMetricKey, 1.0);
+                .containsEntry(closedABMetricKey, 1.0)
+                .containsEntry(activeABMetricKey, 1.0);
 
         connectionPoolListener.connectionOpen(SessionProtocol.H1, addressB, addressA, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
                 .containsEntry(closedABMetricKey, 1.0)
-                .containsEntry(openBAMetricKey, 1.0);
+                .containsEntry(activeABMetricKey, 1.0)
+                .containsEntry(openBAMetricKey, 1.0)
+                .containsEntry(activeBAMetricKey, 1.0);
 
         connectionPoolListener.connectionClosed(SessionProtocol.H1, addressA, addressB, attributeMap);
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry(activeABMetricKey, 0.0)
+                .containsEntry(activeBAMetricKey, 1.0);
         connectionPoolListener.connectionClosed(SessionProtocol.H1, addressB, addressA, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
                 .containsEntry(closedABMetricKey, 2.0)
+                .containsEntry(activeABMetricKey, 0.0)
                 .containsEntry(openBAMetricKey, 1.0)
-                .containsEntry(closedBAMetricKey, 1.0);
+                .containsEntry(closedBAMetricKey, 1.0)
+                .containsEntry(activeBAMetricKey, 0.0);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolCollectingMetricTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolCollectingMetricTest.java
@@ -65,35 +65,43 @@ class ConnectionPoolCollectingMetricTest {
         assertThat(MoreMeters.measureAll(registry)).containsEntry(activeABMetricKey, 1.0);
 
         connectionPoolListener.connectionClosed(SessionProtocol.H1, addressA, addressB, attributeMap);
+        // If the number of connections is 0, the metric is not collected.
+        assertThat(MoreMeters.measureAll(registry))
+                .doesNotContainKey(openABMetricKey)
+                .doesNotContainKey(closedABMetricKey)
+                .doesNotContainKey(activeABMetricKey);
+        connectionPoolListener.connectionOpen(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 1.0)
-                .containsEntry(closedABMetricKey, 1.0)
-                .containsEntry(activeABMetricKey, 0.0);
+                .containsEntry(closedABMetricKey, 0.0)
+                .containsEntry(activeABMetricKey, 1.0);
         connectionPoolListener.connectionOpen(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
-                .containsEntry(closedABMetricKey, 1.0)
-                .containsEntry(activeABMetricKey, 1.0);
+                .containsEntry(closedABMetricKey, 0.0)
+                .containsEntry(activeABMetricKey, 2.0);
 
         connectionPoolListener.connectionOpen(SessionProtocol.H1, addressB, addressA, attributeMap);
+        assertThat(MoreMeters.measureAll(registry))
+                .containsEntry(openABMetricKey, 2.0)
+                .containsEntry(closedABMetricKey, 0.0)
+                .containsEntry(activeABMetricKey, 2.0)
+                .containsEntry(openBAMetricKey, 1.0)
+                .containsEntry(activeBAMetricKey, 1.0);
+
+        connectionPoolListener.connectionClosed(SessionProtocol.H1, addressA, addressB, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
                 .containsEntry(closedABMetricKey, 1.0)
                 .containsEntry(activeABMetricKey, 1.0)
                 .containsEntry(openBAMetricKey, 1.0)
                 .containsEntry(activeBAMetricKey, 1.0);
-
-        connectionPoolListener.connectionClosed(SessionProtocol.H1, addressA, addressB, attributeMap);
-        assertThat(MoreMeters.measureAll(registry))
-                .containsEntry(activeABMetricKey, 0.0)
-                .containsEntry(activeBAMetricKey, 1.0);
         connectionPoolListener.connectionClosed(SessionProtocol.H1, addressB, addressA, attributeMap);
         assertThat(MoreMeters.measureAll(registry))
                 .containsEntry(openABMetricKey, 2.0)
-                .containsEntry(closedABMetricKey, 2.0)
-                .containsEntry(activeABMetricKey, 0.0)
-                .containsEntry(openBAMetricKey, 1.0)
-                .containsEntry(closedBAMetricKey, 1.0)
-                .containsEntry(activeBAMetricKey, 0.0);
+                .containsEntry(closedABMetricKey, 1.0)
+                .containsEntry(activeABMetricKey, 1.0)
+                .doesNotContainKey(openBAMetricKey)
+                .doesNotContainKey(activeBAMetricKey);
     }
 }


### PR DESCRIPTION
Motivation:

There are no metrics for active connections on the client side out of the box. The number has to be computed by metric queries such as PromQL by subtracting `closed` from `opened`.
Otherwise, a custom metric should be implemented by users.

Modifications:

- Record `armeria.client.connections#value{state="active"}` in `MetricCollectingConnectionPoolListener` to get the active connections for a remote peer.

Result:

- You can now monitor the number of active connections with `armeria.client.connections#value{state="active"}`
- Closes #4277

