### PR TITLE
Access logs are written within the Request Context

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogBuilder;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.internal.common.CancellationScheduler.CancellationTask;
 import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
 
@@ -234,7 +235,11 @@ abstract class AbstractHttpResponseHandler {
     final void maybeWriteAccessLog() {
         final ServiceConfig config = reqCtx.config();
         if (config.transientServiceOptions().contains(TransientServiceOption.WITH_ACCESS_LOGGING)) {
-            reqCtx.log().whenComplete().thenAccept(config.accessLogWriter()::log);
+            reqCtx.log().whenComplete().thenAccept(log -> {
+                try (SafeCloseable ignored = reqCtx.push()) {
+                    config.accessLogWriter().log(log);
+                }
+            });
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -572,8 +572,12 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     // Respect the first specified cause.
                     logBuilder.endResponse(firstNonNull(cause, f.cause()));
                 }
-                reqCtx.log().whenComplete().thenAccept(reqCtx.config().accessLogWriter()::log);
             }
+            reqCtx.log().whenComplete().thenAccept(log -> {
+                try (SafeCloseable ignored = reqCtx.push()) {
+                    reqCtx.config().accessLogWriter().log(log);
+                }
+            });
         });
         return future;
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -740,7 +740,7 @@ class ServerBuilderTest {
         final AggregatedHttpResponse response = client.get("/hook").aggregate().join();
 
         assertThat(response.contentUtf8()).isEqualTo("hook");
-        assertThat(poppedCnt.get()).isEqualTo(1);
+        assertThat(poppedCnt.get()).isGreaterThan(0);
     }
 
     @Test
@@ -752,8 +752,8 @@ class ServerBuilderTest {
         final AggregatedHttpResponse response = client.get("/hook_route").aggregate().join();
 
         assertThat(response.contentUtf8()).isEqualTo("hook_route");
-        assertThat(poppedRouterCnt.get()).isEqualTo(1);
-        assertThat(poppedRouterCnt2.get()).isEqualTo(1);
+        assertThat(poppedRouterCnt.get()).isGreaterThan(0);
+        assertThat(poppedRouterCnt2.get()).isGreaterThan(0);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class AccessLoggerIntegrationTest {
+
+    private static final AtomicReference<RequestContext> CTX_REF = new AtomicReference<>();
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+            sb.accessLogWriter(new AccessLogWriter() {
+                @Override
+                public void log(RequestLog log) {
+                    CTX_REF.set(RequestContext.currentOrNull());
+                }
+            }, false);
+        }
+    };
+
+    @BeforeEach
+    void beforeEach() {
+        CTX_REF.set(null);
+    }
+
+    @Test
+    void testAccessLogger() throws Exception {
+        assertThat(server.blockingWebClient().get("/").status().code()).isEqualTo(200);
+        assertThat(server.requestContextCaptor().size()).isEqualTo(1);
+        final ServiceRequestContext ctx = server.requestContextCaptor().poll();
+        assertThat(CTX_REF).hasValue(ctx);
+    }
+}


### PR DESCRIPTION
Motivation:

It is a common use case to use `RequestContextExportingAppender` together with `AccessLogWriter`. However, in order for `RequestContextExportingAppender` to work, the `RequestContext` must be available.

https://github.com/line/armeria/blob/4bfa172606e8059194ccdb2e9fd36c6d22ada786/core/src/main/java/com/linecorp/armeria/common/logging/RequestContextExporter.java#L204

For this reason, I propose that `config.accessLogWriter()::log` be called with the `RequestContext` set on the calling thread

Modifications:

- Searched all references of `config.accessLogWriter()::log` and wrapped in a `ctx.push` call.

Result:

- access logs are written with the `RequestContext` set on the calling thread.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
