### PR TITLE
Ensure subscriptions are completed when a request is completed

### DIFF
--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
@@ -77,7 +77,6 @@ final class GraphqlWebSocketSubscriber implements Subscriber<WebSocketFrame> {
                 subscription.request(1);
                 break;
             case CLOSE:
-                subscription.cancel();
                 outgoing.close();
                 break;
             // PONG is a noop
@@ -111,6 +110,7 @@ final class GraphqlWebSocketSubscriber implements Subscriber<WebSocketFrame> {
         the Subscription cancelled after having received the signal.
          */
         logger.trace("onComplete");
+        graphqlWSSubProtocol.cancel();
         subscription = null;
     }
 }

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
@@ -81,6 +81,7 @@ final class GraphqlWebSocketSubscriber implements Subscriber<WebSocketFrame> {
                 break;
             // PONG is a noop
             case PONG:
+                break;
             // Continuation is not mentioned in the spec. Should never happen.
             case CONTINUATION:
                 logger.trace("Ignoring frame type: {}", webSocketFrame.type());

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java
@@ -81,6 +81,7 @@ final class GraphqlWebSocketSubscriber implements Subscriber<WebSocketFrame> {
                 break;
             // PONG is a noop
             case PONG:
+                subscription.request(1);
                 break;
             // Continuation is not mentioned in the spec. Should never happen.
             case CONTINUATION:

--- a/graphql/src/test/resources/testing/graphql/subscription.graphqls
+++ b/graphql/src/test/resources/testing/graphql/subscription.graphqls
@@ -9,4 +9,5 @@ type Query {
 
 type Subscription {
     hello: String
+    bye: String
 }


### PR DESCRIPTION
Motivation:

We received a report that when using `graphql-ws` in conjunction with coroutine `callbackFlow`, `awaitClose` is not called. Since the `awaitClose` block is used to clean up resources this is a possible leak.
The cause is the `Subscription` which is passed over via `ExecutionResult` is never cancelled.

From further analysis, I found that we call `ctx.cancel` when a `CLOSE` frame is received.
https://github.com/line/armeria/blob/85bbc6533d4462d44c2d9b370dc15de21f6ef123/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java#L80

However, the `GraphqlWebSocketSubscriber` is not subscribed with the `NOTIFY_CANCELLATION` option.
https://github.com/line/armeria/blob/85bbc6533d4462d44c2d9b370dc15de21f6ef123/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketService.java#L74

As a result, neither `GraphqlWSSubProtocol#cancel` is never called. This results in the upstream subscription possibly never being cancelled.
https://github.com/line/armeria/blob/85bbc6533d4462d44c2d9b370dc15de21f6ef123/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWebSocketSubscriber.java#L103

Modifications:

- Removed the `ctx.cancel` call when a `CLOSE` frame is received since the upstream is automatically closed from `WebSocketServiceFrameDecoder`
  - https://github.com/line/armeria/blob/85bbc6533d4462d44c2d9b370dc15de21f6ef123/core/src/main/java/com/linecorp/armeria/internal/server/websocket/WebSocketServiceFrameDecoder.java#L46
- Added a `GraphqlWSSubProtocol#cancel` call to the `onComplete` callback
- Added a missing break statement when a `PONG` is received

Result:

- When a client sends a `CLOSE` frame, the user provided subscription is correctly closed

credit to @tobias- 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
