### PR TITLE
Record causes of failed attempts for RetryingClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
@@ -398,7 +398,6 @@ public final class RequestMetricSupport {
                                                             idPrefix.tags("result", "failure"));
         }
 
-        // TODO(miyoshi): 異なるエラーが発生した場合は異なる分布を持つカウンターを作成したい
         @Override
         public DistributionSummary failureAttempts(Throwable error) {
             final String causeName = error.getClass().getSimpleName();


### PR DESCRIPTION
Motivation:

#5283

Modifications:

- Refactor like separating onResponse into `onResponseOnClientSide` and `onResponseOnServerSide` in `RequestMetricSupport`
- Add `failureAttempts(Throwable error)` method in `ClientRequestMetrics` and Change to record causes of failed attempts in `onResponseOnClientSide` if error isn't null.

Result:

- Closes #5283
- It becomes possible to record causes of failed attempts for RetryingClient like the following.

```
"actual.requests.attempts{result=failure, cause=ResponseTimeoutException}=NN"
```

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
