### PR TITLE
Update LINE Corporation to LY Corporation

### DIFF
--- a/site/src/design/README.md
+++ b/site/src/design/README.md
@@ -1,6 +1,6 @@
 # Armeria design resources
 
-LINE Corporation owns all rights to the logos in this folder.
+LY Corporation owns all rights to the logos in this folder.
 The files in this folder are *not* licensed under any open source license.
 
 See [Design resources](https://line.github.com/armeria/community/design-resources) for more information.

--- a/site/src/layouts/footer.tsx
+++ b/site/src/layouts/footer.tsx
@@ -36,7 +36,7 @@ export default () => {
         </div>
         <div className={styles.copyright}>
           <div>
-            &copy; 2015-{buildDate.year()}, LINE Corporation
+            &copy; 2015-{buildDate.year()}, LY Corporation
             <br />
             {typeof window !== 'undefined' ? (
               <>

--- a/site/src/pages/community/design-resources.mdx
+++ b/site/src/pages/community/design-resources.mdx
@@ -4,9 +4,9 @@
 
 <Warning>
 
-LINE Corporation owns all rights to the logos. The logos and PDF files in this page
+LY Corporation owns all rights to the logos. The logos and PDF files in this page
 are *not* licensed under any open source license.
-[Contact LINE Corporation](https://linecorp.com/en/inquiry/corporate/form.html)
+[Contact LY Corporation](https://linecorp.com/en/inquiry/corporate/form.html)
 about use in television, magazines or other forms of media, or to seek
 clarification.
 

--- a/site/src/pages/community/developer-guide.mdx
+++ b/site/src/pages/community/developer-guide.mdx
@@ -88,9 +88,9 @@ Make sure your change does not break the build.
 All source files must begin with the following copyright header:
 
 ```
-Copyright $today.year LINE Corporation
+Copyright $today.year LY Corporation
 
-LINE Corporation licenses this file to you under the Apache License,
+LY Corporation licenses this file to you under the Apache License,
 version 2.0 (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at:
 

--- a/site/src/pages/community/index.mdx
+++ b/site/src/pages/community/index.mdx
@@ -19,7 +19,7 @@ a virtuous cycle that propels the project into something great.
 - Ask a question or start a discussion at [the discussion forum](https://github.com/line/armeria/discussions).
 - File an issue in [the issue tracker](https://github.com/line/armeria/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
   to report a bug or suggest an idea.
-  - In case of a security issue, use [LINE's security bug bounty program](https://bugbounty.linecorp.com/en/)
+  - In case of a security issue, use [LINE Security Bug Bounty Program](https://bugbounty.linecorp.com/en/)
     or [contact us](mailto:dl_oss_dev@linecorp.com) directly.
 
 ## Watch our community in action 🎬

--- a/site/src/pages/community/toc.json
+++ b/site/src/pages/community/toc.json
@@ -9,6 +9,6 @@
   "See also": {
     "Tutorials": "/tutorials",
     "User manual": "/docs",
-    "LINE Engineering": "https://engineering.linecorp.com/en/"
+    "LY Corporation Tech Blog": "https://techblog.lycorp.co.jp/en"
   }
 }

--- a/site/src/pages/docs/index.mdx
+++ b/site/src/pages/docs/index.mdx
@@ -9,7 +9,7 @@ microservice leveraging your favorite technologies, including [gRPC](https://grp
 [Spring Boot](https://spring.io/projects/spring-boot) and [Dropwizard](https://www.dropwizard.io/).
 
 It is open-sourced by the creator of [Netty](https://netty.io/) and his colleagues at
-[LINE](https://engineering.linecorp.com/en/).
+[LY Corporation](https://techblog.lycorp.co.jp/en).
 
 ## Want a quick tour?
 

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -75,7 +75,7 @@ const IndexPage = (props: RouteComponentProps): JSX.Element => {
         'Armeria is your go-to microservice framework for any situation. ' +
         'You can build any type of microservice leveraging your favorite technologies, ' +
         'including gRPC, Thrift, Kotlin, Retrofit, Reactive Streams, Spring Boot and Dropwizard. ' +
-        'Brought to you by the creator of Netty and his colleagues at LINE.'
+        'Brought to you by the creator of Netty and his colleagues at LY Corporation.'
       }
       contentClassName={styles.wrapper}
     >
@@ -114,9 +114,9 @@ const IndexPage = (props: RouteComponentProps): JSX.Element => {
               <OutboundLink href="https://netty.io/">Netty</OutboundLink>
             </Tooltip>{' '}
             and his colleagues at{' '}
-            <Tooltip title="The company behind the most popular mobile messaging app in Japan, Taiwan and Thai">
-              <OutboundLink href="https://engineering.linecorp.com/en/">
-                LINE
+            <Tooltip title="The company behind LINE and Yahoo! Japan, leaders in digital communication and web services">
+              <OutboundLink href="https://techblog.lycorp.co.jp/en">
+                LY Corporation
               </OutboundLink>
             </Tooltip>{' '}
             &rdquo;


### PR DESCRIPTION
Motivation:

The company name (LINE Corporation) in the Armeria site is outdated.

Modifications:

- Update "LINE Corporation" to "LY Corporation"

Result:

- Update some texts in the footer and a few pages in the Armeria site.