### PR TITLE
Fix a possible deadlock when aborting `StreamMessage`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -323,6 +323,11 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
             return;
         }
 
+        if (subscription.subscriber() instanceof AbortingSubscriber) {
+            // The stream is being aborted.
+            return;
+        }
+
         if (queue.isEmpty()) {
             return;
         }


### PR DESCRIPTION
Motivation:

`DefaultStreamMessage` uses `MpscChunkedArrayQueue` to which a single consumer should be used to access. However, in a certain situation, two threads may access a queue simultaneously.

- On Thread A, `DefaultStreamMessage.abort()` is called and a `Subscriber` is assigned with an ImmediateEventExecutor. https://github.com/line/armeria/blob/2eb8e1faac28fa128fe96f9cf3a68c95f06af376/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L202
- At this point, `DefaultStreamMessage.close()` is called on Thread B and the state is changed from OPEN to CLOSE. https://github.com/line/armeria/blob/2eb8e1faac28fa128fe96f9cf3a68c95f06af376/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L438
- Thread A changes its state from CLOSE to CLEANUP. Afterwards, it accesses `MpscChunkedArrayQueue` https://github.com/line/armeria/blob/2eb8e1faac28fa128fe96f9cf3a68c95f06af376/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L225-L225
- Thread B accesses the MpscChunkedArrayQueue to notify because a `Subscriber` has been assigned already. https://github.com/line/armeria/blob/2eb8e1faac28fa128fe96f9cf3a68c95f06af376/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java#L321-L321

The access to `MpscChunkedArrayQueue` from two threads could result in a deadlock.

Modifications:

- Do not notify `Subscirber` while closing a `DefaultStreamMessage` if the subscriber is an instance of `AbortingSubscriber`

Result:

You no longer see a deadlock when a `StreamMessage` is being aborted.
