### PR TITLE
Fix a bug where all healthy endpoints are removed as `HealthCheckedEndpointGroup` is initialized

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
@@ -299,6 +300,7 @@ final class DefaultHealthCheckerContext
         return future;
     }
 
+    @VisibleForTesting
     int refCnt() {
         return refCnt;
     }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -149,13 +149,13 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
         delegate.addListener(this::setCandidates, true);
     }
 
-    private void setCandidates(List<Endpoint> candidates) {
-        final List<Endpoint> endpoints = healthCheckStrategy.select(candidates);
-        final HashMap<Endpoint, DefaultHealthCheckerContext> contexts = new HashMap<>(endpoints.size());
+    private void setCandidates(List<Endpoint> endpoints) {
+        final List<Endpoint> candidates = healthCheckStrategy.select(endpoints);
+        final HashMap<Endpoint, DefaultHealthCheckerContext> contexts = new HashMap<>(candidates.size());
 
         lock.lock();
         try {
-            for (Endpoint endpoint : endpoints) {
+            for (Endpoint endpoint : candidates) {
                 if (contexts.containsKey(endpoint)) {
                     continue;
                 }
@@ -167,7 +167,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 }
             }
 
-            final HealthCheckContextGroup contextGroup = new HealthCheckContextGroup(contexts, endpoints,
+            final HealthCheckContextGroup contextGroup = new HealthCheckContextGroup(contexts, candidates,
                                                                                      checkerFactory);
             // 'updateHealth()' that retrieves 'contextGroupChain' could be invoked while initializing
             // HealthCheckerContext. For this reason, 'contexts' should be added to 'contextGroupChain'
@@ -182,7 +182,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                     if (logger.isWarnEnabled()) {
                         logger.warn("The first health check failed for all endpoints. " +
                                     "numCandidates: {} candidates: {}",
-                                    endpoints.size(), truncate(endpoints, 10), cause);
+                                    candidates.size(), truncate(candidates, 10), cause);
                     }
                 }
                 initialized = true;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupInitializationRaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupInitializationRaceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.linecorp.armeria.client.endpoint.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import wiremock.com.google.common.collect.ImmutableList;
+
+class HealthCheckedEndpointGroupInitializationRaceTest {
+
+    private static final CompletableFuture<Void> healthy = new CompletableFuture<>();
+
+    @RegisterExtension
+    static final ServerExtension server0 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/health", (ctx, req) -> {
+                return HttpResponse.of(healthy.thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
+            });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension server1 = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/health", (ctx, req) -> {
+                return HttpResponse.of(healthy.thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
+            });
+        }
+    };
+
+    @Test
+    void shouldPreserveNewestContextGroup() throws InterruptedException {
+        final SettableEndpointGroup group = new SettableEndpointGroup();
+        group.updateEndpoints(ImmutableList.of(server0.httpEndpoint(), server0.httpEndpoint(),
+                                               server1.httpEndpoint(), server1.httpEndpoint()));
+        final HealthCheckedEndpointGroup healthGroup = HealthCheckedEndpointGroup.of(group,
+                                                                                     "/health");
+        Queue<HealthCheckContextGroup> contextGroupChain = healthGroup.contextGroupChain();
+        assertThat(contextGroupChain).hasSize(1);
+        assertThat(contextGroupChain.peek().contexts().values())
+                .allSatisfy(ctx -> assertThat(ctx.refCnt()).isOne());
+
+        group.updateEndpoints(ImmutableList.of(server0.httpEndpoint(), server0.httpEndpoint(),
+                                               server1.httpEndpoint()));
+        contextGroupChain = healthGroup.contextGroupChain();
+        assertThat(contextGroupChain).hasSize(2);
+        for (HealthCheckContextGroup checkContextGroup : contextGroupChain) {
+            assertThat(checkContextGroup.contexts().values())
+                    .allSatisfy(ctx -> assertThat(ctx.refCnt()).isEqualTo(2));
+        }
+
+        group.updateEndpoints(ImmutableList.of(server0.httpEndpoint(), server0.httpEndpoint(),
+                                               server1.httpEndpoint(), server1.httpEndpoint()));
+        contextGroupChain = healthGroup.contextGroupChain();
+        assertThat(contextGroupChain).hasSize(3);
+        for (HealthCheckContextGroup checkContextGroup : contextGroupChain) {
+            assertThat(checkContextGroup.contexts().values())
+                    .allSatisfy(ctx -> assertThat(ctx.refCnt()).isEqualTo(3));
+        }
+
+        healthy.complete(null);
+        final List<Endpoint> endpoints = healthGroup.whenReady().join();
+        assertThat(endpoints).hasSize(4);
+        assertThat(endpoints).containsExactlyInAnyOrder(server0.httpEndpoint(), server0.httpEndpoint(),
+                                                        server1.httpEndpoint(), server1.httpEndpoint());
+
+        contextGroupChain = healthGroup.contextGroupChain();
+        contextGroupChain.peek().whenInitialized().join();
+        // Should clean up the old context groups and decrease the `refCnt`s.
+        assertThat(contextGroupChain).hasSize(1);
+        assertThat(contextGroupChain.peek().contexts().values())
+                .allSatisfy(ctx -> assertThat(ctx.refCnt()).isOne());
+    }
+
+    private static final class SettableEndpointGroup extends DynamicEndpointGroup {
+        void updateEndpoints(List<Endpoint> endpoints) {
+            setEndpoints(endpoints);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

If new `Endpoint`s are updated in `HealthCheckedEndpointGroup`, `HealthCheckedEndpointGroup` creates a new `HealthCheckContextGroup`. When the new `HealthCheckContextGroup` is initialized, the old `HealthCheckContextGroup` is removed for rolling updates.

The removal logic is added as a fallback to `contextGroup.whenInitialized()`. https://github.com/line/armeria/blob/3f54be0ce4370b24977994e247fa3816fde25e29/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java#L175-L187 Since context groups are stored in the order in which they were inserted, if the callback added first is executed first, the old value will always be deleted and the latest value will be maintained.

`CompletableFuture` uses a stack structure for callbacks, so the last callback will be executed first when it completes. If all contexts see the same future completion event, the old context group could remove the new context group. For example, `D` context group removes `A` to `C` context groups, and then `C` context group removes groups until it finds itself. But there is no `C` in the context group chain. As a result, `C` removes `D`, the newest and last one.

This situation will rarely occur when:
- An `HealthCheckedEndpointGroup` is not initialized yet.
- The delegate is updated with new endpoints that have the same value as the previous endpoints, but there are duplicate endpoints. The new endpoints create a new `HealthCheckContextGroup` that shares all `HttpHealthChecker`s with the previous one.

Modifications:

- Do not try to remove the old `HealthCheckContextGroup` with a context group if it was removed before.
- Fix a bug where the reference count of `DefaultHealthCheckerContext` is incorrectly counted if there are duplicate endpoints.
- Use the endpoints selected by `HealthCheckStrategy` instead of using the original endpoints updated by the delegate.

Result:

You no longer see `EndpointSelectionTimeoutException` when `HealthCheckedEndpointGroup` is initialized with duplicate `Endpoint`s.
