### PR TITLE
fix support json_name options

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingQueryParamMatchRule.java
@@ -42,16 +42,5 @@ public enum HttpJsonTranscodingQueryParamMatchRule {
     /**
      * Uses the original fields in .proto files to match {@link QueryParams} of an {@link HttpRequest}.
      */
-    ORIGINAL_FIELD,
-
-    /**
-     * Uses the original field and json name.
-     * <a href="https://protobuf.dev/programming-guides/proto3/#json">json mapping</a>
-     */
-    ORIGINAL_FIELD_JSON_NAME,
-
-    /**
-     * Uses camel case and json name.
-     */
-    CAMEL_CASE_JSON_NAME
+    ORIGINAL_FIELD
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -172,7 +172,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 if (httpJsonTranscodingOptions.queryParamMatchRules().contains(LOWER_CAMEL_CASE)) {
                     camelCaseFields =
                             buildFields(methodDesc.getInputType(), ImmutableList.of(), ImmutableSet.of(),
-                                    true);
+                                        true);
                 } else {
                     camelCaseFields = ImmutableMap.of();
                 }
@@ -185,8 +185,7 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
                 final String responseBody = getResponseBody(topLevelFields, httpRule.getResponseBody());
                 int order = 0;
                 specs.put(route, new TranscodingSpec(order++, httpRule, methodDefinition,
-                                                     serviceDesc, methodDesc,
-                                                     originalFields, camelCaseFields,
+                                                     serviceDesc, methodDesc, originalFields, camelCaseFields,
                                                      pathVariables,
                                                      responseBody));
                 for (HttpRule additionalHttpRule : httpRule.getAdditionalBindingsList()) {

--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -326,16 +326,13 @@ public class HttpJsonTranscodingTest {
     static final ServerExtension server = createServer(false, false, true);
 
     @RegisterExtension
-    static final ServerExtension serverPreservingProtoFieldNames =
-            createServer(true, false, true);
+    static final ServerExtension serverPreservingProtoFieldNames = createServer(true, false, true);
 
     @RegisterExtension
-    static final ServerExtension serverCamelCaseQueryOnlyParameters =
-            createServer(false, true, false);
+    static final ServerExtension serverCamelCaseQueryOnlyParameters = createServer(false, true, false);
 
     @RegisterExtension
-    static final ServerExtension serverCamelCaseQueryAndOriginalParameters =
-            createServer(false, true, true);
+    static final ServerExtension serverCamelCaseQueryAndOriginalParameters = createServer(false, true, true);
 
     private final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
 

--- a/grpc/src/test/proto/testing/grpc/transcoding.proto
+++ b/grpc/src/test/proto/testing/grpc/transcoding.proto
@@ -51,12 +51,7 @@ service HttpJsonTranscodingTestService {
   }
   rpc GetMessageV5(GetMessageRequestV5) returns (Message) {
     option (google.api.http) = {
-      get:"/v5/messages/{message_id}"
-    };
-  }
-  rpc GetMessageV6(GetMessageRequestV6) returns (Message) {
-    option (google.api.http) = {
-      get:"/v6/messages/{message_id}"
+      get:"/v5/messages/{messageType}"
     };
   }
   rpc UpdateMessageV1(UpdateMessageRequestV1) returns (Message) {
@@ -244,24 +239,13 @@ message GetMessageRequestV4 {
 }
 
 message GetMessageRequestV5 {
-  string message_id = 1;
-  string query_parameter = 2 [json_name = "first_query"];
-  string query_field_1 = 3 [json_name = "second_query"];
-  ParentMessage parent_field = 4 [json_name = "parent"];
-  message ParentMessage {
-    string child_field = 1 [json_name = "first_field"];
-    string child_field_2 = 2 [json_name = "second_field"];
-  }
-}
-
-message GetMessageRequestV6 {
-  string message_id = 1;
+  string message_id = 1 [json_name = "messageType"];
   string query_parameter = 2;
   string query_field_1 = 3 [json_name = "second_query"];
   ParentMessage parent_field = 4 [json_name = "parent"];
   message ParentMessage {
     string child_field = 1;
-    string child_field_2 = 2;
+    string child_field_2 = 2 [json_name = "second_field"];
   }
 }
 


### PR DESCRIPTION
Motivation:

Currently, LOWER_CAMEL_CASE and ORIGINAL_FIELD are used to match query params with protobuf messages.
It would be nicer if HttpJsonTranscodingQueryParamMatchRule supports json_name field option which is a well-known option that most protobuf JSON codecs implement

Modifications:

- Support for json_name in HttpJsonTranscodingQueryParamMatchRule
- The json name of the field is camelcase by default.  so, it is supported both when it is a camel case and when it is not.
( If json name is used, the default is origin field. https://protobuf.dev/programming-guides/proto3/#json)

Result:

- Closes #5193. (If this resolves the issue.)
- Use origin field and json name
- Use camel case and json name

