### PR TITLE
Fix NPE raised when pending futures of `AbstractEndpointSelector` is removed

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -67,6 +67,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         return endpointGroup;
     }
 
+    @SuppressWarnings("GuardedBy")
     @VisibleForTesting
     final Set<ListeningFuture> pendingFutures() {
         return pendingFutures;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.client.endpoint;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -152,13 +151,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
 
         lock.lock();
         try {
-            // Use iterator to avoid concurrent modification. `future.accept()` may remove the future.
-            for (final Iterator<ListeningFuture> it = pendingFutures.iterator(); it.hasNext();) {
-                final ListeningFuture future = it.next();
-                if (future.tryComplete()) {
-                    it.remove();
-                }
-            }
+            pendingFutures.removeIf(ListeningFuture::tryComplete);
         } finally {
             lock.unlock();
         }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
@@ -15,16 +15,19 @@
  */
 package com.linecorp.armeria.client.endpoint;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
@@ -42,44 +45,67 @@ class AbstractEndpointSelectorTest {
     void immediateSelection() {
         final Endpoint endpoint = Endpoint.of("foo");
         final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
-        assertThat(newSelector(endpoint).select(ctx, ctx.eventLoop(), Long.MAX_VALUE))
+        final AbstractEndpointSelector endpointSelector = newSelector(endpoint);
+        assertThat(endpointSelector.select(ctx, ctx.eventLoop(), Long.MAX_VALUE))
                 .isCompletedWithValue(endpoint);
+        assertThat(endpointSelector.pendingFutures()).isEmpty();
     }
 
     @Test
     void delayedSelection() {
         final DynamicEndpointGroup group = new DynamicEndpointGroup();
         final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
-        final CompletableFuture<Endpoint> future = newSelector(group).select(ctx, ctx.eventLoop(),
-                                                                             Long.MAX_VALUE);
+        final AbstractEndpointSelector endpointSelector = newSelector(group);
+        final CompletableFuture<Endpoint> future = endpointSelector.select(ctx, ctx.eventLoop(),
+                                                                           Long.MAX_VALUE);
         assertThat(future).isNotDone();
 
         final Endpoint endpoint = Endpoint.of("foo");
         group.addEndpoint(endpoint);
         assertThat(future.join()).isSameAs(endpoint);
+        assertThat(endpointSelector.pendingFutures()).isEmpty();
+    }
+
+    @Test
+    void bulkUpdate() {
+        final DynamicEndpointGroup group = new DynamicEndpointGroup();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final AbstractEndpointSelector endpointSelector = newSelector(group);
+        final List<CompletableFuture<Endpoint>> futures = IntStream.range(0, 10).mapToObj(i -> {
+            return endpointSelector.select(ctx, ctx.eventLoop(), Long.MAX_VALUE);
+        }).collect(toImmutableList());
+
+        final List<Endpoint> endpoints = ImmutableList.of(Endpoint.of("foo"));
+        group.setEndpoints(endpoints);
+        for (CompletableFuture<Endpoint> future : futures) {
+            assertThat(future.join()).isEqualTo(endpoints.get(0));
+        }
+        assertThat(endpointSelector.pendingFutures()).isEmpty();
     }
 
     @Test
     void timeout() {
         final DynamicEndpointGroup group = new DynamicEndpointGroup();
         final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final AbstractEndpointSelector endpointSelector = newSelector(group);
         final CompletableFuture<Endpoint> future =
-                newSelector(group).select(ctx, ctx.eventLoop(), 1000)
-                                  .handle((res, cause) -> {
-                                      // Must be invoked from the event loop thread.
-                                      assertThat(ctx.eventLoop().inEventLoop()).isTrue();
+                endpointSelector.select(ctx, ctx.eventLoop(), 1000)
+                                .handle((res, cause) -> {
+                                    // Must be invoked from the event loop thread.
+                                    assertThat(ctx.eventLoop().inEventLoop()).isTrue();
 
-                                      if (cause != null) {
-                                          Exceptions.throwUnsafely(cause);
-                                      }
+                                    if (cause != null) {
+                                        Exceptions.throwUnsafely(cause);
+                                    }
 
-                                      return res;
-                                  });
+                                    return res;
+                                });
         assertThat(future).isNotDone();
 
         final Stopwatch stopwatch = Stopwatch.createStarted();
         assertThat(future.join()).isNull();
         assertThat(stopwatch.elapsed(TimeUnit.MILLISECONDS)).isGreaterThan(900);
+        assertThat(endpointSelector.pendingFutures()).isEmpty();
     }
 
     @Test
@@ -90,7 +116,7 @@ class AbstractEndpointSelectorTest {
                 .hasRootCauseInstanceOf(EndpointSelectionTimeoutException.class);
     }
 
-    private static EndpointSelector newSelector(EndpointGroup endpointGroup) {
+    private static AbstractEndpointSelector newSelector(EndpointGroup endpointGroup) {
         final AbstractEndpointSelector selector = new AbstractEndpointSelector(endpointGroup) {
 
             @Nullable


### PR DESCRIPTION
Motivation:

Calling `Collection.remove(T)` while iterating a `Collection` may result in `ConcurrentModificationException` or `NullPointerException`. So `Iterator.remove()` is recommended to remove an item while iteration.

A pending future in `AbstractEndpointSelector` may be removed from `pendingFutures` with `pendingFutures.remove()` while iterating as new `Endpoint`s are updated with `ListeningFuture.accept(null)`. That is the same case as above.

```java
NullPointerException: Cannot invoke "com.linecorp.armeria.client.endpoint.AbstractEndpointSelector$ListeningFuture.accept(java.lang.Void)" because "future" is null
	at com.linecorp.armeria.client.endpoint.AbstractEndpointSelector.refreshEndpoints(AbstractEndpointSelector.java:154)
	at com.linecorp.armeria.common.util.AbstractListenable.notifyListeners(AbstractListenable.java:60)
```

Modifications:

- Refactored `ListeningFuture` not to remove itself from pending futures when an endpoint is selected.
  - `tryComplete()` reports the result of `Endpoint` selection and the future may be removed by the caller with `.removeIf()`.

Result:

You no longer see `NullPointerException` when an `Endpoint` is selected from `EndpointGroup`