### PR TITLE
Use `-deststoretype pkcs12` to remove warning

### DIFF
--- a/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
+++ b/examples/saml-service-provider/src/main/java/example/armeria/server/saml/sp/Main.java
@@ -29,10 +29,12 @@ public class Main {
      * generated with the following commands:
      * <pre>{@code
      * $ keytool -genkeypair -keystore sample.jks -storepass 'N5^X[hvG' -keyalg rsa -sigalg sha1withrsa \
-     *     -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias signing
+     *     -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias signing \
+     *     -deststoretype pkcs12
      *
      * $ keytool -genkeypair -keystore sample.jks -storepass 'N5^X[hvG' -keyalg rsa -sigalg sha1withrsa \
-     *     -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias encryption
+     *     -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias encryption \
+     *     -deststoretype pkcs12
      * }</pre>
      *
      * <p>The certificate of the SSOCircle can be imported into the keystore with the following command.
@@ -42,7 +44,7 @@ public class Main {
      * Public IDP Configuration</a> of SSOCircle.
      * <pre>{@code
      * $ keytool -importcert -keystore sample.jks -storepass 'N5^X[hvG' -file ssocircle.crt \
-     *     -alias 'https://idp.ssocircle.com'
+     *     -alias 'https://idp.ssocircle.com' -deststoretype pkcs12
      * }</pre>
      */
     private static SamlServiceProvider samlServiceProvider() throws IOException, GeneralSecurityException {

--- a/site/src/pages/docs/advanced-saml.mdx
+++ b/site/src/pages/docs/advanced-saml.mdx
@@ -37,9 +37,11 @@ may help you to get a keystore.
 ```bash
 # Generate new key pairs as alias 'signing' and 'encryption'.
 keytool -genkeypair -keystore sample.jks -storepass 'N5^X[hvG' -keyalg rsa -sigalg sha1withrsa \
-  -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias signing
+  -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias signing \
+  -deststoretype pkcs12
 keytool -genkeypair -keystore sample.jks -storepass 'N5^X[hvG' -keyalg rsa -sigalg sha1withrsa \
-  -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias encryption
+  -dname 'CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown' -alias encryption \
+  -deststoretype pkcs12
 
 # Import a certificate into the keystore as alias 'https://idp.ssocircle.com', which is the entity ID
 # of the SSOCircle. You can make 'ssocircle.crt' file with the certificate from


### PR DESCRIPTION
Motivation:

When I follow https://armeria.dev/docs/advanced-saml/#configuring-your-server-as-a-service-provider, it shows following warnings which suggest to specify `-deststoretype pkcs12`.
```
JKSキーストアは独自の形式を使用しています。"keytool -importkeystore -srckeystore a.jks -destkeystore a.jks -deststoretype pkcs12"を使用する業界標準の形式であるPKCS12に移行することをお薦めします。
```

Modifications:

- Add -deststoretype pkcs12 option to example

Result:
- Less warns at example

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
