### PR TITLE
Provide a way to decorate `THttpService` via annotation

### DIFF
--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -39,6 +39,8 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil;
 import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil.DecoratorAndOrder;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.thrift.THttpService;
 
 /**
  * Provides the metadata of a Thrift service function.
@@ -64,6 +66,8 @@ public final class ThriftFunction {
     private final Map<Class<Throwable>, TFieldIdEnum> exceptionFields;
     private final Class<?>[] declaredExceptions;
     private final List<DecoratorAndOrder> declaredDecorators;
+    @Nullable
+    private HttpService decoratedTHttpService;
 
     ThriftFunction(Class<?> serviceType, ProcessFunction<?, ?> func,
                    @Nullable Object implementation) throws Exception {
@@ -214,6 +218,23 @@ public final class ThriftFunction {
      */
     public List<DecoratorAndOrder> declaredDecorators() {
         return declaredDecorators;
+    }
+
+    /**
+     * Returns the {@link THttpService} which is decorated by {@code declaredDecorators}.
+     * If {@code declaredDecorators} is empty, this returns {@code null}.
+     */
+    @Nullable
+    public HttpService decoratedTHttpService() {
+        return decoratedTHttpService;
+    }
+
+    /**
+     * Sets the given {@link HttpService} as {@code decoratedTHttpService}.
+     */
+    public void decoratedTHttpService(HttpService decoratedTHttpService) {
+        requireNonNull(decoratedTHttpService, "decoratedTHttpService");
+        this.decoratedTHttpService = decoratedTHttpService;
     }
 
     /**

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -232,7 +232,7 @@ public final class ThriftFunction {
     /**
      * Sets the given {@link HttpService} as {@code decoratedTHttpService}.
      */
