### PR TITLE
Close `InputStream` after marshalling gRPC messages

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
@@ -96,7 +96,9 @@ public final class GrpcMessageMarshaller<I, O> {
                 final CompositeByteBuf out = alloc.compositeBuffer();
                 try (ByteBufOutputStream os = new ByteBufOutputStream(out)) {
                     if (isProto) {
-                        ByteStreams.copy(method.streamRequest(message), os);
+                        try (InputStream is = method.streamRequest(message)) {
+                            ByteStreams.copy(is, os);
+                        }
                     } else {
                         jsonMarshaller.serializeMessage(requestMarshaller, message, os);
                     }
@@ -148,7 +150,9 @@ public final class GrpcMessageMarshaller<I, O> {
                 final CompositeByteBuf out = alloc.compositeBuffer();
                 try (ByteBufOutputStream os = new ByteBufOutputStream(out)) {
                     if (isProto) {
-                        ByteStreams.copy(method.streamResponse(message), os);
+                        try (InputStream is = method.streamResponse(message)) {
+                            ByteStreams.copy(is, os);
+                        }
                     } else {
                         jsonMarshaller.serializeMessage(responseMarshaller, message, os);
                     }


### PR DESCRIPTION
Motivation:

`InputStream`s returned by `method.streamRequest()` and `method.streamResponse()` were not closed after use. https://github.com/line/armeria/discussions/5520

Modifications:

- Use try-with-resource to close the `InputStream`s after use

Result:

Fixed a possible memory leak when a custom gRPC marshaler is used.
