### PR TITLE
Avoid addShutdownHook to JVM during its shutdown

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -81,8 +81,7 @@ final class DefaultClientFactory implements ClientFactory {
                 try {
                     Runtime.getRuntime().addShutdownHook(new Thread(ClientFactory::closeDefault));
                 } catch (IllegalStateException e) {
-                    logger.info("Trying to add shutdown hook during JVM shutdown, " +
-                            "skip it because it does not matter any more since the JVM is already shutting down");
+                    logger.info("Skipping shutdown hook addition: JVM is already shutting down");
                 }
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -77,12 +77,10 @@ final class DefaultClientFactory implements ClientFactory {
 
     static {
         if (DefaultClientFactory.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
-            if (!shutdownHookDisabled) {
-                try {
+            try {
                     Runtime.getRuntime().addShutdownHook(new Thread(ClientFactory::closeDefault));
-                } catch (IllegalStateException e) {
+            } catch (IllegalStateException e) {
                     logger.info("Skipping shutdown hook addition: JVM is already shutting down");
-                }
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -84,8 +84,7 @@ final class DefaultClientFactory implements ClientFactory {
                     }
                 }));
             } catch (IllegalStateException e) {
-                logger.info("Trying to add shutdown hook during JVM shutdown, " +
-                            "skip it because it does not matter any more since the JVM is already shutting down");
+                logger.debug("Skipped adding a shutdown hook to the DefaultClientFactory.", e);
             }
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -77,11 +77,14 @@ final class DefaultClientFactory implements ClientFactory {
 
     static {
         if (DefaultClientFactory.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                if (!shutdownHookDisabled) {
-                    ClientFactory.closeDefault();
+            if (!shutdownHookDisabled) {
+                try {
+                    Runtime.getRuntime().addShutdownHook(new Thread(ClientFactory::closeDefault));
+                } catch (IllegalStateException e) {
+                    logger.info("Trying to add shutdown hook during JVM shutdown, " +
+                            "skip it because it does not matter any more since the JVM is already shutting down");
                 }
-            }));
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -78,9 +78,14 @@ final class DefaultClientFactory implements ClientFactory {
     static {
         if (DefaultClientFactory.class.getClassLoader() == ClassLoader.getSystemClassLoader()) {
             try {
-                    Runtime.getRuntime().addShutdownHook(new Thread(ClientFactory::closeDefault));
+                Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                    if (!shutdownHookDisabled) {
+                        ClientFactory.closeDefault();
+                    }
+                }));
             } catch (IllegalStateException e) {
-                    logger.info("Skipping shutdown hook addition: JVM is already shutting down");
+                logger.info("Trying to add shutdown hook during JVM shutdown, " +
+                            "skip it because it does not matter any more since the JVM is already shutting down");
             }
         }
     }


### PR DESCRIPTION
Motivation:

Currently a JVM shutdown hook is added when DefaultClientFactory is used for the first time ([code](https://github.com/line/armeria/blob/main/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java#L80-L83)). It is possible that a JVM shutdown hook is being added after the JVM has started its shutdown and results in an exception below:
```
Caused by: java.lang.IllegalStateException: Shutdown in progress
    at java.base/java.lang.ApplicationShutdownHooks.add(ApplicationShutdownHooks.java:66)
    at java.base/java.lang.Runtime.addShutdownHook(Runtime.java:216)
    at grpc_shaded.com.linecorp.armeria.client.DefaultClientFactory.<clinit>(DefaultClientFactory.java:79)
    ... 24 more
```

Modifications:
- Skip adding the hook if we explicitly disabled it.
- Add try-catch for ` java.lang.IllegalStateException`

Result:
- Closes https://github.com/line/armeria/issues/5494
