### PR TITLE
eureka: allow overriding the healthCheckUrlPath 

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/InstanceInfo.java
+++ b/eureka/src/main/java/com/linecorp/armeria/internal/common/eureka/InstanceInfo.java
@@ -36,7 +36,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 /**
  * An instance information.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(value = { "healthCheckUrlPath" }, ignoreUnknown = true)
 @JsonRootName("instance")
 public final class InstanceInfo {
 
@@ -65,6 +65,8 @@ public final class InstanceInfo {
     private final String homePageUrl;
     @Nullable
     private final String statusPageUrl;
+    @Nullable
+    private final String healthCheckUrlPath;
     @Nullable
     private final String healthCheckUrl;
     @Nullable
@@ -96,6 +98,32 @@ public final class InstanceInfo {
                         @JsonProperty("dataCenterInfo") DataCenterInfo dataCenterInfo,
                         @JsonProperty("leaseInfo") LeaseInfo leaseInfo,
                         @Nullable @JsonProperty("metadata") Map<String, String> metadata) {
+        this(instanceId, appName, appGroupName, hostName, ipAddr, vipAddress, secureVipAddress, port,
+             securePort, status, homePageUrl, statusPageUrl, null, healthCheckUrl,
+             secureHealthCheckUrl, dataCenterInfo, leaseInfo, metadata);
+    }
+
+    /**
+     * Creates a new instance which may have {@link #healthCheckUrlPath}.
+     */
+    public InstanceInfo(@Nullable String instanceId,
+                        @Nullable String appName,
+                        @Nullable String appGroupName,
+                        @Nullable String hostName,
+                        @Nullable String ipAddr,
+                        @Nullable String vipAddress,
+                        @Nullable String secureVipAddress,
+                        PortWrapper port,
+                        PortWrapper securePort,
+                        InstanceStatus status,
+                        @Nullable String homePageUrl,
+                        @Nullable String statusPageUrl,
+                        @Nullable String healthCheckUrlPath, // Not in JSON
+                        @Nullable String healthCheckUrl,
+                        @Nullable String secureHealthCheckUrl,
+                        DataCenterInfo dataCenterInfo,
+                        LeaseInfo leaseInfo,
+                        @Nullable Map<String, String> metadata) {
         this.instanceId = instanceId;
         this.hostName = hostName;
         this.appName = appName;
@@ -108,6 +136,7 @@ public final class InstanceInfo {
         this.status = requireNonNull(status, "status");
         this.homePageUrl = homePageUrl;
         this.statusPageUrl = statusPageUrl;
+        this.healthCheckUrlPath = healthCheckUrlPath;
         this.healthCheckUrl = healthCheckUrl;
         this.secureHealthCheckUrl = secureHealthCheckUrl;
         this.dataCenterInfo = dataCenterInfo;
@@ -217,6 +246,17 @@ public final class InstanceInfo {
     }
 
     /**
+     * Returns the health check path of this instance.
+     *
+     * <p>When set, {@link #getHealthCheckUrl()} will be built from {@link #getHostName()} and
+     * {@link #getPort()} or {@link #getSecurePort()} for {@link #getSecureHealthCheckUrl()}.
+     */
+    @Nullable
+    public String getHealthCheckUrlPath() {
+        return healthCheckUrlPath;
+    }
+
+    /**
      * Returns the health check URL of this instance.
      */
     @Nullable
@@ -289,6 +329,7 @@ public final class InstanceInfo {
                status == that.status &&
                Objects.equal(homePageUrl, that.homePageUrl) &&
                Objects.equal(statusPageUrl, that.statusPageUrl) &&
+               Objects.equal(healthCheckUrlPath, that.healthCheckUrlPath) &&
                Objects.equal(healthCheckUrl, that.healthCheckUrl) &&
                Objects.equal(secureHealthCheckUrl, that.secureHealthCheckUrl) &&
                Objects.equal(dataCenterInfo, that.dataCenterInfo) &&
@@ -300,8 +341,8 @@ public final class InstanceInfo {
     public int hashCode() {
         return Objects.hashCode(instanceId, hostName, appName, appGroupName, ipAddr, vipAddress,
                                 secureVipAddress, port, securePort, status,
-                                homePageUrl, statusPageUrl, healthCheckUrl, secureHealthCheckUrl,
-                                dataCenterInfo, leaseInfo, metadata);
+                                homePageUrl, statusPageUrl, healthCheckUrlPath, healthCheckUrl,
+                                secureHealthCheckUrl, dataCenterInfo, leaseInfo, metadata);
     }
 
     @Override
@@ -319,6 +360,7 @@ public final class InstanceInfo {
                                    .add("status", status)
                                    .add("homePageUrl", homePageUrl)
                                    .add("statusPageUrl", statusPageUrl)
+                                   .add("healthCheckUrlPath", healthCheckUrlPath)
                                    .add("healthCheckUrl", healthCheckUrl)
                                    .add("secureHealthCheckUrl", secureHealthCheckUrl)
                                    .add("dataCenterInfo", dataCenterInfo)

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -145,7 +145,7 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
      */
     EurekaUpdatingListener(EurekaWebClient client, InstanceInfo instanceInfo) {
         this.client = client;
-        this.initialInstanceInfo = instanceInfo;
+        initialInstanceInfo = instanceInfo;
     }
 
     @Override

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -284,7 +284,8 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
         final String baseURL = sessionProtocol.uriText() + "://" +
                                hostnameOrIpAddr(hostnameOrIpAddr) + ':' + portWrapper.getPort();
         if (oldHealthCheckUrlPath != null) {
-            return baseURL + oldHealthCheckUrlPath;
+            return !oldHealthCheckUrlPath.isEmpty() && oldHealthCheckUrlPath.charAt(0) == '/' ?
+                   baseURL + oldHealthCheckUrlPath : baseURL + "/" + oldHealthCheckUrlPath;
         }
         final ServiceConfig healthCheckServiceConfig = healthCheckService.get();
         final Route route = healthCheckServiceConfig.route();

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -285,7 +285,7 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
                                hostnameOrIpAddr(hostnameOrIpAddr) + ':' + portWrapper.getPort();
         if (oldHealthCheckUrlPath != null) {
             return !oldHealthCheckUrlPath.isEmpty() && oldHealthCheckUrlPath.charAt(0) == '/' ?
-                   baseURL + oldHealthCheckUrlPath : baseURL + "/" + oldHealthCheckUrlPath;
+                   baseURL + oldHealthCheckUrlPath : baseURL + '/' + oldHealthCheckUrlPath;
         }
         final ServiceConfig healthCheckServiceConfig = healthCheckService.get();
         final Route route = healthCheckServiceConfig.route();

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -150,8 +150,8 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
 
     @Override
     public void serverStarted(Server server) throws Exception {
-        this.instanceInfo = fillAndCreateNewInfo(initialInstanceInfo, server);
-        this.appName = instanceInfo.getAppName();
+        instanceInfo = fillAndCreateNewInfo(initialInstanceInfo, server);
+        appName = instanceInfo.getAppName();
         register(instanceInfo);
     }
 

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -222,7 +222,8 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     }
 
     /**
-     * Sets the ID of this instance. {@link #hostname(String)} is set if not specified.
+     * Sets the ID of this instance. Derived from {@link #hostname(String)},
+     * {@link #appName(String)} and {@link #port(int)}, if not specified.
      */
     public EurekaUpdatingListenerBuilder instanceId(String instanceId) {
         instanceInfoBuilder.instanceId(instanceId);
@@ -298,6 +299,15 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
      */
     public EurekaUpdatingListenerBuilder statusPageUrl(String statusPageUrl) {
         instanceInfoBuilder.statusPageUrl(statusPageUrl);
+        return this;
+    }
+
+    /**
+     * Sets the health check path used to automatically create {@link #healthCheckUrl(String)} and
+     * {@link #secureHealthCheckUrl(String)}.
+     */
+    public EurekaUpdatingListenerBuilder healthCheckUrlPath(String healthCheckUrlPath) {
+        instanceInfoBuilder.healthCheckUrlPath(healthCheckUrlPath);
         return this;
     }
 

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/InstanceInfoBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/InstanceInfoBuilder.java
@@ -74,6 +74,8 @@ final class InstanceInfoBuilder {
     @Nullable
     private String statusPageUrl;
     @Nullable
+    private String healthCheckUrlPath;
+    @Nullable
     private String healthCheckUrl;
     @Nullable
     private String secureHealthCheckUrl;
@@ -195,6 +197,14 @@ final class InstanceInfoBuilder {
     }
 
     /**
+     * Sets the health check path.
+     */
+    InstanceInfoBuilder healthCheckUrlPath(String healthCheckUrlPath) {
+        this.healthCheckUrlPath = requireNonNull(healthCheckUrlPath, "healthCheckUrlPath");
+        return this;
+    }
+
+    /**
      * Sets the health check URL.
      */
     InstanceInfoBuilder healthCheckUrl(String healthCheckUrl) {
@@ -241,9 +251,10 @@ final class InstanceInfoBuilder {
         final LeaseInfo leaseInfo = new LeaseInfo(renewalIntervalSeconds, leaseDurationSeconds);
         return new InstanceInfo(instanceId, appName, appGroupName, hostname, ipAddr, vipAddress,
                                 secureVipAddress, port, securePort, InstanceStatus.UP,
-                                homePageUrl, statusPageUrl, healthCheckUrl, secureHealthCheckUrl,
-                                new DataCenterInfo(dataCenterName, dataCenterMetadata),
-                                leaseInfo, metadata);
+                                homePageUrl, statusPageUrl, healthCheckUrlPath, healthCheckUrl,
+                                secureHealthCheckUrl,
+                                new DataCenterInfo(dataCenterName, dataCenterMetadata), leaseInfo,
+                                metadata);
     }
 
     private static void validateIpAddr(String ipAddr, String name) {


### PR DESCRIPTION
Motivation:

Zipkin has a custom health check service, in addition to the normal
one of type `HealthCheckService`. This is used to create a custom json
response and predated our use of Armeria. This custom one is mounted at
the path "/health" while the default is "/internal/health".

We recently added Eureka registration, but were not able to change the
path component without having to supply the scheme, host and port as
well. To work around this is a bit hacky, and I would like to remove it
as it cause log warnings.

This change is already supported upstream for similar reasons. See
https://github.com/Netflix/eureka/blob/2b09d77534eae703a36f79f99b27b4d6ed66c3f8/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java#L663-L666

Modifications:

- Added a `healthCheckUrlPath` property to `InstanceInfo` and
  corresponding builders, using a custom constructor to avoid
  serializing it to JSON.
- Modified to use this instead of the default path when set.
- Added an integration test.

Result:

- Health check paths are overridable.