### PR TITLE
Allow HttpFile to pass a Spring Boot 3 nested jar URL

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -199,7 +199,8 @@ public interface HttpFile {
             }
 
             return builder(f.toPath());
-        } else if ("jar".equals(url.getProtocol()) && url.getPath().startsWith("file:") ||
+        } else if ("jar".equals(url.getProtocol()) &&
+                   (url.getPath().startsWith("file:") || url.getPath().startsWith("nested:")) ||
                    "jrt".equals(url.getProtocol()) ||
                    "bundle".equals(url.getProtocol())) {
             return new ClassPathHttpFileBuilder(url);

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -206,7 +206,7 @@ public interface HttpFile {
             return new ClassPathHttpFileBuilder(url);
         }
         throw new IllegalArgumentException("Unsupported URL: " + url + " (must start with " +
-                                           "'file:', 'jar:file', 'jrt:' or 'bundle:')");
+                                           "'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')");
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ServerCacheControl;
+import com.linecorp.armeria.server.file.HttpFileBuilder.ClassPathHttpFileBuilder;
 
 class HttpFileTest {
 
@@ -95,6 +98,25 @@ class HttpFileTest {
             "(must start with 'file:', 'jar:file', 'jrt:' or 'bundle:')";
         assertThatThrownBy(() -> HttpFile.builder(url)).isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(exMsg);
+    }
+
+    private static class NestedJarURLStreamHandler extends URLStreamHandler {
+        @Override
+        protected URLConnection openConnection(URL u) {
+            throw new UnsupportedOperationException("mocked");
+        }
+    }
+
+    @Test
+    void createFromNestedUrl() throws Exception {
+        // Define a Spring Boot 3 nested URL
+        final String nestedURL = "jar:nested:/root/exec.jar/!BOOT-INF/lib/nested.jar!/foo.js";
+
+        // Construct the URL directly because it isn't a built-in type
+        final URL url = new URL(null, nestedURL, new NestedJarURLStreamHandler());
+
+        // Ensure it is detected as a classpath resource
+        assertThat(HttpFile.builder(url)).isInstanceOf(ClassPathHttpFileBuilder.class);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -95,7 +95,7 @@ class HttpFileTest {
     void createFromHttpUrl() throws Exception {
         final URL url = new URL("https://line.me");
         final String exMsg = "Unsupported URL: https://line.me " +
-                             "'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
+                             "(must start with 'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
         assertThatThrownBy(() -> HttpFile.builder(url)).isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(exMsg);
     }
@@ -141,7 +141,7 @@ class HttpFileTest {
     void createFromJarHttpUrl() throws Exception {
         final URL jarHttpUrl = new URL("jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class");
         final String exMsg = "Unsupported URL: jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class " +
-                             "'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
+                             "(must start with 'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
         assertThatThrownBy(() -> HttpFile.builder(jarHttpUrl)).isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(exMsg);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -95,7 +95,7 @@ class HttpFileTest {
     void createFromHttpUrl() throws Exception {
         final URL url = new URL("https://line.me");
         final String exMsg = "Unsupported URL: https://line.me " +
-            "(must start with 'file:', 'jar:file', 'jrt:' or 'bundle:')";
+                             "'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
         assertThatThrownBy(() -> HttpFile.builder(url)).isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(exMsg);
     }
@@ -141,7 +141,7 @@ class HttpFileTest {
     void createFromJarHttpUrl() throws Exception {
         final URL jarHttpUrl = new URL("jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class");
         final String exMsg = "Unsupported URL: jar:http://www.foo.com/bar/baz.jar!/COM/foo/Quux.class " +
-            "(must start with 'file:', 'jar:file', 'jrt:' or 'bundle:')";
+                             "'file:', 'jar:file', 'jar:nested', 'jrt:' or 'bundle:')";
         assertThatThrownBy(() -> HttpFile.builder(jarHttpUrl)).isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(exMsg);
     }


### PR DESCRIPTION
Motivation:

After zipkin upgraded to spring boot, our UI failed to load due to an unanticipated URL format:

```
java.lang.IllegalArgumentException: Unsupported URL: jar:nested:/Users/adrian/oss/zipkin/zipkin-server/target/zipkin-server-3.0.4-SNAPSHOT-exec.jar/!BOOT-INF/lib/zipkin-lens-3.0.4-SNAPSHOT.jar!/zipkin-lens/static/css/main.311b483b.css (must start with 'file:', 'jar:file', 'jrt:' or 'bundle:')
	at com.linecorp.armeria.server.file.HttpFile.builder(HttpFile.java:206) ~[!/:?]
	at com.linecorp.armeria.server.file.HttpFile.builder(HttpFile.java:230) ~[!/:?]
	at com.linecorp.armeria.server.file.ClassPathHttpVfs.blockingGet(ClassPathHttpVfs.java:58) ~[armeria-1.26.4.jar!/:?]
	at com.linecorp.armeria.server.file.AbstractBlockingHttpVfs.lambda$get$0(AbstractBlockingHttpVfs.java:82) ~[armeria-1.26.4.jar!/:?]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at com.linecorp.armeria.common.DefaultContextAwareRunnable.run(DefaultContextAwareRunnable.java:45) ~[armeria-1.26.4.jar!/:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.100.Final.jar!/:4.1.100.Final]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

Modifications:

- Change HttpFile to pass the custom classpath "nested" type defined by spring

Result:

- Closes #5390
- nested classpath URLs work with HttpFile