### PR TITLE
Fix links on kotlin docs and fix service request context propagation example

### DIFF
--- a/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
+++ b/examples/context-propagation/kotlin/src/main/kotlin/example/armeria/contextpropagation/kotlin/MainService.kt
@@ -23,11 +23,11 @@ import com.linecorp.armeria.client.WebClient
 import com.linecorp.armeria.common.AggregatedHttpResponse
 import com.linecorp.armeria.common.HttpRequest
 import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.kotlin.asCoroutineDispatcher
 import com.linecorp.armeria.server.HttpService
 import com.linecorp.armeria.server.ServiceRequestContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.future.asDeferred

--- a/site/src/pages/docs/advanced-kotlin.mdx
+++ b/site/src/pages/docs/advanced-kotlin.mdx
@@ -6,7 +6,7 @@ import versions from '../../../gen-src/versions.json';
 
 <Tip>
 
-Visit [annotated-http-service-kotlin](https://github.com/line/armeria/examples/annotated-http-service-kotlin) to check out a fully working example.
+Visit [annotated-http-service-kotlin](https://github.com/line/armeria/tree/main/examples/annotated-http-service-kotlin) to check out a fully working example.
 
 </Tip>
 
@@ -152,9 +152,17 @@ val response: ResponseEntity<RestResponse> =
 
 <Tip>
 
-Visit [grpc-kotlin](https://github.com/line/armeria/examples/grpc-kotlin) to check out a fully working example.
+Visit [grpc-kotlin](https://github.com/line/armeria/tree/main/examples/grpc-kotlin) to check out a fully working example.
 
 </Tip>
+
+To use gRPC-Kotlin with Armeria, add the following dependency:
+<RequiredDependencies
+  boms={[{ groupId: 'com.linecorp.armeria', artifactId: 'armeria-bom' }]}
+  dependencies={[
+    { groupId: 'com.linecorp.armeria', artifactId: 'armeria-grpc-kotlin' },
+  ]}
+/>
 
 ### Running a gRPC-Kotlin service
 

--- a/site/src/pages/docs/client-grpc.mdx
+++ b/site/src/pages/docs/client-grpc.mdx
@@ -171,6 +171,7 @@ try {
 - [Running a gRPC service](/docs/server-grpc)
 - [Decorating a client](/docs/client-decorator)
 - [Sending custom HTTP headers](/docs/client-custom-http-headers)
+- [Calling a gRPC kotlin service](/docs/advanced-kotlin#calling-a-grpc-kotlin-service)
 
 [CompletableFuture]: https://docs.oracle.com/javase/10/docs/api/java/util/concurrent/CompletableFuture.html
 [Futures]: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/util/concurrent/Futures.html

--- a/site/src/pages/docs/server-grpc.mdx
+++ b/site/src/pages/docs/server-grpc.mdx
@@ -330,6 +330,7 @@ For more information, see the official [gRPC Server Reflection tutorial](https:/
 
 ## See also
 - [Client gRPC](/docs/client-grpc)
+- [Kotlin coroutine gRPC service](/docs/advanced-kotlin#coroutines-support-for-grpc-kotlin)
 
 [gRPC]: https://grpc.io/
 [gRPC-Web]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md


### PR DESCRIPTION
Motivation:

Some links I tried to click were broken.

Modifications:

- Fix links to the examples.
- Add _See also_ links for kotlin-grpc related stuff.
