### PR TITLE
Fix illegal state of the ByteBuf if the CLOSE frame does not contain a reason

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
+++ b/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
@@ -98,13 +98,10 @@ final class CloseByteBufWebSocketFrame extends ByteBufWebSocketFrame implements 
         }
 
         final int index = data.readerIndex();
-        data.readerIndex(index + 2);
-        if (!data.isReadable()) {
-            // According to the RFC-6455, the close frame MAY contain a body.
-            // The reader index is required to be reset even if the data is empty.
-            data.readerIndex(index);
+        if (index + 2 >= data.writerIndex()) { // No reasonPhrase
             return null;
         }
+        data.readerIndex(index + 2);
         final String reasonPhrase = data.toString(StandardCharsets.UTF_8);
         data.readerIndex(index);
         return reasonPhrase;

--- a/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
+++ b/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
@@ -100,6 +100,9 @@ final class CloseByteBufWebSocketFrame extends ByteBufWebSocketFrame implements 
         final int index = data.readerIndex();
         data.readerIndex(index + 2);
         if (!data.isReadable()) {
+            // According to the RFC-6455, the close frame MAY contain a body.
+            // The reader index is required to be reset even if the data is empty.
+            data.readerIndex(index);
             return null;
         }
         final String reasonPhrase = data.toString(StandardCharsets.UTF_8);


### PR DESCRIPTION
Motivation:

When "disconnect" is clicked in the Postman (which is a very common API testing application), a `CLOSE` frame is sent without any reason.

But the `reasonPhrase` function in armeria cannot correctly handle such case.

![image](https://github.com/line/armeria/assets/2568208/9b9c2a4d-2178-4abb-a37c-cc3ac6b3a59b)


According to the RFC-6455, this is fully legal.

https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1

Modifications:

- Reset the reader index if reason is empty

Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
