### PR TITLE
Support `STRICT_DNS`, `HealthCheck` for `XdsEndpointGroup` (xDS-endpoint pt 3)

### DIFF
--- a/xds/src/main/java/com/linecorp/armeria/xds/AbstractRoot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/AbstractRoot.java
@@ -48,7 +48,10 @@ abstract class AbstractRoot<T extends Snapshot<? extends XdsResource>>
         this.eventLoop = eventLoop;
     }
 
-    final EventExecutor eventLoop() {
+    /**
+     * The event loop used to notify updates to {@link SnapshotWatcher}s.
+     */
+    public final EventExecutor eventLoop() {
         return eventLoop;
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/ConfigSourceClient.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ConfigSourceClient.java
@@ -108,7 +108,7 @@ final class ConfigSourceClient implements SafeCloseable {
     @Override
     public void close() {
         stream.close();
-        endpointGroup.close();
+        endpointGroup.closeAsync();
         subscriberStorage.close();
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.AsyncCloseable;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.EndpointSnapshot;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+
+final class ClusterEntry implements Consumer<List<Endpoint>>, AsyncCloseable {
+
+    private final EndpointGroup endpointGroup;
+    private final ClusterManager clusterManager;
+    private final Cluster cluster;
+    private final ClusterLoadAssignment clusterLoadAssignment;
+    private final LoadBalancer loadBalancer;
+    private List<Endpoint> endpoints = Collections.emptyList();
+
+    ClusterEntry(ClusterSnapshot clusterSnapshot, ClusterManager clusterManager) {
+        endpointGroup = XdsEndpointUtil.convertEndpointGroup(clusterSnapshot);
+        this.clusterManager = clusterManager;
+        cluster = clusterSnapshot.xdsResource().resource();
+        final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
+        assert endpointSnapshot != null;
+        clusterLoadAssignment = endpointSnapshot.xdsResource().resource();
+        loadBalancer = new SubsetLoadBalancer(clusterSnapshot);
+
+        // The order of adding listeners is important
+        endpointGroup.addListener(this, true);
+        endpointGroup.addListener(clusterManager, true);
+    }
+
+    @Nullable
+    Endpoint selectNow(ClientRequestContext ctx) {
+        return loadBalancer.selectNow(ctx);
+    }
+
+    @Override
+    public void accept(List<Endpoint> endpoints) {
+        this.endpoints = ImmutableList.copyOf(endpoints);
+        final PrioritySet prioritySet = new PrioritySet(cluster, clusterLoadAssignment,
+                                                        endpoints);
+        loadBalancer.prioritySetUpdated(prioritySet);
+    }
+
+    List<Endpoint> allEndpoints() {
+        return endpoints;
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        endpointGroup.removeListener(this);
+        endpointGroup.removeListener(clusterManager);
+        return endpointGroup.closeAsync();
+    }
+
+    @Override
+    public void close() {
+        endpointGroup.close();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -34,13 +33,11 @@ import com.linecorp.armeria.xds.EndpointSnapshot;
 final class ClusterEntry implements Consumer<List<Endpoint>>, AsyncCloseable {
 
     private final EndpointGroup endpointGroup;
-    private final ClusterManager clusterManager;
     private final LoadBalancer loadBalancer;
-    private List<Endpoint> endpoints = Collections.emptyList();
+    private List<Endpoint> endpoints = ImmutableList.of();
 
     ClusterEntry(ClusterSnapshot clusterSnapshot, ClusterManager clusterManager) {
         endpointGroup = XdsEndpointUtil.convertEndpointGroup(clusterSnapshot);
-        this.clusterManager = clusterManager;
         final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
         assert endpointSnapshot != null;
         loadBalancer = new SubsetLoadBalancer(clusterSnapshot);
@@ -68,8 +65,6 @@ final class ClusterEntry implements Consumer<List<Endpoint>>, AsyncCloseable {
 
     @Override
     public CompletableFuture<?> closeAsync() {
-        endpointGroup.removeListener(this);
-        endpointGroup.removeListener(clusterManager);
         return endpointGroup.closeAsync();
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
@@ -37,12 +37,12 @@ final class ClusterEntry implements Consumer<List<Endpoint>>, AsyncCloseable {
     private List<Endpoint> endpoints = ImmutableList.of();
 
     ClusterEntry(ClusterSnapshot clusterSnapshot, ClusterManager clusterManager) {
-        endpointGroup = XdsEndpointUtil.convertEndpointGroup(clusterSnapshot);
         final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
         assert endpointSnapshot != null;
         loadBalancer = new SubsetLoadBalancer(clusterSnapshot);
 
         // The order of adding listeners is important
+        endpointGroup = XdsEndpointUtil.convertEndpointGroup(clusterSnapshot);
         endpointGroup.addListener(this, true);
         endpointGroup.addListener(clusterManager, true);
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -127,15 +127,16 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
             }
             mappingBuilder.put(clusterSnapshot, clusterEntry);
         }
-        clusterEntries = mappingBuilder.build();
+        final ImmutableMap<ClusterSnapshot, ClusterEntry> newClusterEntries = mappingBuilder.build();
+        clusterEntries = newClusterEntries;
         this.listenerSnapshot = listenerSnapshot;
         notifyListeners();
-        cleanupEndpointGroups(clusterEntries, oldEndpointGroups);
+        cleanupEndpointGroups(newClusterEntries, oldEndpointGroups);
     }
 
     private void cleanupEndpointGroups(Map<ClusterSnapshot, ClusterEntry> newEndpointGroups,
                                        Map<ClusterSnapshot, ClusterEntry> oldEndpointGroups) {
-        for (Entry<ClusterSnapshot, ClusterEntry> entry: oldEndpointGroups.entrySet()) {
+        for (Entry<ClusterSnapshot, ClusterEntry> entry : oldEndpointGroups.entrySet()) {
             if (newEndpointGroups.containsKey(entry.getKey())) {
                 continue;
             }
@@ -183,7 +184,7 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
             return new State(listenerSnapshot, ImmutableList.of());
         }
         final ImmutableList.Builder<Endpoint> endpointsBuilder = ImmutableList.builder();
-        for (ClusterEntry clusterEntry: clusterEntries.values()) {
+        for (ClusterEntry clusterEntry : clusterEntries.values()) {
             endpointsBuilder.addAll(clusterEntry.allEndpoints());
         }
         return new State(listenerSnapshot, endpointsBuilder.build());

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -117,7 +117,7 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
         final ImmutableMap.Builder<ClusterSnapshot, ClusterEntry> mappingBuilder =
                 ImmutableMap.builder();
         final Map<ClusterSnapshot, ClusterEntry> oldEndpointGroups = clusterEntries;
-        for (ClusterSnapshot clusterSnapshot: routeSnapshot.clusterSnapshots()) {
+        for (ClusterSnapshot clusterSnapshot : routeSnapshot.clusterSnapshots()) {
             if (clusterSnapshot.endpointSnapshot() == null) {
                 continue;
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.xds.client.endpoint;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -181,7 +180,7 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
     private State state() {
         final Map<ClusterSnapshot, ClusterEntry> clusterEntries = this.clusterEntries;
         if (clusterEntries.isEmpty()) {
-            return new State(listenerSnapshot, Collections.emptyList());
+            return new State(listenerSnapshot, ImmutableList.of());
         }
         final ImmutableList.Builder<Endpoint> endpointsBuilder = ImmutableList.builder();
         for (ClusterEntry clusterEntry: clusterEntries.values()) {
@@ -234,7 +233,7 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
 
     static final class State {
 
-        static final State INITIAL_STATE = new State(null, Collections.emptyList());
+        static final State INITIAL_STATE = new State(null, ImmutableList.of());
 
         // There is no guarantee that endpoints corresponds to the listenerSnapshot.
         // However, the state will be eventually consistent and the state is only used

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -78,10 +78,10 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
     private final List<Consumer<? super State>> listeners = new ArrayList<>();
     private final ReentrantShortLock listenersLock = new ReentrantShortLock();
 
-    ClusterManager(ListenerRoot safeCloseable) {
-        eventLoop = safeCloseable.eventLoop();
-        this.safeCloseable = safeCloseable;
-        safeCloseable.addSnapshotWatcher(this);
+    ClusterManager(ListenerRoot listenerRoot) {
+        eventLoop = listenerRoot.eventLoop();
+        safeCloseable = listenerRoot;
+        listenerRoot.addSnapshotWatcher(this);
     }
 
     ClusterManager(ClusterSnapshot clusterSnapshot) {
@@ -190,7 +190,7 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
         return new State(listenerSnapshot, endpointsBuilder.build());
     }
 
-    void notifyListeners() {
+    private void notifyListeners() {
         if (clusterEntries == INITIAL_CLUSTER_ENTRIES) {
             return;
         }
@@ -236,14 +236,14 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
 
         static final State INITIAL_STATE = new State(null, Collections.emptyList());
 
-        // There is no guarantee that clusterEntries corresponds to the listenerSnapshot.
+        // There is no guarantee that endpoints corresponds to the listenerSnapshot.
         // However, the state will be eventually consistent and the state is only used
         // for signalling purposes so there should be no issue.
         @Nullable
         private final ListenerSnapshot listenerSnapshot;
         private final List<Endpoint> endpoints;
 
-        State(@Nullable ListenerSnapshot listenerSnapshot, List<Endpoint> endpoints) {
+        private State(@Nullable ListenerSnapshot listenerSnapshot, List<Endpoint> endpoints) {
             this.listenerSnapshot = listenerSnapshot;
             this.endpoints = ImmutableList.copyOf(endpoints);
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
+import com.spotify.futures.CompletableFutures;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.AsyncCloseable;
+import com.linecorp.armeria.common.util.Listenable;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.RouteSnapshot;
+import com.linecorp.armeria.xds.SnapshotWatcher;
+import com.linecorp.armeria.xds.client.endpoint.ClusterManager.State;
+
+import io.netty.util.concurrent.EventExecutor;
+
+final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCloseable,
+                                      Listenable<State>, Consumer<List<Endpoint>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClusterManager.class);
+    private static final Map<ClusterSnapshot, ClusterEntry> INITIAL_CLUSTER_ENTRIES = new HashMap<>();
+
+    private final EventExecutor eventLoop;
+    private final SafeCloseable safeCloseable;
+    private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+    private volatile Map<ClusterSnapshot, ClusterEntry> clusterEntries = INITIAL_CLUSTER_ENTRIES;
+    @Nullable
+    private volatile ListenerSnapshot listenerSnapshot;
+    private final Set<CompletableFuture<?>> pendingRemovals = Sets.newConcurrentHashSet();
+    private boolean closed;
+
+    @GuardedBy("listenersLock")
+    private final List<Consumer<? super State>> listeners = new ArrayList<>();
+    private final ReentrantShortLock listenersLock = new ReentrantShortLock();
+
+    ClusterManager(ListenerRoot safeCloseable) {
+        eventLoop = safeCloseable.eventLoop();
+        this.safeCloseable = safeCloseable;
+        safeCloseable.addSnapshotWatcher(this);
+    }
+
+    ClusterManager(ClusterSnapshot clusterSnapshot) {
+        checkArgument(clusterSnapshot.endpointSnapshot() != null,
+                      "An endpoint snapshot must exist for the provided (%s)", clusterSnapshot);
+        eventLoop = CommonPools.workerGroup().next();
+        clusterEntries = ImmutableMap.of(clusterSnapshot, new ClusterEntry(clusterSnapshot, this));
+        safeCloseable = () -> {};
+    }
+
+    @Nullable
+    Endpoint selectNow(ClientRequestContext ctx) {
+        final Map<ClusterSnapshot, ClusterEntry> clusterEntries = this.clusterEntries;
+        for (Entry<ClusterSnapshot, ClusterEntry> entry: clusterEntries.entrySet()) {
+            // Just use the first snapshot for now
+            final ClusterEntry clusterEntry = entry.getValue();
+            return clusterEntry.selectNow(ctx);
+        }
+        return null;
+    }
+
+    @Override
+    public void snapshotUpdated(ListenerSnapshot listenerSnapshot) {
+        if (closed) {
+            return;
+        }
+        final RouteSnapshot routeSnapshot = listenerSnapshot.routeSnapshot();
+        if (routeSnapshot == null) {
+            return;
+        }
+
+        // it is important that the entries are added in order of ClusterSnapshot#index
+        // so that the first matching route is selected in #selectNow
+        final ImmutableMap.Builder<ClusterSnapshot, ClusterEntry> mappingBuilder =
+                ImmutableMap.builder();
+        final Map<ClusterSnapshot, ClusterEntry> oldEndpointGroups = clusterEntries;
+        for (ClusterSnapshot clusterSnapshot: routeSnapshot.clusterSnapshots()) {
+            if (clusterSnapshot.endpointSnapshot() == null) {
+                continue;
+            }
+            ClusterEntry clusterEntry = oldEndpointGroups.get(clusterSnapshot);
+            if (clusterEntry == null) {
+                clusterEntry = new ClusterEntry(clusterSnapshot, this);
+            }
+            mappingBuilder.put(clusterSnapshot, clusterEntry);
+        }
+        clusterEntries = mappingBuilder.build();
+        this.listenerSnapshot = listenerSnapshot;
+        notifyListeners();
+        cleanupEndpointGroups(clusterEntries, oldEndpointGroups);
+    }
+
+    private void cleanupEndpointGroups(Map<ClusterSnapshot, ClusterEntry> newEndpointGroups,
+                                       Map<ClusterSnapshot, ClusterEntry> oldEndpointGroups) {
+        for (Entry<ClusterSnapshot, ClusterEntry> entry: oldEndpointGroups.entrySet()) {
+            if (newEndpointGroups.containsKey(entry.getKey())) {
+                continue;
+            }
+            final ClusterEntry clusterEntry = entry.getValue();
+            final CompletableFuture<?> closeFuture = clusterEntry.closeAsync();
+            pendingRemovals.add(closeFuture);
+            closeFuture.handle((ignored, t) -> {
+                pendingRemovals.remove(closeFuture);
+                return null;
+            });
+        }
+    }
+
+    @Override
+    public void addListener(Consumer<? super State> listener) {
+        listenersLock.lock();
+        try {
+            listeners.add(listener);
+        } finally {
+            listenersLock.unlock();
+        }
+        if (clusterEntries != INITIAL_CLUSTER_ENTRIES) {
+            listener.accept(state());
+        }
+    }
+
+    @Override
+    public void removeListener(Consumer<?> listener) {
+        listenersLock.lock();
+        try {
+            listeners.remove(listener);
+        } finally {
+            listenersLock.unlock();
+        }
+    }
+
+    @Override
+    public void accept(List<Endpoint> endpoints) {
+        notifyListeners();
+    }
+
+    private State state() {
+        final Map<ClusterSnapshot, ClusterEntry> clusterEntries = this.clusterEntries;
+        if (clusterEntries.isEmpty()) {
+            return new State(listenerSnapshot, Collections.emptyList());
+        }
+        final ImmutableList.Builder<Endpoint> endpointsBuilder = ImmutableList.builder();
+        for (ClusterEntry clusterEntry: clusterEntries.values()) {
+            endpointsBuilder.addAll(clusterEntry.allEndpoints());
+        }
+        return new State(listenerSnapshot, endpointsBuilder.build());
+    }
+
+    void notifyListeners() {
+        if (clusterEntries == INITIAL_CLUSTER_ENTRIES) {
+            return;
+        }
+        final State state = state();
+        listenersLock.lock();
+        try {
+            for (Consumer<? super State> listener : listeners) {
+                try {
+                    listener.accept(state);
+                } catch (Exception e) {
+                    logger.warn("Unexpected exception while notifying listeners");
+                }
+            }
+        } finally {
+            listenersLock.unlock();
+        }
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        if (!eventLoop.inEventLoop()) {
+            eventLoop.execute(this::closeAsync);
+            return closeFuture;
+        }
+        if (closed) {
+            return closeFuture;
+        }
+        closed = true;
+        safeCloseable.close();
+        final List<CompletableFuture<?>> closeFutures = Streams.concat(
+                clusterEntries.values().stream().map(ClusterEntry::closeAsync),
+                pendingRemovals.stream()).collect(Collectors.toList());
+        CompletableFutures.allAsList(closeFutures).handle((ignored, e) -> closeFuture.complete(null));
+        return closeFuture;
+    }
+
+    @Override
+    public void close() {
+        closeAsync().join();
+    }
+
+    static final class State {
+
+        static final State INITIAL_STATE = new State(null, Collections.emptyList());
+
+        // There is no guarantee that clusterEntries corresponds to the listenerSnapshot.
+        // However, the state will be eventually consistent and the state is only used
+        // for signalling purposes so there should be no issue.
+        @Nullable
+        private final ListenerSnapshot listenerSnapshot;
+        private final List<Endpoint> endpoints;
+
+        State(@Nullable ListenerSnapshot listenerSnapshot, List<Endpoint> endpoints) {
+            this.listenerSnapshot = listenerSnapshot;
+            this.endpoints = ImmutableList.copyOf(endpoints);
+        }
+
+        List<Endpoint> endpoints() {
+            return endpoints;
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (object == null || getClass() != object.getClass()) {
+                return false;
+            }
+            final State state = (State) object;
+            return Objects.equal(listenerSnapshot, state.listenerSnapshot) &&
+                   Objects.equal(endpoints, state.endpoints);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(listenerSnapshot, endpoints);
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LoadBalancer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+interface LoadBalancer {
+
+    @Nullable
+    Endpoint selectNow(ClientRequestContext ctx);
+
+    void prioritySetUpdated(PrioritySet prioritySet);
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/MetadataUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/MetadataUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.linecorp.armeria.xds.client.endpoint.XdsConstants.SUBSET_LOAD_BALANCING_FILTER_NAME;
+
+import java.util.Map;
+
+import com.google.protobuf.ProtocolStringList;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+import com.linecorp.armeria.xds.ClusterSnapshot;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbSubsetConfig;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetSelector;
+import io.envoyproxy.envoy.config.route.v3.Route;
+import io.envoyproxy.envoy.config.route.v3.RouteAction;
+
+final class MetadataUtil {
+
+    static Struct filterMetadata(ClusterSnapshot clusterSnapshot) {
+        final Route route = clusterSnapshot.route();
+        if (route == null) {
+            return Struct.getDefaultInstance();
+        }
+        final RouteAction action = route.getRoute();
+        return action.getMetadataMatch().getFilterMetadataOrDefault(SUBSET_LOAD_BALANCING_FILTER_NAME,
+                                                                    Struct.getDefaultInstance());
+    }
+
+    static boolean findMatchedSubsetSelector(LbSubsetConfig lbSubsetConfig, Struct filterMetadata) {
+        for (LbSubsetSelector subsetSelector : lbSubsetConfig.getSubsetSelectorsList()) {
+            final ProtocolStringList keysList = subsetSelector.getKeysList();
+            if (filterMetadata.getFieldsCount() != keysList.size()) {
+                continue;
+            }
+            boolean found = true;
+            final Map<String, Value> filterMetadataMap = filterMetadata.getFieldsMap();
+            for (String key : filterMetadataMap.keySet()) {
+                if (!keysList.contains(key)) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private MetadataUtil() {}
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/PrioritySet.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/PrioritySet.java
@@ -22,22 +22,11 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Endpoint;
 
-import io.envoyproxy.envoy.config.cluster.v3.Cluster;
-import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
-
 final class PrioritySet {
-    private final Cluster cluster;
-    private final ClusterLoadAssignment clusterLoadAssignment;
     private final List<Endpoint> endpoints;
 
-    PrioritySet(Cluster cluster, ClusterLoadAssignment clusterLoadAssignment, List<Endpoint> endpoints) {
-        this.cluster = cluster;
-        this.clusterLoadAssignment = clusterLoadAssignment;
+    PrioritySet(List<Endpoint> endpoints) {
         this.endpoints = ImmutableList.copyOf(endpoints);
-    }
-
-    ClusterLoadAssignment clusterLoadAssignment() {
-        return clusterLoadAssignment;
     }
 
     List<Endpoint> endpoints() {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/PrioritySet.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/PrioritySet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+
+final class PrioritySet {
+    private final Cluster cluster;
+    private final ClusterLoadAssignment clusterLoadAssignment;
+    private final List<Endpoint> endpoints;
+
+    PrioritySet(Cluster cluster, ClusterLoadAssignment clusterLoadAssignment, List<Endpoint> endpoints) {
+        this.cluster = cluster;
+        this.clusterLoadAssignment = clusterLoadAssignment;
+        this.endpoints = ImmutableList.copyOf(endpoints);
+    }
+
+    ClusterLoadAssignment clusterLoadAssignment() {
+        return clusterLoadAssignment;
+    }
+
+    List<Endpoint> endpoints() {
+        return endpoints;
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
@@ -95,7 +95,7 @@ final class SubsetLoadBalancer implements LoadBalancer {
         return createEndpointGroup(endpoints);
     }
 
-    EndpointGroup createEndpointGroup(List<Endpoint> endpoints) {
+    private static EndpointGroup createEndpointGroup(List<Endpoint> endpoints) {
         return EndpointGroup.of(endpoints);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.linecorp.armeria.xds.client.endpoint.MetadataUtil.filterMetadata;
+import static com.linecorp.armeria.xds.client.endpoint.MetadataUtil.findMatchedSubsetSelector;
+import static com.linecorp.armeria.xds.client.endpoint.XdsEndpointUtil.convertEndpoints;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.Struct;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbSubsetConfig;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetFallbackPolicy;
+
+final class SubsetLoadBalancer implements LoadBalancer {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubsetLoadBalancer.class);
+
+    private final ClusterSnapshot clusterSnapshot;
+    @Nullable
+    private volatile EndpointGroup endpointGroup;
+
+    SubsetLoadBalancer(ClusterSnapshot clusterSnapshot) {
+        this.clusterSnapshot = clusterSnapshot;
+    }
+
+    @Override
+    @Nullable
+    public Endpoint selectNow(ClientRequestContext ctx) {
+        final EndpointGroup endpointGroup = this.endpointGroup;
+        if (endpointGroup == null) {
+            return null;
+        }
+        return endpointGroup.selectNow(ctx);
+    }
+
+    @Override
+    public void prioritySetUpdated(PrioritySet prioritySet) {
+        endpointGroup = createEndpointGroup(prioritySet);
+    }
+
+    private EndpointGroup createEndpointGroup(PrioritySet prioritySet) {
+        final Struct filterMetadata = filterMetadata(clusterSnapshot);
+        if (filterMetadata.getFieldsCount() == 0) {
+            // No metadata. Use the whole endpoints.
+            return createEndpointGroup(prioritySet.endpoints());
+        }
+
+        final Cluster cluster = clusterSnapshot.xdsResource().resource();
+        final LbSubsetConfig lbSubsetConfig = cluster.getLbSubsetConfig();
+        if (lbSubsetConfig == LbSubsetConfig.getDefaultInstance()) {
+            // No lbSubsetConfig. Use the whole endpoints.
+            return createEndpointGroup(prioritySet.endpoints());
+        }
+        final LbSubsetFallbackPolicy fallbackPolicy = lbSubsetConfig.getFallbackPolicy();
+        if (fallbackPolicy != LbSubsetFallbackPolicy.ANY_ENDPOINT) {
+            logger.warn("Currently, only {} is supported.", LbSubsetFallbackPolicy.ANY_ENDPOINT);
+        }
+
+        if (!findMatchedSubsetSelector(lbSubsetConfig, filterMetadata)) {
+            // No matched subset selector. Use the whole endpoints.
+            return createEndpointGroup(prioritySet.endpoints());
+        }
+        final List<Endpoint> endpoints = convertEndpoints(prioritySet.endpoints(),
+                                                          filterMetadata);
+        if (endpoints.isEmpty()) {
+            // No matched metadata. Use the whole endpoints.
+            return createEndpointGroup(prioritySet.endpoints());
+        }
+        return createEndpointGroup(endpoints);
+    }
+
+    EndpointGroup createEndpointGroup(List<Endpoint> endpoints) {
+        return EndpointGroup.of(endpoints);
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributeAssigningEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributeAssigningEndpointGroup.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.linecorp.armeria.xds.client.endpoint.XdsAttributesKeys.LB_ENDPOINT_KEY;
+import static com.linecorp.armeria.xds.client.endpoint.XdsAttributesKeys.LOCALITY_LB_ENDPOINTS_KEY;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+
+final class XdsAttributeAssigningEndpointGroup extends DynamicEndpointGroup
+        implements Consumer<List<Endpoint>> {
+
+    private final LocalityLbEndpoints localityLbEndpoints;
+    private final LbEndpoint lbEndpoint;
+
+    XdsAttributeAssigningEndpointGroup(EndpointGroup delegate, LocalityLbEndpoints localityLbEndpoints,
+                                       LbEndpoint lbEndpoint) {
+        this.localityLbEndpoints = localityLbEndpoints;
+        this.lbEndpoint = lbEndpoint;
+        delegate.addListener(this, true);
+    }
+
+    @Override
+    public void accept(List<Endpoint> endpoints) {
+        final List<Endpoint> mappedEndpoints =
+                endpoints.stream()
+                         .map(endpoint -> endpoint.withAttr(LB_ENDPOINT_KEY, lbEndpoint)
+                                                  .withAttr(LOCALITY_LB_ENDPOINTS_KEY, localityLbEndpoints)
+                                                  .withWeight(XdsEndpointUtil.endpointWeight(lbEndpoint)))
+                         .collect(Collectors.toList());
+        setEndpoints(mappedEndpoints);
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributesKeys.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributesKeys.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+import io.netty.util.AttributeKey;
+
+final class XdsAttributesKeys {
+
+    static final AttributeKey<LbEndpoint> LB_ENDPOINT_KEY =
+            AttributeKey.valueOf(XdsAttributesKeys.class, "LB_ENDPOINT_KEY");
+    static final AttributeKey<LocalityLbEndpoints> LOCALITY_LB_ENDPOINTS_KEY =
+            AttributeKey.valueOf(XdsAttributesKeys.class, "LOCALITY_LB_ENDPOINTS_KEY");
+
+    private XdsAttributesKeys() {}
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -109,7 +109,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>> i
         this.clusterManager = clusterManager;
     }
 
-    void updateState(State state) {
+    private void updateState(State state) {
         if (!allowEmptyEndpoints && Iterables.isEmpty(state.endpoints())) {
             return;
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -67,7 +67,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>> i
      */
     public static EndpointGroup of(ListenerRoot listenerRoot) {
         requireNonNull(listenerRoot, "listenerRoot");
-        return new XdsEndpointGroup(new ClusterManager(listenerRoot), false);
+        return of(listenerRoot, false);
     }
 
     /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointSelector.java
@@ -16,17 +16,13 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
-import java.util.concurrent.CompletableFuture;
-
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.AbstractEndpointSelector;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.util.AsyncCloseable;
 
-final class XdsEndpointSelector extends AbstractEndpointSelector
-        implements AsyncCloseable {
+final class XdsEndpointSelector extends AbstractEndpointSelector {
 
     private final ClusterManager clusterManager;
 
@@ -40,15 +36,5 @@ final class XdsEndpointSelector extends AbstractEndpointSelector
     @Nullable
     public Endpoint selectNow(ClientRequestContext ctx) {
         return clusterManager.selectNow(ctx);
-    }
-
-    @Override
-    public CompletableFuture<?> closeAsync() {
-        return clusterManager.closeAsync();
-    }
-
-    @Override
-    public void close() {
-        clusterManager.close();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointSelector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.AbstractEndpointSelector;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.AsyncCloseable;
+
+final class XdsEndpointSelector extends AbstractEndpointSelector
+        implements AsyncCloseable {
+
+    private final ClusterManager clusterManager;
+
+    XdsEndpointSelector(ClusterManager clusterManager, EndpointGroup endpointGroup) {
+        super(endpointGroup);
+        this.clusterManager = clusterManager;
+        initialize();
+    }
+
+    @Override
+    @Nullable
+    public Endpoint selectNow(ClientRequestContext ctx) {
+        return clusterManager.selectNow(ctx);
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return clusterManager.closeAsync();
+    }
+
+    @Override
+    public void close() {
+        clusterManager.close();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
@@ -26,25 +26,39 @@ import java.util.Map.Entry;
 import java.util.function.Predicate;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
+import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckedEndpointGroup;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.EndpointSnapshot;
 
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.RefreshRate;
+import io.envoyproxy.envoy.config.core.v3.HealthCheck;
+import io.envoyproxy.envoy.config.core.v3.HealthCheck.HttpHealthCheck;
+import io.envoyproxy.envoy.config.core.v3.RequestMethod;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
 import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
 
 final class XdsEndpointUtil {
 
-    static List<Endpoint> convertEndpoints(ClusterLoadAssignment clusterLoadAssignment) {
-        return convertEndpoints(clusterLoadAssignment, lbEndpoint -> true);
-    }
-
-    static List<Endpoint> convertEndpoints(ClusterLoadAssignment clusterLoadAssignment, Struct filterMetadata) {
+    static List<Endpoint> convertEndpoints(List<Endpoint> endpoints, Struct filterMetadata) {
         checkArgument(filterMetadata.getFieldsCount() > 0,
                       "filterMetadata.getFieldsCount(): %s (expected: > 0)", filterMetadata.getFieldsCount());
-        final Predicate<LbEndpoint> lbEndpointPredicate = lbEndpoint -> {
+        final Predicate<Endpoint> lbEndpointPredicate = endpoint -> {
+            final LbEndpoint lbEndpoint = endpoint.attr(XdsAttributesKeys.LB_ENDPOINT_KEY);
+            assert lbEndpoint != null;
             final Struct endpointMetadata = lbEndpoint.getMetadata().getFilterMetadataOrDefault(
                     SUBSET_LOAD_BALANCING_FILTER_NAME, Struct.getDefaultInstance());
             if (endpointMetadata.getFieldsCount() == 0) {
@@ -52,27 +66,14 @@ final class XdsEndpointUtil {
             }
             return containsFilterMetadata(filterMetadata, endpointMetadata);
         };
-        return convertEndpoints(clusterLoadAssignment, lbEndpointPredicate);
+        return convertEndpoints(endpoints, lbEndpointPredicate);
     }
 
-    private static List<Endpoint> convertEndpoints(ClusterLoadAssignment clusterLoadAssignment,
-                                                   Predicate<LbEndpoint> lbEndpointPredicate) {
-        return clusterLoadAssignment.getEndpointsList().stream().flatMap(
-                localityLbEndpoints -> localityLbEndpoints
-                        .getLbEndpointsList()
-                        .stream()
+    private static List<Endpoint> convertEndpoints(List<Endpoint> endpoints,
+                                                   Predicate<Endpoint> lbEndpointPredicate) {
+        return endpoints.stream()
                         .filter(lbEndpointPredicate)
-                        .map(lbEndpoint -> {
-                            final SocketAddress socketAddress =
-                                    lbEndpoint.getEndpoint().getAddress().getSocketAddress();
-                            final String hostname = lbEndpoint.getEndpoint().getHostname();
-                            if (!Strings.isNullOrEmpty(hostname)) {
-                                return Endpoint.of(hostname, socketAddress.getPortValue())
-                                               .withIpAddr(socketAddress.getAddress());
-                            } else {
-                                return Endpoint.of(socketAddress.getAddress(), socketAddress.getPortValue());
-                            }
-                        })).collect(toImmutableList());
+                        .collect(toImmutableList());
     }
 
     private static boolean containsFilterMetadata(Struct filterMetadata, Struct endpointMetadata) {
@@ -84,6 +85,144 @@ final class XdsEndpointUtil {
             }
         }
         return true;
+    }
+
+    static EndpointGroup convertEndpointGroup(ClusterSnapshot clusterSnapshot) {
+        final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
+        if (endpointSnapshot == null) {
+            return EndpointGroup.of();
+        }
+        final Cluster cluster = clusterSnapshot.xdsResource().resource();
+        final EndpointGroup endpointGroup;
+        switch (cluster.getType()) {
+            case STATIC:
+            case EDS:
+                endpointGroup = staticEndpointGroup(clusterSnapshot);
+                break;
+            case STRICT_DNS:
+                endpointGroup = strictDnsEndpointGroup(clusterSnapshot);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported cluster type: " + cluster.getType() + '.' +
+                                                        "Only (STATIC, STRICT_DNS, EDS) are supported.");
+        }
+        if (!cluster.getHealthChecksList().isEmpty()) {
+            // multiple health-checks aren't supported
+            final HealthCheck healthCheck = cluster.getHealthChecksList().get(0);
+            return maybeHealthChecked(endpointGroup, healthCheck);
+        }
+        return endpointGroup;
+    }
+
+    private static EndpointGroup maybeHealthChecked(EndpointGroup delegate, HealthCheck healthCheck) {
+        if (!healthCheck.hasHttpHealthCheck()) {
+            return delegate;
+        }
+        final HttpHealthCheck httpHealthCheck = healthCheck.getHttpHealthCheck();
+        final String path = httpHealthCheck.getPath();
+
+        // We can't support SessionProtocol, excluded endpoints,
+        // per-cluster-member health checking, etc without refactoring how we deal with health checking.
+        // For now, just simply health check all targets depending on the cluster configuration.
+        return HealthCheckedEndpointGroup.builder(delegate, path)
+                                         .useGet(healthCheckMethod(httpHealthCheck) == HttpMethod.GET)
+                                         .build();
+    }
+
+    private static HttpMethod healthCheckMethod(HttpHealthCheck httpHealthCheck) {
+        if (httpHealthCheck.getMethod() == RequestMethod.GET) {
+            return HttpMethod.GET;
+        }
+        return HttpMethod.HEAD;
+    }
+
+    private static EndpointGroup staticEndpointGroup(ClusterSnapshot clusterSnapshot) {
+        final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
+        assert endpointSnapshot != null;
+        final List<Endpoint> endpoints = convertLoadAssignment(endpointSnapshot.xdsResource().resource());
+        return EndpointGroup.of(endpoints);
+    }
+
+    private static EndpointGroup strictDnsEndpointGroup(ClusterSnapshot clusterSnapshot) {
+        final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
+        assert endpointSnapshot != null;
+        final Cluster cluster = clusterSnapshot.xdsResource().resource();
+
+        final ImmutableList.Builder<EndpointGroup> endpointGroupBuilder = ImmutableList.builder();
+        final ClusterLoadAssignment loadAssignment = endpointSnapshot.xdsResource().resource();
+        for (LocalityLbEndpoints localityLbEndpoints: loadAssignment.getEndpointsList()) {
+            for (LbEndpoint lbEndpoint: localityLbEndpoints.getLbEndpointsList()) {
+                final SocketAddress socketAddress = lbEndpoint.getEndpoint().getAddress().getSocketAddress();
+                final String dnsAddress = socketAddress.getAddress();
+                final DnsAddressEndpointGroupBuilder builder = DnsAddressEndpointGroup.builder(dnsAddress);
+                if (socketAddress.hasPortValue()) {
+                    builder.port(socketAddress.getPortValue());
+                }
+                if (!cluster.getRespectDnsTtl()) {
+                    final int refreshRateSeconds =
+                            cluster.hasDnsRefreshRate() ?
+                            Ints.saturatedCast(cluster.getDnsRefreshRate().getSeconds()) : 5;
+                    builder.ttl(refreshRateSeconds, refreshRateSeconds);
+
+                    if (cluster.hasDnsFailureRefreshRate()) {
+                        final RefreshRate failureRefreshRate = cluster.getDnsFailureRefreshRate();
+                        int baseSeconds = refreshRateSeconds;
+                        int maxSeconds = refreshRateSeconds;
+                        if (failureRefreshRate.hasBaseInterval()) {
+                            baseSeconds = Ints.saturatedCast(failureRefreshRate.getBaseInterval().getSeconds());
+                        }
+                        if (failureRefreshRate.hasMaxInterval()) {
+                            maxSeconds = Ints.saturatedCast(failureRefreshRate.getMaxInterval().getSeconds());
+                        }
+                        builder.backoff(Backoff.random(baseSeconds, maxSeconds));
+                    }
+                }
+
+                // wrap in an assigning EndpointGroup to set appropriate attributes
+                final EndpointGroup xdsEndpointGroup = new XdsAttributeAssigningEndpointGroup(
+                        builder.build(), localityLbEndpoints, lbEndpoint);
+                endpointGroupBuilder.add(xdsEndpointGroup);
+            }
+        }
+        return EndpointGroup.of(endpointGroupBuilder.build());
+    }
+
+    private static List<Endpoint> convertLoadAssignment(ClusterLoadAssignment clusterLoadAssignment) {
+        return clusterLoadAssignment.getEndpointsList().stream().flatMap(
+                                            localityLbEndpoints -> localityLbEndpoints
+                                                    .getLbEndpointsList()
+                                                    .stream()
+                                                    .map(lbEndpoint -> convertToEndpoint(localityLbEndpoints,
+                                                                                         lbEndpoint)))
+                                    .collect(toImmutableList());
+    }
+
+    private static Endpoint convertToEndpoint(LocalityLbEndpoints localityLbEndpoints, LbEndpoint lbEndpoint) {
+        final SocketAddress socketAddress =
+                lbEndpoint.getEndpoint().getAddress().getSocketAddress();
+        final String hostname = lbEndpoint.getEndpoint().getHostname();
+        final int weight = endpointWeight(lbEndpoint);
+        final Endpoint endpoint;
+        if (!Strings.isNullOrEmpty(hostname)) {
+            endpoint = Endpoint.of(hostname)
+                               .withIpAddr(socketAddress.getAddress())
+                               .withAttr(XdsAttributesKeys.LB_ENDPOINT_KEY, lbEndpoint)
+                               .withAttr(XdsAttributesKeys.LOCALITY_LB_ENDPOINTS_KEY, localityLbEndpoints);
+        } else {
+            endpoint = Endpoint.of(socketAddress.getAddress())
+                               .withAttr(XdsAttributesKeys.LB_ENDPOINT_KEY, lbEndpoint)
+                               .withAttr(XdsAttributesKeys.LOCALITY_LB_ENDPOINTS_KEY, localityLbEndpoints)
+                               .withWeight(weight);
+        }
+        if (socketAddress.hasPortValue()) {
+            return endpoint.withPort(socketAddress.getPortValue());
+        }
+        return endpoint;
+    }
+
+    static int endpointWeight(LbEndpoint lbEndpoint) {
+        return lbEndpoint.hasLoadBalancingWeight() ?
+               Math.max(1, lbEndpoint.getLoadBalancingWeight().getValue()) : 1;
     }
 
     private XdsEndpointUtil() {}

--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/HealthCheckedTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/HealthCheckedTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.linecorp.armeria.xds.XdsTestResources.createStaticCluster;
+import static com.linecorp.armeria.xds.XdsTestResources.endpoint;
+import static com.linecorp.armeria.xds.XdsTestResources.localityLbEndpoints;
+import static com.linecorp.armeria.xds.XdsTestResources.staticBootstrap;
+import static com.linecorp.armeria.xds.XdsTestResources.staticResourceListener;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.core.v3.HealthCheck;
+import io.envoyproxy.envoy.config.core.v3.HealthCheck.HttpHealthCheck;
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Policy;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class HealthCheckedTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0);
+            sb.http(0);
+            sb.http(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+            sb.service("/monitor/healthcheck", HealthCheckService.builder().build());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension noHealthCheck = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.http(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void basicCase() {
+        final Listener listener = staticResourceListener();
+        final int weight = 6;
+
+        final List<Integer> healthyPorts = server.server().activePorts().keySet()
+                                          .stream().map(InetSocketAddress::getPort)
+                                          .collect(Collectors.toList());
+        assertThat(healthyPorts).hasSize(3);
+
+        final List<LbEndpoint> healthyEndpoints =
+                healthyPorts.stream()
+                     .map(port -> endpoint("127.0.0.1", port, weight))
+                     .collect(Collectors.toList());
+        final LbEndpoint noHealthyEndpoint = endpoint("127.0.0.1", noHealthCheck.httpPort(), weight);
+        final List<LbEndpoint> allEndpoints = ImmutableList.<LbEndpoint>builder()
+                                                           .addAll(healthyEndpoints)
+                                                           .add(noHealthyEndpoint).build();
+
+        final ClusterLoadAssignment loadAssignment =
+                ClusterLoadAssignment
+                        .newBuilder()
+                        .addEndpoints(localityLbEndpoints(Locality.getDefaultInstance(), allEndpoints))
+                        .setPolicy(Policy.newBuilder().setWeightedPriorityHealth(true))
+                        .build();
+        final Cluster cluster = createStaticCluster("cluster", loadAssignment)
+                .toBuilder()
+                .addHealthChecks(HealthCheck.newBuilder()
+                                         .setHttpHealthCheck(HttpHealthCheck.newBuilder()
+                                                                            .setPath("/monitor/healthcheck")))
+                .build();
+
+        final Bootstrap bootstrap = staticBootstrap(listener, cluster);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap)) {
+            final ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener");
+            // disable allowEmptyEndpoints since the first update iteration in no available healthy endpoints
+            final EndpointGroup endpointGroup = XdsEndpointGroup.of(listenerRoot, false);
+            await().untilAsserted(() -> assertThat(endpointGroup.whenReady()).isDone());
+
+            final ClientRequestContext ctx =
+                    ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            final Endpoint endpoint = endpointGroup.selectNow(ctx);
+            assertThat(endpoint).isNotNull();
+            assertThat(endpoint.port()).isIn(healthyPorts);
+            assertThat(endpoint.weight()).isEqualTo(weight);
+        }
+    }
+}

--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteMetadataSubsetTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteMetadataSubsetTest.java
@@ -31,8 +31,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Struct;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -116,9 +119,12 @@ class RouteMetadataSubsetTest {
                                                          staticResourceListener(routeMetadataMatch1),
                                                          bootstrapCluster);
         try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap)) {
-            final EndpointGroup xdsEndpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
-            await().untilAsserted(() -> assertThat(xdsEndpointGroup.endpoints())
-                    .containsExactly(Endpoint.of("127.0.0.1", 8082)));
+            final EndpointGroup endpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
+
+            await().untilAsserted(() -> assertThat(endpointGroup.whenReady()).isDone());
+            final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8082));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8082));
         }
 
         // No metadata. Fallback to all endpoints.
@@ -127,10 +133,13 @@ class RouteMetadataSubsetTest {
         bootstrap = XdsTestResources.bootstrap(configSource, staticResourceListener(routeMetadataMatch2),
                                                bootstrapCluster);
         try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap)) {
-            final EndpointGroup xdsEndpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
-            await().untilAsserted(() -> assertThat(xdsEndpointGroup.endpoints())
-                    .containsExactlyInAnyOrder(Endpoint.of("127.0.0.1", 8080), Endpoint.of("127.0.0.1", 8081),
-                                               Endpoint.of("127.0.0.1", 8082)));
+            final EndpointGroup endpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
+
+            await().untilAsserted(() -> assertThat(endpointGroup.whenReady()).isDone());
+            final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8080));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8081));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8082));
         }
 
         // No matched metadata. Fallback to all endpoints.
@@ -141,10 +150,13 @@ class RouteMetadataSubsetTest {
         bootstrap = XdsTestResources.bootstrap(configSource, staticResourceListener(routeMetadataMatch3),
                                                bootstrapCluster);
         try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap)) {
-            final EndpointGroup xdsEndpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
-            await().untilAsserted(() -> assertThat(xdsEndpointGroup.endpoints())
-                    .containsExactlyInAnyOrder(Endpoint.of("127.0.0.1", 8080), Endpoint.of("127.0.0.1", 8081),
-                                               Endpoint.of("127.0.0.1", 8082)));
+            final EndpointGroup endpointGroup = XdsEndpointGroup.of(xdsBootstrap.listenerRoot("listener"));
+
+            await().untilAsserted(() -> assertThat(endpointGroup.whenReady()).isDone());
+            final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8080));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8081));
+            assertThat(endpointGroup.selectNow(ctx)).isEqualTo(Endpoint.of("127.0.0.1", 8082));
         }
     }
 }

--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/StrictDnsIntegrationTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/StrictDnsIntegrationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import static com.linecorp.armeria.xds.XdsTestResources.createStaticCluster;
+import static com.linecorp.armeria.xds.XdsTestResources.endpoint;
+import static com.linecorp.armeria.xds.XdsTestResources.localityLbEndpoints;
+import static com.linecorp.armeria.xds.XdsTestResources.staticBootstrap;
+import static com.linecorp.armeria.xds.XdsTestResources.staticResourceListener;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster.DiscoveryType;
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Policy;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class StrictDnsIntegrationTest {
+
+    @Test
+    void basicCase() {
+        final Listener listener = staticResourceListener();
+        final int weight = 6;
+
+        // use armeria.dev until we implement a better way to override the dns resolver via xDS
+        final LbEndpoint lbEndpoint = endpoint("armeria.dev", 80, weight);
+        final ClusterLoadAssignment loadAssignment =
+                ClusterLoadAssignment
+                        .newBuilder()
+                        .addEndpoints(localityLbEndpoints(Locality.getDefaultInstance(), lbEndpoint))
+                        .setPolicy(Policy.newBuilder()
+                                         .setWeightedPriorityHealth(true))
+                        .build();
+        final Cluster cluster = createStaticCluster("cluster", loadAssignment)
+                .toBuilder()
+                .setType(DiscoveryType.STRICT_DNS)
+                .build();
+
+        final Bootstrap bootstrap = staticBootstrap(listener, cluster);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap)) {
+            final ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener");
+            final EndpointGroup endpointGroup = XdsEndpointGroup.of(listenerRoot, false);
+            await().untilAsserted(() -> assertThat(endpointGroup.whenReady()).isDone());
+
+            final ClientRequestContext ctx =
+                    ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            final Endpoint endpoint = endpointGroup.selectNow(ctx);
+            assertThat(endpoint)
+                    .withFailMessage("Failed for endpoints: (%s)", endpointGroup.endpoints())
+                    .isNotNull();
+            assertThat(endpoint.weight()).isEqualTo(weight);
+        }
+    }
+}


### PR DESCRIPTION
This PR attempts to support `DNS`, Health Checked clusters. This is done by converting `ClusterSnapshot` to an `EndpointGroup` via `XdsEndpointUtil#convertEndpoints`. The rest of the changes are simply refactoring.

Motivation:

There are three major points of change:

1. `XdsEndpointUtil#convertEndpointGroup` has been introduced which converts a `ClusterSnapshot` into an `EndpointGroup`.

This method essentially converts a `ClusterSnapshot` into a `DnsAddressEndpointGroup` or a `HealthCheckedEndpointGroup`. Note that only basic functionality is supported at this stage.

During this implementation, I found it convenient to refer to a `LbEndpoint` or `LocalityLbEndpoints` for a particular `Endpoint`. For this reason, `XdsAttributeKeys`, `XdsAttributeAssigningEndpointGroup` has been introduced so that xDS resource information can be retrieved easily. This is useful later as well, in order to fetch the locality, priority, health, etc. of a particular endpoint.

2. New data structures have been introduced to match that of envoy's.
Some include:
- `LoadBalancer`: https://github.com/envoyproxy/envoy/blob/d5bfc06f110647127edc5ddc3bd6cfda78f2760b/source/common/upstream/load_balancer_impl.h#L83
- `ClusterManager`: https://github.com/envoyproxy/envoy/blob/d5bfc06f110647127edc5ddc3bd6cfda78f2760b/source/common/upstream/cluster_manager_impl.h#L245
- `ClusterEntry`: https://github.com/envoyproxy/envoy/blob/d5bfc06f110647127edc5ddc3bd6cfda78f2760b/source/common/upstream/cluster_manager_impl.h#L578
- `PrioritySet`: https://github.com/envoyproxy/envoy/blob/d5bfc06f110647127edc5ddc3bd6cfda78f2760b/envoy/upstream/upstream.h#L533
- `SubsetLoadBalancer`: https://github.com/envoyproxy/envoy/blob/d5bfc06f110647127edc5ddc3bd6cfda78f2760b/source/extensions/load_balancing_policies/subset/subset_lb.h#L135

The nuances are slightly different due to a difference in existing APIs, difference in threading model and lifecycles. However, an effort has been made to keep the implementation relatively similarly looking.

Note that the logic inside `SubsetLoadBalancer` is changed minimally to keep the changeset small.

3. The way updates are propagated has changed for `XdsEndpointGroup`.

`ClusterManager` now receives updates on the `ListenerSnapshot` by listening to the provided `ListenerRoot`. On each snapshot update, a `ClusterEntry` is created for each `ClusterSnapshot`. `ClusterEntry` constructs the `EndpointGroup` based on the provided `ClusterSnapshot` and endpoint updates (dns/health checked `EndpointGroup`s may update multiple times).

Whenever 1) A `ClusterEntry#endpointGroup`'s endpoints are updated or 2) `ListenerSnapshot` is updated, then `ClusterManager#notifyListeners` calls `XdsEndpointGroup#setEndpoints`.  This will eventually trigger `XdsEndpointSelector#selectNow`. This will subsequently trigger `ClusterManager#selectNow` and `LoadBalancer#selectNow`.

**Miscellaneous changes**
- `XdsEndpointGroup` implements `EndpointGroup` directly since custom comparison logic is required for `XdsEndpointGroup#updateState`
- I think we will eventually need to turn `Endpoint` into an interface, and supported various types of endpoints (e.g. `HealthCheckedEndpoint`, `XdsEndpoint`, etc..). For now, I propose to use attributes for simplicity.
- Because `ClusterManager#notifyListeners` is called for any update (i.e. update to the snapshot, `DnsAddressEndpointGroup` updates, etc..) there is a good chance that empty endpoints will be set. This isn't ideal based on the normal use case where users usually wait for initial endpoints via `EndpointGroup#whenComplete`. I've set `allowEmptyEndpoints = false` to be the default.

POC: https://github.com/line/armeria/pull/5450

Modifications:

- Introduce `XdsEndpointUtil#convertEndpointGroup`, which creates an `EndpointGroup` based on the `ClusterSnapshot`. `DNS`, `HealthCheck` capabilities are partially supported.
- `LoadBalancer`, `ClusterManager`, `ClusterEntry`, `PrioritySet`, `SubsetLoadBalancer` are newly introduced.
- `ClusterManager` listens for any updates regarding `Endpoint`s or `Snapshot`s and notifies `EndpointGroup` if there are any changes. Every time this occurs, `LoadBalancer#selectNow` is called.

Result:

- `XdsEndpointGroup` now partially supports DNS and health check.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
