### PR TITLE
Fix HttpHeaderNamesTest as upgrade Guava

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -901,6 +901,20 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString CDN_LOOP = create("CDN-Loop");
 
+    /**
+     * The HTTP <a
+     * href="https://wicg.github.io/turtledove/#handling-direct-from-seller-signals">{@code
+     * Sec-Ad-Auction-Fetch}</a> header field name.
+     */
+    public static final AsciiString SEC_AD_AUCTION_FETCH = create("Sec-Ad-Auction-Fetch");
+
+    /**
+     * The HTTP <a
+     * href="https://wicg.github.io/turtledove/#handling-direct-from-seller-signals">{@code
+     * Ad-Auction-Signals}</a> header field name.
+     */
+    public static final AsciiString AD_AUCTION_SIGNALS = create("Ad-Auction-Signals");
+
     private static final Map<CharSequence, AsciiString> map;
     private static final Map<AsciiString, String> inverseMap;
 


### PR DESCRIPTION
### Motivation:
Fix `HttpHeaderNamesTest. httpHeaderNamesContainsAllFieldsInHttpHeadersInGuava` fail

### Modifications:
- Add `SEC_AD_AUCTION_FETCH` and `AD_AUCTION_SIGNALS` to `HttpHeaderNames`

Result:
Closes: https://github.com/line/armeria/issues/5492
