### PR TITLE
Grant @dependabot write permission for workflow files.

### DIFF
--- a/.github/check-workflow-write-permission.sh
+++ b/.github/check-workflow-write-permission.sh
@@ -20,7 +20,8 @@ if [[ "$WORKFLOW_CHANGES" -eq "0" ]]; then
   exit 0
 fi
 
-MAINTAINERS=("ikhoon" "jrhee17" "minwoox" "trustin")
+# dependabot is a special user that is used to update dependencies in the workflow files.
+MAINTAINERS=("ikhoon" "dependabot" "jrhee17" "minwoox" "trustin")
 for maintainer in "${MAINTAINERS[@]}"
 do
   if [[ $maintainer == "$GITHUB_ACTOR" ]]; then


### PR DESCRIPTION
Because @dependabot sends pull requests to update the versions of GitHub Actions plugins in workflow files.