### PR TITLE
Enhance error reporting for failed gRPC client stub creation.

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -21,8 +21,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -110,7 +110,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         GrpcClientStubFactory clientStubFactory = options.get(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY);
         ServiceDescriptor serviceDescriptor = null;
 
-        final Map<String, Throwable> exceptions = new HashMap<>();
+        final List<ServiceDescriptorResolutionException> exceptions = new ArrayList<>();
         if (clientStubFactory == NullGrpcClientStubFactory.INSTANCE) {
             for (GrpcClientStubFactory stubFactory : clientStubFactories) {
                 try {
@@ -120,7 +120,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                         break;
                     }
                 } catch (ServiceDescriptorResolutionException e) {
-                    exceptions.put(e.factorySimpleName(), e.getCause());
+                    exceptions.add(e);
                 }
             }
         } else {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -109,19 +110,32 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         GrpcClientStubFactory clientStubFactory = options.get(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY);
         ServiceDescriptor serviceDescriptor = null;
 
+        final ArrayList<Throwable> exceptions = new ArrayList<>();
         if (clientStubFactory == NullGrpcClientStubFactory.INSTANCE) {
             for (GrpcClientStubFactory stubFactory : clientStubFactories) {
-                serviceDescriptor = stubFactory.findServiceDescriptor(clientType);
-                if (serviceDescriptor != null) {
-                    clientStubFactory = stubFactory;
-                    break;
+                try {
+                    serviceDescriptor = stubFactory.findServiceDescriptor(clientType);
+                    if (serviceDescriptor != null) {
+                        clientStubFactory = stubFactory;
+                        break;
+                    }
+                } catch (ServiceDescriptorResolutionException e) {
+                    exceptions.add(e.getCause());
                 }
             }
         } else {
             serviceDescriptor = clientStubFactory.findServiceDescriptor(clientType);
         }
         if (serviceDescriptor == null) {
-            throw newUnknownClientTypeException(clientType);
+            if (!exceptions.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Failed to create a gRPC client stub for " + clientType.getName() +
+                        ". Possible reasons: no gRPC client stub class or due to one of the " +
+                        "following exceptions. " + exceptions);
+            }
+            throw new IllegalArgumentException(
+                    "Unknown client type: " + clientType.getName() +
+                    " (expected: a gRPC client stub class, e.g. MyServiceGrpc.MyServiceStub)");
         }
 
         final Map<MethodDescriptor<?, ?>, String> simpleMethodNames =
@@ -210,12 +224,6 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         return ClientBuilderParams.of(
                 params.scheme(), params.endpointGroup(), params.absolutePathRef(),
                 params.clientType(), optionsBuilder.build());
-    }
-
-    private static IllegalArgumentException newUnknownClientTypeException(Class<?> clientType) {
-        return new IllegalArgumentException(
-                "Unknown client type: " + clientType.getName() +
-                " (expected: a gRPC client stub class, e.g. MyServiceGrpc.MyServiceStub)");
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -21,8 +21,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.client.grpc.GrpcClientUtil.maxInboundMessageSizeBytes;
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -110,7 +110,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         GrpcClientStubFactory clientStubFactory = options.get(GrpcClientOptions.GRPC_CLIENT_STUB_FACTORY);
         ServiceDescriptor serviceDescriptor = null;
 
-        final ArrayList<Throwable> exceptions = new ArrayList<>();
+        final Map<String, Throwable> exceptions = new HashMap<>();
         if (clientStubFactory == NullGrpcClientStubFactory.INSTANCE) {
             for (GrpcClientStubFactory stubFactory : clientStubFactories) {
                 try {
@@ -120,7 +120,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                         break;
                     }
                 } catch (ServiceDescriptorResolutionException e) {
-                    exceptions.add(e.getCause());
+                    exceptions.put(e.factorySimpleName(), e.getCause());
                 }
             }
         } else {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.grpc.Channel;
 import io.grpc.ServiceDescriptor;
@@ -51,14 +52,7 @@ public final class JavaGrpcClientStubFactory implements GrpcClientStubFactory {
             final Method getServiceDescriptorMethod = enclosingClass.getDeclaredMethod("getServiceDescriptor");
             return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            Throwable t = e;
-            if (e instanceof InvocationTargetException) {
-                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
-                if (targetException != null) {
-                    t = targetException;
-                }
-            }
-            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), Exceptions.peel(e));
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
@@ -51,7 +51,14 @@ public final class JavaGrpcClientStubFactory implements GrpcClientStubFactory {
             final Method getServiceDescriptorMethod = enclosingClass.getDeclaredMethod("getServiceDescriptor");
             return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            return null;
+            Throwable t = e;
+            if (e instanceof InvocationTargetException) {
+                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
+                if (targetException != null) {
+                    t = targetException;
+                }
+            }
+            throw new ServiceDescriptorResolutionException(t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/JavaGrpcClientStubFactory.java
@@ -58,7 +58,7 @@ public final class JavaGrpcClientStubFactory implements GrpcClientStubFactory {
                     t = targetException;
                 }
             }
-            throw new ServiceDescriptorResolutionException(t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
@@ -40,19 +40,20 @@ public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory 
     public ServiceDescriptor findServiceDescriptor(Class<?> clientType) {
         if (clientType.getName().endsWith("CoroutineStub")) {
             final Annotation annotation = stubForAnnotation(clientType);
+            final Method getServiceDescriptor;
+            final Class<?> generatedStub;
             try {
                 final Method valueMethod = annotation.annotationType().getDeclaredMethod("value", null);
-                final Class<?> generatedStub = generatedStub(annotation, valueMethod);
-                final Method getServiceDescriptor =
-                        generatedStub.getDeclaredMethod("getServiceDescriptor", null);
-                try {
-                    return (ServiceDescriptor) getServiceDescriptor.invoke(generatedStub);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new IllegalStateException(
-                            "Could not invoke getServiceDescriptor on a gRPC Kotlin client stub.");
-                }
+                generatedStub = generatedStub(annotation, valueMethod);
+                getServiceDescriptor = generatedStub.getDeclaredMethod("getServiceDescriptor", null);
             } catch (NoSuchMethodException e) {
-                throw new IllegalStateException("Could not find value getter on StubFor annotation.");
+                throw new IllegalStateException("Could not find value getter on StubFor annotation.", e);
+            }
+            try {
+                return (ServiceDescriptor) getServiceDescriptor.invoke(generatedStub);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException(
+                        "Could not invoke getServiceDescriptor on a gRPC Kotlin client stub.", e);
             }
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/KotlinGrpcClientStubFactory.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.grpc.BindableService;
 import io.grpc.Channel;
@@ -47,12 +48,12 @@ public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory 
                 generatedStub = generatedStub(annotation, valueMethod);
                 getServiceDescriptor = generatedStub.getDeclaredMethod("getServiceDescriptor", null);
             } catch (NoSuchMethodException e) {
-                throw new IllegalStateException("Could not find value getter on StubFor annotation.", e);
+                throw new IllegalArgumentException("Could not find value getter on StubFor annotation.", e);
             }
             try {
                 return (ServiceDescriptor) getServiceDescriptor.invoke(generatedStub);
             } catch (IllegalAccessException | InvocationTargetException e) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                         "Could not invoke getServiceDescriptor on a gRPC Kotlin client stub.", e);
             }
         }
