### PR TITLE
Properly convert implicit request object in the annotated doc service to type signature

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -256,6 +256,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         if (annotationType == RequestObject.class) {
             final BeanFactoryId beanFactoryId = resolver.beanFactoryId();
             final AnnotatedBeanFactory<?> factory = AnnotatedBeanFactoryRegistry.find(beanFactoryId);
+            final TypeSignature typeSignature;
             if (factory != null) {
                 final Builder<AnnotatedValueResolver> builder = ImmutableList.builder();
                 factory.constructor().getValue().forEach(builder::add);
@@ -268,23 +269,16 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
                 }
 
                 final Class<?> type = beanFactoryId.type();
-                final DescriptiveTypeSignature typeSignature =
-                        new RequestObjectTypeSignature(TypeSignatureType.STRUCT, type.getName(), type,
-                                                       new AnnotatedValueResolversWrapper(resolvers));
-                return FieldInfo.builder(resolver.httpElementName(), typeSignature)
-                                .requirement(resolver.shouldExist() ?
-                                             FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
-                                .descriptionInfo(resolver.description())
-                                .build();
+                typeSignature = new RequestObjectTypeSignature(TypeSignatureType.STRUCT, type.getName(), type,
+                                                               new AnnotatedValueResolversWrapper(resolvers));
             } else {
-                final Class<?> elementType = resolver.elementType();
-                final DescriptiveTypeSignature typeSignature = TypeSignature.ofStruct(elementType);
-                return FieldInfo.builder(resolver.httpElementName(), typeSignature)
-                                .requirement(resolver.shouldExist() ?
-                                             FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
-                                .descriptionInfo(resolver.description())
-                                .build();
+                typeSignature = toTypeSignature(resolver.elementType());
             }
+            return FieldInfo.builder(resolver.httpElementName(), typeSignature)
+                            .requirement(resolver.shouldExist() ?
+                                         FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
+                            .descriptionInfo(resolver.description())
+                            .build();
         }
 
         if (annotationType != Param.class && annotationType != Header.class) {


### PR DESCRIPTION
Motivation:
The current implementation fails to convert `byte[]`, an implicitRequestObject, to `TypeSignature` correctly within the `AnnotatedDocServicePlugin`. [Reference](https://github.com/line/armeria/blob/6f0a1f65fbbc45b0a1ef870b163ee11b01f0bd31/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java#L498-L501)

Modifications:
- Use `AnnotatedDocServicePlugin.toTypeSignature()` to properly convert `byte[]` to `TypeSignature`. This method ensures proper checking of the type before conversion to a struct, as opposed to directly calling `TypeSignature.ofStruct()`.

Result:
- Close #5389.
- Implicit request objects are now correctly converted.
