### PR TITLE
Fix to send 400 from gRPC HTTP/JSON transcoding service when the request is invalid

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -646,7 +646,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         @Nullable
         final MediaType contentType = request.contentType();
         if (contentType == null || !contentType.isJson()) {
-            return null;
+            throw new IllegalArgumentException("Missing or invalid content-type in JSON request.");
         }
         try {
             return mapper.readTree(request.contentUtf8());

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -16,6 +16,29 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE;
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,14 +53,40 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.protobuf.*;
+import com.google.protobuf.Any;
+import com.google.protobuf.BoolValue;
+import com.google.protobuf.BytesValue;
 import com.google.protobuf.DescriptorProtos.MethodOptions;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
-import com.linecorp.armeria.common.*;
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Duration;
+import com.google.protobuf.FieldMask;
+import com.google.protobuf.FloatValue;
+import com.google.protobuf.Int32Value;
+import com.google.protobuf.Int64Value;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.UInt32Value;
+import com.google.protobuf.UInt64Value;
+import com.google.protobuf.Value;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
@@ -57,29 +106,13 @@ import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.PathSegmen
 import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.Stringifier;
 import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.VariablePathSegment;
 import com.linecorp.armeria.server.grpc.HttpJsonTranscodingService.PathVariable.ValueDefinition.Type;
+
 import io.grpc.MethodDescriptor.MethodType;
 import io.grpc.ServerMethodDefinition;
 import io.grpc.ServerServiceDefinition;
 import io.grpc.protobuf.ProtoMethodDescriptorSupplier;
 import io.grpc.protobuf.ProtoServiceDescriptorSupplier;
 import io.netty.util.internal.StringUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.linecorp.armeria.server.grpc.HttpJsonTranscodingQueryParamMatchRule.LOWER_CAMEL_CASE;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Converts HTTP/JSON request to gRPC request and delegates it to the {@link FramedGrpcService}.

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -610,8 +610,11 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                         final ObjectNode root;
                         if (body instanceof ObjectNode) {
                             root = (ObjectNode) body;
+                        } else if (body == null) {
+                            root = mapper.createObjectNode();
                         } else {
-                            throw new IllegalArgumentException("Expected json object.");
+                            throw new IllegalArgumentException("Unexpected JSON: " +
+                                    body + ", (expected: ObjectNode or null).");
                         }
                         return setParametersAndWriteJson(root, ctx, spec);
                     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -651,7 +651,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         try {
             return mapper.readTree(request.contentUtf8());
         } catch (JsonProcessingException e) {
-            return null;
+            throw new IllegalArgumentException("error ocurred while parsing json request", e);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -649,7 +649,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         @Nullable
         final MediaType contentType = request.contentType();
         if (contentType == null || !contentType.isJson()) {
-            if (request.contentUtf8().isEmpty()) {
+            if (request.content().isEmpty()) {
                 return null;
             }
             throw new IllegalArgumentException("Missing or invalid content-type in JSON request.");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -651,7 +651,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
         try {
             return mapper.readTree(request.contentUtf8());
         } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("error ocurred while parsing json request", e);
+            throw new IllegalArgumentException("Failed to parse JSON request.", e);
         }
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -828,6 +828,18 @@ public class HttpJsonTranscodingTest {
     }
 
     @Test
+    void shouldDenyEmptyBody() {
+        final String validJson = "";
+        final RequestHeaders headers = RequestHeaders.builder()
+                .method(HttpMethod.POST)
+                .path("/v1/echo/response_body/repeated")
+                .contentType(MediaType.JSON)
+                .build();
+        final AggregatedHttpResponse response = webClient.execute(headers, validJson).aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     void shouldAcceptResponseBodyValueStructPreservingProtoFieldNames() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}," +
                                    "\"arrayField\":[\"value1\",\"value2\"]}";

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -264,10 +264,10 @@ public class HttpJsonTranscodingTest {
 
         static EchoResponseBodyResponse getResponseBodyResponse(EchoResponseBodyRequest request) {
             return EchoResponseBodyResponse.newBuilder()
-                    .setValue(request.getValue())
-                    .addAllArrayField(request.getArrayFieldList())
-                    .setStructBody(request.getStructBody())
-                    .build();
+                                           .setValue(request.getValue())
+                                           .addAllArrayField(request.getArrayFieldList())
+                                           .setStructBody(request.getStructBody())
+                                           .build();
         }
 
         @Override
@@ -734,17 +734,17 @@ public class HttpJsonTranscodingTest {
         final QueryParamsBuilder query = QueryParams.builder();
         query.add("value", "value");
         final AggregatedHttpResponse response = webClient.get("/v1/echo/response_body/value?" +
-                query.toQueryString())
-                .aggregate().join();
+                                                              query.toQueryString())
+                                                         .aggregate().join();
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(response.contentUtf8()).isEqualTo("\"value\"");
     }
 
     @Test
     void shouldAcceptResponseBodyRepeated() throws JsonProcessingException {
-        final AggregatedHttpResponse response = webClient.get(
-                "/v1/echo/response_body/repeated?array_field=value1&array_field=value2")
-                .aggregate().join();
+        final AggregatedHttpResponse response =
+                webClient.get("/v1/echo/response_body/repeated?array_field=value1&array_field=value2")
+                         .aggregate().join();
         final JsonNode root = mapper.readTree(response.contentUtf8());
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(root.isArray()).isTrue();
@@ -754,9 +754,9 @@ public class HttpJsonTranscodingTest {
     @Test
     void shouldAcceptResponseBodyValueStruct() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}," +
-                "\"arrayField\":[\"value1\",\"value2\"]}";
+                                   "\"arrayField\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
-                "/v1/echo/response_body/struct", jsonContent);
+                                                                "/v1/echo/response_body/struct", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(root.has("structBody")).isTrue();
@@ -766,9 +766,9 @@ public class HttpJsonTranscodingTest {
     @Test
     void shouldAcceptResponseBodyValueNullValue() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\"," +
-                "\"arrayField\":[\"value1\",\"value2\"]}";
+                                   "\"arrayField\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
-                "/v1/echo/response_body/struct", jsonContent);
+                                                                "/v1/echo/response_body/struct", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(root.isEmpty()).isTrue();
@@ -777,9 +777,9 @@ public class HttpJsonTranscodingTest {
     @Test
     void shouldAcceptResponseBodyValueAnonymusField() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}" +
-                ",\"arrayField\":[\"value1\",\"value2\"]}";
+                                   ",\"arrayField\":[\"value1\",\"value2\"]}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
-                "/v1/echo/response_body/nomatch", jsonContent);
+                                                                "/v1/echo/response_body/nomatch", jsonContent);
         final JsonNode root = mapper.readTree(response.contentUtf8());
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(root).isEqualTo("{\"value\":\"value\"," +
@@ -790,8 +790,8 @@ public class HttpJsonTranscodingTest {
     @Test
     void shouldAcceptResponseBodyValueNoMatchInside() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"} }";
-        final AggregatedHttpResponse response = jsonPostRequest(webClient,
-                "/v1/echo/response_body/repeated", jsonContent);
+        final AggregatedHttpResponse response = jsonPostRequest(
+                webClient, "/v1/echo/response_body/repeated", jsonContent);
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(response.contentUtf8()).isEqualTo("null");
     }
@@ -799,8 +799,8 @@ public class HttpJsonTranscodingTest {
     @Test
     void shouldDenyMalformedJson() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}";
-        final AggregatedHttpResponse response = jsonPostRequest(webClient,
-                                                                "/v1/echo/response_body/repeated", jsonContent);
+        final AggregatedHttpResponse response =
+                jsonPostRequest(webClient, "/v1/echo/response_body/repeated", jsonContent);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
@@ -808,9 +808,9 @@ public class HttpJsonTranscodingTest {
     void shouldDenyMissingContentType() {
         final String validJson = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"} }";
         final RequestHeaders headers = RequestHeaders.builder()
-                .method(HttpMethod.POST)
-                .path("/v1/echo/response_body/repeated")
-                .build();
+                                                     .method(HttpMethod.POST)
+                                                     .path("/v1/echo/response_body/repeated")
+                                                     .build();
         final AggregatedHttpResponse response = webClient.execute(headers, validJson).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
@@ -819,10 +819,10 @@ public class HttpJsonTranscodingTest {
     void shouldDenyNonJsonContentType() {
         final String validJson = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"} }";
         final RequestHeaders headers = RequestHeaders.builder()
-                .method(HttpMethod.POST)
-                .path("/v1/echo/response_body/repeated")
-                .contentType(MediaType.CSV_UTF_8)
-                .build();
+                                                     .method(HttpMethod.POST)
+                                                     .path("/v1/echo/response_body/repeated")
+                                                     .contentType(MediaType.CSV_UTF_8)
+                                                     .build();
         final AggregatedHttpResponse response = webClient.execute(headers, validJson).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
@@ -831,10 +831,10 @@ public class HttpJsonTranscodingTest {
     void shouldDenyEmptyJson() {
         final String emptyJson = "";
         final RequestHeaders headers = RequestHeaders.builder()
-                .method(HttpMethod.POST)
-                .path("/v1/echo/response_body/repeated")
-                .contentType(MediaType.JSON)
-                .build();
+                                                     .method(HttpMethod.POST)
+                                                     .path("/v1/echo/response_body/repeated")
+                                                     .contentType(MediaType.JSON)
+                                                     .build();
         final AggregatedHttpResponse response = webClient.execute(headers, emptyJson).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
@@ -843,9 +843,9 @@ public class HttpJsonTranscodingTest {
     void shouldAcceptEmptyNonJson() {
         final String body = "";
         final RequestHeaders headers = RequestHeaders.builder()
-                .method(HttpMethod.POST)
-                .path("/v1/echo/response_body/repeated")
-                .build();
+                                                     .method(HttpMethod.POST)
+                                                     .path("/v1/echo/response_body/repeated")
+                                                     .build();
         final AggregatedHttpResponse response = webClient.execute(headers, body).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
     }
@@ -854,9 +854,9 @@ public class HttpJsonTranscodingTest {
     void shouldDenyNonObjectJson() {
         final String body = "[ 42, null ]";
         final RequestHeaders headers = RequestHeaders.builder()
-                .method(HttpMethod.POST)
-                .path("/v1/echo/response_body/repeated")
-                .build();
+                                                     .method(HttpMethod.POST)
+                                                     .path("/v1/echo/response_body/repeated")
+                                                     .build();
         final AggregatedHttpResponse response = webClient.execute(headers, body).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -828,14 +828,36 @@ public class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldDenyEmptyBody() {
-        final String validJson = "";
+    void shouldDenyEmptyJson() {
+        final String emptyJson = "";
         final RequestHeaders headers = RequestHeaders.builder()
                 .method(HttpMethod.POST)
                 .path("/v1/echo/response_body/repeated")
                 .contentType(MediaType.JSON)
                 .build();
-        final AggregatedHttpResponse response = webClient.execute(headers, validJson).aggregate().join();
+        final AggregatedHttpResponse response = webClient.execute(headers, emptyJson).aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldAcceptEmptyNonJson() {
+        final String body = "";
+        final RequestHeaders headers = RequestHeaders.builder()
+                .method(HttpMethod.POST)
+                .path("/v1/echo/response_body/repeated")
+                .build();
+        final AggregatedHttpResponse response = webClient.execute(headers, body).aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void shouldDenyNonObjectJson() {
+        final String body = "[ 42, null ]";
+        final RequestHeaders headers = RequestHeaders.builder()
+                .method(HttpMethod.POST)
+                .path("/v1/echo/response_body/repeated")
+                .build();
+        final AggregatedHttpResponse response = webClient.execute(headers, body).aggregate().join();
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -788,12 +788,11 @@ public class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldAcceptResponseBodyValueNoMatchInside() throws JsonProcessingException {
+    void shouldDenyMalformedJson() throws JsonProcessingException {
         final String jsonContent = "{\"value\":\"value\",\"structBody\":{\"structBody\":\"struct_value\"}";
         final AggregatedHttpResponse response = jsonPostRequest(webClient,
                                                                 "/v1/echo/response_body/repeated", jsonContent);
-        assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
-        assertThat(response.contentUtf8()).isEqualTo("null");
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Malformed json requests continued with an empty request instead of returning an error.

Modifications:

Throw an illegal argument exception when json processing fails instead of ignoring it. The surrounding service will translate it into a BAD_REQUEST response.

Result:

- Closes #5306 
- Requests with a malformed json body will now return a BAD_REQUEST status
