### PR TITLE
Add authenticated user to mdc by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -56,6 +56,15 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 public enum BuiltInProperty {
     /**
+     * {@code "authenticated.user"} - the authenticated user if exists.
+     */
+    AUTHENTICATED_USER("authenticated.user", log -> {
+        if (log.isAvailable(RequestLogProperty.AUTHENTICATED_USER)) {
+            return log.authenticatedUser();
+        }
+        return null;
+    }),
+    /**
      * {@code "remote.host"} - the host name part of the remote socket address. Unavailable if the connection
      * is not established yet.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/BuiltInProperty.java
@@ -58,12 +58,8 @@ public enum BuiltInProperty {
     /**
      * {@code "authenticated.user"} - the authenticated user if exists.
      */
-    AUTHENTICATED_USER("authenticated.user", log -> {
-        if (log.isAvailable(RequestLogProperty.AUTHENTICATED_USER)) {
-            return log.authenticatedUser();
-        }
-        return null;
-    }),
+    AUTHENTICATED_USER("authenticated.user", log ->
+            log.isAvailable(RequestLogProperty.AUTHENTICATED_USER) ? log.authenticatedUser() : null),
     /**
      * {@code "remote.host"} - the host name part of the remote socket address. Unavailable if the connection
      * is not established yet.

--- a/logback/logback12/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
+++ b/logback/logback12/src/test/java/com/linecorp/armeria/common/logback/RequestContextExportingAppenderTest.java
@@ -539,6 +539,7 @@ class RequestContextExportingAppenderTest {
         final ClientRequestContext ctx = newClientContext("/bar", null);
         try (SafeCloseable ignored = ctx.push()) {
             final RequestLogBuilder log = ctx.logBuilder();
+            log.authenticatedUser("auth_user");
             log.serializationFormat(ThriftSerializationFormats.BINARY);
             log.requestLength(64);
             log.requestHeaders(RequestHeaders.of(HttpMethod.GET, "/bar",
@@ -581,7 +582,8 @@ class RequestContextExportingAppenderTest {
                            .containsEntry("attrs.my_attr_value", "some-value")
                            .containsKey("req.id")
                            .containsKey("elapsed_nanos")
-                           .hasSize(27);
+                           .containsEntry("authenticated.user", "auth_user")
+                           .hasSize(28);
         }
     }
 


### PR DESCRIPTION
Motivation:

We use `ctx.log.authenticatedUser` to record the authenticated user in Central Dogma.
https://github.com/line/centraldogma/blob/54205bfcee1167f84bc1ab1a69e08fa0c3e3f2f3/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/ApplicationTokenAuthorizer.java#L74

It would be more convenient to provide `authenticatedUser` as a built in property since it is already a part of the armeria core APIs anyways.

Modifications:

- Added a built in property for `RequestLogProperty.AUTHENTICATED_USER`

Result:

- Users can propagate `authenticatedUser` via mdc more conveniently

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
