### PR TITLE
Handle an empty query parameter with @Default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Default.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Default.java
@@ -22,6 +22,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Specifies the default value of an optional parameter.
@@ -35,7 +37,19 @@ public @interface Default {
      * When {@link Default} annotation exists but {@link Default#value()} is not specified, {@code null}
      * value would be set if the parameter is not present in the request.
      *
-     * {@link Default} annotation is not allowed for a path variable. If a user uses {@link Default}
+     * <p>When {@link Default} annotation exists and {@link Default#value()} is not specified, but parameter is
+     * present in the request without the value e.g., {@code /foo?bar=}, then actions below will be processed
+     * depending on the type of the parameter.
+     * <table>
+     * <caption>Actions</caption>
+     * <tr><th>Type</th><th>Action</th></tr>
+     * <tr><td>Primitive types</td><td>An {@link IllegalArgumentException} will be thrown</td></tr>
+     * <tr><td>{@link String}</td><td>An empty string {@code ""} will be set</td></tr>
+     * <tr><td>{@link List} or {@link Set}</td><td>An empty collection will be set</td></tr>
+     * <tr><td>Other</td><td>The {@code null} value will be set</td></tr>
+     * </table>
+     *
+     * <p>{@link Default} annotation is not allowed for a path variable. If a user uses {@link Default}
      * annotation on a path variable, {@link IllegalArgumentException} would be raised.
      */
     String value() default UNSPECIFIED;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/Default.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/Default.java
@@ -37,9 +37,9 @@ public @interface Default {
      * When {@link Default} annotation exists but {@link Default#value()} is not specified, {@code null}
      * value would be set if the parameter is not present in the request.
      *
-     * <p>When {@link Default} annotation exists and {@link Default#value()} is not specified, but parameter is
-     * present in the request without the value e.g., {@code /foo?bar=}, then actions below will be processed
-     * depending on the type of the parameter.
+     * <p>When {@link Default} annotation exists and {@link Default#value()} is not specified, the parameter
+     * may be present in the request without a value (e.g. {@code /foo?bar=}). In this case, the behavior
+     * depends on the java type with which the parameter will be bound to.
      * <table>
      * <caption>Actions</caption>
      * <tr><th>Type</th><th>Action</th></tr>

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/EmptyParameterWithDefaultAnnotationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/EmptyParameterWithDefaultAnnotationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.Default;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class EmptyParameterWithDefaultAnnotationTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.annotatedService("/default", new EmptyParameterService());
+        }
+    };
+
+    static class EmptyParameterService {
+        @Get("/string")
+        public String string(@Default @Param String param) {
+            return String.valueOf(param);
+        }
+
+        @Get("/integer")
+        public String integer(@Default @Param Integer param) {
+            return String.valueOf(param);
+        }
+
+        @Get("/primitive")
+        public String primitive(@Default @Param int param) {
+            return String.valueOf(param);
+        }
+
+        @Get("/string-list")
+        public HttpResponse stringList(@Default @Param("param") List<String> params) {
+            return HttpResponse.ofJson(params);
+        }
+
+        @Get("/integer-list")
+        public HttpResponse integerList(@Default @Param("param") List<Integer> params) {
+            return HttpResponse.ofJson(params);
+        }
+
+        @Get("/integer-list-with-default")
+        public HttpResponse integerListWithDefault(@Default("1") @Param("param") List<Integer> params) {
+            return HttpResponse.ofJson(params);
+        }
+    }
+
+    private static final String NULL = "null";
+
+    private final WebClient client = WebClient.of(server.httpUri() + "/default");
+
+    @Test
+    void testEmptyStringParameterIsEmpty() {
+        AggregatedHttpResponse res = aggregate(client.get("/string?param=v"));
+        assertThat(res.contentUtf8()).isEqualTo("v");
+
+        res = aggregate(client.get("/string?param="));
+        assertThat(res.contentUtf8()).isEmpty();
+    }
+
+    @Test
+    void testEmptyIntegerParameter() {
+        AggregatedHttpResponse res = aggregate(client.get("/integer?param=1"));
+        assertThat(res.contentUtf8()).isEqualTo("1");
+
+        res = aggregate(client.get("/integer?param="));
+        assertThat(res.contentUtf8()).isEqualTo(NULL);
+    }
+
+    @Test
+    void testEmptyPrimitiveParameter() {
+        AggregatedHttpResponse res = aggregate(client.get("/primitive?param=1"));
+        assertThat(res.contentUtf8()).isEqualTo("1");
+
+        res = aggregate(client.get("/primitive"));
+        assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+        res = aggregate(client.get("/primitive?param="));
+        assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void testEmptyStringListParameter() {
+        AggregatedHttpResponse res = aggregate(client.get("/string-list?param=v"));
+        assertThat(res.contentUtf8()).isEqualTo("[\"v\"]");
+
+        res = aggregate(client.get("/string-list?param="));
+        assertThat(res.contentUtf8()).isEqualTo("[]");
+    }
+
+    @Test
+    void testEmptyIntegerListParameter() {
+        AggregatedHttpResponse res = aggregate(client.get("/integer-list?param=1"));
+        assertThat(res.contentUtf8()).isEqualTo("[1]");
+
+        res = aggregate(client.get("/integer-list?param="));
+        assertThat(res.contentUtf8()).isEqualTo("[]");
+    }
+
+    @Test
+    void testEmptyIntegerListWithDefaultParameter() {
+        AggregatedHttpResponse res = aggregate(client.get("/integer-list-with-default"));
+        assertThat(res.contentUtf8()).isEqualTo("[1]");
+
+        res = aggregate(client.get("/integer-list-with-default?param="));
+        assertThat(res.contentUtf8()).isEqualTo("[]");
+    }
+
+    private static AggregatedHttpResponse aggregate(HttpResponse response) {
+        return response.aggregate().join();
+    }
+}


### PR DESCRIPTION
Motivation:

Say we have an annotated service that uses `@Default `annotation to optionally bind query parameters.

```java
class MyService {
    @Get("/list")
    public String list(@Default @Param Integer page) {
        ...
    }
}
```

It does not inject `null` if there is a parameter but no value. A NumberFormatException is raised when `/list?page=` is sent as the request path.

It would be better to solve this problem as follows the value of the parameter is empty.

Modifications:

- Logger will warn that the parameter value is not present (It may be intended, such as sending an empty string as the parameter)
- Inject an empty string `""` if the type of the parameter is `String`
- Inject `null` if the type of the parameter is not `String` such as `Integer`, `Boolean` and so on
- Throw an `IllegalArgumentException` if the type of the parameter is primitive type
- Inject an empty list `[]` if the type of the parameter is `List` or `Set`

Result:

- Closes #5515.
