### PR TITLE
Add a gradle enterprise PR tag for pull request builds

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -130,6 +130,13 @@ jobs:
           name: ${{ env.PR_NUMBER && format('{0}-', env.PR_NUMBER) || '' }}build-scan-${{ env.JOB_NAME }}
           path: ~/.gradle/build-scan-data
 
+      - name: Clean up gradle build scan
+        if: always()
+        run: |
+          rm -r ~/.gradle/build-scan-data/*
+          rm -r ~/.gradle/init.d
+        shell: bash
+
       - if: ${{ matrix.snapshot && github.ref_name == 'main' }}
         name: Publish snapshots
         run: |

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ gradleEnterprise {
             def prNumber = System.getenv("PR_NUMBER")
             if (prNumber != null) {
                 link "GitHub PR", "${githubUrl}/pull/${prNumber}"
+                tag "PR"
                 def sha = System.getenv("COMMIT_SHA")
                 if (sha != null) {
                     link "GitHub commit", "${githubUrl}/pull/${prNumber}/commits/${sha}"


### PR DESCRIPTION
Motivation:

- Added a PR tag for builds that are uploaded via the PR workflow
- It is a known issue that PR workflow also uploads not-clean gradle builds. Added an actions step to clean the gradle workflow.

Modifications:

- Added a PR tag for build scans from the PR workflow
- Added gradle build scan cleanup logic

Result:

- We can filter on PR tags

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
