### PR TITLE
Add exception when tryWrite returns false

### DIFF
--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionResultSubscriber.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/ExecutionResultSubscriber.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.common.stream.NoopSubscription;
 
 import graphql.ExecutionResult;
@@ -67,7 +68,7 @@ final class ExecutionResultSubscriber implements Subscriber<ExecutionResult> {
                 protocol.sendGraphqlErrors(executionResult.getErrors());
                 subscription.cancel();
             }
-        } catch (JsonProcessingException e) {
+        } catch (JsonProcessingException | ClosedStreamException e) {
             protocol.completeWithError(e);
             if (subscription != null) {
                 subscription.cancel();

--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWSSubProtocol.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlWSSubProtocol.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.websocket.WebSocketCloseStatus;
 import com.linecorp.armeria.common.websocket.WebSocketWriter;
@@ -352,7 +353,9 @@ class GraphqlWSSubProtocol {
                 "payload", executionResult.toSpecification());
         final String event = serializeToJson(response);
         logger.trace("NEXT: {}", event);
-        out.tryWrite(event);
+        if (!out.tryWrite(event)) {
+            throw ClosedStreamException.get();
+        }
     }
 
     private static void writeError(WebSocketWriter out, String operationId, List<GraphQLError> errors)


### PR DESCRIPTION
Motivation:

`tryWrite` in `GraphqlWSSubProtocol.writeNext(...)` can return `false` when `WebSocketWriter` is closed which makes not to cancel the publisher and cleanup the resource.

Modifications:

- When `tryWrite` returns `false`, it throws `ClosedStreamException`.
- If `ClosedStreamException` is occurred, the exception handler in `ExecutionResultSubscriber.onNext(...)` can lead to cancel the publisher through `subscription.cancel()`.

Result:

- Closes #5542