### PR TITLE
Fix incorrect sample metrics YAML property in Spring Boot integration documentation page

### DIFF
--- a/site/src/pages/docs/advanced-spring-boot-integration.mdx
+++ b/site/src/pages/docs/advanced-spring-boot-integration.mdx
@@ -293,7 +293,7 @@ You do not need to specify `armeria.enable-metrics` or `armeria.metrics-path` as
 armeria:
   internal-services:
     include: metrics
-  health-check-path: /internal/healthcheck
+  metrics-path: /internal/metrics
   enable-metrics: true  # default is true
 ```
 


### PR DESCRIPTION
Motivation:

In the Spring Boot Integration document, the sample YAML in the `Collecting metrics` section is using incorrect property and value.

Modifications:

- Change `health-check-path` to `metrics-path`
- Change `/internal/healthcheck` to `/internal/metrics`

Result:

- https://armeria.dev/docs/advanced-spring-boot-integration shows correct sample YAML in the `Collecting metrics` section.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
