### PR TITLE
Fix the incorrect name of @dependabot in `check-workflow-write-permission.sh`

### DIFF
--- a/.github/check-workflow-write-permission.sh
+++ b/.github/check-workflow-write-permission.sh
@@ -20,8 +20,8 @@ if [[ "$WORKFLOW_CHANGES" -eq "0" ]]; then
   exit 0
 fi
 
-# dependabot is a special user that is used to update dependencies in the workflow files.
-MAINTAINERS=("ikhoon" "dependabot" "jrhee17" "minwoox" "trustin")
+# dependabot[bot] is a special user that is used to update dependencies in the workflow files.
+MAINTAINERS=("ikhoon" "dependabot[bot]" "jrhee17" "minwoox" "trustin")
 for maintainer in "${MAINTAINERS[@]}"
 do
   if [[ $maintainer == "$GITHUB_ACTOR" ]]; then


### PR DESCRIPTION
`GITHUB_ACTOR` name of @dependabot is not `dependabot` but `dependabot[bot]`.
