### PR TITLE
Improve incorrect cyclic redirect detection logic

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -642,7 +642,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
                    method == that.method;
         }
 
-        public String uri() {
+        String uri() {
             return protocol + "://" + authority + pathAndQuery;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -274,8 +274,8 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             }
 
             final Set<RedirectSignature> redirectSignatures = redirectCtx.redirectSignatures();
-            // Plus 1 to maxRedirects because the original signature is also included.
-            if (redirectSignatures.size() > maxRedirects + 1) {
+            // Minus 1 because the original signature is also included.
+            if (redirectSignatures.size() - 1 > maxRedirects) {
                 handleException(ctx, derivedCtx, reqDuplicator, responseFuture,
                                 response, TooManyRedirectsException.of(maxRedirects, redirectCtx.originalUri(),
                                                                        redirectCtx.redirectUris()));
@@ -640,9 +640,9 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             }
 
             final RedirectSignature that = (RedirectSignature) obj;
-            return protocol.equals(that.protocol) &&
+            return pathAndQuery.equals(that.pathAndQuery) &&
                    authority.equals(that.authority) &&
-                   pathAndQuery.equals(that.pathAndQuery) &&
+                   protocol.equals(that.protocol) &&
                    method == that.method;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -567,14 +567,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             return responseFuture;
         }
 
-        String originalUri() {
-            if (originalUri == null) {
-                originalUri = buildUri(ctx, request.headers());
-            }
-            return originalUri;
-        }
-
-        boolean addRedirectSignature(RequestTarget nextTarget, HttpMethod nextMethod) {
+        boolean addRedirectSignature(RequestTarget nextReqTarget, HttpMethod nextMethod) {
             if (redirectSignatures == null) {
                 redirectSignatures = new LinkedHashSet<>();
             }
@@ -589,11 +582,18 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
                 isAddedOriginalSignature = true;
             }
 
-            final RedirectSignature signature = new RedirectSignature(nextTarget.scheme(),
-                                                                      nextTarget.authority(),
-                                                                      nextTarget.pathAndQuery(),
+            final RedirectSignature signature = new RedirectSignature(nextReqTarget.scheme(),
+                                                                      nextReqTarget.authority(),
+                                                                      nextReqTarget.pathAndQuery(),
                                                                       nextMethod);
             return redirectSignatures.add(signature);
+        }
+
+        String originalUri() {
+            if (originalUri == null) {
+                originalUri = buildUri(ctx, request.headers());
+            }
+            return originalUri;
         }
 
         Set<RedirectSignature> redirectSignatures() {

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -607,6 +607,7 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
         }
     }
 
+    @VisibleForTesting
     static class RedirectSignature {
         private final String uri;
         private final HttpMethod method;

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -32,8 +32,6 @@ import java.util.function.Function;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.LinkedListMultimap;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import com.linecorp.armeria.client.redirect.CyclicRedirectsException;

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -545,7 +545,6 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
         private String originalUri;
         @Nullable
         private Set<RedirectSignature> redirectSignatures;
-        private boolean isAddedOriginalSignature;
 
         RedirectContext(ClientRequestContext ctx, HttpRequest request,
                         HttpResponse response, CompletableFuture<HttpResponse> responseFuture) {
@@ -570,16 +569,13 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
         boolean addRedirectSignature(RequestTarget nextReqTarget, HttpMethod nextMethod) {
             if (redirectSignatures == null) {
                 redirectSignatures = new LinkedHashSet<>();
-            }
 
-            if (!isAddedOriginalSignature) {
                 final String originalProtocol = ctx.sessionProtocol().isTls() ? "https" : "http";
                 final RedirectSignature originalSignature = new RedirectSignature(originalProtocol,
                                                                                   ctx.authority(),
                                                                                   request.headers().path(),
                                                                                   request.method());
                 redirectSignatures.add(originalSignature);
-                isAddedOriginalSignature = true;
             }
 
             final RedirectSignature signature = new RedirectSignature(nextReqTarget.scheme(),

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.RedirectingClient.RedirectSignature;
+import com.linecorp.armeria.common.HttpMethod;
+
+public class RedirectSignatureTest {
+    @Test
+    public void equality() {
+        final RedirectSignature signature1 = new RedirectSignature("http://example.com", HttpMethod.GET);
+        final RedirectSignature signature2 = new RedirectSignature("http://example.com", HttpMethod.GET);
+        final RedirectSignature signature3 = new RedirectSignature("http://another.com", HttpMethod.GET);
+        final RedirectSignature signature4 = new RedirectSignature("http://example.com", HttpMethod.POST);
+
+        assertThat(signature1).isEqualTo(signature2);
+        assertThat(signature1).isNotEqualTo(signature3);
+        assertThat(signature1).isNotEqualTo(signature4);
+    }
+
+    @Test
+    public void hash() {
+        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
+        final int hash = Objects.hash("http://example.com", HttpMethod.GET);
+
+        assertThat(signature.hashCode()).isEqualTo(hash);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.client.RedirectingClient.RedirectSignature;
 import com.linecorp.armeria.common.HttpMethod;
 
-public class RedirectSignatureTest {
+class RedirectSignatureTest {
 
     private static final String PROTOCOL = "http";
     private static final String AUTHORITY = "example.com";
@@ -36,25 +36,25 @@ public class RedirectSignatureTest {
             new RedirectSignature(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
 
     @Test
-    public void equalityWithSameObject() {
+    void equalityWithSameObject() {
         assertThat(SIGNATURE.equals(SIGNATURE)).isTrue();
     }
 
     @Test
-    public void equalityWithDifferentType() {
+    void equalityWithDifferentType() {
         final Object other = new Object();
         assertThat(SIGNATURE).isNotEqualTo(other);
     }
 
     @Test
-    public void equalityWithEquivalentObjects() {
+    void equalityWithEquivalentObjects() {
         final RedirectSignature signature =
                 new RedirectSignature(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
         assertThat(SIGNATURE).isEqualTo(signature);
     }
 
     @Test
-    public void equalityWithNonEquivalentObjects() {
+    void equalityWithNonEquivalentObjects() {
         final RedirectSignature differentProtocolSignature =
                 new RedirectSignature("https", AUTHORITY, PATH_AND_QUERY, METHOD);
         final RedirectSignature differentAuthoritySignature =
@@ -70,14 +70,14 @@ public class RedirectSignatureTest {
     }
 
     @Test
-    public void hash() {
+    void hash() {
         final int hash = Objects.hash(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
 
         assertThat(SIGNATURE.hashCode()).isEqualTo(hash);
     }
 
     @Test
-    public void uri() {
+    void uri() {
         assertThat(SIGNATURE.uri()).isEqualTo("http://example.com/query?q=1");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
@@ -26,42 +26,58 @@ import com.linecorp.armeria.client.RedirectingClient.RedirectSignature;
 import com.linecorp.armeria.common.HttpMethod;
 
 public class RedirectSignatureTest {
+
+    private static final String PROTOCOL = "http";
+    private static final String AUTHORITY = "example.com";
+    private static final String PATH_AND_QUERY = "/query?q=1";
+    private static final HttpMethod METHOD = HttpMethod.GET;
+
+    private static final RedirectSignature SIGNATURE =
+            new RedirectSignature(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
+
     @Test
     public void equalityWithSameObject() {
-        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
-        assertThat(signature.equals(signature)).isTrue();
+        assertThat(SIGNATURE.equals(SIGNATURE)).isTrue();
     }
 
     @Test
     public void equalityWithDifferentType() {
-        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
         final Object other = new Object();
-        assertThat(signature).isNotEqualTo(other);
+        assertThat(SIGNATURE).isNotEqualTo(other);
     }
 
     @Test
     public void equalityWithEquivalentObjects() {
-        final RedirectSignature signature1 = new RedirectSignature("http://example.com", HttpMethod.GET);
-        final RedirectSignature signature2 = new RedirectSignature("http://example.com", HttpMethod.GET);
-        assertThat(signature1).isEqualTo(signature2);
+        final RedirectSignature signature =
+                new RedirectSignature(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
+        assertThat(SIGNATURE).isEqualTo(signature);
     }
 
     @Test
     public void equalityWithNonEquivalentObjects() {
-        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
-        final RedirectSignature differentUriSignature =
-                new RedirectSignature("http://another.com", HttpMethod.GET);
+        final RedirectSignature differentProtocolSignature =
+                new RedirectSignature("https", AUTHORITY, PATH_AND_QUERY, METHOD);
+        final RedirectSignature differentAuthoritySignature =
+                new RedirectSignature(PROTOCOL, "another.com", PATH_AND_QUERY, METHOD);
+        final RedirectSignature differentPathAndQuerySignature =
+                new RedirectSignature(PROTOCOL, AUTHORITY, "/another?q=2", METHOD);
         final RedirectSignature differentMethodSignature =
-                new RedirectSignature("http://example.com", HttpMethod.POST);
-        assertThat(signature).isNotEqualTo(differentUriSignature);
-        assertThat(signature).isNotEqualTo(differentMethodSignature);
+                new RedirectSignature(PROTOCOL, AUTHORITY, PATH_AND_QUERY, HttpMethod.POST);
+        assertThat(SIGNATURE).isNotEqualTo(differentProtocolSignature);
+        assertThat(SIGNATURE).isNotEqualTo(differentAuthoritySignature);
+        assertThat(SIGNATURE).isNotEqualTo(differentPathAndQuerySignature);
+        assertThat(SIGNATURE).isNotEqualTo(differentMethodSignature);
     }
 
     @Test
     public void hash() {
-        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
-        final int hash = Objects.hash("http://example.com", HttpMethod.GET);
+        final int hash = Objects.hash(PROTOCOL, AUTHORITY, PATH_AND_QUERY, METHOD);
 
-        assertThat(signature.hashCode()).isEqualTo(hash);
+        assertThat(SIGNATURE.hashCode()).isEqualTo(hash);
+    }
+
+    @Test
+    public void uri() {
+        assertThat(SIGNATURE.uri()).isEqualTo("http://example.com/query?q=1");
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Objects;
 
@@ -27,15 +28,34 @@ import com.linecorp.armeria.common.HttpMethod;
 
 public class RedirectSignatureTest {
     @Test
-    public void equality() {
+    public void equalityWithSameObject() {
+        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
+        assertThat(signature.equals(signature)).isTrue();
+    }
+
+    @Test
+    public void equalityWithDifferentType() {
+        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
+        final Object other = new Object();
+        assertThat(signature).isNotEqualTo(other);
+    }
+
+    @Test
+    public void equalityWithEquivalentObjects() {
         final RedirectSignature signature1 = new RedirectSignature("http://example.com", HttpMethod.GET);
         final RedirectSignature signature2 = new RedirectSignature("http://example.com", HttpMethod.GET);
-        final RedirectSignature signature3 = new RedirectSignature("http://another.com", HttpMethod.GET);
-        final RedirectSignature signature4 = new RedirectSignature("http://example.com", HttpMethod.POST);
-
         assertThat(signature1).isEqualTo(signature2);
-        assertThat(signature1).isNotEqualTo(signature3);
-        assertThat(signature1).isNotEqualTo(signature4);
+    }
+
+    @Test
+    public void equalityWithNonEquivalentObjects() {
+        final RedirectSignature signature = new RedirectSignature("http://example.com", HttpMethod.GET);
+        final RedirectSignature differentUriSignature =
+                new RedirectSignature("http://another.com", HttpMethod.GET);
+        final RedirectSignature differentMethodSignature =
+                new RedirectSignature("http://example.com", HttpMethod.POST);
+        assertThat(signature).isNotEqualTo(differentUriSignature);
+        assertThat(signature).isNotEqualTo(differentMethodSignature);
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectSignatureTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Objects;
 

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
@@ -147,7 +147,6 @@ class RedirectingClientTest {
                   return HttpResponse.ofRedirect(redirectUrl);
               });
 
-
             sb.service("/differentHttpMethod", (ctx, req) -> {
                 if (ctx.method() == HttpMethod.GET) {
                     return HttpResponse.of(200);

--- a/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RedirectingClientTest.java
@@ -116,13 +116,37 @@ class RedirectingClientTest {
               .service("/removeDoubleDotSegments/foo",
                        (ctx, req) -> HttpResponse.ofRedirect("../removeDotSegments/bar"));
 
-            sb.service("/completeLoop", (ctx, req) -> HttpResponse.ofRedirect("completeLoop1"))
-              .service("/completeLoop1", (ctx, req) -> HttpResponse.ofRedirect("completeLoop2"))
-              .service("/completeLoop2", (ctx, req) -> HttpResponse.ofRedirect("completeLoop"));
+            sb.service("/completeLoop1", (ctx, req) -> HttpResponse.ofRedirect("completeLoop2"))
+              .service("/completeLoop2", (ctx, req) -> HttpResponse.ofRedirect("completeLoop3"))
+              .service("/completeLoop3", (ctx, req) -> HttpResponse.ofRedirect("completeLoop1"));
 
-            sb.service("/partialLoop", (ctx, req) -> HttpResponse.ofRedirect("partialLoop1"))
-              .service("/partialLoop1", (ctx, req) -> HttpResponse.ofRedirect("partialLoop2"))
-              .service("/partialLoop2", (ctx, req) -> HttpResponse.ofRedirect("partialLoop1"));
+            sb.service("/partialLoop1", (ctx, req) -> HttpResponse.ofRedirect("partialLoop2"))
+              .service("/partialLoop2", (ctx, req) -> HttpResponse.ofRedirect("partialLoop3"))
+              .service("/partialLoop3", (ctx, req) -> HttpResponse.ofRedirect("partialLoop2"));
+
+            sb.service("/protocolLoop", (ctx, req) ->
+                    HttpResponse.ofRedirect("h1c://127.0.0.1:" + server.httpPort() + "/protocolLoop"));
+
+            sb.service("/authorityLoop", (ctx, req) -> HttpResponse.ofRedirect(
+                    "http://domain1.com:" + server.httpPort() + "/authorityLoop"));
+            sb.virtualHost("domain1.com")
+              .service("/authorityLoop", (ctx, req) -> HttpResponse.ofRedirect(
+                      "http://domain2.com:" + server.httpPort() + "/authorityLoop"));
+            sb.virtualHost("domain2.com")
+              .service("/authorityLoop", (ctx, req) -> HttpResponse.ofRedirect(
+                      "http://domain1.com:" + server.httpPort() + "/authorityLoop"));
+
+            sb.service("/queryLoop1", (ctx, req) -> {
+                final String queryParams = ctx.query();
+                final String redirectUrl = "/queryLoop2" + (queryParams == null ? "" : '?' + queryParams);
+                return HttpResponse.ofRedirect(redirectUrl);
+              })
+              .service("/queryLoop2", (ctx, req) -> {
+                  final String queryParams = ctx.query();
+                  final String redirectUrl = "/queryLoop1?" + (queryParams == null ? "q=1" : queryParams);
+                  return HttpResponse.ofRedirect(redirectUrl);
+              });
+
 
             sb.service("/differentHttpMethod", (ctx, req) -> {
                 if (ctx.method() == HttpMethod.GET) {
@@ -297,10 +321,16 @@ class RedirectingClientTest {
     @ParameterizedTest
     @MethodSource("provideRedirectPatterns")
     void cyclicRedirectsException(String originalPath, List<String> expectedPathRegexPatterns) {
+        final ClientFactory factory = localhostAccessingClientFactory();
+        final RedirectConfig redirectConfig = RedirectConfig.builder()
+                                                            .allowDomains("domain1.com", "domain2.com")
+                                                            .build();
         final WebClient client = Clients.builder(server.httpUri())
-                                        .followRedirects()
+                                        .factory(factory)
+                                        .followRedirects(redirectConfig)
                                         .decorator(LoggingClient.newDecorator())
                                         .build(WebClient.class);
+
         assertThatThrownBy(() -> client.get(originalPath).aggregate().join())
                 .hasCauseInstanceOf(CyclicRedirectsException.class)
                 .hasMessageContainingAll("The original URI:", "Redirect URIs:")
@@ -314,17 +344,30 @@ class RedirectingClientTest {
 
     private static Stream<Arguments> provideRedirectPatterns() {
         return Stream.of(
-                Arguments.of("/completeLoop",
+                Arguments.of("/completeLoop1",
                              redirectExceptionPathRegexPatterns(
-                                     "http://.*:[0-9]+/completeLoop",
                                      "http://.*:[0-9]+/completeLoop1",
-                                     "http://.*:[0-9]+/completeLoop2")),
-                Arguments.of("/partialLoop",
+                                     "http://.*:[0-9]+/completeLoop2",
+                                     "http://.*:[0-9]+/completeLoop3")),
+                Arguments.of("/partialLoop1",
                              redirectExceptionPathRegexPatterns(
-                                     "http://.*:[0-9]+/partialLoop",
                                      "http://.*:[0-9]+/partialLoop1",
-                                     "http://.*:[0-9]+/partialLoop2"))
-        );
+                                     "http://.*:[0-9]+/partialLoop2",
+                                     "http://.*:[0-9]+/partialLoop3")),
+                Arguments.of("/protocolLoop",
+                             redirectExceptionPathRegexPatterns(
+                                     "http://.*:[0-9]+/protocolLoop")),
+                Arguments.of("/authorityLoop",
+                             redirectExceptionPathRegexPatterns(
+                                     "http://.*:[0-9]+/authorityLoop",
+                                     "http://domain1.com:[0-9]+/authorityLoop",
+                                     "http://domain2.com:[0-9]+/authorityLoop")),
+                Arguments.of("/queryLoop1",
+                             redirectExceptionPathRegexPatterns(
+                                     "http://.*:[0-9]+/queryLoop1",
+                                     "http://.*:[0-9]+/queryLoop2",
+                                     "http://.*:[0-9]+/queryLoop1\\?q=1",
+                                     "http://.*:[0-9]+/queryLoop2\\?q=1")));
     }
 
     private static List<String> redirectExceptionPathRegexPatterns(String... patterns) {


### PR DESCRIPTION
Motivation:

Current implements can detect only cyclic redirect which comes back to original URL like `a --> b --> c --> a`.
And cannot detect some cases, for example, partial cyclic one like `a --> b --> c --> b` , however it returns [TooManyRedirectsException](https://github.com/line/armeria/blob/db3973d74e70e177b0849f201fdd96615f2f6292/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java#L274-L277) instead of [CyclicRedirectsException](https://github.com/line/armeria/blob/db3973d74e70e177b0849f201fdd96615f2f6292/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java#L266-L270).

This is caused because adding redirect info to `Multimap` to check the cyclic always returns `true`. ([code](https://github.com/line/armeria/blob/db3973d74e70e177b0849f201fdd96615f2f6292/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java#L587))
And I think the reasons we couldn't notice was that test cases were insufficient and didn't validate the exception type.

To resolve the above problems, I add the following changes.

Modifications:

- Add `RedirectSignature` class to store redirect information.
- Use `Set` instead of `Multimap` to check cyclic redirections with the above class.
    - `Set.add()` returns `false` when the same data is added.
- Add tests to verify some cases such as partial loop as mentioned in motivation.
    - Verify `CyclicRedirectsException` is thrown.

Result:

- Closes #5491
