### PR TITLE
Update the tutorial introduction

### DIFF
--- a/site/src/pages/tutorials/index.mdx
+++ b/site/src/pages/tutorials/index.mdx
@@ -8,17 +8,17 @@ tags:
 
 # Tutorials
 
-Learn how to write a service with Armeria by walking through this tutorial.
-The tutorial takes you through steps based on a sample service, a blog service, to offer you practical guidance.
+Welcome to our Armeria tutorials!
+Learn how to write a service with Armeria by walking through these tutorials.
+These tutorials take you through steps based on a sample service, a blog service, to offer you practical guidance.
 
-## Try running the service
+We've prepared three different tutorials for you:
 
-Before you dive into coding, try running the sample blog service to get an idea of the service.
-Thanks to Armeria's [Documentation service](/docs/server-docservice), you can view a list of APIs the service provides and make API calls to see how to use the service.
+- [REST tutorial](/tutorials/rest/blog): Learn how to build a REST service with Armeria.
+- [gRPC tutorial](/tutorials/grpc/blog): Learn how to build a [gRPC](https://grpc.io/) service with Armeria.
+- [Thrift tutorial](/tutorials/thrift/blog): Learn how to build a service using [Apache Thrift](https://thrift.apache.org/) with Armeria.
 
-- [Run the sample for REST services](/tutorials/rest/blog#run-sample-service)
+You can choose any tutorial that interests you.
+Each one is designed to be clear and simple, so you'll be able to build your own service with Armeria by the time you're done.
 
-## Get started
-
-If your service is RESTful, then you're lucky! The first Armeria tutorial available targets REST services.
-Get your hands on the [tutorial for REST services](/tutorials/rest/blog) now!
+Let's get started!


### PR DESCRIPTION
Motivation:
The tutorial introduction (https://armeria.dev/tutorials) mentions the REST tutorial only.

Modifications:
- Rewrite the tutorial introduction to cover all tutorials including the gRPC and Thrift tutorials.

Result:
- Updates the tutorial introduction on Armeria site.
