### PR TITLE
Add dependabot configuration for `npm` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,5 +34,4 @@ updates:
       directory: "/"
       schedule:
         interval: "monthly"
-        timezone: "Asia/Seoul"
         versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,6 @@ updates:
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-        interval: "daily"
-        time: "10:00"
-        # Use Korea Standard Time (UTC +09:00)
+        interval: "monthly"
         timezone: "Asia/Seoul"
         versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,12 @@ updates:
           time: "10:00"
           # Use Korea Standard Time (UTC +09:00)
           timezone: "Asia/Seoul"
+
+    - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+        interval: "daily"
+        time: "10:00"
+        # Use Korea Standard Time (UTC +09:00)
+        timezone: "Asia/Seoul"
+        versioning-strategy: increase


### PR DESCRIPTION
Motivation:

The following [PR](https://github.com/line/armeria/pull/5377) attempts to update the `package-lock.json` file only.
I've read through the following documents, and believe that specifying the versioning strategy will help update the actual `package.json` dependencies

Modifications:

- Added a versioning strategy for dependabot
- Specified the interval to monthly so that it is better in-sync with our release schedule and we don't receive multiple update pull requests

Result:

- Improved dependabot pull requests

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
