### PR TITLE
Replace Optional with Spring's ObjectProvider to manage the optionality of injection points more clearly

### DIFF
--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.spring;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.internal.spring.ArmeriaConfigurationUtil.configureServerWithArmeriaSettings;
 
 import java.net.InetAddress;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -68,15 +70,15 @@ public abstract class AbstractArmeriaAutoConfiguration {
             ArmeriaSettings armeriaSettings,
             InternalServices internalService,
             Optional<MeterRegistry> meterRegistry,
-            Optional<List<MetricCollectingServiceConfigurator>> metricCollectingServiceConfigurators,
+            ObjectProvider<MetricCollectingServiceConfigurator> metricCollectingServiceConfigurators,
             Optional<MeterIdPrefixFunction> meterIdPrefixFunction,
-            Optional<List<ArmeriaServerConfigurator>> armeriaServerConfigurators,
-            Optional<List<Consumer<ServerBuilder>>> armeriaServerBuilderConsumers,
-            Optional<List<DependencyInjector>> dependencyInjectors,
+            ObjectProvider<ArmeriaServerConfigurator> armeriaServerConfigurators,
+            ObjectProvider<Consumer<ServerBuilder>> armeriaServerBuilderConsumers,
+            ObjectProvider<DependencyInjector> dependencyInjectors,
             BeanFactory beanFactory) {
 
-        if (!armeriaServerConfigurators.isPresent() &&
-            !armeriaServerBuilderConsumers.isPresent()) {
+        if (armeriaServerConfigurators.getIfAvailable() == null &&
+            armeriaServerBuilderConsumers.getIfAvailable() == null) {
             throw new IllegalStateException(
                     "No services to register, " +
                     "use ArmeriaServerConfigurator or Consumer<ServerBuilder> to configure an Armeria server.");
@@ -91,13 +93,17 @@ public abstract class AbstractArmeriaAutoConfiguration {
         }
 
         configureServerWithArmeriaSettings(serverBuilder, armeriaSettings, internalService,
-                                           armeriaServerConfigurators.orElse(ImmutableList.of()),
-                                           armeriaServerBuilderConsumers.orElse(ImmutableList.of()),
+                                           armeriaServerConfigurators
+                                                   .orderedStream().collect(toImmutableList()),
+                                           armeriaServerBuilderConsumers
+                                                   .orderedStream().collect(toImmutableList()),
                                            meterRegistry.orElse(Flags.meterRegistry()),
                                            meterIdPrefixFunction.orElse(
                                                    MeterIdPrefixFunction.ofDefault("armeria.server")),
-                                           metricCollectingServiceConfigurators.orElse(ImmutableList.of()),
-                                           dependencyInjectors.orElse(ImmutableList.of()),
+                                           metricCollectingServiceConfigurators
+                                                   .orderedStream().collect(toImmutableList()),
+                                           dependencyInjectors
+                                                   .orderedStream().collect(toImmutableList()),
                                            beanFactory);
 
         return serverBuilder.build();
@@ -128,16 +134,16 @@ public abstract class AbstractArmeriaAutoConfiguration {
     public InternalServices internalServices(
             ArmeriaSettings settings,
             Optional<MeterRegistry> meterRegistry,
-            Optional<List<HealthChecker>> healthCheckers,
-            Optional<List<HealthCheckServiceConfigurator>> healthCheckServiceConfigurators,
-            Optional<List<DocServiceConfigurator>> docServiceConfigurators,
+            ObjectProvider<HealthChecker> healthCheckers,
+            ObjectProvider<HealthCheckServiceConfigurator> healthCheckServiceConfigurators,
+            ObjectProvider<DocServiceConfigurator> docServiceConfigurators,
             @Value("${management.server.port:#{null}}") @Nullable Integer managementServerPort,
             @Value("${management.server.address:#{null}}") @Nullable InetAddress managementServerAddress,
             @Value("${management.server.ssl.enabled:#{false}}") boolean enableManagementServerSsl) {
         return InternalServices.of(settings, meterRegistry.orElse(Flags.meterRegistry()),
-                                   healthCheckers.orElse(ImmutableList.of()),
-                                   healthCheckServiceConfigurators.orElse(ImmutableList.of()),
-                                   docServiceConfigurators.orElse(ImmutableList.of()),
+                                   healthCheckers.orderedStream().collect(toImmutableList()),
+                                   healthCheckServiceConfigurators.orderedStream().collect(toImmutableList()),
+                                   docServiceConfigurators.orderedStream().collect(toImmutableList()),
                                    managementServerPort, managementServerAddress, enableManagementServerSsl);
     }
 

--- a/spring/boot3-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryAutoConfiguration.java
+++ b/spring/boot3-webflux-autoconfigure/src/main/java/com/linecorp/armeria/spring/web/reactive/ArmeriaReactiveWebServerFactoryAutoConfiguration.java
@@ -15,10 +15,12 @@
  */
 package com.linecorp.armeria.spring.web.reactive;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.net.InetAddress;
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
@@ -87,16 +89,16 @@ public class ArmeriaReactiveWebServerFactoryAutoConfiguration {
     public InternalServices internalServices(
             ArmeriaSettings settings,
             Optional<MeterRegistry> meterRegistry,
-            Optional<List<HealthChecker>> healthCheckers,
-            Optional<List<HealthCheckServiceConfigurator>> healthCheckServiceConfigurators,
-            Optional<List<DocServiceConfigurator>> docServiceConfigurators,
+            ObjectProvider<HealthChecker> healthCheckers,
+            ObjectProvider<HealthCheckServiceConfigurator> healthCheckServiceConfigurators,
+            ObjectProvider<DocServiceConfigurator> docServiceConfigurators,
             @Value("${management.server.port:#{null}}") @Nullable Integer managementServerPort,
             @Value("${management.server.address:#{null}}") @Nullable InetAddress managementServerAddress,
             @Value("${management.server.ssl.enabled:#{false}}") boolean enableManagementServerSsl) {
         return InternalServices.of(settings, meterRegistry.orElse(Flags.meterRegistry()),
-                                   healthCheckers.orElse(ImmutableList.of()),
-                                   healthCheckServiceConfigurators.orElse(ImmutableList.of()),
-                                   docServiceConfigurators.orElse(ImmutableList.of()),
+                                   healthCheckers.orderedStream().collect(toImmutableList()),
+                                   healthCheckServiceConfigurators.orderedStream().collect(toImmutableList()),
+                                   docServiceConfigurators.orderedStream().collect(toImmutableList()),
                                    managementServerPort, managementServerAddress, enableManagementServerSsl);
     }
 }


### PR DESCRIPTION
Motivation:

`Optional<T>` is not as compatible as `ObjectProvider<T>`, which is included in Spring Framework since Spring 4.3, so use `ObjectProvider` would improve the programmatic resolution of Beans.

Modifications:

Two file are affected, `AbstractArmeriaAutoConfiguration.java` and `ArmeriaReactiveWebServerFactoryAutoConfiguration.java`

Result:

- Closes #5527 .
