### PR TITLE
Add SchemeAndAuthority class which is in charge of authority normalization

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -57,7 +57,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.DomainSocketAddress;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
-import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
+import com.linecorp.armeria.internal.common.SchemeAndAuthority;
 import com.linecorp.armeria.internal.common.util.IpAddrUtil;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 
@@ -105,10 +105,10 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         requireNonNull(authority, "authority");
         checkArgument(!authority.isEmpty(), "authority is empty");
         return cache.get(authority, key -> {
-            final URI uri = ArmeriaHttpUtil.normalizeAuthority(key);
+            final SchemeAndAuthority schemeAndAuthority = SchemeAndAuthority.fromAuthority(key);
             // If the port is undefined, set to 0
-            final int port = uri.getPort() == -1 ? 0 : uri.getPort();
-            return create(uri.getHost(), port, true);
+            final int port = schemeAndAuthority.getPort() == -1 ? 0 : schemeAndAuthority.getPort();
+            return create(schemeAndAuthority.getHost(), port, true);
         });
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -105,7 +105,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         requireNonNull(authority, "authority");
         checkArgument(!authority.isEmpty(), "authority is empty");
         return cache.get(authority, key -> {
-            final SchemeAndAuthority schemeAndAuthority = SchemeAndAuthority.fromAuthority(key);
+            final SchemeAndAuthority schemeAndAuthority = SchemeAndAuthority.fromSchemeAndAuthority(null, key);
             // If the port is undefined, set to 0
             final int port = schemeAndAuthority.getPort() == -1 ? 0 : schemeAndAuthority.getPort();
             return create(schemeAndAuthority.getHost(), port, true);

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -85,7 +85,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
      * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
      */
     private static final Predicate<String> SCHEME_VALIDATOR =
-            scheme -> Pattern.compile("^([a-z][a-z0-9+\\-.]*)").matcher(scheme).matches();
+            scheme -> Pattern.compile("^([a-zA-Z][a-zA-Z0-9+\\-.]*)").matcher(scheme).matches();
 
     private static final Cache<String, Endpoint> cache =
             Caffeine.newBuilder()
@@ -763,6 +763,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         if (!SCHEME_VALIDATOR.test(scheme)) {
             throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
         }
+        scheme = Ascii.toLowerCase(scheme);
 
         try {
             return new URI(scheme, authority, path, null, null);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -474,7 +474,7 @@ public final class DefaultClientRequestContext
             // The connection will be established with the IP address but `host` set to the `Endpoint`
             // could be used for SNI. It would make users send HTTPS requests with CSLB or configure a reverse
             // proxy based on an authority.
-            final String host = SchemeAndAuthority.fromSchemeAndAuthority(null, authority).getHost();
+            final String host = SchemeAndAuthority.of(null, authority).host();
             if (!NetUtil.isValidIpV4Address(host) && !NetUtil.isValidIpV6Address(host)) {
                 endpoint = endpoint.withHost(host);
             }
@@ -758,7 +758,7 @@ public final class DefaultClientRequestContext
         if (authority == null) {
             return null;
         }
-        return SchemeAndAuthority.fromSchemeAndAuthority(null, authority).getHost();
+        return SchemeAndAuthority.of(null, authority).host();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -474,7 +474,7 @@ public final class DefaultClientRequestContext
             // The connection will be established with the IP address but `host` set to the `Endpoint`
             // could be used for SNI. It would make users send HTTPS requests with CSLB or configure a reverse
             // proxy based on an authority.
-            final String host = SchemeAndAuthority.fromAuthority(authority).getHost();
+            final String host = SchemeAndAuthority.fromSchemeAndAuthority(null, authority).getHost();
             if (!NetUtil.isValidIpV4Address(host) && !NetUtil.isValidIpV6Address(host)) {
                 endpoint = endpoint.withHost(host);
             }
@@ -758,7 +758,7 @@ public final class DefaultClientRequestContext
         if (authority == null) {
             return null;
         }
-        return SchemeAndAuthority.fromAuthority(authority).getHost();
+        return SchemeAndAuthority.fromSchemeAndAuthority(null, authority).getHost();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -69,10 +69,10 @@ import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.TextFormatter;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
-import com.linecorp.armeria.internal.common.ArmeriaHttpUtil;
 import com.linecorp.armeria.internal.common.CancellationScheduler;
 import com.linecorp.armeria.internal.common.NonWrappingRequestContext;
 import com.linecorp.armeria.internal.common.RequestContextExtension;
+import com.linecorp.armeria.internal.common.SchemeAndAuthority;
 import com.linecorp.armeria.internal.common.stream.FixedStreamMessage;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
@@ -474,7 +474,7 @@ public final class DefaultClientRequestContext
             // The connection will be established with the IP address but `host` set to the `Endpoint`
             // could be used for SNI. It would make users send HTTPS requests with CSLB or configure a reverse
             // proxy based on an authority.
-            final String host = ArmeriaHttpUtil.normalizeAuthority(authority).getHost();
+            final String host = SchemeAndAuthority.fromAuthority(authority).getHost();
             if (!NetUtil.isValidIpV4Address(host) && !NetUtil.isValidIpV6Address(host)) {
                 endpoint = endpoint.withHost(host);
             }
@@ -758,7 +758,7 @@ public final class DefaultClientRequestContext
         if (authority == null) {
             return null;
         }
-        return ArmeriaHttpUtil.normalizeAuthority(authority).getHost();
+        return SchemeAndAuthority.fromAuthority(authority).getHost();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -40,6 +40,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -49,6 +50,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -247,6 +250,13 @@ public final class ArmeriaHttpUtil {
             Flags.headerValueCacheSpec() != null ? buildCache(Flags.headerValueCacheSpec()) : null;
     private static final Set<AsciiString> CACHED_HEADERS = Flags.cachedHeaders().stream().map(AsciiString::of)
                                                                 .collect(toImmutableSet());
+
+    /**
+     * Validator for the scheme part of the URI, as defined in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
+     */
+    private static final Predicate<String> SCHEME_VALIDATOR =
+            scheme -> Pattern.compile("^([a-z][a-z0-9+\\-.]*)").matcher(scheme).matches();
 
     private static LoadingCache<AsciiString, String> buildCache(String spec) {
         return Caffeine.from(spec).build(AsciiString::toString);
@@ -1263,6 +1273,66 @@ public final class ArmeriaHttpUtil {
                 writer.accept(output, HttpHeaderNames.HOST, v);
             }
         }
+    }
+
+    /**
+     * Attempts to parse this URI's authority component and return {@link URI}.
+     * The authority part may have one of the following formats (The userinfo part will be ignored.):
+     * <ul>
+     *   <li>{@code "<host>:<port>"} for a host endpoint </li>
+     *   <li>{@code "<host>"}, {@code "<host>:"} for a host endpoint with no port number specified</li>
+     * </ul>
+     * An IPv4 or IPv6 address can be specified in lieu of a host name, e.g. {@code "127.0.0.1:8080"} and
+     * {@code "[::1]:8080"}.
+     *
+     * @throws IllegalArgumentException if {@code authority} do not comply with RFC 2396
+     */
+    public static URI normalizeAuthority(String authority) {
+        requireNonNull(authority, "authority");
+        final String authorityWithoutUserInfo = removeUserInfo(authority);
+        try {
+            final URI uri = new URI(null, authorityWithoutUserInfo, null, null, null);
+            return uri.parseServerAuthority();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Attempts to parse this URI's scheme and authority component and return {@link URI}.
+     * The authority part may have one of the following formats (The userinfo part will be ignored.):
+     * <ul>
+     *   <li>{@code "<host>:<port>"} for a host endpoint </li>
+     *   <li>{@code "<host>"}, {@code "<host>:"} for a host endpoint with no port number specified</li>
+     * </ul>
+     * An IPv4 or IPv6 address can be specified in lieu of a host name, e.g. {@code "127.0.0.1:8080"} and
+     * {@code "[::1]:8080"}.
+     *
+     * @throws IllegalArgumentException if {@code scheme} or {@code authority} do not comply with RFC 2396
+     */
+    public static URI normalizeSchemeAndAuthority(String scheme, String authority) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(authority, "authority");
+
+        if (!SCHEME_VALIDATOR.test(scheme)) {
+            throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
+        }
+
+        final String authorityWithoutUserInfo = removeUserInfo(authority);
+        try {
+            final URI uri = new URI(scheme, authorityWithoutUserInfo, null, null, null);
+            return uri.parseServerAuthority();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    private static String removeUserInfo(String authority) {
+        final int indexOfDelimiter = authority.lastIndexOf('@');
+        if (indexOfDelimiter == -1) {
+            return authority;
+        }
+        return authority.substring(indexOfDelimiter + 1);
     }
 
     // TODO(minwoox): Will provide this interface to public API

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -249,20 +249,21 @@ public final class ArmeriaHttpUtil {
     private static final Set<AsciiString> CACHED_HEADERS = Flags.cachedHeaders().stream().map(AsciiString::of)
                                                                 .collect(toImmutableSet());
 
-    private static LoadingCache<AsciiString, String> buildCache(String spec) {
-        return Caffeine.from(spec).build(AsciiString::toString);
-    }
-
     /**
      * Validator for the scheme part of the URI, as defined in
      * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
      */
     private static final Pattern SCHEME_PATTERN = Pattern.compile("^([a-zA-Z][a-zA-Z0-9+\\-.]*)");
 
+    private static LoadingCache<AsciiString, String> buildCache(String spec) {
+        return Caffeine.from(spec).build(AsciiString::toString);
+    }
+
     /**
      * Returns normalized scheme.
      *
-     * @throws IllegalArgumentException if {@code scheme} is not an conformed the RFC3986 criteria.
+     * @throws IllegalArgumentException if the provided {@code scheme} does not conform to the criteria
+     *                                  specified in RFC 3986.
      */
     public static String schemeValidateAndNormalize(String scheme) {
         final boolean isValidScheme = SCHEME_PATTERN.matcher(scheme).matches();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -49,6 +49,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -250,6 +251,26 @@ public final class ArmeriaHttpUtil {
 
     private static LoadingCache<AsciiString, String> buildCache(String spec) {
         return Caffeine.from(spec).build(AsciiString::toString);
+    }
+
+    /**
+     * Validator for the scheme part of the URI, as defined in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
+     */
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^([a-zA-Z][a-zA-Z0-9+\\-.]*)");
+
+    /**
+     * Returns normalized scheme.
+     *
+     * @throws IllegalArgumentException if {@code scheme} is not an conformed the RFC3986 criteria.
+     */
+    public static String schemeValidateAndNormalize(String scheme) {
+        final boolean isValidScheme = SCHEME_PATTERN.matcher(scheme).matches();
+        if (isValidScheme) {
+            return Ascii.toLowerCase(scheme);
+        } else {
+            throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -19,7 +19,6 @@ import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.findAuthority
 import static io.netty.util.internal.StringUtil.decodeHexNibble;
 import static java.util.Objects.requireNonNull;
 
-import java.net.URI;
 import java.util.BitSet;
 import java.util.Objects;
 
@@ -436,7 +435,7 @@ public final class DefaultRequestTarget implements RequestTarget {
     @Nullable
     private static RequestTarget slowAbsoluteFormForClient(String reqTarget, int authorityPos) {
         // Extract scheme and authority while looking for path.
-        final URI schemeAndAuthority;
+        final SchemeAndAuthority schemeAndAuthority;
         final String scheme = reqTarget.substring(0, authorityPos - 3);
         final int nextPos = findNextComponent(reqTarget, authorityPos);
         final String authority;
@@ -455,7 +454,7 @@ public final class DefaultRequestTarget implements RequestTarget {
 
         try {
             // Normalize scheme and authority.
-            schemeAndAuthority = ArmeriaHttpUtil.normalizeSchemeAndAuthority(scheme, authority);
+            schemeAndAuthority = SchemeAndAuthority.fromSchemeAndAuthority(scheme, authority);
         } catch (Exception ignored) {
             // Invalid scheme or authority.
             return null;
@@ -483,7 +482,7 @@ public final class DefaultRequestTarget implements RequestTarget {
 
     @Nullable
     private static RequestTarget slowForClient(String reqTarget,
-                                               @Nullable URI schemeAndAuthority,
+                                               @Nullable SchemeAndAuthority schemeAndAuthority,
                                                int pathPos) {
         final Bytes fragment;
         final Bytes path;
@@ -604,11 +603,11 @@ public final class DefaultRequestTarget implements RequestTarget {
     }
 
     private static DefaultRequestTarget newAbsoluteTarget(
-            URI schemeAndAuthority, String encodedPath,
+            SchemeAndAuthority schemeAndAuthority, String encodedPath,
             @Nullable String encodedQuery, @Nullable String encodedFragment) {
 
         final String scheme = schemeAndAuthority.getScheme();
-        final String maybeAuthority = schemeAndAuthority.getRawAuthority();
+        final String maybeAuthority = schemeAndAuthority.getAuthority();
         final String maybeHost = schemeAndAuthority.getHost();
         final int maybePort = schemeAndAuthority.getPort();
         final String authority;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -453,9 +453,10 @@ public final class DefaultRequestTarget implements RequestTarget {
             return null;
         }
 
-        // Normalize scheme and authority.
-        schemeAndAuthority = normalizeSchemeAndAuthority(scheme, authority);
-        if (schemeAndAuthority == null) {
+        try {
+            // Normalize scheme and authority.
+            schemeAndAuthority = ArmeriaHttpUtil.normalizeSchemeAndAuthority(scheme, authority);
+        } catch (Exception ignored) {
             // Invalid scheme or authority.
             return null;
         }
@@ -646,15 +647,6 @@ public final class DefaultRequestTarget implements RequestTarget {
                                         encodedPath,
                                         encodedQuery,
                                         encodedFragment);
-    }
-
-    @Nullable
-    private static URI normalizeSchemeAndAuthority(String scheme, String authority) {
-        try {
-            return new URI(scheme + "://" + authority);
-        } catch (Exception unused) {
-            return null;
-        }
     }
 
     private static boolean isRelativePath(Bytes path) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -454,7 +454,7 @@ public final class DefaultRequestTarget implements RequestTarget {
 
         try {
             // Normalize scheme and authority.
-            schemeAndAuthority = SchemeAndAuthority.fromSchemeAndAuthority(scheme, authority);
+            schemeAndAuthority = SchemeAndAuthority.of(scheme, authority);
         } catch (Exception ignored) {
             // Invalid scheme or authority.
             return null;
@@ -606,10 +606,10 @@ public final class DefaultRequestTarget implements RequestTarget {
             SchemeAndAuthority schemeAndAuthority, String encodedPath,
             @Nullable String encodedQuery, @Nullable String encodedFragment) {
 
-        final String scheme = schemeAndAuthority.getScheme();
-        final String maybeAuthority = schemeAndAuthority.getAuthority();
-        final String maybeHost = schemeAndAuthority.getHost();
-        final int maybePort = schemeAndAuthority.getPort();
+        final String scheme = schemeAndAuthority.scheme();
+        final String maybeAuthority = schemeAndAuthority.authority();
+        final String maybeHost = schemeAndAuthority.host();
+        final int maybePort = schemeAndAuthority.port();
         final String authority;
         final String host;
         final int port;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -23,6 +23,8 @@ import java.net.URISyntaxException;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import com.google.common.base.Ascii;
+
 import com.linecorp.armeria.common.annotation.Nullable;
 
 public final class SchemeAndAuthority {
@@ -31,7 +33,7 @@ public final class SchemeAndAuthority {
      * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
      */
     private static final Predicate<String> SCHEME_VALIDATOR =
-            scheme -> Pattern.compile("^([a-z][a-z0-9+\\-.]*)").matcher(scheme).matches();
+            scheme -> Pattern.compile("^([a-zA-Z][a-zA-Z0-9+\\-.]*)").matcher(scheme).matches();
 
     @Nullable
     private final String scheme;
@@ -118,6 +120,7 @@ public final class SchemeAndAuthority {
         if (!SCHEME_VALIDATOR.test(scheme)) {
             throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
         }
+        scheme = Ascii.toLowerCase(scheme);
 
         final SchemeAndAuthority authorityObj = fromAuthority(authority);
         return new SchemeAndAuthority(scheme, authorityObj.authority, authorityObj.host, authorityObj.port);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -20,57 +20,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-
-import com.google.common.base.Ascii;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 
 public final class SchemeAndAuthority {
-    /**
-     * Validator for the scheme part of the URI, as defined in
-     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
-     */
-    private static final Predicate<String> SCHEME_VALIDATOR =
-            scheme -> Pattern.compile("^([a-zA-Z][a-zA-Z0-9+\\-.]*)").matcher(scheme).matches();
-
-    @Nullable
-    private final String scheme;
-    private final String authority;
-    private final String host;
-    private final int port;
-
-    private SchemeAndAuthority(@Nullable String scheme, String authority, String host, int port) {
-        this.scheme = scheme;
-        this.authority = authority;
-        this.host = host;
-        this.port = port;
-    }
-
-    @Nullable
-    public String getScheme() {
-        return scheme;
-    }
-
-    public String getAuthority() {
-        return authority;
-    }
-
-    public String getHost() {
-        return host;
-    }
-
-    /**
-     * Returns the port number of this authority.
-     *
-     * @return The port component of this URI,
-     *          or {@code -1} if the port is undefined
-     */
-    public int getPort() {
-        return port;
-    }
-
     /**
      * Attempts to parse this URI's authority component and return {@link SchemeAndAuthority}.
      * The authority part may have one of the following formats (The userinfo part will be ignored.):
@@ -84,11 +37,11 @@ public final class SchemeAndAuthority {
      *
      * @throws IllegalArgumentException if {@code scheme} or {@code authority} do not comply with RFC 2396
      */
-    public static SchemeAndAuthority fromSchemeAndAuthority(@Nullable String scheme, String authority) {
+    public static SchemeAndAuthority of(@Nullable String scheme, String authority) {
         requireNonNull(authority, "authority");
 
         if (scheme != null) {
-            scheme = schemeValidateAndNormalize(scheme);
+            scheme = ArmeriaHttpUtil.schemeValidateAndNormalize(scheme);
         }
 
         if (authority.startsWith("unix%3A") || authority.startsWith("unix%3a")) {
@@ -104,18 +57,47 @@ public final class SchemeAndAuthority {
         }
     }
 
-    private static String schemeValidateAndNormalize(String scheme) {
-        if (!SCHEME_VALIDATOR.test(scheme)) {
-            throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
-        }
-        return Ascii.toLowerCase(scheme);
-    }
-
     private static String removeUserInfo(String authority) {
         final int indexOfDelimiter = authority.lastIndexOf('@');
         if (indexOfDelimiter == -1) {
             return authority;
         }
         return authority.substring(indexOfDelimiter + 1);
+    }
+
+    @Nullable
+    private final String scheme;
+    private final String authority;
+    private final String host;
+    private final int port;
+
+    private SchemeAndAuthority(@Nullable String scheme, String authority, String host, int port) {
+        this.scheme = scheme;
+        this.authority = authority;
+        this.host = host;
+        this.port = port;
+    }
+
+    @Nullable
+    public String scheme() {
+        return scheme;
+    }
+
+    public String authority() {
+        return authority;
+    }
+
+    public String host() {
+        return host;
+    }
+
+    /**
+     * Returns the port number of this authority.
+     *
+     * @return The port component of this URI,
+     *          or {@code -1} if the port is undefined
+     */
+    public int port() {
+        return port;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -95,7 +95,7 @@ public final class SchemeAndAuthority {
      * Returns the port number of this authority.
      *
      * @return The port component of this URI,
-     *          or {@code -1} if the port is undefined
+     *         or {@code -1} if the port is undefined
      */
     public int port() {
         return port;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+public final class SchemeAndAuthority {
+    /**
+     * Validator for the scheme part of the URI, as defined in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">the section 3.1 of RFC3986</a>.
+     */
+    private static final Predicate<String> SCHEME_VALIDATOR =
+            scheme -> Pattern.compile("^([a-z][a-z0-9+\\-.]*)").matcher(scheme).matches();
+
+    @Nullable
+    private final String scheme;
+    private final String authority;
+    private final String host;
+    private final int port;
+
+    private SchemeAndAuthority(@Nullable String scheme, String authority, String host, int port) {
+        this.scheme = scheme;
+        this.authority = authority;
+        this.host = host;
+        this.port = port;
+    }
+
+    @Nullable
+    public String getScheme() {
+        return scheme;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Returns the port number of this authority.
+     *
+     * @return The port component of this URI,
+     *          or {@code -1} if the port is undefined
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Attempts to parse this URI's authority component and return {@link SchemeAndAuthority}.
+     * The authority part may have one of the following formats (The userinfo part will be ignored.):
+     * <ul>
+     *   <li>{@code "unix$3A<socket file>"} for a domain socket authority </li>
+     *   <li>{@code "<host>:<port>"} for a host endpoint </li>
+     *   <li>{@code "<host>"}, {@code "<host>:"} for a host endpoint with no port number specified</li>
+     * </ul>
+     * An IPv4 or IPv6 address can be specified in lieu of a host name, e.g. {@code "127.0.0.1:8080"} and
+     * {@code "[::1]:8080"}.
+     *
+     * @throws IllegalArgumentException if {@code authority} do not comply with RFC 2396
+     */
+    public static SchemeAndAuthority fromAuthority(String authority) {
+        requireNonNull(authority, "authority");
+
+        if (authority.startsWith("unix%3A") || authority.startsWith("unix%3a")) {
+            return new SchemeAndAuthority(null, authority, authority, -1);
+        }
+
+        final String authorityWithoutUserInfo = removeUserInfo(authority);
+        try {
+            final URI uri = new URI(null, authorityWithoutUserInfo, null, null, null).parseServerAuthority();
+            return new SchemeAndAuthority(null, uri.getRawAuthority(), uri.getHost(), uri.getPort());
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Attempts to parse this URI's authority component and return {@link SchemeAndAuthority}.
+     * The authority part may have one of the following formats (The userinfo part will be ignored.):
+     * <ul>
+     *   <li>{@code "unix$3A<socket file>"} for a domain socket authority </li>
+     *   <li>{@code "<host>:<port>"} for a host endpoint </li>
+     *   <li>{@code "<host>"}, {@code "<host>:"} for a host endpoint with no port number specified</li>
+     * </ul>
+     * An IPv4 or IPv6 address can be specified in lieu of a host name, e.g. {@code "127.0.0.1:8080"} and
+     * {@code "[::1]:8080"}.
+     *
+     * @throws IllegalArgumentException if {@code scheme} or {@code authority} do not comply with RFC 2396
+     */
+    public static SchemeAndAuthority fromSchemeAndAuthority(String scheme, String authority) {
+        requireNonNull(scheme, "scheme");
+        requireNonNull(authority, "authority");
+
+        if (!SCHEME_VALIDATOR.test(scheme)) {
+            throw new IllegalArgumentException("scheme: " + scheme + " (expected: a valid scheme)");
+        }
+
+        final SchemeAndAuthority authorityObj = fromAuthority(authority);
+        return new SchemeAndAuthority(scheme, authorityObj.authority, authorityObj.host, authorityObj.port);
+    }
+
+    private static String removeUserInfo(String authority) {
+        final int indexOfDelimiter = authority.lastIndexOf('@');
+        if (indexOfDelimiter == -1) {
+            return authority;
+        }
+        return authority.substring(indexOfDelimiter + 1);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -79,6 +79,17 @@ class EndpointTest {
         assertThat(barWithUserInfo.hasIpAddr()).isFalse();
         assertThat(barWithUserInfo.hasPort()).isTrue();
         assertThat(barWithUserInfo.toUri("none+http").toString()).isEqualTo("none+http://bar:80");
+
+        final Endpoint barWithoutPort = Endpoint.parse("foo@bar:");
+        assertThat(barWithoutPort).isEqualTo(Endpoint.of("bar"));
+        assertThat(barWithoutPort.type()).isSameAs(Type.HOSTNAME_ONLY);
+        assertThatThrownBy(barWithoutPort::port).isInstanceOf(IllegalStateException.class);
+        assertThat(barWithoutPort.weight()).isEqualTo(1000);
+        assertThat(barWithoutPort.ipAddr()).isNull();
+        assertThat(barWithoutPort.ipFamily()).isNull();
+        assertThat(barWithoutPort.hasIpAddr()).isFalse();
+        assertThat(barWithoutPort.hasPort()).isFalse();
+        assertThat(barWithoutPort.toUri("none+http").toString()).isEqualTo("none+http://bar");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/WebClientWithoutPortTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WebClientWithoutPortTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpResponse;
+
+public class WebClientWithoutPortTest {
+    @Test
+    void defaultWebClient() {
+        final WebClient defaultWebClient = WebClient.builder()
+                                                    .decorator((delegate, ctx, req) -> {
+                                                        final Endpoint endpoint = ctx.endpoint();
+                                                        assertThat(endpoint.host()).isEqualTo("a.com");
+                                                        assertThat(endpoint.hasPort()).isFalse();
+                                                        return HttpResponse.of(200);
+                                                    })
+                                                    .build();
+        assertThat(defaultWebClient.blocking().get("http://a.com:/").status().code()).isEqualTo(200);
+    }
+
+    @Test
+    void buildedByUriStringWebClient() {
+        final WebClient webClient = WebClient.builder("http://a.com:")
+                                             .decorator((delegate, ctx, req) -> {
+                                                 final Endpoint endpoint = ctx.endpoint();
+                                                 assertThat(endpoint.host()).isEqualTo("a.com");
+                                                 assertThat(endpoint.hasPort()).isFalse();
+                                                 return HttpResponse.of(200);
+                                             })
+                                             .build();
+        assertThat(webClient.blocking().get("/").status().code()).isEqualTo(200);
+    }
+
+    @Test
+    void buildedByUriWebClient() throws URISyntaxException {
+        final URI testUri = new URI("http://a.com:");
+        final WebClient webClient = WebClient.builder(testUri)
+                                             .decorator((delegate, ctx, req) -> {
+                                                 final Endpoint endpoint = ctx.endpoint();
+                                                 assertThat(endpoint.host()).isEqualTo("a.com");
+                                                 assertThat(endpoint.hasPort()).isFalse();
+                                                 return HttpResponse.of(200);
+                                             })
+                                             .build();
+        assertThat(webClient.blocking().get("/").status().code()).isEqualTo(200);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetSocketAddress;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -42,7 +41,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.net.HostAndPort;
 
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -597,7 +595,7 @@ class ArmeriaHttpUtilTest {
             "foo@bar:80,    bar:80,         bar,        80",
     })
     void normalizeBadAuthorityaa(String authority, String expectedAuthority, String expectedHost,
-                                 int expectedPort) throws Exception {
+                                 int expectedPort) {
         assertThat(ArmeriaHttpUtil.normalizeAuthority(authority)).satisfies(uri -> {
             assertThat(uri.getScheme()).isNull();
             assertThat(uri.getAuthority()).isEqualTo(expectedAuthority);
@@ -612,7 +610,7 @@ class ArmeriaHttpUtilTest {
             "foo:bar", "http://foo:80", "foo/bar", "foo?bar=1", "foo#bar",
             "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0"
     })
-    void normalizeBadAuthority(String badAuthority) throws Exception {
+    void normalizeBadAuthority(String badAuthority) {
         System.out.println(badAuthority);
         assertThatThrownBy(() -> ArmeriaHttpUtil.normalizeAuthority(badAuthority))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -620,7 +618,7 @@ class ArmeriaHttpUtilTest {
 
     @ParameterizedTest
     @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh" })
-    void normalizeSchemeAndAuthority(String scheme) throws URISyntaxException {
+    void normalizeSchemeAndAuthority(String scheme) {
         assertThat(ArmeriaHttpUtil.normalizeSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
             assertThat(uri.getScheme()).isEqualTo(scheme);
         });
@@ -630,7 +628,7 @@ class ArmeriaHttpUtilTest {
     @CsvSource({
             "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp", "htTP", "HTTP"
     })
-    void normalizeBadSchemeAndAuthority(String badScheme) throws URISyntaxException {
+    void normalizeBadSchemeAndAuthority(String badScheme) {
         assertThatThrownBy(() -> ArmeriaHttpUtil.normalizeSchemeAndAuthority(badScheme, "foo"))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -585,54 +585,6 @@ class ArmeriaHttpUtilTest {
                                           .add(HttpHeaderNames.CONNECTION, "close"));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "0.0.0.0:80,    0.0.0.0:80,     0.0.0.0,    80",
-            "[::1]:8080,    [::1]:8080,     [::1],      8080",
-            "foo.bar,       foo.bar,        foo.bar,    -1",
-            "foo:,          foo:,           foo,        -1",
-            "bar:80,        bar:80,         bar,        80",
-            "foo@bar:80,    bar:80,         bar,        80",
-    })
-    void normalizeBadAuthorityaa(String authority, String expectedAuthority, String expectedHost,
-                                 int expectedPort) {
-        assertThat(ArmeriaHttpUtil.normalizeAuthority(authority)).satisfies(uri -> {
-            assertThat(uri.getScheme()).isNull();
-            assertThat(uri.getAuthority()).isEqualTo(expectedAuthority);
-            assertThat(uri.getUserInfo()).isNull();
-            assertThat(uri.getHost()).isEqualTo(expectedHost);
-            assertThat(uri.getPort()).isEqualTo(expectedPort);
-        });
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "foo:bar", "http://foo:80", "foo/bar", "foo?bar=1", "foo#bar",
-            "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0"
-    })
-    void normalizeBadAuthority(String badAuthority) {
-        System.out.println(badAuthority);
-        assertThatThrownBy(() -> ArmeriaHttpUtil.normalizeAuthority(badAuthority))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @ParameterizedTest
-    @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh" })
-    void normalizeSchemeAndAuthority(String scheme) {
-        assertThat(ArmeriaHttpUtil.normalizeSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
-            assertThat(uri.getScheme()).isEqualTo(scheme);
-        });
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp", "htTP", "HTTP"
-    })
-    void normalizeBadSchemeAndAuthority(String badScheme) {
-        assertThatThrownBy(() -> ArmeriaHttpUtil.normalizeSchemeAndAuthority(badScheme, "foo"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
     private static ServerConfig serverConfig() {
         final Server server = Server.builder()
                                     .defaultHostname("foo")

--- a/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/DefaultRequestTargetTest.java
@@ -461,7 +461,7 @@ class DefaultRequestTargetTest {
             "a://b?c#d,      a, b, /, c, d",
             "a://b#c?d,      a, b, /,, c?d",
             // Userinfo and port in authority
-            "a://b@c:80,     a, b@c:80, /,,",
+            "a://b@c:80,     a, c:80, /,,",
             // IP addresses
             "a://127.0.0.1/, a, 127.0.0.1, /,,",
             "a://[::1]:80/,  a, [::1]:80, /,,",

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class SchemeAndAuthorityTest {
+    @ParameterizedTest
+    @CsvSource({
+            "0.0.0.0:80,        0.0.0.0:80,         0.0.0.0,            80",    // IPv4
+            "[::1]:8080,        [::1]:8080,         [::1],              8080",  // IPv6
+            "unix%3Afoo.sock,   unix%3Afoo.sock,    unix%3Afoo.sock,    -1",    // Domain socket
+            "foo.bar,           foo.bar,            foo.bar,            -1",    // Only host
+            "foo:,              foo:,               foo,                -1",    // Empty port
+            "bar:80,            bar:80,             bar,                80",    // Host and port
+            "foo@bar:80,        bar:80,             bar,                80",    // Userinfo and host and port
+    })
+    void fromAuthority(String authority, String expectedAuthority, String expectedHost,
+                       int expectedPort) {
+        assertThat(SchemeAndAuthority.fromAuthority(authority)).satisfies(uri -> {
+            assertThat(uri.getScheme()).isNull();
+            assertThat(uri.getAuthority()).isEqualTo(expectedAuthority);
+            assertThat(uri.getHost()).isEqualTo(expectedHost);
+            assertThat(uri.getPort()).isEqualTo(expectedPort);
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "foo:bar", "http://foo:80", "foo/bar", "foo?bar=1", "foo#bar",
+            "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
+    })
+    void fromBadAuthority(String badAuthority) {
+        assertThatThrownBy(() -> SchemeAndAuthority.fromAuthority(badAuthority))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh" })
+    void fromSchemeAndAuthority(String scheme) {
+        assertThat(SchemeAndAuthority.fromSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
+            assertThat(uri.getScheme()).isEqualTo(scheme);
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp", "htTP", "HTTP"
+    })
+    void fromBadSchemeAndAuthority(String badScheme) {
+        assertThatThrownBy(() -> SchemeAndAuthority.fromSchemeAndAuthority(badScheme, "foo"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -22,8 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.google.common.base.Ascii;
-
 class SchemeAndAuthorityTest {
     @ParameterizedTest
     @CsvSource({
@@ -37,7 +35,7 @@ class SchemeAndAuthorityTest {
     })
     void fromAuthority(String authority, String expectedAuthority, String expectedHost,
                        int expectedPort) {
-        assertThat(SchemeAndAuthority.fromAuthority(authority)).satisfies(uri -> {
+        assertThat(SchemeAndAuthority.fromSchemeAndAuthority(null, authority)).satisfies(uri -> {
             assertThat(uri.getScheme()).isNull();
             assertThat(uri.getAuthority()).isEqualTo(expectedAuthority);
             assertThat(uri.getHost()).isEqualTo(expectedHost);
@@ -51,16 +49,18 @@ class SchemeAndAuthorityTest {
             "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
     })
     void fromBadAuthority(String badAuthority) {
-        assertThatThrownBy(() -> SchemeAndAuthority.fromAuthority(badAuthority))
+        assertThatThrownBy(() -> SchemeAndAuthority.fromSchemeAndAuthority(null, badAuthority))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest
-    @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh", "htTP", "HTTP", "http+none" })
-    void fromSchemeAndAuthority(String scheme) {
-        final String lowerCaseScheme = Ascii.toLowerCase(scheme);
+    @CsvSource({
+            "http, http", "https, https", "ftp, ftp", "mailto, mailto", "file, file", "tel, tel", "ssh, ssh",
+            "htTP, http", "HTTP, http", "http+none, http+none"
+    })
+    void fromSchemeAndAuthority(String scheme, String expectedScheme) {
         assertThat(SchemeAndAuthority.fromSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
-            assertThat(uri.getScheme()).isEqualTo(lowerCaseScheme);
+            assertThat(uri.getScheme()).isEqualTo(expectedScheme);
         });
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -35,11 +35,11 @@ class SchemeAndAuthorityTest {
     })
     void fromAuthority(String authority, String expectedAuthority, String expectedHost,
                        int expectedPort) {
-        assertThat(SchemeAndAuthority.fromSchemeAndAuthority(null, authority)).satisfies(uri -> {
-            assertThat(uri.getScheme()).isNull();
-            assertThat(uri.getAuthority()).isEqualTo(expectedAuthority);
-            assertThat(uri.getHost()).isEqualTo(expectedHost);
-            assertThat(uri.getPort()).isEqualTo(expectedPort);
+        assertThat(SchemeAndAuthority.of(null, authority)).satisfies(uri -> {
+            assertThat(uri.scheme()).isNull();
+            assertThat(uri.authority()).isEqualTo(expectedAuthority);
+            assertThat(uri.host()).isEqualTo(expectedHost);
+            assertThat(uri.port()).isEqualTo(expectedPort);
         });
     }
 
@@ -49,7 +49,7 @@ class SchemeAndAuthorityTest {
             "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
     })
     void fromBadAuthority(String badAuthority) {
-        assertThatThrownBy(() -> SchemeAndAuthority.fromSchemeAndAuthority(null, badAuthority))
+        assertThatThrownBy(() -> SchemeAndAuthority.of(null, badAuthority))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -58,9 +58,9 @@ class SchemeAndAuthorityTest {
             "http, http", "https, https", "ftp, ftp", "mailto, mailto", "file, file", "tel, tel", "ssh, ssh",
             "htTP, http", "HTTP, http", "http+none, http+none"
     })
-    void fromSchemeAndAuthority(String scheme, String expectedScheme) {
-        assertThat(SchemeAndAuthority.fromSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
-            assertThat(uri.getScheme()).isEqualTo(expectedScheme);
+    void fromScheme(String scheme, String expectedScheme) {
+        assertThat(SchemeAndAuthority.of(scheme, "foo")).satisfies(uri -> {
+            assertThat(uri.scheme()).isEqualTo(expectedScheme);
         });
     }
 
@@ -68,8 +68,8 @@ class SchemeAndAuthorityTest {
     @CsvSource({
             "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp"
     })
-    void fromBadSchemeAndAuthority(String badScheme) {
-        assertThatThrownBy(() -> SchemeAndAuthority.fromSchemeAndAuthority(badScheme, "foo"))
+    void fromBadScheme(String badScheme) {
+        assertThatThrownBy(() -> SchemeAndAuthority.of(badScheme, "foo"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.google.common.base.Ascii;
+
 class SchemeAndAuthorityTest {
     @ParameterizedTest
     @CsvSource({
@@ -54,16 +56,17 @@ class SchemeAndAuthorityTest {
     }
 
     @ParameterizedTest
-    @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh" })
+    @CsvSource({ "http", "https", "ftp", "mailto", "file", "data", "tel", "ssh", "htTP", "HTTP", "http+none" })
     void fromSchemeAndAuthority(String scheme) {
+        final String lowerCaseScheme = Ascii.toLowerCase(scheme);
         assertThat(SchemeAndAuthority.fromSchemeAndAuthority(scheme, "foo")).satisfies(uri -> {
-            assertThat(uri.getScheme()).isEqualTo(scheme);
+            assertThat(uri.getScheme()).isEqualTo(lowerCaseScheme);
         });
     }
 
     @ParameterizedTest
     @CsvSource({
-            "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp", "htTP", "HTTP"
+            "1http", "+http", ".http", "-http", "http!", "http$", "http?", "http#", "http ftp"
     })
     void fromBadSchemeAndAuthority(String badScheme) {
         assertThatThrownBy(() -> SchemeAndAuthority.fromSchemeAndAuthority(badScheme, "foo"))


### PR DESCRIPTION
Motivation:

- Make util method to deduplicate the code that strips the user info from authority

Modifications:

- ~Add `normalizeAuthority()`, `normalizeSchemeAndAuthority()` static method in `ArmeriaHttpUtil`~
- Add SchemeAndAuthorit class which is in charge of authority normalization


Result:

- Closes #5490. (If this resolves the issue.)

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