@@ -67,12 +68,13 @@ public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory 
                     BindableService.class.getPackage().getName() + ".kotlin.StubFor");
             final Annotation annotation = clientType.getAnnotation(annotationClass);
             if (annotation == null) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                         "Could not find StubFor annotation on a gRPC Kotlin client stub.");
             }
             return annotation;
         } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Could not find StubFor annotation on a gRPC Kotlin client stub.");
+            throw new IllegalArgumentException(
+                    "Could not find StubFor annotation on a gRPC Kotlin client stub.", e);
         }
     }
 
@@ -80,7 +82,8 @@ public final class KotlinGrpcClientStubFactory implements GrpcClientStubFactory 
         try {
             return (Class<?>) valueMethod.invoke(annotation, null);
         } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalStateException("Could not find a gRPC Kotlin generated client stub.");
+            throw new IllegalArgumentException(
+                    "Could not find a gRPC Kotlin generated client stub.", Exceptions.peel(e));
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
@@ -45,7 +45,14 @@ public final class ReactorGrpcClientStubFactory implements GrpcClientStubFactory
             return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
         } catch (NoSuchMethodException | IllegalAccessException |
                 InvocationTargetException | NoSuchFieldException e) {
-            return null;
+            Throwable t = e;
+            if (e instanceof InvocationTargetException) {
+                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
+                if (targetException != null) {
+                    t = targetException;
+                }
+            }
+            throw new ServiceDescriptorResolutionException(t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
@@ -52,7 +52,7 @@ public final class ReactorGrpcClientStubFactory implements GrpcClientStubFactory
                     t = targetException;
                 }
             }
