### PR TITLE
Apply ktlint with `max_line_length` as 112

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+max_line_length = 112

--- a/benchmarks/jmh/src/jmh/kotlin/com/linecorp/armeria/internal/common/kotlin/AnnotatedServiceFlowBenchmark.kt
+++ b/benchmarks/jmh/src/jmh/kotlin/com/linecorp/armeria/internal/common/kotlin/AnnotatedServiceFlowBenchmark.kt
@@ -58,7 +58,8 @@ open class AnnotatedServiceFlowBenchmark {
 
                         @Get("/publisher")
                         @ProducesJsonSequences
-                        fun publisherBm(): Publisher<String> = Flux.fromStream(IntStream.range(0, 1000).mapToObj { it.toString() })
+                        fun publisherBm(): Publisher<String> =
+                            Flux.fromStream(IntStream.range(0, 1000).mapToObj { it.toString() })
                     },
                 )
                 .build()

--- a/examples/graphql-kotlin/src/test/kotlin/example/armeria/server/graphql/kotlin/GraphqlArmeriaClient.kt
+++ b/examples/graphql-kotlin/src/test/kotlin/example/armeria/server/graphql/kotlin/GraphqlArmeriaClient.kt
@@ -20,7 +20,8 @@ class GraphqlArmeriaClient(
     private val serializer: GraphQLClientSerializer = defaultGraphQLSerializer(),
     // TODO(ikhoon): support Automatic Persisted Queries
     //               See: https://github.com/ExpediaGroup/graphql-kotlin/issues/1640
-    override val automaticPersistedQueriesSettings: AutomaticPersistedQueriesSettings = AutomaticPersistedQueriesSettings(),
+    override val automaticPersistedQueriesSettings: AutomaticPersistedQueriesSettings =
+        AutomaticPersistedQueriesSettings(),
 ) : GraphQLClient<HttpRequestBuilder> {
     override suspend fun <T : Any> execute(
         request: GraphQLClientRequest<T>,

--- a/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
+++ b/examples/grpc-kotlin/src/main/kotlin/example/armeria/grpc/kotlin/HelloServiceImpl.kt
@@ -99,7 +99,10 @@ class HelloServiceImpl : HelloServiceGrpcKt.HelloServiceCoroutineImplBase() {
         suspend fun <T> withArmeriaBlockingContext(block: suspend CoroutineScope.() -> T): T =
             withContext(ServiceRequestContext.current().blockingTaskExecutor().asCoroutineDispatcher(), block)
 
-        private fun buildReply(message: String): HelloReply = HelloReply.newBuilder().setMessage(message).build()
+        private fun buildReply(message: String): HelloReply =
+            HelloReply.newBuilder().setMessage(
+                message,
+            ).build()
 
         private fun toMessage(message: String): String = "Hello, $message!"
     }

--- a/grpc-kotlin/src/main/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptor.kt
+++ b/grpc-kotlin/src/main/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptor.kt
@@ -95,7 +95,9 @@ interface CoroutineServerInterceptor : AsyncServerInterceptor {
             CoroutineContextServerInterceptor::class.let { kclass ->
                 val companionObject = checkNotNull(kclass.companionObject)
                 val property = companionObject.memberProperties.single { it.name == "COROUTINE_CONTEXT_KEY" }
-                checkNotNull(property.getter.call(kclass.companionObjectInstance)) as Context.Key<CoroutineContext>
+                checkNotNull(
+                    property.getter.call(kclass.companionObjectInstance),
+                ) as Context.Key<CoroutineContext>
             }
     }
 }

--- a/grpc-kotlin/src/test/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptorTest.kt
+++ b/grpc-kotlin/src/test/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptorTest.kt
@@ -394,7 +394,9 @@ internal class CoroutineServerInterceptorTest {
                 return SimpleResponse.getDefaultInstance()
             }
 
-            override fun streamingOutputCall(request: StreamingOutputCallRequest): Flow<StreamingOutputCallResponse> {
+            override fun streamingOutputCall(
+                request: StreamingOutputCallRequest,
+            ): Flow<StreamingOutputCallResponse> {
                 return flow {
                     for (i in 1..5) {
                         delay(500)
@@ -404,7 +406,9 @@ internal class CoroutineServerInterceptorTest {
                 }
             }
 
-            override suspend fun streamingInputCall(requests: Flow<StreamingInputCallRequest>): StreamingInputCallResponse {
+            override suspend fun streamingInputCall(
+                requests: Flow<StreamingInputCallRequest>,
+            ): StreamingInputCallResponse {
                 val names = requests.map { it.payload.body.toString() }.toList()
 
                 assertContextPropagation()
@@ -412,7 +416,9 @@ internal class CoroutineServerInterceptorTest {
                 return buildReply(names)
             }
 
-            override fun fullDuplexCall(requests: Flow<StreamingOutputCallRequest>): Flow<StreamingOutputCallResponse> {
+            override fun fullDuplexCall(
+                requests: Flow<StreamingOutputCallRequest>,
+            ): Flow<StreamingOutputCallResponse> {
                 return flow {
                     requests.collect {
                         delay(500)

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/TestServiceImpl.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/TestServiceImpl.kt
@@ -105,12 +105,16 @@ class TestServiceImpl : TestServiceGrpcKt.TestServiceCoroutineImplBase() {
             ServiceRequestContext.current().blockingTaskExecutor().asCoroutineDispatcher()
 
         // A blocking dispatcher that does not propagate a request context
-        fun blockingDispatcher(): CoroutineDispatcher = CommonPools.blockingTaskExecutor().asCoroutineDispatcher()
+        fun blockingDispatcher(): CoroutineDispatcher =
+            CommonPools.blockingTaskExecutor().asCoroutineDispatcher()
 
         suspend fun <T> withArmeriaBlockingContext(block: suspend CoroutineScope.() -> T): T =
             withContext(ServiceRequestContext.current().blockingTaskExecutor().asCoroutineDispatcher(), block)
 
-        private fun buildReply(message: String): HelloReply = HelloReply.newBuilder().setMessage(message).build()
+        private fun buildReply(message: String): HelloReply =
+            HelloReply.newBuilder().setMessage(
+                message,
+            ).build()
 
         private fun toMessage(message: String): String = "Hello, $message!"
     }

--- a/it/kotlin/src/test/kotlin/com/linecorp/armeria/it/AnnotatedServiceErrorMessageTest.kt
+++ b/it/kotlin/src/test/kotlin/com/linecorp/armeria/it/AnnotatedServiceErrorMessageTest.kt
@@ -31,7 +31,8 @@ class AnnotatedServiceErrorMessageTest {
 
         assertThatThrownBy { serverBuilder.build() }
             .hasMessageContaining(
-                "Kotlin suspending functions are supported only when you added 'armeria-kotlin' as a dependency.",
+                "Kotlin suspending functions are supported" +
+                    " only when you added 'armeria-kotlin' as a dependency.",
             )
     }
 

--- a/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaRequestCoroutineContext.kt
+++ b/kotlin/src/main/kotlin/com/linecorp/armeria/internal/common/kotlin/ArmeriaRequestCoroutineContext.kt
@@ -25,7 +25,10 @@ import kotlin.coroutines.CoroutineContext
 /**
  * Propagates [ServiceRequestContext] over coroutines.
  */
-@Deprecated("Use RequestContext.asCoroutineContext() instead.", ReplaceWith("RequestContext.asCoroutineContext()"))
+@Deprecated(
+    "Use RequestContext.asCoroutineContext() instead.",
+    ReplaceWith("RequestContext.asCoroutineContext()"),
+)
 class ArmeriaRequestCoroutineContext(
     private val requestContext: ServiceRequestContext,
 ) : ThreadContextElement<SafeCloseable>, AbstractCoroutineContextElement(Key) {

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/FlowAnnotatedServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/FlowAnnotatedServiceTest.kt
@@ -243,7 +243,9 @@ internal class FlowAnnotatedServiceTest {
                                 fun runsWithinEventLoop() =
                                     flow {
                                         ServiceRequestContext.current()
-                                        assertThat(Thread.currentThread().name).contains("armeria-common-worker")
+                                        assertThat(
+                                            Thread.currentThread().name,
+                                        ).contains("armeria-common-worker")
                                         emit("OK")
                                     }
                             },

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/SuspendingAnnotatedServiceTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/server/kotlin/SuspendingAnnotatedServiceTest.kt
@@ -256,7 +256,9 @@ class SuspendingAnnotatedServiceTest {
                                 @Get("/baz")
                                 suspend fun baz(): String {
                                     ServiceRequestContext.current()
-                                    assertThat(Thread.currentThread().name).contains("armeria-common-blocking-tasks")
+                                    assertThat(
+                                        Thread.currentThread().name,
+                                    ).contains("armeria-common-blocking-tasks")
                                     return "OK"
                                 }
                             },


### PR DESCRIPTION
Motivation:

Currently kotlin maximum line length is set with 140 which is default for ktlint_official(https://pinterest.github.io/ktlint/latest/rules/standard/#max-line-length)

Modifications:

- Set maximum line length of ktlint as 112. This rule is added by `.editorconfig` file.
- Apply ktlint

Result:

- Closes #5421