### PR TITLE
Fix a bug where decorator's `serviceAdded` is not invoked

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/RouteDecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/RouteDecoratingService.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.internal.server;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Queue;
 import java.util.function.Function;
 
@@ -30,8 +31,10 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Router;
 import com.linecorp.armeria.server.RoutingContext;
+import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.server.VirtualHost;
 import com.linecorp.armeria.server.VirtualHostBuilder;
 
 import io.netty.util.AttributeKey;
@@ -77,13 +80,16 @@ public final class RouteDecoratingService implements HttpService {
     private static final AttributeKey<Queue<HttpService>> DECORATOR_KEY =
             AttributeKey.valueOf(RouteDecoratingService.class, "SERVICE_CHAIN");
 
-    public static Function<? super HttpService, InitialDispatcherService> newDecorator(
-            Router<RouteDecoratingService> router) {
-        return delegate -> new InitialDispatcherService(delegate, router);
+    public static Function<? super HttpService, HttpService> newDecorator(
+            Router<RouteDecoratingService> router, List<RouteDecoratingService> routeDecoratingServices) {
+        return delegate -> new InitialDispatcherService(delegate, router, routeDecoratingServices);
     }
 
     private final Route route;
     private final HttpService decorator;
+
+    @Nullable
+    private VirtualHost defaultVirtualHost;
 
     public RouteDecoratingService(Route route, String contextPath,
                                   Function<? super HttpService, ? extends HttpService> decoratorFunction) {
@@ -101,6 +107,19 @@ public final class RouteDecoratingService implements HttpService {
      */
     public RouteDecoratingService withRoutePrefix(String prefix) {
         return new RouteDecoratingService(route.withPrefix(prefix), decorator);
+    }
+
+    @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        final VirtualHost defaultVirtualHost = cfg.server().config().defaultVirtualHost();
+        if (this.defaultVirtualHost == defaultVirtualHost) {
+            // This condition is necessary because:
+            // - The same decorator can be added multiple times.
+            // - Avoid infinite loop. The delegate of `decorator` is this.
+            return;
+        }
+        this.defaultVirtualHost = defaultVirtualHost;
+        decorator.serviceAdded(cfg);
     }
 
     @Override
@@ -146,10 +165,21 @@ public final class RouteDecoratingService implements HttpService {
     private static class InitialDispatcherService extends SimpleDecoratingHttpService {
 
         private final Router<RouteDecoratingService> router;
+        private final List<RouteDecoratingService> routeDecoratingServices;
 
-        InitialDispatcherService(HttpService delegate, Router<RouteDecoratingService> router) {
+        InitialDispatcherService(HttpService delegate, Router<RouteDecoratingService> router,
+                                 List<RouteDecoratingService> routeDecoratingServices) {
             super(delegate);
             this.router = router;
+            this.routeDecoratingServices = routeDecoratingServices;
+        }
+
+        @Override
+        public void serviceAdded(ServiceConfig cfg) throws Exception {
+            super.serviceAdded(cfg);
+            for (RouteDecoratingService routeDecoratingService : routeDecoratingServices) {
+                routeDecoratingService.serviceAdded(cfg);
+            }
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
@@ -115,6 +115,13 @@ public final class DefaultWebSocketService implements WebSocketService, WebSocke
     }
 
     @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        if (fallbackService != null) {
+            fallbackService.serviceAdded(cfg);
+        }
+    }
+
+    @Override
     public WebSocketUpgradeResult upgrade(ServiceRequestContext ctx, HttpRequest req) throws Exception {
         final HttpMethod method = ctx.method();
         switch (method) {

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingHttpServiceFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingHttpServiceFunction.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * A functional interface that enables building a {@link SimpleDecoratingHttpService} with
@@ -35,4 +36,12 @@ public interface DecoratingHttpServiceFunction {
      * @return the {@link HttpResponse}
      */
     HttpResponse serve(HttpService delegate, ServiceRequestContext ctx, HttpRequest req) throws Exception;
+
+    /**
+     * Invoked when this service has been added to a {@link Server} with the specified
+     * configuration. Please note that this method can be invoked more than once if this service
+     * has been added more than once.
+     */
+    @UnstableApi
+    default void serviceAdded(ServiceConfig cfg) throws Exception {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingService.java
@@ -45,7 +45,11 @@ public abstract class DecoratingService<T_I extends Request, T_O extends Respons
 
     @Override
     public void serviceAdded(ServiceConfig cfg) throws Exception {
-        ServiceCallbackInvoker.invokeServiceAdded(cfg, unwrap());
+        final Service<T_I, T_O> unwrapped = unwrap();
+        if (unwrapped == this) {
+            return;
+        }
+        ServiceCallbackInvoker.invokeServiceAdded(cfg, unwrapped);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/FunctionalDecoratingHttpService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FunctionalDecoratingHttpService.java
@@ -46,6 +46,12 @@ final class FunctionalDecoratingHttpService extends SimpleDecoratingHttpService 
     }
 
     @Override
+    public void serviceAdded(ServiceConfig cfg) throws Exception {
+        super.serviceAdded(cfg);
+        function.serviceAdded(cfg);
+    }
+
+    @Override
     public String toString() {
         return FunctionalDecoratingHttpService.class.getSimpleName() + '(' + unwrap() + ", " + function + ')';
     }

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -144,7 +144,9 @@ public final class Server implements ListenableAsyncCloseable {
 
         // Invoke the serviceAdded() method in Service so that it can keep the reference to this Server or
         // add a listener to it.
-        config.serviceConfigs().forEach(cfg -> ServiceCallbackInvoker.invokeServiceAdded(cfg, cfg.service()));
+        for (ServiceConfig cfg : config.serviceConfigs()) {
+            ServiceCallbackInvoker.invokeServiceAdded(cfg, cfg.service());
+        }
         hasWebSocketService = hasWebSocketService(config);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -737,7 +737,8 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                     routeDecoratingServices.stream()
                                            .map(service -> service.withRoutePrefix(baseContextPath))
                                            .collect(toImmutableList());
-            return RouteDecoratingService.newDecorator(Routers.ofRouteDecoratingService(prefixed));
+            return RouteDecoratingService.newDecorator(Routers.ofRouteDecoratingService(prefixed),
+                                                       routeDecoratingServices);
         } else {
             return null;
         }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceAddedTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceAddedTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class ServiceAddedTest {
+
+    private static final Queue<String> decoratingEvents = new ConcurrentLinkedQueue<>();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(delegate -> new MyDecoratingService(delegate, "root"));
+            sb.decorator("prefix:/path", delegate -> new MyDecoratingService(delegate, "path"));
+            sb.service("/path", new MyService("service"));
+            sb.service("/path/decorated", new MyService("service.decorated").decorate(delegate -> {
+                return new MyDecoratingService(delegate, "decorated");
+            }));
+        }
+    };
+
+    @Test
+    void shouldInvokeServiceAdded() {
+        assertThat(decoratingEvents).containsExactlyInAnyOrder(
+                "root", "path", "service", "decorated", "service.decorated");
+        decoratingEvents.clear();
+        server.server().reconfigure(sb -> {
+            sb.decorator("prefix:/path", delegate -> new MyDecoratingService(delegate, "path"));
+            sb.service("/path", new MyService("service"));
+        });
+        assertThat(decoratingEvents).containsExactlyInAnyOrder("path", "service");
+        decoratingEvents.clear();
+    }
+
+    private static final class MyService implements HttpService {
+        private final String name;
+
+        private MyService(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return HttpResponse.of(200);
+        }
+
+        @Override
+        public void serviceAdded(ServiceConfig cfg) throws Exception {
+            decoratingEvents.add(name);
+        }
+    }
+
+    private static final class MyDecoratingService extends SimpleDecoratingHttpService {
+        private final String name;
+
+        MyDecoratingService(HttpService delegate, String name) {
+            super(delegate);
+            this.name = name;
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            return unwrap().serve(ctx, req);
+        }
+
+        @Override
+        public void serviceAdded(ServiceConfig cfg) throws Exception {
+            super.serviceAdded(cfg);
+            decoratingEvents.add(name);
+        }
+    }
+}

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -85,6 +85,7 @@ import com.linecorp.armeria.server.RpcService;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.VirtualHost;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.AttributeKey;
@@ -290,6 +291,9 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
     private Map<SerializationFormat, TProtocolFactory> requestProtocolFactories;
     private Map<ThriftFunction, HttpService> decoratedTHttpServices;
 
+    @Nullable
+    private VirtualHost defaultVirtualHost;
+
     THttpService(RpcService delegate, SerializationFormat defaultSerializationFormat,
                  Set<SerializationFormat> supportedSerializationFormats,
                  int maxRequestStringLength, int maxRequestContainerLength,
@@ -346,6 +350,13 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
 
     @Override
     public void serviceAdded(ServiceConfig cfg) throws Exception {
+        final VirtualHost defaultVirtualHost = cfg.server().config().defaultVirtualHost();
+        if (this.defaultVirtualHost == defaultVirtualHost) {
+            // Avoid infinite loop. The delegate of annotated decorators is this.
+            return;
+        }
+        this.defaultVirtualHost = defaultVirtualHost;
+
         if (maxRequestStringLength == -1) {
             maxRequestStringLength = Ints.saturatedCast(cfg.maxRequestLength());
         }
@@ -372,7 +383,9 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
                         final DecoratorAndOrder d = decorators.get(i);
                         decorator = decorator.andThen(d.decorator(dependencyInjector));
                     }
-                    decoratedTHttpServices.put(thriftFunction, decorator.apply(this));
+                    final HttpService decorated = decorator.apply(this);
+                    decorated.serviceAdded(cfg);
+                    decoratedTHttpServices.put(thriftFunction, decorated);
                 }
             }
         }


### PR DESCRIPTION
Motivation:

Checking the cause of CI failure, I found that `serviceAdded` is not called for the decorators directly added to a server. https://ge.armeria.dev/s/lqh63hxstqzou/tests/task/:xds:shadedTest/details/com.linecorp.armeria.xds.ConfigSourceGrpcServiceTest/testHeader()?top-execution=1

Previously, `serviceAdded` was only invoked for services and decorators wrapping the services. Decorators that were added dynamically were not being called:
- Route decorators
- Annotated decorators for Thrift
- Created by `DecoratingHttpServiceFunction`

Modifications:

- All internal decorators of `RouteDecoratingService` are correctly invoked.
  - A condition is added logic to prevent duplicate calls and infinitive calls.
- Added a similar approach to `THttpService`.
- Added `serviceAdded` method to `DecoratingHttpServiceFunction` to listen to service-added events
- Fixed an infinity loop where the unwrapped service is itself in `DecoratingService`

Result:

`Service.serviceAdded()` is now correctly invoked for dynamic decorators.
