### PR TITLE
Relax the validation of `Location` header when redirecting

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -294,6 +294,13 @@ public interface ClientRequestContext extends RequestContext {
     String authority();
 
     /**
+     * Returns the host part of {@link #authority()}, without a port number.
+     */
+    @Nullable
+    @UnstableApi
+    String host();
+
+    /**
      * Returns the {@link URI} constructed based on {@link ClientRequestContext#sessionProtocol()},
      * {@link ClientRequestContext#authority()}, {@link ClientRequestContext#path()} and
      * {@link ClientRequestContext#query()}.

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -73,6 +73,11 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public String host() {
+        return unwrap().host();
+    }
+
+    @Override
     public URI uri() {
         return unwrap().uri();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -294,7 +294,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
     @VisibleForTesting
     static RequestTarget resolveLocation(ClientRequestContext ctx, String location) {
         final long length = location.length();
-        assert length > 0 : location;
+        assert length > 0;
 
         final String resolvedUri;
         if (location.charAt(0) == '/') {

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -154,7 +154,7 @@ public abstract class AbstractRequestContextBuilder {
             this.reqTarget = reqTarget;
         } else {
             reqTarget = DefaultRequestTarget.createWithoutValidation(
-                    RequestTargetForm.ORIGIN, null, null,
+                    RequestTargetForm.ORIGIN, null, null, null, -1,
                     uri.getRawPath(), uri.getRawPath(), uri.getRawQuery(), uri.getRawFragment());
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeadersBase.java
@@ -57,6 +57,7 @@ import com.google.common.math.IntMath;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.StringUtil;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
 import io.netty.util.AsciiString;
 
@@ -214,18 +215,17 @@ class HttpHeadersBase
             checkState(scheme != null, ":scheme header does not exist.");
             final String authority = authority();
 
-            final StringBuilder sb = new StringBuilder(
-                    scheme.length() + 1 +
-                    (authority != null ? (authority.length() + 2) : 0) +
-                    path.length());
-            sb.append(scheme);
-            sb.append(':');
-            if (authority != null) {
-                sb.append("//");
-                sb.append(authority);
+            try (TemporaryThreadLocals tmp = TemporaryThreadLocals.acquire()) {
+                final StringBuilder sb = tmp.stringBuilder();
+                sb.append(scheme);
+                sb.append(':');
+                if (authority != null) {
+                    sb.append("//");
+                    sb.append(authority);
+                }
+                sb.append(path);
+                uri = sb.toString();
             }
-            sb.append(path);
-            uri = sb.toString();
         }
 
         try {

--- a/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
@@ -99,6 +99,24 @@ public interface RequestTarget {
     String authority();
 
     /**
+     * Returns the host of this {@link RequestTarget}. Unlike {@link #authority()}, host doesn't include
+     * a port number.
+     *
+     * @return a non-empty string if {@link #form()} is {@link RequestTargetForm#ABSOLUTE}.
+     *         {@code null} otherwise.
+     */
+    @Nullable
+    String host();
+
+    /**
+     * Returns the port of this {@link RequestTarget}.
+     *
+     * @return a positive port number if {@link #form()} is {@link RequestTargetForm#ABSOLUTE} and
+     *         {@link #authority()} has the port number. Zero or a negative value otherwise.
+     */
+    int port();
+
+    /**
      * Returns the path of this {@link RequestTarget}, which always starts with {@code '/'}.
      */
     String path();

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -753,8 +753,20 @@ public final class DefaultClientRequestContext
     @Override
     public URI uri() {
         final String scheme = getScheme(sessionProtocol());
-        try {
-            return new URI(scheme, authority(), path(), query(), fragment());
+        final String authority = authority();
+        final String path = path();
+        final String query = query();
+        final String fragment = fragment();
+        try (TemporaryThreadLocals tmp = TemporaryThreadLocals.acquire()) {
+            final StringBuilder buf = tmp.stringBuilder();
+            buf.append(scheme).append("://").append(authority).append(path);
+            if (query != null) {
+                buf.append('?').append(query);
+            }
+            if (fragment != null) {
+                buf.append('#').append(fragment);
+            }
+            return new URI(buf.toString());
         } catch (URISyntaxException e) {
             throw new IllegalStateException("not a valid URI", e);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -773,7 +773,13 @@ public final class DefaultClientRequestContext
         final String fragment = fragment();
         try (TemporaryThreadLocals tmp = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tmp.stringBuilder();
-            buf.append(scheme).append("://").append(authority).append(path);
+            buf.append(scheme);
+            if (authority != null) {
+                buf.append("://").append(authority);
+            } else {
+                buf.append(':');
+            }
+            buf.append(path);
             if (query != null) {
                 buf.append('?').append(query);
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -464,7 +464,7 @@ public final class DefaultClientRequestContext
             // The connection will be established with the IP address but `host` set to the `Endpoint`
             // could be used for SNI. It would make users send HTTPS requests with CSLB or configure a reverse
             // proxy based on an authority.
-            final String host = HostAndPort.fromString(removeUserInfo(authority)).getHost();
+            final String host = authorityToHost(authority);
             if (!NetUtil.isValidIpV4Address(host) && !NetUtil.isValidIpV6Address(host)) {
                 endpoint = endpoint.withHost(host);
             }
@@ -485,6 +485,10 @@ public final class DefaultClientRequestContext
             }
         }
         internalRequestHeaders = headersBuilder.build();
+    }
+
+    private static String authorityToHost(String authority) {
+        return HostAndPort.fromString(removeUserInfo(authority)).getHost();
     }
 
     private static String removeUserInfo(String authority) {
@@ -748,6 +752,16 @@ public final class DefaultClientRequestContext
             origin = internalRequestHeaders.get(HttpHeaderNames.ORIGIN);
         }
         return origin;
+    }
+
+    @Override
+    public String host() {
+        final String authority = authority();
+        if (authority == null) {
+            return null;
+        }
+
+        return authorityToHost(authority);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -253,6 +253,27 @@ public final class ArmeriaHttpUtil {
     }
 
     /**
+     * Returns the index of the authority part if the specified {@code reqTarget} is an absolute URI.
+     * Returns {@code -1} otherwise.
+     */
+    public static int findAuthority(String reqTarget) {
+        final int firstColonIdx = reqTarget.indexOf(':');
+        if (firstColonIdx <= 0 || reqTarget.length() <= firstColonIdx + 3) {
+            return -1;
+        }
+        final int firstSlashIdx = reqTarget.indexOf('/');
+        if (firstSlashIdx <= 0 || firstSlashIdx < firstColonIdx) {
+            return -1;
+        }
+
+        if (reqTarget.charAt(firstColonIdx + 1) == '/' && reqTarget.charAt(firstColonIdx + 2) == '/') {
+            return firstColonIdx + 3;
+        }
+
+        return -1;
+    }
+
+    /**
      * Concatenates the specified {@code prefix} and {@code path} into an absolute path.
      *
      * @throws IllegalArgumentException if {@code prefix} is not an absolute path prefix

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.internal.common;
 
+import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.findAuthority;
 import static io.netty.util.internal.StringUtil.decodeHexNibble;
 import static java.util.Objects.requireNonNull;
 
@@ -122,6 +123,8 @@ public final class DefaultRequestTarget implements RequestTarget {
             RequestTargetForm.ASTERISK,
             null,
             null,
+            null,
+            -1,
             "*",
             "*",
             null,
@@ -185,9 +188,10 @@ public final class DefaultRequestTarget implements RequestTarget {
      */
     public static RequestTarget createWithoutValidation(
             RequestTargetForm form, @Nullable String scheme, @Nullable String authority,
-            String path, String pathWithMatrixVariables, @Nullable String query, @Nullable String fragment) {
+            @Nullable String host, int port, String path, String pathWithMatrixVariables,
+            @Nullable String query, @Nullable String fragment) {
         return new DefaultRequestTarget(
-                form, scheme, authority, path, pathWithMatrixVariables, query, fragment);
+                form, scheme, authority, host, port, path, pathWithMatrixVariables, query, fragment);
     }
 
     private final RequestTargetForm form;
@@ -195,6 +199,9 @@ public final class DefaultRequestTarget implements RequestTarget {
     private final String scheme;
     @Nullable
     private final String authority;
+    @Nullable
+    private final String host;
+    private final int port;
     private final String path;
     private final String maybePathWithMatrixVariables;
     @Nullable
@@ -203,16 +210,20 @@ public final class DefaultRequestTarget implements RequestTarget {
     private final String fragment;
     private boolean cached;
 
-    private DefaultRequestTarget(RequestTargetForm form, @Nullable String scheme, @Nullable String authority,
+    private DefaultRequestTarget(RequestTargetForm form, @Nullable String scheme,
+                                 @Nullable String authority, @Nullable String host, int port,
                                  String path, String maybePathWithMatrixVariables,
                                  @Nullable String query, @Nullable String fragment) {
 
-        assert (scheme != null && authority != null) ||
-               (scheme == null && authority == null) : "scheme: " + scheme + ", authority: " + authority;
+        assert (scheme != null && authority != null && host != null) ||
+               (scheme == null && authority == null && host == null)
+                : "scheme: " + scheme + ", authority: " + authority + ", host: " + host;
 
         this.form = form;
         this.scheme = scheme;
         this.authority = authority;
+        this.host = host;
+        this.port = port;
         this.path = path;
         this.maybePathWithMatrixVariables = maybePathWithMatrixVariables;
         this.query = query;
@@ -232,6 +243,17 @@ public final class DefaultRequestTarget implements RequestTarget {
     @Override
     public String authority() {
         return authority;
+    }
+
+    @Override
+    @Nullable
+    public String host() {
+        return host;
+    }
+
+    @Override
+    public int port() {
+        return port;
     }
 
     @Override
@@ -369,6 +391,8 @@ public final class DefaultRequestTarget implements RequestTarget {
         return new DefaultRequestTarget(RequestTargetForm.ORIGIN,
                                         null,
                                         null,
+                                        null,
+                                        -1,
                                         matrixVariablesRemovedPath,
                                         encodedPath,
                                         encodeQueryToPercents(query),
@@ -439,6 +463,8 @@ public final class DefaultRequestTarget implements RequestTarget {
             return new DefaultRequestTarget(RequestTargetForm.ABSOLUTE,
                                             schemeAndAuthority.getScheme(),
                                             schemeAndAuthority.getRawAuthority(),
+                                            schemeAndAuthority.getHost(),
+                                            schemeAndAuthority.getPort(),
                                             "/",
                                             "/", null,
                                             null);
@@ -572,6 +598,8 @@ public final class DefaultRequestTarget implements RequestTarget {
             return new DefaultRequestTarget(RequestTargetForm.ABSOLUTE,
                                             schemeAndAuthority.getScheme(),
                                             schemeAndAuthority.getRawAuthority(),
+                                            schemeAndAuthority.getHost(),
+                                            schemeAndAuthority.getPort(),
                                             encodedPath,
                                             encodedPath, encodedQuery,
                                             encodedFragment);
@@ -579,31 +607,12 @@ public final class DefaultRequestTarget implements RequestTarget {
             return new DefaultRequestTarget(RequestTargetForm.ORIGIN,
                                             null,
                                             null,
+                                            null,
+                                            -1,
                                             encodedPath,
                                             encodedPath, encodedQuery,
                                             encodedFragment);
         }
-    }
-
-    /**
-     * Returns the index of the authority part if the specified {@code reqTarget} is an absolute URI.
-     * Returns {@code -1} otherwise.
-     */
-    private static int findAuthority(String reqTarget) {
-        final int firstColonIdx = reqTarget.indexOf(':');
-        if (firstColonIdx <= 0 || reqTarget.length() <= firstColonIdx + 3) {
-            return -1;
-        }
-        final int firstSlashIdx = reqTarget.indexOf('/');
-        if (firstSlashIdx <= 0 || firstSlashIdx < firstColonIdx) {
-            return -1;
-        }
-
-        if (reqTarget.charAt(firstColonIdx + 1) == '/' && reqTarget.charAt(firstColonIdx + 2) == '/') {
-            return firstColonIdx + 3;
-        }
-
-        return -1;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -595,11 +595,24 @@ public final class DefaultRequestTarget implements RequestTarget {
         final String encodedFragment = encodeFragmentToPercents(fragment);
 
         if (schemeAndAuthority != null) {
+            final String authority = schemeAndAuthority.getRawAuthority();
+            final String maybeHost = schemeAndAuthority.getHost();
+            final int maybePort = schemeAndAuthority.getPort();
+            final String host;
+            final int port;
+            if (maybeHost == null) {
+                host = authority;
+                port = -1;
+            } else {
+                host = maybeHost;
+                port = maybePort;
+            }
+
             return new DefaultRequestTarget(RequestTargetForm.ABSOLUTE,
                                             schemeAndAuthority.getScheme(),
-                                            schemeAndAuthority.getRawAuthority(),
-                                            schemeAndAuthority.getHost(),
-                                            schemeAndAuthority.getPort(),
+                                            authority,
+                                            host,
+                                            port,
                                             encodedPath,
                                             encodedPath, encodedQuery,
                                             encodedFragment);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
@@ -69,6 +69,7 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
 
     @Nullable
     private String decodedPath;
+
     private final Request originalRequest;
     @Nullable
     private volatile HttpRequest req;

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.DefaultRequestTarget.removeMatrixVariables;
 import static java.util.Objects.requireNonNull;
 
@@ -148,13 +149,19 @@ public interface RoutingContext {
      */
     default RoutingContext withPath(String path) {
         requireNonNull(path, "path");
+        final String pathWithoutMatrixVariables = removeMatrixVariables(path);
+        checkArgument(pathWithoutMatrixVariables != null,
+                      "path with invalid matrix variables: %s", path);
+
         final RequestTarget oldReqTarget = requestTarget();
         final RequestTarget newReqTarget =
                 DefaultRequestTarget.createWithoutValidation(
                         oldReqTarget.form(),
                         oldReqTarget.scheme(),
                         oldReqTarget.authority(),
-                        removeMatrixVariables(path),
+                        oldReqTarget.host(),
+                        oldReqTarget.port(),
+                        pathWithoutMatrixVariables,
                         path,
                         oldReqTarget.query(),
                         oldReqTarget.fragment());

--- a/core/src/test/java/com/linecorp/armeria/client/DomainSocketClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DomainSocketClientTest.java
@@ -105,6 +105,11 @@ class DomainSocketClientTest {
             final String expectedAddress = domainSocketAddress(useAbstractNamespace).toString();
             assertThat(ctx.localAddress()).hasToString(expectedAddress);
             assertThat(ctx.remoteAddress()).hasToString(expectedAddress);
+
+            final String expectedUri = (protocol.isTls() ? "https" : "http") +
+                                       baseUri.replaceAll("^[^:]+", "") +
+                                       "/greet";
+            assertThat(ctx.uri()).hasToString(expectedUri);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
@@ -335,6 +335,7 @@ class RedirectingClientTest {
         final RequestLog log2 = logs.get(1);
         assertThat(log2.requestHeaders().path()).isEqualTo("/unencodedLocation/foo%20bar?value=$%7BP%7D");
         assertThat(log2.responseHeaders().status()).isEqualTo(HttpStatus.OK);
+        assertThat(log2.context().uri().toString()).endsWith("/unencodedLocation/foo%20bar?value=$%7BP%7D");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
@@ -465,6 +465,11 @@ class DefaultRequestTargetTest {
             // IP addresses
             "a://127.0.0.1/, a, 127.0.0.1, /,,",
             "a://[::1]:80/,  a, [::1]:80, /,,",
+            // default port numbers should be omitted
+            "http://a:80/,   http, a, /,,",
+            "http://a:443/,  http, a:443, /,,",
+            "https://a:80/,  https, a:80, /,,",
+            "https://a:443/, https, a, /,,",
     })
     void clientShouldAcceptAbsoluteUri(String uri,
                                        String expectedScheme, String expectedAuthority, String expectedPath,


### PR DESCRIPTION
Reported by @ohadgur at https://discord.com/channels/1087271586832318494/1209914423494311948

Motivation:

If a client is configured to follow redirects with `followRedirects()`, the client will validate the value of `Location` header before sending a follow-up request to the given redirect location. `RedirectingClient` validates and resolves the target location using `URI.resolve()` which rejects poorly encoded `Location` header values such as:

- `Location: /foo bar` (space should be percent-encoded)
- `Location: /?${}` (`$`, `{` and `}` should be percent-encoded.)

Such strict validation might not be suitable in real world scenarios and we could
normalize them just like a client validates and normalizes the initial request target.

Modifications:

- `RedirectingClient` now uses `RequestTarget.forClient()` to parse and normalize the target location so it is more tolerant to poorly encoded `Location` header values.
- `RedirectingClient` now implements its own relative path resolution logic. See
  `RedirectingClient.resolveLocation()` and `resolveRelativeLocation() for the detail.
- Added `host` and `port` properties to `RequestTarget`.
- Added `host` property to `ClientRequestContext`.
- Moved `DefaultRequestTarget.findAuthority()` to `ArmeriaHttpUtil` to reuse it in `RedirectingClient`.
- Miscellaneous:
  - Fixed a potential bug where `RoutingContext.newPath()` creates a new `RequestTarget` whose `path` is `null`
  - Fixed a bug where `ClientRequestContext.uri()` returns a double-encoded URI
    (Special thanks to @ohadgur for reporting this bug and suggesting a fix.)
  - Improved `RequestTarget.forClient()` to remove the port number in an absolute
    request target when possible, so that `http://a:80` is normalized into `http://a`.

Result:

- (Bug fix) An Armeria client is now more tolerant to poorly encoded `Location` header values when following redirects.
- (New feature) You can now get the host and port part separately from a `RequestTarget`
  using `RequestTarget.host()` and `RequestTarget.port()`.
- (New feature) You can now get the host part from authority of the request URI using
  `ClientRequestContext.host()`.
- (Improvement) `RequestTarget.forClient()` now removes a redundant port number from
  the specified URI for simpler request target comparison. For example, `https://foo` and
  `https://foo:443` are considered equal.