### PR TITLE
Fix flaky FixedStreamMessageTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -263,7 +263,7 @@ class FixedStreamMessageTest {
         assertThatThrownBy(stream.whenComplete()::join)
                 .isInstanceOf(CompletionException.class)
                 .hasCause(abortCause);
-        assertThat(subscriptionRef).hasValue(NoopSubscription.get());
+        await().untilAsserted(() -> assertThat(subscriptionRef).hasValue(NoopSubscription.get()));
         assertThat(causeRef).hasValue(abortCause);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessageTest.java
@@ -263,8 +263,10 @@ class FixedStreamMessageTest {
         assertThatThrownBy(stream.whenComplete()::join)
                 .isInstanceOf(CompletionException.class)
                 .hasCause(abortCause);
-        await().untilAsserted(() -> assertThat(subscriptionRef).hasValue(NoopSubscription.get()));
-        assertThat(causeRef).hasValue(abortCause);
+        await().untilAsserted(() -> {
+            assertThat(subscriptionRef).hasValue(NoopSubscription.get());
+            assertThat(causeRef).hasValue(abortCause);
+        });
     }
 
     @ArgumentsSource(FixedStreamMessageProvider.class)


### PR DESCRIPTION
In the test, streamMessage is aborted before `subscribe0` is called: https://github.com/line/armeria/blob/33d1c5ec8f8d99b6bc6908aec01b5b0032ed4d3b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java#L361 https://github.com/line/armeria/blob/33d1c5ec8f8d99b6bc6908aec01b5b0032ed4d3b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java#L141-L144 Thus, `whenComplete` future is exceptionally completed before `subscriber.onSubscribe()` is called.
https://github.com/line/armeria/blob/33d1c5ec8f8d99b6bc6908aec01b5b0032ed4d3b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java#L381

Close #5362 