### PR TITLE
Retry test failure when publishing release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   LC_ALL: "en_US.UTF-8"
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:
   publish:
@@ -28,7 +29,9 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PflakyTests=false build
+          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PflakyTests=false \
+          -Pretry=true -PfailOnPassedAfterRetry=false \
+          build
         shell: bash
 
       - name: Publish and close repository


### PR DESCRIPTION
Motivation:

It requires effort to retry the release process due to a test failure.
It may be a better idea to
1) Verify that the build is stable before triggering the release
2) Enable test retries when running the final build for release

Modifications:

- Added a token, retry flag for release build

Result:

- More stable releases

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
