### PR TITLE
Handle flaky xds test

### DIFF
--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterRoot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterRoot.java
@@ -40,7 +40,7 @@ public final class ClusterRoot extends AbstractRoot<ClusterSnapshot> {
             eventLoop().execute(this::close);
             return;
         }
-        super.close();
         node.close();
+        super.close();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ListenerRoot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ListenerRoot.java
@@ -40,7 +40,7 @@ public final class ListenerRoot extends AbstractRoot<ListenerSnapshot> {
             eventLoop().execute(this::close);
             return;
         }
-        super.close();
         node.close();
+        super.close();
     }
 }

--- a/xds/src/test/java/com/linecorp/armeria/xds/XdsClientIntegrationTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/XdsClientIntegrationTest.java
@@ -141,6 +141,7 @@ class XdsClientIntegrationTest {
 
             // try removing the watcher for cluster1
             clusterRoot.close();
+            await().untilAsserted(() -> assertThat(clusterRoot.closed()).isTrue());
 
             cache.setSnapshot(
                     GROUP,


### PR DESCRIPTION
Motivation:

Close operations are done on the event loop from the following change: https://github.com/line/armeria/pull/5336#discussion_r1464615997

However, a flaky test has been introduced.
https://ge.armeria.dev/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.xds.XdsClientIntegrationTest&tests.test=multipleResources()#

In short, I believe the cause is we update the snapshot before close is fully completed.

Modifications:

- Add an await statement to `XdsClientIntegrationTest#multipleResources`
- Modified so that the `closed` boolean flag is set after the `unsubscribe` is completed

Result:

- Less xds related flaky tests
- Fixes #5411

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
