### PR TITLE
Prevent open redirect by appending a trailing slash

### DIFF
--- a/site/src/layouts/base.tsx
+++ b/site/src/layouts/base.tsx
@@ -36,7 +36,7 @@ const BaseLayout: React.FC<BaseLayoutProps> = (props) => {
   );
   let redirectUrl;
   if (hrefMatches && hrefMatches.length === 2) {
-    redirectUrl = `https://armeria.dev${hrefMatches[1]}`;
+    redirectUrl = `https://armeria.dev/${hrefMatches[1]}`;
     globalHistory.navigate(redirectUrl);
   }
   // Do not index redirect pages.


### PR DESCRIPTION
Motivation:
The absence of a trailing slash on the `redirectUrl` host of BaseLayout exposes the system to Open Redirect vulnerabilities when the matched value of the regex is altered.

Modifications:
- Added logic to append a trailing slash to the `redirectUrl` host.

Result:
- Open redirect vulnerabilities are mitigated on armeria.dev site.
