### PR TITLE
Provide an API in RequestLog to obtain traceId and spanId.

### DIFF
--- a/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
+++ b/brave/src/main/java/com/linecorp/armeria/client/brave/BraveClient.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.logging.ClientConnectionTimings;
 import com.linecorp.armeria.internal.common.RequestContextExtension;
+import com.linecorp.armeria.internal.common.brave.SpanConverter;
 import com.linecorp.armeria.internal.common.brave.SpanTags;
 
 import brave.Span;
@@ -126,6 +127,8 @@ public final class BraveClient extends SimpleDecoratingHttpClient {
             // Make the span the current span and run scope decorators when the ctx is pushed.
             ctxExtension.hook(() -> currentTraceContext.newScope(span.context()));
         }
+
+        ctx.logBuilder().tracingContext(SpanConverter.toLogTracingContext(span));
 
         maybeAddTagsToSpan(ctx, braveReq, span);
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {

--- a/brave/src/main/java/com/linecorp/armeria/internal/common/brave/SpanConverter.java
+++ b/brave/src/main/java/com/linecorp/armeria/internal/common/brave/SpanConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.brave;
+
+import com.linecorp.armeria.common.logging.TracingContext;
+
+import brave.Span;
+import brave.propagation.TraceContext;
+
+public final class SpanConverter {
+
+    public static TracingContext toLogTracingContext(Span span) {
+        final TraceContext traceContext = span.context();
+
+        return TracingContext.of(traceContext.traceIdHigh(), traceContext.traceId(),
+                                 traceContext.traceIdString(), traceContext.parentId(),
+                                 traceContext.parentIdString(), traceContext.spanId(),
+                                 traceContext.spanIdString(), traceContext.localRootId(),
+                                 traceContext.localRootIdString());
+    }
+
+    private SpanConverter() {}
+}

--- a/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
+++ b/brave/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
@@ -24,6 +24,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.internal.common.RequestContextExtension;
+import com.linecorp.armeria.internal.common.brave.SpanConverter;
 import com.linecorp.armeria.internal.common.brave.SpanTags;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -106,6 +107,8 @@ public final class BraveService extends SimpleDecoratingHttpService {
             ctxExtension.hook(() -> currentTraceContext.decorateScope(span.context(),
                                                                       SERVICE_REQUEST_DECORATING_SCOPE));
         }
+
+        ctx.logBuilder().tracingContext(SpanConverter.toLogTracingContext(span));
 
         maybeAddTagsToSpan(ctx, braveReq, span);
         try (SpanInScope ignored = tracer.withSpanInScope(span)) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -167,6 +167,9 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     @Nullable
     private Object rawResponseContent;
 
+    @Nullable
+    private TracingContext tracingContext;
+
     DefaultRequestLog(RequestContext ctx) {
         this.ctx = requireNonNull(ctx, "ctx");
     }
@@ -596,6 +599,17 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         hasLastChild = true;
         final RequestLogAccess lastChild = children.get(children.size() - 1);
         propagateResponseSideLog(lastChild.partial());
+    }
+
+    @Nullable
+    @Override
+    public TracingContext tracingContext() {
+        return this.tracingContext;
+    }
+
+    @Override
+    public void tracingContext(TracingContext tracingContext) {
+        this.tracingContext = requireNonNull(tracingContext, "tracingContext");
     }
 
     private void propagateResponseSideLog(RequestLog lastChild) {
@@ -1842,6 +1856,12 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         @Override
         public HttpHeaders responseTrailers() {
             return responseTrailers;
+        }
+
+        @Nullable
+        @Override
+        public TracingContext tracingContext() {
+            return tracingContext;
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -424,6 +424,11 @@ public interface RequestLogBuilder extends RequestLogAccess {
      */
     void defer(Iterable<RequestLogProperty> properties);
 
+    /**
+     * Fills the tracing context.
+     */
+    void tracingContext(TracingContext tracingContext);
+
     // Methods related with nested logs
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestOnlyLog.java
@@ -272,6 +272,16 @@ public interface RequestOnlyLog extends RequestLogAccess {
     HttpHeaders requestTrailers();
 
     /**
+     * Returns the tracing context log of the {@link Request}.
+     * Note that a {@link Service} or a {@link Client} must be decorated
+     * with BraveService or BraveClient decorators of armeria-brave module to enable the tracing.
+     *
+     * @return the tracing context.
+     */
+    @Nullable
+    TracingContext tracingContext();
+
+    /**
      * Returns the string representation of the {@link Request}, with no sanitization of headers or content.
      * This method is a shortcut for:
      * <pre>{@code

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TracingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TracingContext.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * A holder class which has the tracing(e.g. zipkin) information.
+ */
+public final class TracingContext {
+    final long traceIdHigh;
+
+    final long traceId;
+    final String traceIdString;
+
+    @Nullable
+    final Long parentId;
+    @Nullable
+    final String parentIdString;
+
+    final long spanId;
+    final String spanIdString;
+
+    final long localRootId;
+    final String localRootIdString;
+
+    /**
+     * Create a newly created {@link TracingContext}.
+     */
+    public static TracingContext of(long traceIdHigh, long traceId, String traceIdString,
+                                    @Nullable Long parentId, @Nullable String parentIdString,
+                                    Long spanId, String spanIdString,
+                                    long localRootId, String localRootIdString) {
+        return new TracingContext(traceIdHigh, traceId, traceIdString, parentId, parentIdString, spanId,
+                              spanIdString, localRootId, localRootIdString);
+    }
+
+    TracingContext(long traceIdHigh, long traceId, String traceIdString,
+                   @Nullable Long parentId, @Nullable String parentIdString,
+                   Long spanId, String spanIdString,
+                   long localRootId, String localRootIdString) {
+        this.traceIdHigh = traceIdHigh;
+        this.traceId = traceId;
+        this.traceIdString = requireNonNull(traceIdString, "traceIdString");
+        this.parentId = parentId;
+        this.parentIdString = parentIdString;
+        this.spanId = spanId;
+        this.spanIdString = requireNonNull(spanIdString, "spanIdString");
+        this.localRootId = localRootId;
+        this.localRootIdString = requireNonNull(localRootIdString, "localRootIdString");
+    }
+
+    /**
+     * Returns the trace id high.
+     */
+    public long traceIdHigh() {
+        return traceIdHigh;
+    }
+
+    /**
+     * Returns the trace id of the {@link Request}.
+     */
+    public long traceId() {
+        return traceId;
+    }
+
+    /**
+     * Returns the trace id of the {@link Request}.
+     */
+    public String traceIdString() {
+        return traceIdString;
+    }
+
+    /**
+     * Returns the parent span id of the {@link Request}.
+     */
+    @Nullable
+    public Long parentId() {
+        return parentId;
+    }
+
+    /**
+     * Returns the parent span id of the {@link Request}.
+     */
+    @Nullable
+    public String parentIdString() {
+        return parentIdString;
+    }
+
+    /**
+     * Returns the span id of the {@link Request}.
+     */
+    public long spanId() {
+        return spanId;
+    }
+
+    /**
+     * Returns the span id of the {@link Request}.
+     */
+    public String spanIdString() {
+        return spanIdString;
+    }
+
+    /**
+     * Returns the local root id of the {@link Request}.
+     */
+    public long localRootId() {
+        return localRootId;
+    }
+
+    /**
+     * Returns the local root id of the {@link Request}.
+     */
+    public String localRootIdString() {
+        return localRootIdString;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("traceIdHigh", traceIdHigh)
+                          .add("traceId", traceId)
+                          .add("traceIdString", traceIdString)
+                          .add("parentId", parentId)
+                          .add("parentIdString", parentIdString)
+                          .add("spanId", spanId)
+                          .add("spanIdString", spanIdString)
+                          .add("localRootId", localRootId)
+                          .add("localRootIdString", localRootIdString).toString();
+    }
+}


### PR DESCRIPTION
Motivation:

#1824 

Currently, `RequestLog` does not expose information such as `traceId` and `spanId`.
Consequently, when `traceId` and `spanId` are needed in `AccessLogWriter`, we have to be directly retrieved via `com.linecorp.armeria.internal.common.brave.TraceContextUtil.traceContext`.

Introducing an API in RequestLog to access trace information would be beneficial.

Modifications:

- Add `TracingContext` as a holder class for traceContext log information.
- For `tracingContext`, a getter is added to `RequestOnlyLog` and a setter to `RequestLogBuilder`.
- In `BraveService::serve` and `BraveClient::execute`, the method `ctx.logBuilder().tracingContext()` is invoked before proceeding to the delegate to populate the tracing information.

Result:

- Closes #1824
