### PR TITLE
Guess `ExchangeType` if it is not set in `RequestOptions`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/WebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClient.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.client.DefaultWebClient.RESPONSE_STREAMING_REQUEST_OPTIONS;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
@@ -37,7 +36,6 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.Unwrappable;
-import com.linecorp.armeria.internal.common.stream.FixedStreamMessage;
 
 import io.netty.channel.EventLoop;
 
@@ -236,13 +234,7 @@ public interface WebClient extends ClientBuilderParams, Unwrappable {
      */
     @CheckReturnValue
     default HttpResponse execute(HttpRequest req) {
-        final RequestOptions requestOptions;
-        if (req instanceof FixedStreamMessage) {
-            requestOptions = RESPONSE_STREAMING_REQUEST_OPTIONS;
-        } else {
-            requestOptions = RequestOptions.of();
-        }
-        return execute(req, requestOptions);
+        return execute(req, RequestOptions.of());
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -172,12 +172,12 @@ public final class DefaultClientRequestContext
      * @param eventLoop the {@link EventLoop} associated with this context
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that represents the identifier of the current {@link Request}
-     * and {@link Response} pair.
+     *           and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     * e.g. {@code System.currentTimeMillis() * 1000}.
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
      */
     public DefaultClientRequestContext(
             EventLoop eventLoop, MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -197,12 +197,12 @@ public final class DefaultClientRequestContext
      *
      * @param sessionProtocol the {@link SessionProtocol} of the invocation
      * @param id the {@link RequestId} that contains the identifier of the current {@link Request}
-     * and {@link Response} pair.
+     *           and {@link Response} pair.
      * @param req the {@link HttpRequest} associated with this context
      * @param rpcReq the {@link RpcRequest} associated with this context
      * @param requestStartTimeNanos {@link System#nanoTime()} value when the request started.
      * @param requestStartTimeMicros the number of microseconds since the epoch,
-     * e.g. {@code System.currentTimeMillis() * 1000}.
+     *                               e.g. {@code System.currentTimeMillis() * 1000}.
      */
     public DefaultClientRequestContext(
             MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
@@ -541,7 +541,7 @@ public final class DefaultClientRequestContext
         defaultRequestHeaders = ctx.defaultRequestHeaders();
         additionalRequestHeaders = ctx.additionalRequestHeaders();
 
-        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext(); ) {
+        for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext();) {
             addAttr(i.next());
         }
 
@@ -854,7 +854,7 @@ public final class DefaultClientRequestContext
     @Override
     public void mutateAdditionalRequestHeaders(Consumer<HttpHeadersBuilder> mutator) {
         requireNonNull(mutator, "mutator");
-        for (; ; ) {
+        for (;;) {
             final HttpHeaders oldValue = additionalRequestHeaders;
             final HttpHeadersBuilder builder = oldValue.toBuilder();
             mutator.accept(builder);

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientExchangeTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientExchangeTypeTest.java
@@ -68,6 +68,27 @@ class WebClientExchangeTypeTest {
     }
 
     @Test
+    void fixedMessageWithCustomRequestOptions() {
+        assertExchangeType(() -> {
+            client.execute(HttpRequest.of(HttpMethod.POST, "/",
+                                          MediaType.PLAIN_TEXT, "foo"),
+                           RequestOptions.builder()
+                                         .maxResponseLength(1000)
+                                         .build())
+                  .aggregate();
+        }).isEqualTo(ExchangeType.RESPONSE_STREAMING);
+
+        assertExchangeType(() -> {
+            client.execute(HttpRequest.of(HttpMethod.POST, "/",
+                                          MediaType.PLAIN_TEXT, "foo"),
+                           RequestOptions.builder()
+                                         .exchangeType(ExchangeType.BIDI_STREAMING)
+                                         .build())
+                  .aggregate();
+        }).isEqualTo(ExchangeType.BIDI_STREAMING);
+    }
+
+    @Test
     void publisher() {
         assertExchangeType(() -> {
             client.execute(HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/"),


### PR DESCRIPTION
Motivation:

`ExchangeType` is a hint for performance optimization. If no `RequestOptions` is set, it is inferred from the type of `HttpRequest`. However, a custom `RequestOptions` is set, `ExchangeType` is not inferred even if the `RequestOptions.exchangeType()` is null.

Modifications:

- Use `ExchangeType.RESPONSE_STREAMING` if `RequestOptions.exchangeType()` is null and `HttpRequest` is an instance of `FixedStreamMessage`.
- If none of the above conditions are met, the method defaults to returning ExchangeType.BIDI_STREAMING.


Result:

`ExchangeType` is guessed correctly even if `RequestOptions` is set.
