### PR TITLE
Support gRPC exception handler for client-side

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -23,6 +23,7 @@ import static com.linecorp.armeria.client.grpc.GrpcClientOptions.DECOMPRESSOR_RE
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.EXCEPTION_HANDLER;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.INTERCEPTORS;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS;
@@ -390,7 +391,7 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
 
         final List<ClientInterceptor> clientInterceptors = interceptors.build();
         if (!clientInterceptors.isEmpty()) {
-            option(GrpcClientOptions.INTERCEPTORS.newValue(clientInterceptors));
+            option(INTERCEPTORS.newValue(clientInterceptors));
         }
         if (exceptionHandler != null) {
             option(EXCEPTION_HANDLER.newValue(exceptionHandler));

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -81,6 +81,7 @@ import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
 
 /**
  * Creates a new gRPC client that connects to the specified {@link URI} using the builder pattern.
@@ -391,6 +392,9 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
         if (!clientInterceptors.isEmpty()) {
             option(GrpcClientOptions.INTERCEPTORS.newValue(clientInterceptors));
         }
+        if (exceptionHandler != null) {
+            option(EXCEPTION_HANDLER.newValue(exceptionHandler));
+        }
 
         final Object client;
         final ClientOptions options = buildOptions();
@@ -566,8 +570,17 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
         return (GrpcClientBuilder) super.contextCustomizer(contextCustomizer);
     }
 
+    /**
+     * Sets the specified {@link GrpcExceptionHandlerFunction} that maps a {@link Throwable}
+     * to a gRPC {@link Status}.
+     */
     public GrpcClientBuilder exceptionHandler(GrpcExceptionHandlerFunction exceptionHandler) {
         requireNonNull(exceptionHandler, "exceptionHandler");
-        return option(EXCEPTION_HANDLER, exceptionHandler);
+        if (this.exceptionHandler == null) {
+            this.exceptionHandler = exceptionHandler;
+        } else {
+            this.exceptionHandler = this.exceptionHandler.orElse(exceptionHandler);
+        }
+        return this;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.CALL_CREDENTIALS;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.COMPRESSOR;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.DECOMPRESSOR_REGISTRY;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.EXCEPTION_HANDLER;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.GRPC_JSON_MARSHALLER_FACTORY;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES;
@@ -66,6 +67,7 @@ import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
 import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshallerBuilder;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
@@ -96,6 +98,8 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     @Nullable
     private String prefix;
     private Scheme scheme;
+    @Nullable
+    private GrpcExceptionHandlerFunction exceptionHandler;
 
     GrpcClientBuilder(URI uri) {
         requireNonNull(uri, "uri");
@@ -560,5 +564,10 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     public GrpcClientBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (GrpcClientBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    public GrpcClientBuilder exceptionHandler(GrpcExceptionHandlerFunction exceptionHandler) {
+        requireNonNull(exceptionHandler, "exceptionHandler");
+        return option(EXCEPTION_HANDLER, exceptionHandler);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -171,13 +171,7 @@ public final class GrpcClientOptions {
      * via request metadata.
      */
     public static final ClientOption<GrpcExceptionHandlerFunction> EXCEPTION_HANDLER =
-            ClientOption.define("EXCEPTION_HANDLER", (ctx, cause, metadata) -> null,
-                                Function.identity(),
-                                (oldValue, newValue) -> {
-                                    final GrpcExceptionHandlerFunction merged =
-                                            oldValue.value().orElse(newValue.value());
-                                    return newValue.option().newValue(merged);
-                                });
+            ClientOption.define("EXCEPTION_HANDLER", (ctx, cause, metadata) -> null);
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
 import com.linecorp.armeria.internal.client.grpc.NullCallCredentials;
 import com.linecorp.armeria.internal.client.grpc.NullGrpcClientStubFactory;
+import com.linecorp.armeria.internal.common.grpc.GrpcStatus;
 import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.CallCredentials;
@@ -45,6 +46,7 @@ import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.DecompressorRegistry;
 import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
 
 /**
  * {@link ClientOption}s to control gRPC-specific behavior.
@@ -167,11 +169,12 @@ public final class GrpcClientOptions {
             ClientOption.define("GRPC_CLIENT_CALL_CREDENTIALS", NullCallCredentials.INSTANCE);
 
     /**
-     * Sets the {@link CallCredentials} that carries credential data that will be propagated to the server
-     * via request metadata.
+     * Sets the specified {@link GrpcExceptionHandlerFunction} that maps a {@link Throwable}
+     * to a gRPC {@link Status}.
      */
     public static final ClientOption<GrpcExceptionHandlerFunction> EXCEPTION_HANDLER =
-            ClientOption.define("EXCEPTION_HANDLER", (ctx, cause, metadata) -> null);
+            ClientOption.define("EXCEPTION_HANDLER",
+                                (ctx, cause, metadata) -> GrpcStatus.fromThrowable(cause));
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.client.ClientOption;
 import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.SerializationFormat;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshallerBuilder;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
@@ -164,6 +165,19 @@ public final class GrpcClientOptions {
      */
     public static final ClientOption<CallCredentials> CALL_CREDENTIALS =
             ClientOption.define("GRPC_CLIENT_CALL_CREDENTIALS", NullCallCredentials.INSTANCE);
+
+    /**
+     * Sets the {@link CallCredentials} that carries credential data that will be propagated to the server
+     * via request metadata.
+     */
+    public static final ClientOption<GrpcExceptionHandlerFunction> EXCEPTION_HANDLER =
+            ClientOption.define("EXCEPTION_HANDLER", (ctx, cause, metadata) -> null,
+                                Function.identity(),
+                                (oldValue, newValue) -> {
+                                    final GrpcExceptionHandlerFunction merged =
+                                            oldValue.value().orElse(newValue.value());
+                                    return newValue.option().newValue(merged);
+                                });
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -179,7 +179,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 decompressorRegistry,
                 serializationFormat,
                 jsonMarshaller,
-                unsafeWrapResponseBuffers);
+                unsafeWrapResponseBuffers,
+                exceptionHandler);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcCallOptions;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.SystemInfo;
@@ -97,6 +98,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
     private final Compressor compressor;
     private final DecompressorRegistry decompressorRegistry;
     private final CallCredentials credentials0;
+    private final GrpcExceptionHandlerFunction exceptionHandler;
 
     ArmeriaChannel(ClientBuilderParams params,
                    HttpClient httpClient,
@@ -120,6 +122,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
         compressor = options.get(GrpcClientOptions.COMPRESSOR);
         decompressorRegistry = options.get(GrpcClientOptions.DECOMPRESSOR_REGISTRY);
         credentials0 = options.get(GrpcClientOptions.CALL_CREDENTIALS);
+        exceptionHandler = options.get(GrpcClientOptions.EXCEPTION_HANDLER);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageFramer;
@@ -122,6 +123,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
     private final int maxInboundMessageSizeBytes;
     private final boolean grpcWebText;
     private final Compressor compressor;
+    private final GrpcExceptionHandlerFunction exceptionHandler;
 
     private boolean endpointInitialized;
     @Nullable
@@ -155,7 +157,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             DecompressorRegistry decompressorRegistry,
             SerializationFormat serializationFormat,
             @Nullable GrpcJsonMarshaller jsonMarshaller,
-            boolean unsafeWrapResponseBuffers) {
+            boolean unsafeWrapResponseBuffers,
+            GrpcExceptionHandlerFunction exceptionHandler) {
         this.ctx = ctx;
         this.endpointGroup = endpointGroup;
         this.httpClient = httpClient;
@@ -170,6 +173,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         this.unsafeWrapResponseBuffers = unsafeWrapResponseBuffers;
         grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
         this.maxInboundMessageSizeBytes = maxInboundMessageSizeBytes;
+        this.exceptionHandler = exceptionHandler;
 
         ctx.whenInitialized().handle((unused1, unused2) -> {
             runPendingTask();

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
@@ -16,20 +16,36 @@
 
 package com.linecorp.armeria.client.grpc;
 
-import java.util.concurrent.Executors;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
-import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ClientCall.Listener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
+import testing.grpc.TestServiceGrpc;
 import testing.grpc.TestServiceGrpc.TestServiceBlockingStub;
 
 class GrpcClientExceptionHandlerTest {
@@ -38,21 +54,74 @@ class GrpcClientExceptionHandlerTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            sb.service(GrpcService.builder()
-                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
-                                  .build());
-            sb.decorator(LoggingService.newDecorator());
+            sb.service(
+                    GrpcService.builder()
+                               .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                               .build());
         }
     };
 
     @Test
-    void basicCase() {
+    void requestLengthExceeded() {
+        final GrpcExceptionHandlerFunction exceptionHandler =
+                GrpcExceptionHandlerFunction.builder()
+                                            .on(ContentTooLargeException.class, Status.FAILED_PRECONDITION)
+                                            .build();
         final TestServiceBlockingStub stub =
                 GrpcClients.builder(server.httpUri())
-                           .exceptionHandler(GrpcExceptionHandlerFunction.builder()
-                                                                         .build())
+                           .maxResponseLength(1)
+                           .exceptionHandler(exceptionHandler)
                            .build(TestServiceBlockingStub.class);
-        final SimpleResponse res = stub.unaryCall(SimpleRequest.getDefaultInstance());
-        System.out.println(res);
+        assertThatThrownBy(() -> stub.unaryCall(SimpleRequest.getDefaultInstance()))
+                .isInstanceOf(StatusRuntimeException.class)
+                .extracting(e -> ((StatusRuntimeException) e).getStatus())
+                .extracting(Status::getCode)
+                .isEqualTo(Code.FAILED_PRECONDITION);
+    }
+
+    @Test
+    void chaining() {
+        final Deque<String> stringDeque = new ConcurrentLinkedDeque<>();
+        final RuntimeException exception = new RuntimeException();
+        final TestServiceBlockingStub stub =
+                GrpcClients.builder(server.httpUri())
+                           .exceptionHandler(((ctx, cause, metadata) -> {
+                               stringDeque.add("1");
+                               return null;
+                           }))
+                           .exceptionHandler(((ctx, cause, metadata) -> {
+                               stringDeque.add("2");
+                               return null;
+                           }))
+                           .exceptionHandler(((ctx, cause, metadata) -> {
+                               if (cause == exception) {
+                                   stringDeque.add("3");
+                                   return Status.DATA_LOSS;
+                               }
+                               return null;
+                           }))
+                           .build(TestServiceBlockingStub.class);
+        final ClientCall<SimpleRequest, SimpleResponse> clientCall =
+                stub.getChannel().newCall(TestServiceGrpc.getUnaryCallMethod(), CallOptions.DEFAULT);
+
+        final AtomicReference<Status> statusRef = new AtomicReference<>();
+        clientCall.start(new Listener<SimpleResponse>() {
+            @Override
+            public void onHeaders(Metadata headers) {
+                throw exception;
+            }
+
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+                statusRef.set(status);
+            }
+        }, new Metadata());
+
+        clientCall.sendMessage(SimpleRequest.getDefaultInstance());
+        clientCall.halfClose();
+        clientCall.request(Integer.MAX_VALUE);
+        await().untilAtomic(statusRef, Matchers.notNullValue());
+        assertThat(statusRef.get().getCode()).isEqualTo(Code.DATA_LOSS);
+        assertThat(stringDeque).containsExactly("1", "2", "3");
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.grpc;
+
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
+import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import testing.grpc.Messages.SimpleRequest;
+import testing.grpc.Messages.SimpleResponse;
+import testing.grpc.TestServiceGrpc.TestServiceBlockingStub;
+
+class GrpcClientExceptionHandlerTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .build());
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    @Test
+    void basicCase() {
+        final TestServiceBlockingStub stub =
+                GrpcClients.builder(server.httpUri())
+                           .exceptionHandler(GrpcExceptionHandlerFunction.builder()
+                                                                         .build())
+                           .build(TestServiceBlockingStub.class);
+        final SimpleResponse res = stub.unaryCall(SimpleRequest.getDefaultInstance());
+        System.out.println(res);
+    }
+}


### PR DESCRIPTION
Motivation:

This PR attempts to support `GrpcExceptionHandlerFunction` for gRPC client side

Modifications:

- Add `GrpcClientBuilder.exceptionHandler` which accepts a `GrpcExceptionHandlerFunction`
- Modify all `GrpcStatus.fromThrowable(Throwable)` calls to use `GrpcStatus.fromThrowable(GrpcStatusFunction, RequestContext, Throwable, Metadata)` instead

Result:

- Closes #5347

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
