### PR TITLE
Add `BlockHoundIntegration` for kubernetes integration moulde

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/KubernetesBlockHoundIntegration.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/KubernetesBlockHoundIntegration.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2024 LINE Corporation
+ *
+ *  LINE Corporation licenses this file to you under the Apache License,
+ *  version 2.0 (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at:
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import reactor.blockhound.BlockHound.Builder;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+/**
+ * A {@link BlockHoundIntegration} for the Fabric Kubernetes module.
+ */
+@UnstableApi
+public final class KubernetesBlockHoundIntegration implements BlockHoundIntegration {
+    @Override
+    public void applyTo(Builder builder) {
+        // KubernetesClient uses a ReentrantLock. The lock is not acquired for a long time because we create
+        // a fully readable ByteBuffer.
+        builder.allowBlockingCallsInside(
+                "io.fabric8.kubernetes.client.http.HttpClientReadableByteChannel", "doLockedAndSignal");
+    }
+}

--- a/kubernetes/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/kubernetes/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+com.linecorp.armeria.client.kubernetes.KubernetesBlockHoundIntegration


### PR DESCRIPTION
Motivation:

The following method is detected as a blocking operation because `doLockedAndSignal` acquires a lock with `ReentranceLock`.
```
at io.fabric8.kubernetes.client.http.HttpClientReadableByteChannel.doLockedAndSignal(HttpClientReadableByteChannel.java:71)
```
The lock is used to read the remaining data from the given `ByteBuffer`. The Armeria integration creates a fully readable `ByteBuffer` so the lock condition would not happen.
https://github.com/fabric8io/kubernetes-client/blob/2c4d01d6bbc3ef5f077e07611f3723ad49388b5a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/HttpClientReadableByteChannel.java#L128-L130

Modification:

- Add `KubernetesBlockHoundIntegration` and register `HttpClientReadableByteChannel.doLockedAndSignal()` as a safe call.

Result:

- No false positive BlockBound report.
- Fixes #5424
