### PR TITLE
Add `SessionProtocol` property to `RoutingContext`.

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
@@ -93,7 +94,8 @@ public class RoutersBenchmark {
     @Benchmark
     public Routed<ServiceConfig> exactMatch() {
         final RoutingContext ctx = DefaultRoutingContext.of(HOST, "localhost", METHOD1_REQ_TARGET,
-                                                            METHOD1_HEADERS, RoutingStatus.OK);
+                                                            METHOD1_HEADERS, RoutingStatus.OK,
+                                                            SessionProtocol.H2C);
         final Routed<ServiceConfig> routed = ROUTER.find(ctx);
         if (routed.value() != SERVICES.get(0)) {
             throw new IllegalStateException("Routing error");
@@ -105,7 +107,7 @@ public class RoutersBenchmark {
     public Routed<ServiceConfig> exactMatch_wrapped() {
         final RoutingContext ctx = new RoutingContextWrapper(
                 DefaultRoutingContext.of(HOST, "localhost", METHOD1_REQ_TARGET,
-                                         METHOD1_HEADERS, RoutingStatus.OK));
+                                         METHOD1_HEADERS, RoutingStatus.OK, SessionProtocol.H2C));
         final Routed<ServiceConfig> routed = ROUTER.find(ctx);
         if (routed.value() != SERVICES.get(0)) {
             throw new IllegalStateException("Routing error");

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
@@ -41,8 +42,10 @@ final class DefaultRoutingContext implements RoutingContext {
      * Returns a new {@link RoutingContext} instance.
      */
     static RoutingContext of(VirtualHost virtualHost, String hostname, RequestTarget reqTarget,
-                             RequestHeaders headers, RoutingStatus routingStatus) {
-        return new DefaultRoutingContext(virtualHost, hostname, headers, reqTarget, routingStatus);
+                             RequestHeaders headers, RoutingStatus routingStatus,
+                             SessionProtocol sessionProtocol) {
+        return new DefaultRoutingContext(virtualHost, hostname, headers, reqTarget, routingStatus,
+                                         sessionProtocol);
     }
 
     private final VirtualHost virtualHost;
@@ -54,6 +57,7 @@ final class DefaultRoutingContext implements RoutingContext {
     private final MediaType contentType;
     private final List<MediaType> acceptTypes;
     private final RoutingStatus routingStatus;
+    private final SessionProtocol sessionProtocol;
     @Nullable
     private volatile QueryParams queryParams;
     @Nullable
@@ -64,12 +68,14 @@ final class DefaultRoutingContext implements RoutingContext {
     private final int hashCode;
 
     DefaultRoutingContext(VirtualHost virtualHost, String hostname, RequestHeaders headers,
-                          RequestTarget reqTarget, RoutingStatus routingStatus) {
+                          RequestTarget reqTarget, RoutingStatus routingStatus,
+                          SessionProtocol sessionProtocol) {
         this.virtualHost = requireNonNull(virtualHost, "virtualHost");
         this.hostname = requireNonNull(hostname, "hostname");
         this.headers = requireNonNull(headers, "headers");
         this.reqTarget = requireNonNull(reqTarget, "reqTarget");
         this.routingStatus = routingStatus;
+        this.sessionProtocol = sessionProtocol;
         method = headers.method();
         contentType = headers.contentType();
         acceptTypes = headers.accept();
@@ -146,6 +152,11 @@ final class DefaultRoutingContext implements RoutingContext {
     @Override
     public RoutingStatus status() {
         return routingStatus;
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return sessionProtocol;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -32,6 +32,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.AsciiString;
 
 final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler {
 
@@ -46,7 +47,7 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
     Http2ServerConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                  Http2Settings initialSettings, Channel channel, ServerConfig cfg,
                                  Timer keepAliveTimer, GracefulShutdownSupport gracefulShutdownSupport,
-                                 String scheme) {
+                                 AsciiString scheme) {
 
         super(decoder, encoder, initialSettings, newKeepAliveHandler(encoder, channel, cfg, keepAliveTimer));
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
@@ -22,6 +22,7 @@ import io.netty.channel.Channel;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.util.AsciiString;
 
 final class Http2ServerConnectionHandlerBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<Http2ServerConnectionHandler,
@@ -30,10 +31,10 @@ final class Http2ServerConnectionHandlerBuilder
     private final ServerConfig config;
     private final Timer keepAliveTimer;
     private final GracefulShutdownSupport gracefulShutdownSupport;
-    private final String scheme;
+    private final AsciiString scheme;
 
     Http2ServerConnectionHandlerBuilder(Channel ch, ServerConfig config, Timer keepAliveTimer,
-                                        GracefulShutdownSupport gracefulShutdownSupport, String scheme) {
+                                        GracefulShutdownSupport gracefulShutdownSupport, AsciiString scheme) {
         super(ch);
         this.config = config;
         this.keepAliveTimer = keepAliveTimer;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -112,8 +112,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
     private static final int MAX_CLIENT_HELLO_LENGTH = 4096; // 4KiB should be more than enough.
 
-    private static final AsciiString SCHEME_HTTP = AsciiString.cached("http");
-    private static final AsciiString SCHEME_HTTPS = AsciiString.cached("https");
+    static final AsciiString SCHEME_HTTP = AsciiString.cached("http");
+    static final AsciiString SCHEME_HTTPS = AsciiString.cached("https");
 
     private static final byte[] PROXY_V1_MAGIC_BYTES = {
             (byte) 'P', (byte) 'R', (byte) 'O', (byte) 'X', (byte) 'Y'
@@ -245,7 +245,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final Http2ConnectionEncoder encoder = encoder(connection);
         final Http2ConnectionDecoder decoder = decoder(connection, encoder);
         return new Http2ServerConnectionHandlerBuilder(pipeline.channel(), config, keepAliveTimer,
-                                                       gracefulShutdownSupport, scheme.toString())
+                                                       gracefulShutdownSupport, scheme)
                 .codec(decoder, encoder)
                 .initialSettings(http2Settings())
                 .build();

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
 import com.linecorp.armeria.common.RequestTargetForm;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.internal.common.DefaultRequestTarget;
@@ -121,6 +122,12 @@ public interface RoutingContext {
      */
     @UnstableApi
     RoutingStatus status();
+
+    /**
+     * Returns the {@link SessionProtocol} of the request.
+     */
+    @UnstableApi
+    SessionProtocol sessionProtocol();
 
     /**
      * Defers throwing an {@link HttpStatusException} until reaching the end of the service list.

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 class RoutingContextWrapper implements RoutingContext {
@@ -91,6 +92,11 @@ class RoutingContextWrapper implements RoutingContext {
     @Override
     public RoutingStatus status() {
         return delegate.status();
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return delegate.sessionProtocol();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -215,7 +215,7 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
                 localAddress().getHostString(),
                 requestTarget(),
                 req.headers(),
-                RoutingStatus.OK);
+                RoutingStatus.OK, sessionProtocol());
 
         final RoutingResult routingResult =
                 this.routingResult != null ? this.routingResult

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRouteUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRouteUtil.java
@@ -21,6 +21,7 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isCorsPreflig
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
 
 import io.netty.channel.Channel;
@@ -28,6 +29,7 @@ import io.netty.channel.Channel;
 final class ServiceRouteUtil {
 
     static RoutingContext newRoutingContext(ServerConfig serverConfig, Channel channel,
+                                            SessionProtocol sessionProtocol,
                                             RequestHeaders headers, RequestTarget reqTarget) {
 
         final String hostname = hostname(headers);
@@ -48,7 +50,7 @@ final class ServiceRouteUtil {
         }
 
         return DefaultRoutingContext.of(serverConfig.findVirtualHost(hostname, port),
-                                        hostname, reqTarget, headers, routingStatus);
+                                        hostname, reqTarget, headers, routingStatus, sessionProtocol);
     }
 
     private static String hostname(RequestHeaders headers) {

--- a/core/src/test/java/com/linecorp/armeria/server/CachingRoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/CachingRoutingContextTest.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.RouteCache.CachingRoutingContext;
 
 class CachingRoutingContextTest {
@@ -46,7 +47,7 @@ class CachingRoutingContextTest {
                         virtualHost, virtualHost.defaultHostname(),
                         reqTarget,
                         RequestHeaders.of(HttpMethod.GET, reqTarget.pathAndQuery()),
-                        RoutingStatus.OK)) {
+                        RoutingStatus.OK, SessionProtocol.H2C)) {
                     @Override
                     public boolean requiresMatchingParamsPredicates() {
                         return true;
@@ -78,7 +79,7 @@ class CachingRoutingContextTest {
                         reqTarget,
                         RequestHeaders.of(HttpMethod.GET, reqTarget.pathAndQuery(),
                                           "foo", "qux"),
-                        RoutingStatus.OK)) {
+                        RoutingStatus.OK, SessionProtocol.H2C)) {
                     @Override
                     public boolean requiresMatchingHeadersPredicates() {
                         return true;

--- a/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouteTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 
 class RouteTest {
 
@@ -459,21 +460,22 @@ class RouteTest {
 
     private static RoutingContext withMethod(HttpMethod method) {
         return DefaultRoutingContext.of(virtualHost(), "example.com",
-                                        REQ_TARGET, RequestHeaders.of(method, PATH), RoutingStatus.OK);
+                                        REQ_TARGET, RequestHeaders.of(method, PATH), RoutingStatus.OK,
+                                        SessionProtocol.H2C);
     }
 
     private static RoutingContext withConsumeType(HttpMethod method, MediaType contentType) {
         final RequestHeaders headers = RequestHeaders.of(method, PATH,
                                                          HttpHeaderNames.CONTENT_TYPE, contentType);
         return DefaultRoutingContext.of(virtualHost(), "example.com",
-                                        REQ_TARGET, headers, RoutingStatus.OK);
+                                        REQ_TARGET, headers, RoutingStatus.OK, SessionProtocol.H2C);
     }
 
     private static RoutingContext withAcceptHeader(HttpMethod method, String acceptHeader) {
         final RequestHeaders headers = RequestHeaders.of(method, PATH,
                                                          HttpHeaderNames.ACCEPT, acceptHeader);
         return DefaultRoutingContext.of(virtualHost(), "example.com",
-                                        REQ_TARGET, headers, RoutingStatus.OK);
+                                        REQ_TARGET, headers, RoutingStatus.OK, SessionProtocol.H2C);
     }
 
     private static RoutingContext withPath(String path) {
@@ -482,13 +484,13 @@ class RouteTest {
 
         return DefaultRoutingContext.of(virtualHost(), "example.com",
                                         reqTarget, RequestHeaders.of(HttpMethod.GET, path),
-                                        RoutingStatus.OK);
+                                        RoutingStatus.OK, SessionProtocol.H2C);
     }
 
     private static RoutingContext withRequestHeaders(RequestHeaders headers) {
         final RequestTarget reqTarget = RequestTarget.forServer(headers.path());
         assertThat(reqTarget).isNotNull();
         return DefaultRoutingContext.of(virtualHost(), "example.com",
-                                        reqTarget, headers, RoutingStatus.OK);
+                                        reqTarget, headers, RoutingStatus.OK, SessionProtocol.H2C);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RouterTest.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 
 class RouterTest {
     private static final Logger logger = LoggerFactory.getLogger(RouterTest.class);
@@ -119,7 +120,7 @@ class RouterTest {
     private static DefaultRoutingContext routingCtx(String path) {
         return new DefaultRoutingContext(virtualHost(), "example.com",
                                          RequestHeaders.of(HttpMethod.GET, path),
-                                         RequestTarget.forServer(path), RoutingStatus.OK);
+                                         RequestTarget.forServer(path), RoutingStatus.OK, SessionProtocol.H2C);
     }
 
     static Stream<Arguments> generateRouteMatchData() {

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextSessionProtocolTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextSessionProtocolTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.testing.server.ServiceRequestContextCaptor;
+
+class RoutingContextSessionProtocolTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = { "H1C", "H1", "H2C", "H2" })
+    void routingContextSessionProtocol(SessionProtocol sessionProtocol) throws InterruptedException {
+        final BlockingWebClient blockingClient = WebClient.builder(server.uri(sessionProtocol))
+                                                          .factory(ClientFactory.insecure())
+                                                          .build()
+                                                          .blocking();
+        assertSessionProtocol(blockingClient, sessionProtocol);
+    }
+
+    @Test
+    void upgradeRequest() throws InterruptedException {
+        final BlockingWebClient blockingClient =
+                WebClient.builder(server.httpUri())
+                         .factory(ClientFactory.builder().useHttp2Preface(false).build())
+                         .build()
+                         .blocking();
+        assertSessionProtocol(blockingClient, SessionProtocol.H2C);
+    }
+
+    private static void assertSessionProtocol(
+            BlockingWebClient blockingClient, SessionProtocol sessionProtocol) throws InterruptedException {
+        assertThat(blockingClient.get("/").status()).isSameAs(HttpStatus.OK);
+        final ServiceRequestContextCaptor captor = server.requestContextCaptor();
+        assertThat(captor.poll().routingContext().sessionProtocol()).isSameAs(sessionProtocol);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RoutingContextTest.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 class RoutingContextTest {
@@ -61,7 +62,7 @@ class RoutingContextTest {
                                                             HttpHeaderNames.ACCEPT,
                                                             MediaType.JSON_UTF_8 + ", " +
                                                             MediaType.XML_UTF_8 + "; q=0.8"),
-                                          reqTarget, RoutingStatus.OK);
+                                          reqTarget, RoutingStatus.OK, SessionProtocol.H2C);
         final RoutingContext ctx2 =
                 new DefaultRoutingContext(virtualHost, "example.com",
                                           RequestHeaders.of(HttpMethod.GET, "/hello",
@@ -69,7 +70,7 @@ class RoutingContextTest {
                                                             HttpHeaderNames.ACCEPT,
                                                             MediaType.JSON_UTF_8 + ", " +
                                                             MediaType.XML_UTF_8 + "; q=0.8"),
-                                          reqTarget, RoutingStatus.OK);
+                                          reqTarget, RoutingStatus.OK, SessionProtocol.H2C);
         final RoutingContext ctx3 =
                 new DefaultRoutingContext(virtualHost, "example.com",
                                           RequestHeaders.of(HttpMethod.GET, "/hello",
@@ -77,7 +78,7 @@ class RoutingContextTest {
                                                             HttpHeaderNames.ACCEPT,
                                                             MediaType.XML_UTF_8 + ", " +
                                                             MediaType.JSON_UTF_8 + "; q=0.8"),
-                                          reqTarget, RoutingStatus.OK);
+                                          reqTarget, RoutingStatus.OK, SessionProtocol.H2C);
 
         assertThat(ctx1.hashCode()).isEqualTo(ctx2.hashCode());
         assertThat(ctx1).isEqualTo(ctx2);
@@ -106,7 +107,7 @@ class RoutingContextTest {
                                                             HttpHeaderNames.ACCEPT,
                                                             MediaType.JSON_UTF_8 + ", " +
                                                             MediaType.XML_UTF_8 + "; q=0.8"),
-                                          reqTarget, RoutingStatus.OK);
+                                          reqTarget, RoutingStatus.OK, SessionProtocol.H2C);
         final RoutingContext ctx2 =
                 new DefaultRoutingContext(virtualHost, "example.com",
                                           RequestHeaders.of(HttpMethod.POST, "/hello",
@@ -114,7 +115,7 @@ class RoutingContextTest {
                                                             HttpHeaderNames.ACCEPT,
                                                             MediaType.JSON_UTF_8 + ", " +
                                                             MediaType.XML_UTF_8 + "; q=0.8"),
-                                          reqTarget, RoutingStatus.OK);
+                                          reqTarget, RoutingStatus.OK, SessionProtocol.H2C);
         final RoutingContext ctx3 = ctx1.withMethod(HttpMethod.POST);
         assertThat(ctx1.hashCode()).isNotEqualTo(ctx3.hashCode());
         assertThat(ctx2.hashCode()).isEqualTo(ctx3.hashCode());
@@ -135,7 +136,7 @@ class RoutingContextTest {
         assertThat(reqTarget).isNotNull();
 
         return DefaultRoutingContext.of(virtualHost, "example.com",
-                                        reqTarget, headers, RoutingStatus.OK);
+                                        reqTarget, headers, RoutingStatus.OK, SessionProtocol.H2C);
     }
 
     static VirtualHost virtualHost() {

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRouteUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRouteUtilTest.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 
 import io.netty.channel.Channel;
 
@@ -39,7 +40,7 @@ class ServiceRouteUtilTest {
                                                      .authority("foo.com")
                                                      .build();
         final RoutingContext routingContext = ServiceRouteUtil.newRoutingContext(
-                config, channel, headers, RequestTarget.forServer(headers.path()));
+                config, channel, SessionProtocol.H1C, headers, RequestTarget.forServer(headers.path()));
         assertThat(routingContext.status()).isEqualTo(RoutingStatus.OPTIONS);
     }
 
@@ -49,7 +50,7 @@ class ServiceRouteUtilTest {
                                                      .authority("foo.com")
                                                      .build();
         final RoutingContext routingContext = ServiceRouteUtil.newRoutingContext(
-                config, channel, headers, RequestTarget.forServer(headers.path()));
+                config, channel, SessionProtocol.H1C, headers, RequestTarget.forServer(headers.path()));
         assertThat(routingContext.status()).isEqualTo(RoutingStatus.OK);
     }
 
@@ -64,7 +65,7 @@ class ServiceRouteUtilTest {
                                          "X-PINGOTHER, Content-Type")
                               .build();
         final RoutingContext routingContext = ServiceRouteUtil.newRoutingContext(
-                config, channel, headers, RequestTarget.forServer(headers.path()));
+                config, channel, SessionProtocol.H1C, headers, RequestTarget.forServer(headers.path()));
         assertThat(routingContext.status()).isEqualTo(RoutingStatus.CORS_PREFLIGHT);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/VirtualHostBuilderTest.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestTarget;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.SuccessFunction;
 
 import io.netty.handler.ssl.SslContextBuilder;
@@ -331,7 +332,8 @@ class VirtualHostBuilderTest {
         assertThat(virtualHost.serviceConfigs().size()).isEqualTo(2);
         final RoutingContext routingContext = new DefaultRoutingContext(virtualHost(), "example.com",
                                                                         RequestHeaders.of(HttpMethod.GET, "/"),
-                                                                        reqTarget, RoutingStatus.OK);
+                                                                        reqTarget, RoutingStatus.OK,
+                                                                        SessionProtocol.H2C);
         final Routed<ServiceConfig> serviceConfig = virtualHost.findServiceConfig(routingContext);
         final HttpResponse res = serviceConfig.value().service().serve(null, null);
         assertThat(res.aggregate().join().status().code()).isEqualTo(200);


### PR DESCRIPTION
Motivation:
`SessionProtocol` is needed for determining the exchange type in the [GraphQL over WebSocket Protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#graphql-over-websocket-protocol). https://github.com/line/armeria/pull/5280/files#diff-a47022183a66aad84e8b2d5e43fb0a07c27b5de0299c19b4cfaecd723d0a8e5eR111-R112

Modification:
- Add `SessionProtocol` property to the `RoutingContext`.

Result:
- `RoutingContext` now includes the `SessionProtocol` property, facilitating the determination of exchange types.