### PR TITLE
BlockHound: Temporarily disable detection of `SecureRandom` as blocking

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/KubernetesBlockHoundIntegration.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/KubernetesBlockHoundIntegration.java
@@ -32,5 +32,12 @@ public final class KubernetesBlockHoundIntegration implements BlockHoundIntegrat
         // a fully readable ByteBuffer.
         builder.allowBlockingCallsInside(
                 "io.fabric8.kubernetes.client.http.HttpClientReadableByteChannel", "doLockedAndSignal");
+        // StandardHttpRequest creates UUIDs using java.util.UUID.randomUUID() that uses SecureRandom.
+        // The method is temporarily allowed until the problem is resolved in the upstream.
+        // See: https://github.com/fabric8io/kubernetes-client/issues/5735
+        // TODO(ikhoon): Remove this once the issue is fixed.
+        builder.allowBlockingCallsInside(
+                "io.fabric8.kubernetes.client.http.StandardHttpRequest$Builder",
+                "build");
     }
 }


### PR DESCRIPTION
Motivation:

BlockHound reported that `io.fabric8.kubernetes.client.http.StandardHttpRequest` invokes blocking calls.
https://github.com/line/armeria/actions/runs/7721798741/job/21048920064?pr=5370#step:17:30
```
java.lang.Exception: java.io.FileInputStream#readBytes
	at com.linecorp.armeria.internal.testing.InternalTestingBlockHoundIntegration.writeBlockingMethod(InternalTestingBlockHoundIntegration.java:84)
	at reactor.blockhound.BlockHound$Builder.lambda$install$8(BlockHound.java:472)
	at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:89)
	at java.base/java.io.FileInputStream.readBytes(FileInputStream.java)
	at java.base/java.io.FileInputStream.read(FileInputStream.java:293)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:119)
	at java.base/sun.security.provider.NativePRNG$RandomIO.readFully(NativePRNG.java:425)
	at java.base/sun.security.provider.NativePRNG$RandomIO.ensureBufferValid(NativePRNG.java:528)
	at java.base/sun.security.provider.NativePRNG$RandomIO.implNextBytes(NativePRNG.java:547)
	at java.base/sun.security.provider.NativePRNG.engineNextBytes(NativePRNG.java:221)
	at java.base/java.security.SecureRandom.nextBytes(SecureRandom.java:758)
	at java.base/java.util.UUID.randomUUID(UUID.java:151)
	at io.fabric8.kubernetes.client.http.StandardHttpRequest.<init>(StandardHttpRequest.java:116)
	at io.fabric8.kubernetes.client.http.StandardHttpRequest$Builder.build(StandardHttpRequest.java:201)
```

There is nothing we can do except add an exception rule for that. So the issue is reported to the upstream.
https://github.com/fabric8io/kubernetes-client/issues/5735 
The blocking call is temporarily allowed until the problem is resolved in the upstream.

Modifications:

- Allow blocking calls inside `StandardHttpRequest$Builder.build()`.

Result:

Make CI build pass to identify meaningful problems.