-    public void decoratedTHttpService(HttpService decoratedTHttpService) {
+    public void setDecoratedTHttpService(HttpService decoratedTHttpService) {
         requireNonNull(decoratedTHttpService, "decoratedTHttpService");
         this.decoratedTHttpService = decoratedTHttpService;
     }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -36,6 +37,8 @@ import org.apache.thrift.protocol.TMessageType;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil;
+import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil.DecoratorAndOrder;
 
 /**
  * Provides the metadata of a Thrift service function.
@@ -60,23 +63,27 @@ public final class ThriftFunction {
     private final TFieldIdEnum successField;
     private final Map<Class<Throwable>, TFieldIdEnum> exceptionFields;
     private final Class<?>[] declaredExceptions;
+    private final List<DecoratorAndOrder> declaredDecorators;
 
     ThriftFunction(Class<?> serviceType, ProcessFunction<?, ?> func,
                    @Nullable Object implementation) throws Exception {
         this(serviceType, func.getMethodName(), func, Type.SYNC,
-             getArgFields(func), getResult(func), getDeclaredExceptions(func), implementation);
+             getArgFields(func), getResult(func), getDeclaredExceptions(func),
+             getDeclaredDecorators(implementation, func.getMethodName()), implementation);
     }
 
     ThriftFunction(Class<?> serviceType, AsyncProcessFunction<?, ?, ?> func,
                    @Nullable Object implementation) throws Exception {
         this(serviceType, func.getMethodName(), func, Type.ASYNC,
-             getArgFields(func), getResult(func), getDeclaredExceptions(func), implementation);
+             getArgFields(func), getResult(func), getDeclaredExceptions(func),
+             getDeclaredDecorators(implementation, func.getMethodName()), implementation);
     }
 
     private <T extends TBase<T, F>, F extends TFieldIdEnum> ThriftFunction(
             Class<?> serviceType, String name, Object func, Type type,
             TFieldIdEnum[] argFields, @Nullable TBase<?, ?> result,
-            Class<?>[] declaredExceptions, @Nullable Object implementation) throws Exception {
+            Class<?>[] declaredExceptions, List<DecoratorAndOrder> declaredDecorators,
+            @Nullable Object implementation) throws Exception {
 
         this.func = func;
         this.type = type;
@@ -85,6 +92,7 @@ public final class ThriftFunction {
         this.argFields = argFields;
         this.result = result;
         this.declaredExceptions = declaredExceptions;
+        this.declaredDecorators = declaredDecorators;
         this.implementation = implementation;
 
         // Determine the success and exception fields of the function.
@@ -199,6 +207,13 @@ public final class ThriftFunction {
      */
     public Class<?>[] declaredExceptions() {
         return declaredExceptions;
+    }
+
+    /**
+     * Returns the decorators declared by this function.
+     */
+    public List<DecoratorAndOrder> declaredDecorators() {
+        return declaredDecorators;
     }
 
     /**
@@ -361,6 +376,22 @@ public final class ThriftFunction {
             throw new IllegalStateException(
                     "cannot determine the declared exceptions of method: " + methodName, e);
         }
+    }
+
+    private static List<DecoratorAndOrder> getDeclaredDecorators(@Nullable Object implementation,
+                                                                 String methodName) {
+        if (implementation == null) {
+            return Collections.emptyList();
+        }
+
+        final Class<?> implClass = implementation.getClass();
+        final String methodNameCamel = getCamelMethodName(methodName);
+        for (Method m : implClass.getDeclaredMethods()) {
+            if (m.getName().equals(methodName) || m.getName().equals(methodNameCamel)) {
+                return DecoratorAnnotationUtil.collectDecorators(implClass, m);
+            }
+        }
+        return Collections.emptyList();
     }
 
     private static String typeName(Type type, Class<?> funcClass, String methodName, String toAppend) {

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -19,13 +19,10 @@ package com.linecorp.armeria.internal.common.thrift;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 
 import org.apache.thrift.AsyncProcessFunction;
 import org.apache.thrift.ProcessFunction;
@@ -36,6 +33,7 @@ import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.meta_data.FieldMetaData;
 import org.apache.thrift.protocol.TMessageType;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -383,7 +381,7 @@ public final class ThriftFunction {
     private static List<DecoratorAndOrder> getDeclaredDecorators(@Nullable Object implementation,
                                                                  String methodName) {
         if (implementation == null) {
-            return Collections.emptyList();
+            return ImmutableList.of();
         }
 
         final Class<?> implClass = implementation.getClass();
@@ -393,7 +391,7 @@ public final class ThriftFunction {
                 return DecoratorAnnotationUtil.collectDecorators(implClass, m);
             }
         }
-        return Collections.emptyList();
+        return ImmutableList.of();
     }
 
     private static String typeName(Type type, Class<?> funcClass, String methodName, String toAppend) {
@@ -433,36 +431,5 @@ public final class ThriftFunction {
             }
         }
         return builder.toString();
-    }
-
-    @Override
-    public boolean equals(@Nullable Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof ThriftFunction)) {
-            return false;
-        }
-        final ThriftFunction that = (ThriftFunction) obj;
-        return Objects.equals(func, that.func) &&
-               type == that.type &&
-               Objects.equals(serviceType, that.serviceType) &&
-               Objects.equals(name, that.name) &&
-               Objects.equals(implementation, that.implementation) &&
-               Objects.equals(result, that.result) &&
-               Arrays.equals(argFields, that.argFields) &&
-               Objects.equals(successField, that.successField) &&
-               Objects.equals(exceptionFields, that.exceptionFields) &&
-               Arrays.equals(declaredExceptions, that.declaredExceptions) &&
-               Objects.equals(declaredDecorators, that.declaredDecorators);
-    }
-
-    @Override
-    public int hashCode() {
-        int result1 = Objects.hash(func, type, serviceType, name, implementation, result, successField,
-                                   exceptionFields, declaredDecorators);
-        result1 = 31 * result1 + Arrays.hashCode(argFields);
-        result1 = 31 * result1 + Arrays.hashCode(declaredExceptions);
-        return result1;
     }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftFunction.java
@@ -19,11 +19,13 @@ package com.linecorp.armeria.internal.common.thrift;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apache.thrift.AsyncProcessFunction;
 import org.apache.thrift.ProcessFunction;
@@ -39,8 +41,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil;
 import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil.DecoratorAndOrder;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.thrift.THttpService;
 
 /**
  * Provides the metadata of a Thrift service function.
@@ -66,8 +66,6 @@ public final class ThriftFunction {
     private final Map<Class<Throwable>, TFieldIdEnum> exceptionFields;
     private final Class<?>[] declaredExceptions;
     private final List<DecoratorAndOrder> declaredDecorators;
-    @Nullable
-    private HttpService decoratedTHttpService;
 
     ThriftFunction(Class<?> serviceType, ProcessFunction<?, ?> func,
                    @Nullable Object implementation) throws Exception {
@@ -218,23 +216,6 @@ public final class ThriftFunction {
      */
     public List<DecoratorAndOrder> declaredDecorators() {
         return declaredDecorators;
-    }
-
-    /**
-     * Returns the {@link THttpService} which is decorated by {@code declaredDecorators}.
-     * If {@code declaredDecorators} is empty, this returns {@code null}.
-     */
-    @Nullable
-    public HttpService decoratedTHttpService() {
-        return decoratedTHttpService;
-    }
-
-    /**
-     * Sets the given {@link HttpService} as {@code decoratedTHttpService}.
-     */
-    public void setDecoratedTHttpService(HttpService decoratedTHttpService) {
-        requireNonNull(decoratedTHttpService, "decoratedTHttpService");
-        this.decoratedTHttpService = decoratedTHttpService;
     }
 
     /**
@@ -452,5 +433,36 @@ public final class ThriftFunction {
             }
         }
         return builder.toString();
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof ThriftFunction)) {
+            return false;
+        }
+        final ThriftFunction that = (ThriftFunction) obj;
+        return Objects.equals(func, that.func) &&
+               type == that.type &&
+               Objects.equals(serviceType, that.serviceType) &&
+               Objects.equals(name, that.name) &&
+               Objects.equals(implementation, that.implementation) &&
+               Objects.equals(result, that.result) &&
+               Arrays.equals(argFields, that.argFields) &&
+               Objects.equals(successField, that.successField) &&
+               Objects.equals(exceptionFields, that.exceptionFields) &&
+               Arrays.equals(declaredExceptions, that.declaredExceptions) &&
+               Objects.equals(declaredDecorators, that.declaredDecorators);
+    }
+
+    @Override
+    public int hashCode() {
+        int result1 = Objects.hash(func, type, serviceType, name, implementation, result, successField,
+                                   exceptionFields, declaredDecorators);
+        result1 = 31 * result1 + Arrays.hashCode(argFields);
+        result1 = 31 * result1 + Arrays.hashCode(declaredExceptions);
+        return result1;
     }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftServiceMetadata.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/common/thrift/ThriftServiceMetadata.java
@@ -248,6 +248,14 @@ public final class ThriftServiceMetadata {
     }
 
     /**
+     * Returns a map whose key is a method name and whose value is {@link AsyncProcessFunction} or
+     * {@link ProcessFunction}.
+     */
+    public Map<String, ThriftFunction> functions() {
+        return functions;
+    }
+
+    /**
      * Returns the {@link ThriftFunction} that provides the metadata of the specified Thrift function.
      *
      * @return the {@link ThriftFunction}, or {@code null} if there's no such function.

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -22,8 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +44,7 @@ import org.apache.thrift.transport.TTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 
@@ -310,7 +310,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         // The actual requestProtocolFactories will be set when this service is added.
         requestProtocolFactories = responseProtocolFactories;
         // The actual decoratedTHttpServices will be set when this service is added.
-        decoratedTHttpServices = Collections.emptyMap();
+        decoratedTHttpServices = ImmutableMap.of();
     }
 
     private static ThriftCallService findThriftService(Service<?, ?> delegate) {
@@ -362,7 +362,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         super.serviceAdded(cfg);
 
         final DependencyInjector dependencyInjector = cfg.server().config().dependencyInjector();
-        final Map<ThriftFunction, HttpService> decoratedTHttpServices = new HashMap<>();
+        final Map<ThriftFunction, HttpService> decoratedTHttpServices = new IdentityHashMap<>();
         for (ThriftServiceEntry thriftServiceEntry : entries().values()) {
             for (ThriftFunction thriftFunction : thriftServiceEntry.metadata.functions().values()) {
                 if (!thriftFunction.declaredDecorators().isEmpty()) {

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +288,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
     private int maxRequestContainerLength;
     private final Map<SerializationFormat, TProtocolFactory> responseProtocolFactories;
     private Map<SerializationFormat, TProtocolFactory> requestProtocolFactories;
-    private final Map<ThriftFunction, HttpService> decoratedTHttpServices = new HashMap<>();
+    private Map<ThriftFunction, HttpService> decoratedTHttpServices;
 
     THttpService(RpcService delegate, SerializationFormat defaultSerializationFormat,
                  Set<SerializationFormat> supportedSerializationFormats,
@@ -308,6 +309,8 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                         format -> ThriftSerializationFormats.protocolFactory(format, 0, 0)));
         // The actual requestProtocolFactories will be set when this service is added.
         requestProtocolFactories = responseProtocolFactories;
+        // The actual decoratedTHttpServices will be set when this service is added.
+        decoratedTHttpServices = Collections.emptyMap();
     }
 
     private static ThriftCallService findThriftService(Service<?, ?> delegate) {
@@ -359,6 +362,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         super.serviceAdded(cfg);
 
         final DependencyInjector dependencyInjector = cfg.server().config().dependencyInjector();
+        final Map<ThriftFunction, HttpService> decoratedTHttpServices = new HashMap<>();
         for (ThriftServiceEntry thriftServiceEntry : entries().values()) {
             for (ThriftFunction thriftFunction : thriftServiceEntry.metadata.functions().values()) {
                 if (!thriftFunction.declaredDecorators().isEmpty()) {
@@ -372,6 +376,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                 }
             }
         }
+        this.decoratedTHttpServices = decoratedTHttpServices;
     }
 
     @Override

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -367,8 +367,8 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         if (ctx.hasAttr(DECODED_REQUEST)) {
             final DecodedRequest decodedRequest = ctx.attr(DECODED_REQUEST);
             final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
-            invoke(ctx, decodedRequest.serializationFormat, decodedRequest.seqId, decodedRequest.f,
-                   decodedRequest.decodedReq, responseFuture);
+            invoke(ctx, decodedRequest.serializationFormat, decodedRequest.seqId,
+                   decodedRequest.thriftFunction, decodedRequest.decodedReq, responseFuture);
             return HttpResponse.of(responseFuture);
         }
 
@@ -824,14 +824,14 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
 
         private final SerializationFormat serializationFormat;
         private final int seqId;
-        private final ThriftFunction f;
+        private final ThriftFunction thriftFunction;
         private final RpcRequest decodedReq;
 
-        private DecodedRequest(SerializationFormat serializationFormat, int seqId, ThriftFunction f,
-                              RpcRequest decodedReq) {
+        private DecodedRequest(SerializationFormat serializationFormat, int seqId,
+                               ThriftFunction thriftFunction, RpcRequest decodedReq) {
             this.serializationFormat = serializationFormat;
             this.seqId = seqId;
-            this.f = f;
+            this.thriftFunction = thriftFunction;
             this.decodedReq = decodedReq;
         }
 
@@ -846,13 +846,13 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
             final DecodedRequest that = (DecodedRequest) obj;
             return seqId == that.seqId &&
                    Objects.equals(serializationFormat, that.serializationFormat) &&
-                   Objects.equals(f, that.f) &&
+                   Objects.equals(thriftFunction, that.thriftFunction) &&
                    Objects.equals(decodedReq, that.decodedReq);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(serializationFormat, seqId, f, decodedReq);
+            return Objects.hash(serializationFormat, seqId, thriftFunction, decodedReq);
         }
     }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
@@ -367,7 +366,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                         final DecoratorAndOrder d = decorators.get(i);
                         decorator = decorator.andThen(d.decorator(dependencyInjector));
                     }
-                    thriftFunction.decoratedTHttpService(decorator.apply(this));
+                    thriftFunction.setDecoratedTHttpService(decorator.apply(this));
                 }
             }
         }
@@ -833,26 +832,6 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
             this.seqId = seqId;
             this.thriftFunction = thriftFunction;
             this.decodedReq = decodedReq;
-        }
-
-        @Override
-        public boolean equals(@Nullable Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (!(obj instanceof DecodedRequest)) {
-                return false;
-            }
-            final DecodedRequest that = (DecodedRequest) obj;
-            return seqId == that.seqId &&
-                   Objects.equals(serializationFormat, that.serializationFormat) &&
-                   Objects.equals(thriftFunction, that.thriftFunction) &&
-                   Objects.equals(decodedReq, that.decodedReq);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(serializationFormat, seqId, thriftFunction, decodedReq);
         }
     }
 }

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/DecoratingTHttpServiceTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/DecoratingTHttpServiceTest.java
@@ -56,7 +56,7 @@ class DecoratingTHttpServiceTest {
         @Override
         protected void configure(ServerBuilder sb) {
             sb.service("/", THttpService.builder()
-                                        .decorate(GlobalDecorator.newDecorator())
+                                        .decorate(GlobalRpcDecorator.newDecorator())
                                         .addService(new DecoratedHelloService())
                                         .build());
         }
@@ -81,7 +81,7 @@ class DecoratingTHttpServiceTest {
         assertThat(decorators.poll()).isEqualTo("MethodSecondDecorator");
         assertThat(decorators.poll()).isEqualTo("CustomDecorator");
         // Rpc decorators will be executed later than http decorators
-        assertThat(decorators.poll()).isEqualTo("GlobalDecorator");
+        assertThat(decorators.poll()).isEqualTo("GlobalRpcDecorator");
         assertThat(decorators).isEmpty();
     }
 
@@ -92,18 +92,18 @@ class DecoratingTHttpServiceTest {
         int order() default 0;
     }
 
-    private static final class GlobalDecorator extends SimpleDecoratingRpcService {
-        private GlobalDecorator(RpcService delegate) {
+    private static final class GlobalRpcDecorator extends SimpleDecoratingRpcService {
+        private GlobalRpcDecorator(RpcService delegate) {
             super(delegate);
         }
 
-        private static Function<? super RpcService, GlobalDecorator> newDecorator() {
-            return GlobalDecorator::new;
+        private static Function<? super RpcService, GlobalRpcDecorator> newDecorator() {
+            return GlobalRpcDecorator::new;
         }
 
         @Override
         public RpcResponse serve(ServiceRequestContext ctx, RpcRequest req) throws Exception {
-            decorators.offer("GlobalDecorator");
+            decorators.offer("GlobalRpcDecorator");
             return unwrap().serve(ctx, req);
         }
     }

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/DecoratingTHttpServiceTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/server/thrift/DecoratingTHttpServiceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Function;
+
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.thrift.ThriftClients;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.server.annotation.Decorator;
+import com.linecorp.armeria.server.annotation.DecoratorFactory;
+import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import testing.thrift.main.HelloService;
+
+class DecoratingTHttpServiceTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", THttpService.of(new DecoratedHelloService()));
+        }
+    };
+
+    private static final BlockingDeque<String> decorators = new LinkedBlockingDeque<>();
+
+    @BeforeEach
+    void setUp() {
+        decorators.clear();
+    }
+
+    @Test
+    public void decorateTHttpService() throws TException {
+        final HelloService.Iface iface = ThriftClients.newClient(server.httpUri(), HelloService.Iface.class);
+
+        assertThat(iface.hello("foo")).isEqualTo("Hello foo!");
+
+        assertThat(decorators.poll()).isEqualTo("ClassFirstDecorator");
+        assertThat(decorators.poll()).isEqualTo("ClassSecondDecorator");
+        assertThat(decorators.poll()).isEqualTo("MethodFirstDecorator");
+        assertThat(decorators.poll()).isEqualTo("MethodSecondDecorator");
+        assertThat(decorators.poll()).isEqualTo("CustomDecorator");
+        assertThat(decorators).isEmpty();
+    }
+
+    @DecoratorFactory(CustomDecoratorFunction.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public @interface CustomDecorator {
+        int order() default 0;
+    }
+
+    private static class ClassFirstDecorator implements DecoratingHttpServiceFunction {
+        @Override
+        public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            decorators.offer("ClassFirstDecorator");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    private static class ClassSecondDecorator implements DecoratingHttpServiceFunction {
+        @Override
+        public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            decorators.offer("ClassSecondDecorator");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    private static class MethodFirstDecorator implements DecoratingHttpServiceFunction {
+        @Override
+        public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            decorators.offer("MethodFirstDecorator");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    private static class MethodSecondDecorator implements DecoratingHttpServiceFunction {
+        @Override
+        public HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req)
+                throws Exception {
+            decorators.offer("MethodSecondDecorator");
+            return delegate.serve(ctx, req);
+        }
+    }
+
+    private static class CustomDecoratorFunction implements DecoratorFactoryFunction<CustomDecorator> {
+        @Override
+        public Function<? super HttpService, ? extends HttpService> newDecorator(CustomDecorator parameter) {
+            return service -> new SimpleDecoratingHttpService(service) {
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    decorators.offer("CustomDecorator");
+                    return service.serve(ctx, req);
+                }
+            };
+        }
+    }
+
+    @Decorator(value = ClassSecondDecorator.class, order = 2)
+    @Decorator(value = ClassFirstDecorator.class, order = 1)
+    private static class DecoratedHelloService implements HelloService.Iface {
+
+        @Decorator(value = MethodFirstDecorator.class, order = 3)
+        @Decorator(value = MethodSecondDecorator.class, order = 4)
+        @CustomDecorator(order = 5)
+        @Override
+        public String hello(String name) throws TException {
+            return "Hello " + name + '!';
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

It would be very useful if we can use `@Decorator` or user defined annotation using `@DecoratorFactory` in `THttpService`.

Modifications:

- Store declared decorator annotations in `ThriftFunction`
- Decorate `THttpService` if there's declared annotations 

Result:

- Closes #4230 
<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
