### PR TITLE
Fix a bug where `RequestLog` does not complete when `HttpResponse` is cancelled

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
@@ -51,7 +51,8 @@ public final class InternalStreamMessageUtil {
         return false;
     }
 
-    public static SubscriptionOption[] toSubscriptionOptions(boolean withPooledObjects, boolean notifyCancellation) {
+    public static SubscriptionOption[] toSubscriptionOptions(boolean withPooledObjects,
+                                                             boolean notifyCancellation) {
         if (withPooledObjects) {
             if (notifyCancellation) {
                 return CANCELLATION_AND_POOLED_OPTIONS;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/InternalStreamMessageUtil.java
@@ -51,5 +51,21 @@ public final class InternalStreamMessageUtil {
         return false;
     }
 
+    public static SubscriptionOption[] toSubscriptionOptions(boolean withPooledObjects, boolean notifyCancellation) {
+        if (withPooledObjects) {
+            if (notifyCancellation) {
+                return CANCELLATION_AND_POOLED_OPTIONS;
+            } else {
+                return POOLED_OBJECTS;
+            }
+        } else {
+            if (notifyCancellation) {
+                return CANCELLATION_OPTION;
+            } else {
+                return EMPTY_OPTIONS;
+            }
+        }
+    }
+
     private InternalStreamMessageUtil() {}
 }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +50,7 @@ class FilteredStreamMessageTest {
     @RegisterExtension
     static final EventLoopExtension eventLoopExtension = new EventLoopExtension();
 
+    @Timeout(Long.MAX_VALUE)
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void withPooledObjects(boolean filterSupportsPooledObjects, boolean subscribedWithPooledObjects,
@@ -101,7 +103,7 @@ class FilteredStreamMessageTest {
             }
         }, options);
 
-        await().untilAsserted(() -> assertThat(completed).isTrue());
+        await().forever().untilAsserted(() -> assertThat(completed).isTrue());
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/FilteredStreamMessageTest.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,7 +49,6 @@ class FilteredStreamMessageTest {
     @RegisterExtension
     static final EventLoopExtension eventLoopExtension = new EventLoopExtension();
 
-    @Timeout(Long.MAX_VALUE)
     @ParameterizedTest
     @ArgumentsSource(ParametersProvider.class)
     void withPooledObjects(boolean filterSupportsPooledObjects, boolean subscribedWithPooledObjects,
@@ -103,7 +101,7 @@ class FilteredStreamMessageTest {
             }
         }, options);
 
-        await().forever().untilAsserted(() -> assertThat(completed).isTrue());
+        await().untilAsserted(() -> assertThat(completed).isTrue());
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewerCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewerCancellationTest.java
@@ -63,9 +63,7 @@ class ContentPreviewerCancellationTest {
         @Override
         protected void configure(ServerBuilder sb) {
             final PrometheusMeterRegistry registry = PrometheusMeterRegistries.newRegistry();
-            sb.http(8080)
-              .requestTimeoutMillis(0)
-              .meterRegistry(registry)
+            sb.meterRegistry(registry)
               .decorator(
                       MetricCollectingService.newDecorator(
                               MeterIdPrefixFunction.ofDefault("armeria.server")))
@@ -85,7 +83,7 @@ class ContentPreviewerCancellationTest {
 
     @Test
     void shouldCompleteLogWithNoContentResponse() throws InterruptedException {
-        final BlockingWebClient client = server.blockingWebClient(cb -> cb.responseTimeoutMillis(0));
+        final BlockingWebClient client = server.blockingWebClient();
         final AggregatedHttpResponse response = client.get("/test");
         assertThat(response.status()).isEqualTo(HttpStatus.NO_CONTENT);
         final ServiceRequestContext ctx = server.requestContextCaptor().take();
@@ -110,7 +108,7 @@ class ContentPreviewerCancellationTest {
 
             @Override
             public void onSubscribe(Subscription s) {
-                this.subscription = s;
+                subscription = s;
                 s.request(1);
             }
 

--- a/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewerCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/ContentPreviewerCancellationTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.ContentPreviewerFactory;
+import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
+import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
+import com.linecorp.armeria.common.stream.CancelledSubscriptionException;
+import com.linecorp.armeria.common.util.Functions;
+import com.linecorp.armeria.internal.logging.ContentPreviewingUtil;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ExceptionHandler;
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.cors.CorsService;
+import com.linecorp.armeria.server.metric.MetricCollectingService;
+import com.linecorp.armeria.server.metric.PrometheusExpositionService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+class ContentPreviewerCancellationTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final PrometheusMeterRegistry registry = PrometheusMeterRegistries.newRegistry();
+            sb.http(8080)
+              .requestTimeoutMillis(0)
+              .meterRegistry(registry)
+              .decorator(
+                      MetricCollectingService.newDecorator(
+                              MeterIdPrefixFunction.ofDefault("armeria.server")))
+              .decorator(ContentPreviewingService.newDecorator(Integer.MAX_VALUE))
+              .decorator(
+                      CorsService
+                              .builderForAnyOrigin()
+                              .allowCredentials()
+                              .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
+                              .maxAge(3600)
+                              .newDecorator()
+              )
+              .annotatedService(new TestService())
+              .service("/metrics", PrometheusExpositionService.of(registry.getPrometheusRegistry()));
+        }
+    };
+
+    @Test
+    void shouldCompleteLogWithNoContentResponse() throws InterruptedException {
+        final BlockingWebClient client = server.blockingWebClient(cb -> cb.responseTimeoutMillis(0));
+        final AggregatedHttpResponse response = client.get("/test");
+        assertThat(response.status()).isEqualTo(HttpStatus.NO_CONTENT);
+        final ServiceRequestContext ctx = server.requestContextCaptor().take();
+        // Make sure the log is complete.
+        ctx.log().whenComplete().join();
+    }
+
+    @Test
+    void shouldCompleteContentPreviewerResponseWhenCancelled() {
+        final ContentPreviewerFactory previewerFactory = ContentPreviewerFactory.text(100);
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        HttpResponse response = HttpResponse.of(HttpStatus.NO_CONTENT);
+        response = response.recover(cause -> null);
+        response = response.mapHeaders(Function.identity());
+        final HttpResponse contentPreviewingResponse =
+                ContentPreviewingUtil.setUpResponseContentPreviewer(previewerFactory, ctx, response,
+                                                                    Functions.second());
+        contentPreviewingResponse.subscribe(new Subscriber<HttpObject>() {
+
+            @Nullable
+            private Subscription subscription;
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                this.subscription = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(HttpObject httpObject) {
+                assertThat(httpObject).isInstanceOf(ResponseHeaders.class);
+                subscription.cancel();
+            }
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onComplete() {}
+        }, ImmediateEventLoop.INSTANCE);
+
+        assertThatThrownBy(() -> {
+            contentPreviewingResponse.whenComplete().join();
+        }).isInstanceOf(CompletionException.class)
+          .hasCauseInstanceOf(CancelledSubscriptionException.class);
+    }
+
+    @ExceptionHandler(SomeExceptionHandler.class)
+    private static class TestService {
+        @Get("/test")
+        public void noContent() {}
+    }
+
+    private static final class SomeExceptionHandler implements ExceptionHandlerFunction {
+
+        @Override
+        public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+            return ExceptionHandlerFunction.fallthrough();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

An `HttpResponse` is cancelled if either the `ResponseHeaders` is `END_OF_STREAM` or the content is expected to be empty. https://github.com/line/armeria/blob/9ddd6c1b76fdc0fe8943dd417e80773cb92eebdc/core/src/main/java/com/linecorp/armeria/server/HttpResponseSubscriber.java#L66-L67

If `SubscriptionOption.NOTIFY_CANCELLATION` is set when subscribing, `CancellationSubscripitonException` should be propagated through `Subscriber.onError()`. However, there was a bug in `FuseableStreamMessage` where this error was not propagated. `onError()` signal is ignored if the `StreamMessage` has been canceled.
https://github.com/line/armeria/blob/756c17797f95c1ddc7afbb8038ad046c080ba605/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java#L297-L300

Apart from that, there are other problems. `CancellationSubscripitonException` may not be delivered to `Subscriber.onError()` even though `SubscriptionOption.NOTIFY_CANCELLATION` is set if a `StreamMessage` has already published all elements. `Subscription.cancel()` event will be silently ignored.
https://github.com/line/armeria/blob/871d87297e4d051241589cb1ae95641cbc83f880/core/src/main/java/com/linecorp/armeria/internal/common/stream/OneElementFixedStreamMessage.java#L92-L95

Modifications:

- Intercept using `Subscription.cancel()` in `FilteredStreamMessage` and complete `FilteredStreamMessage.whenComplete()` with `CancelledSubscriptionException` instead of relying on `NOTIFY_CANCELLATION` option.
- Fix `FuseableStreamMessage` to notify cancellation event via `Subscriber.onError()` when `NOTIFY_CANCELLATION` option is set.

Result:

Fix a bug where `RequestLog` may be not completed when an `HttpResponse` only has `ResponsesHeaders`.