### PR TITLE
Eureka: Remove encoded port from VIP address defaults

### DIFF
--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListener.java
@@ -190,12 +190,8 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
     }
 
     private static InstanceInfo fillAndCreateNewInfo(InstanceInfo oldInfo, Server server) {
-        final String hostName;
-        if (oldInfo.getHostName() != null) {
-            hostName = oldInfo.getHostName();
-        } else {
-            hostName = withoutPort(server.defaultHostname());
-        }
+        final String defaultHostname = server.defaultHostname();
+        final String hostName = oldInfo.getHostName() != null ? oldInfo.getHostName() : defaultHostname;
         final String appName = oldInfo.getAppName() != null ? oldInfo.getAppName() : hostName;
 
         final Inet4Address defaultInet4Address = SystemInfo.defaultNonLoopbackIpV4Address();
@@ -242,19 +238,6 @@ public final class EurekaUpdatingListener extends ServerListenerAdapter {
                                 oldInfo.getHomePageUrl(), oldInfo.getStatusPageUrl(), healthCheckUrl,
                                 secureHealthCheckUrl, oldInfo.getDataCenterInfo(),
                                 oldInfo.getLeaseInfo(), oldInfo.getMetadata());
-    }
-
-    /**
-     * Strip any port in {@linkplain Server#defaultHostname()}, so that it can be used in Eureka
-     * registration as a {@code hostName} or {@code vipAddress}.
-     */
-    private static String withoutPort(String hostname) {
-        final int hostnameColonIdx = hostname.lastIndexOf(':');
-        if (hostnameColonIdx < 0) {
-            return hostname;
-        }
-
-        return hostname.substring(0, hostnameColonIdx);
     }
 
     private static PortWrapper portWrapper(Server server, PortWrapper oldPortWrapper,

--- a/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
+++ b/eureka/src/test/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerTest.java
@@ -195,8 +195,8 @@ class EurekaUpdatingListenerTest {
         }
         final int port = application.activePort(SessionProtocol.HTTP).localAddress().getPort();
         final int securePort = application.activePort(SessionProtocol.HTTPS).localAddress().getPort();
-        builder.vipAddress(application.defaultHostname() + ':' + port)
-               .secureVipAddress(application.defaultHostname() + ':' + securePort)
+        builder.vipAddress(application.defaultHostname())
+               .secureVipAddress(application.defaultHostname())
                .port(port)
                .securePort(securePort)
                .healthCheckUrl("http://" + hostnameOrIpAddr + ':' + port + "/health")


### PR DESCRIPTION
Motivation:

Currently, when armeria registers a server, it appends `:${port}` to Eureka VIP addresses to. While it makes sense to encode the port into the Eureka `serviceId`, the VIP address fields are meant to be hostnames or IPs. Encoding a port into the VIP address makes these unusable for certain clients like spring-cloud-sleuth who heuristically look for a port and only if it is absent trigger Eureka lookups.

Modifications:

- I removed the logic that appended `:${port}` to both the `vipAddress` and `secureVipAddress`
- I changed the test which actually proved the bug was present!

Result:

- Manual integration with zipkin, sleuth is now able to look up its endpoint in Eureka.
