### PR TITLE
Add production checklist about `maxNumEventLoopsPerEndpoint`

### DIFF
--- a/site/src/pages/docs/advanced-production-checklist.mdx
+++ b/site/src/pages/docs/advanced-production-checklist.mdx
@@ -96,3 +96,20 @@ See [Using CircuitBreaker with non-Armeria client](/docs/client-circuit-breaker#
   ClientBuilder cb = Clients.builder(...);
   cb.factory(cf);
   ```
+
+- Increase `maxNumEventLoopsPerEndpoint` and `maxNumEventLoopsPerHttp1Endpoint` when your clients send requests
+  to a small number of servers. As an Endpoint uses a single event loop, there may be a bottleneck.
+
+  ```java
+  import com.linecorp.armeria.client.Clients;
+  import com.linecorp.armeria.client.ClientBuilder;
+  import com.linecorp.armeria.client.ClientFactory;
+  import com.linecorp.armeria.client.ClientFactoryBuilder;
+
+  ClientFactoryBuilder cfb = new ClientFactoryBuilder();
+  cfb.maxNumEventLoopsPerEndpoint(16); // default: 1
+  cfb.maxNumEventLoopsPerHttp1Endpoint(16); // default: 1
+  ClientFactory cf = cfb.build();
+  ClientBuilder cb = Clients.builder(...);
+  cb.factory(cf);
+  ```


### PR DESCRIPTION
Motivation:

Using `maxNumEventLoopsPerEndpoint` and `maxNumEventLoopsPerHttp1Endpoint` with the default value (1) may be a bottleneck when a client sends lots of requests to a small number of servers because an `Endpoint` uses a single event loop.

Modifications:

- Add a production checklist about `maxNumEventLoopsPerEndpoint` and `maxNumEventLoopsPerHttp1Endpoint`.

Result:

- Users would recognize the bottleneck problem earlier.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
