### PR TITLE
[Docs] Omit "$" character when copying code 

### DIFF
--- a/site/src/components/code-block.tsx
+++ b/site/src/components/code-block.tsx
@@ -153,9 +153,8 @@ const CodeBlock: React.FC<CodeBlockProps> = (props) => {
     return null;
   }
 
-  const codeWithDollarPrefixRemoved = code.startsWith('$ ')
-    ? code.substring(2)
-    : code;
+  const codeToCopy =
+    props.language === 'bash' ? removeDollarPrefixes(code) : code;
   const applyHighlightStyle = (lineNumber: number) => {
     if (lineNumber !== 0 && targetLines.includes(`${lineNumber}`)) {
       return { style: lineHighlights };
@@ -172,10 +171,7 @@ const CodeBlock: React.FC<CodeBlockProps> = (props) => {
       {props.filename && (
         <div className={styles.filename}>{props.filename}</div>
       )}
-      <CopyToClipboard
-        text={codeWithDollarPrefixRemoved}
-        onCopy={onCopyCallback}
-      >
+      <CopyToClipboard text={codeToCopy} onCopy={onCopyCallback}>
         <Button
           className={styles.clipboardButton}
           aria-label="Copy to clipboard"
@@ -241,6 +237,13 @@ function process(code: React.ReactNode) {
   return (
     indentation !== 0 ? lines.map((line) => line.substring(indentation)) : lines
   ).join('\n');
+}
+
+function removeDollarPrefixes(code: string): string {
+  return code
+    .split('\n')
+    .map((line) => (line.startsWith('$ ') ? line.substring(2) : line))
+    .join('\n');
 }
 
 export default CodeBlock;

--- a/site/src/components/code-block.tsx
+++ b/site/src/components/code-block.tsx
@@ -152,6 +152,10 @@ const CodeBlock: React.FC<CodeBlockProps> = (props) => {
   if (code.length === 0) {
     return null;
   }
+
+  const codeWithDollarPrefixRemoved = code.startsWith('$ ')
+    ? code.substring(2)
+    : code;
   const applyHighlightStyle = (lineNumber: number) => {
     if (lineNumber !== 0 && targetLines.includes(`${lineNumber}`)) {
       return { style: lineHighlights };
@@ -168,7 +172,10 @@ const CodeBlock: React.FC<CodeBlockProps> = (props) => {
       {props.filename && (
         <div className={styles.filename}>{props.filename}</div>
       )}
-      <CopyToClipboard text={code} onCopy={onCopyCallback}>
+      <CopyToClipboard
+        text={codeWithDollarPrefixRemoved}
+        onCopy={onCopyCallback}
+      >
         <Button
           className={styles.clipboardButton}
           aria-label="Copy to clipboard"

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -449,6 +449,6 @@ By doing so, you may:
 Let us know at the [Armeria Discord](/s/discord) channel, and we'll create an account
 for you. Afterwards, you may integrate your local environment with the following command:
 
-```shell
+```bash
 ./gradlew provisionGradleEnterpriseAccessKey
 ```


### PR DESCRIPTION
Motivation:

When copying code from documentation, "$" is copied. It's painful to copy code with "$" because users will have to delete the it everytime. 

Modifications:

- Omit the "$" when it's a prefix 

Result:

- Closes #<https://github.com/line/armeria/issues/5322>. (If this resolves the issue.)
- Code is copied without "$" prefix 

![image](https://github.com/line/armeria/assets/69591622/05261596-d8d1-406e-ac6d-ef5682f72423)
