### PR TITLE
Suggestion: Set intellij project icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,8 @@ hs_err_pid*
 .gradle
 
 # IntelliJ
-.idea
+**/.idea/*
+!.idea/icon.svg
 *.iml
 *.iws
 *.ipr

--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="297mm" height="297mm" viewBox="0 0 160 154" version="1.1" id="svg140" xmlns="http://www.w3.org/2000/svg">
+  <g id="layer1" transform="matrix(1, 0, 0, 1, -66.059792, -107.460991)">
+    <g id="g260" transform="matrix(2.182102, 0, 0, 2.182102, -1793.828857, 164.840744)">
+      <g transform="matrix(0.35277777,0,0,-0.35277777,888.99975,-5.1289648)" id="g12">
+        <path id="path14" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,-20 V -60 L 0,-80 34.641,-60 v 40 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,913.44097,-5.1289648)" id="g16">
+        <path id="path18" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 V 40 L -34.641,20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,864.55871,8.9821452)" id="g20">
+        <path id="path22" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 V 40 L -34.641,20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,901.22036,44.259915)" id="g24">
+        <path id="path26" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 V 40 L -34.641,20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,864.55871,-19.240079)" id="g28">
+        <path id="path30" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v -40 l 34.641,20 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,913.44097,-5.1289648)" id="g32">
+        <path id="path34" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v -40 l 34.641,20 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,876.77932,30.148805)" id="g36">
+        <path id="path38" style="fill:#ff9dc3;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v -40 l 34.641,20 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,876.77932,-26.295635)" id="g40">
+        <path id="path42" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,-20 0,-40 34.641,-20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,913.44097,-19.240079)" id="g44">
+        <path id="path46" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,20 -69.282,0 -34.641,-20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,901.22036,1.9265852)" id="g48">
+        <path id="path50" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v 0 -40 l 34.641,20 V 20 L 0,40 -34.641,20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,876.77932,1.9265852)" id="g52">
+        <path id="path54" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 34.641,20 0,40 -34.641,20 V -20 L 0,-40 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,901.22036,44.259915)" id="g56">
+        <path id="path58" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 34.641,20 V 60 L 0,40 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,913.44097,8.9821452)" id="g60">
+        <path id="path62" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v -40 l 34.641,20 0.001,40 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,864.55871,37.204365)" id="g64">
+        <path id="path66" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 34.641,-20 V 20 L 0,40 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,852.3381,1.9265852)" id="g68">
+        <path id="path70" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="m 0,0 v -40 l 34.641,-20 v 40 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,888.99975,23.093255)" id="g72">
+        <path id="path74" style="fill:#ff0089;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,20 V -20 L 0,-40 34.641,-20 v 40 z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,901.22036,-12.184525)" id="g76">
+        <path id="path78" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,20 -69.282,0 -34.641,-20 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,913.44097,8.9821452)" id="g80">
+        <path id="path82" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 -34.641,-20 V -60 L 0,-40 Z"/>
+      </g>
+      <g transform="matrix(0.35277777,0,0,-0.35277777,864.55871,8.9821452)" id="g84">
+        <path id="path86" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" d="M 0,0 34.641,-20 V -60 L 0,-40 Z"/>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Motivation:

There is no intellij project icon.

Modifications:

- Add icon to `.idea/icon.svg`
- (Copied and edited [this logo file](https://github.com/line/armeria/blob/main/site/src/design/armeria_icon.svg) to trim space and make square)

Result:

- Looks good

<img width="468" alt="Screenshot 2024-02-15 at 9 03 32 PM" src="https://github.com/line/armeria/assets/11611397/8a87e959-9009-469d-8262-10d23cf686ae">

example


<img width="1035" alt="Screenshot 2024-02-15 at 9 14 31 PM" src="https://github.com/line/armeria/assets/11611397/9aa4d105-6ee0-45c5-ad5a-68e6f6c30bdf">

Project icon can be set from welcome page

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