-            throw new ServiceDescriptorResolutionException(t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ReactorGrpcClientStubFactory.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.grpc.Channel;
 import io.grpc.ServiceDescriptor;
@@ -45,14 +46,7 @@ public final class ReactorGrpcClientStubFactory implements GrpcClientStubFactory
             return (ServiceDescriptor) getServiceDescriptorMethod.invoke(null);
         } catch (NoSuchMethodException | IllegalAccessException |
                 InvocationTargetException | NoSuchFieldException e) {
-            Throwable t = e;
-            if (e instanceof InvocationTargetException) {
-                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
-                if (targetException != null) {
-                    t = targetException;
-                }
-            }
-            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), Exceptions.peel(e));
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
@@ -42,7 +42,14 @@ public final class ScalaPbGrpcClientStubFactory implements GrpcClientStubFactory
             final Method method = stubClass.getDeclaredMethod("SERVICE");
             return (ServiceDescriptor) method.invoke(null);
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            return null;
+            Throwable t = e;
+            if (e instanceof InvocationTargetException) {
+                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
+                if (targetException != null) {
+                    t = targetException;
+                }
+            }
+            throw new ServiceDescriptorResolutionException(t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
@@ -49,7 +49,7 @@ public final class ScalaPbGrpcClientStubFactory implements GrpcClientStubFactory
                     t = targetException;
                 }
             }
-            throw new ServiceDescriptorResolutionException(t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ScalaPbGrpcClientStubFactory.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+import com.linecorp.armeria.common.util.Exceptions;
 
 import io.grpc.Channel;
 import io.grpc.ServiceDescriptor;
@@ -42,14 +43,7 @@ public final class ScalaPbGrpcClientStubFactory implements GrpcClientStubFactory
             final Method method = stubClass.getDeclaredMethod("SERVICE");
             return (ServiceDescriptor) method.invoke(null);
         } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            Throwable t = e;
-            if (e instanceof InvocationTargetException) {
-                final Throwable targetException = ((InvocationTargetException) e).getTargetException();
-                if (targetException != null) {
-                    t = targetException;
-                }
-            }
-            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), t);
+            throw new ServiceDescriptorResolutionException(getClass().getSimpleName(), Exceptions.peel(e));
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.client.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
+
+/**
+ * A wrapper exception for propagating exceptions raised during the invocation of
+ * {@link GrpcClientStubFactory#findServiceDescriptor(Class)} within Armeria's built-in factories.
+ * Note that this class is for internal use thus it's not exposed to users.
+ */
+public final class ServiceDescriptorResolutionException extends RuntimeException {
+
+    private static final long serialVersionUID = -4062645240586772465L;
+
+    public ServiceDescriptorResolutionException(Throwable cause) {
+        super(requireNonNull(cause, "cause"));
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
@@ -27,8 +27,14 @@ import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 public final class ServiceDescriptorResolutionException extends RuntimeException {
 
     private static final long serialVersionUID = -4062645240586772465L;
+    private final String factorySimpleName;
 
-    public ServiceDescriptorResolutionException(Throwable cause) {
+    public ServiceDescriptorResolutionException(String factorySimpleName, Throwable cause) {
         super(requireNonNull(cause, "cause"));
+        this.factorySimpleName = requireNonNull(factorySimpleName, "factorySimpleName");
+    }
+
+    public String factorySimpleName() {
+        return factorySimpleName;
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
@@ -37,4 +37,9 @@ public final class ServiceDescriptorResolutionException extends RuntimeException
     public String factorySimpleName() {
         return factorySimpleName;
     }
+
+    @Override
+    public String toString() {
+        return factorySimpleName + '=' + getCause().toString();
+    }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ServiceDescriptorResolutionException.java
@@ -27,19 +27,15 @@ import com.linecorp.armeria.client.grpc.GrpcClientStubFactory;
 public final class ServiceDescriptorResolutionException extends RuntimeException {
 
     private static final long serialVersionUID = -4062645240586772465L;
-    private final String factorySimpleName;
+    private final String stubFactoryName;
 
-    public ServiceDescriptorResolutionException(String factorySimpleName, Throwable cause) {
+    public ServiceDescriptorResolutionException(String stubFactoryName, Throwable cause) {
         super(requireNonNull(cause, "cause"));
-        this.factorySimpleName = requireNonNull(factorySimpleName, "factorySimpleName");
-    }
-
-    public String factorySimpleName() {
-        return factorySimpleName;
+        this.stubFactoryName = requireNonNull(stubFactoryName, "stubFactoryName");
     }
 
     @Override
     public String toString() {
-        return factorySimpleName + '=' + getCause().toString();
+        return stubFactoryName + '=' + getCause().toString();
     }
 }


### PR DESCRIPTION
Motivation:
I got a report that it's not easy to trouble shoot when an exception is raised while creating a gRPC client stub because the exception is swallowed currently.

Modification:
- Introduce `ServiceDescriptorResolutionException` to capture exceptions raised during the invocation of `GrpcClientStubFactory#findServiceDescriptor(Class)` within Armeria's built-in factories.
  - Store these exceptions and display them to the user if `GrpcClientFactory` fails to create the client stub.

Result:
-  You can now easily identify issues when failing to create a gRPC client stub.