### PR TITLE
Websocket bug: PING to server sends PING Frame instead of PONG Frame

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/websocket/WebSocketFrame.java
+++ b/core/src/main/java/com/linecorp/armeria/common/websocket/WebSocketFrame.java
@@ -174,7 +174,7 @@ public interface WebSocketFrame extends Bytes {
         if (data.length == 0) {
             return EMPTY_PONG;
         }
-        return new ByteArrayWebSocketFrame(data, WebSocketFrameType.PING);
+        return new ByteArrayWebSocketFrame(data, WebSocketFrameType.PONG);
     }
 
     /**

--- a/it/websocket/src/test/java/com/linecorp/armeria/it/websocket/WebSocketServiceItTest.java
+++ b/it/websocket/src/test/java/com/linecorp/armeria/it/websocket/WebSocketServiceItTest.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -106,8 +105,8 @@ class WebSocketServiceItTest {
 
         client.sendFrame(pingFrame);
 
-        final String pongContent = client.receivedMessages().poll(5, TimeUnit.SECONDS);
-
+        await().untilAsserted(() -> assertThat(client.receivedMessages()).isNotEmpty());
+        final String pongContent = client.receivedMessages().poll();
         assertThat(pongContent).isEqualTo(pingContent);
     }
 

--- a/it/websocket/src/test/java/com/linecorp/armeria/it/websocket/WebSocketServiceItTest.java
+++ b/it/websocket/src/test/java/com/linecorp/armeria/it/websocket/WebSocketServiceItTest.java
@@ -255,9 +255,9 @@ class WebSocketServiceItTest {
 
                 @Override
                 public void onNext(WebSocketFrame webSocketFrame) {
-                    if(webSocketFrame.type() == WebSocketFrameType.PING) {
+                    if (webSocketFrame.type() == WebSocketFrameType.PING) {
                         writer.writePong(webSocketFrame.array());
-                    }else if(webSocketFrame.type() != WebSocketFrameType.PONG) {
+                    } else if (webSocketFrame.type() != WebSocketFrameType.PONG) {
                         writer.write(webSocketFrame);
                     }
                 }


### PR DESCRIPTION
Motivation:

There is a bug in the Websocket Server PING/PONG handing. When a PING message is sent to Server, the Server incorrectly sends out another PING message as a reply. This is because the code to create the PONG message has a bug in it. The problem is that when testing the PING/PONG mechanism, the Server incorrectly send a PING as a reply for a PING. And this caused whoever was sending the initial PING to receive an incorrect reply to the PING. This was only happening for the case when the PING message has data.

Modifications:

- In the method: `com.linecorp.armeria.common.websocket.WebSocketFrame#ofPong(byte[])`, there is the bug. I modified the code to return the correct Frame. See the files changed.
- I also created unit test for this case

![image](https://github.com/line/armeria/assets/104100/3aa51cb2-d3d3-4e23-9350-e808b51f1833)


Result:

- Websocker PING that contain data are now correctly handled and a PONG Frame sent out.
- This means that when testing with a [websocket cli tool](https://github.com/vi/websocat), I now get the correct frame.
BEFORE:
```
$ websocat --print-ping-rtts --ping-interval 5 ws://localhost:8080/ws
[WARN  websocat::ws_peer] Received a pong with a strange content from websocket
[WARN  websocat::ws_peer] Received a pong with a strange content from websocket
[WARN  websocat::ws_peer] Received a pong with a strange content from websocket
```

AFTER:
```
$ websocat --print-ping-rtts --ping-interval 5 ws://localhost:8080/ws
RTT 0.003123 s
RTT 0.000542 s
RTT 0.000530 s

```

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
