### PR TITLE
Make @Description annotation at super class/interface work

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -591,7 +591,7 @@ public final class AnnotatedServiceFactory {
      */
     static DescriptionInfo findDescription(AnnotatedElement annotatedElement) {
         requireNonNull(annotatedElement, "annotatedElement");
-        final Description description = AnnotationUtil.findFirst(annotatedElement, Description.class);
+        final Description description = AnnotationUtil.findFirstDescription(annotatedElement);
         if (description != null) {
             final String value = description.value();
             if (DefaultValues.isSpecified(value)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MapMaker;
 
@@ -97,6 +98,11 @@ public final class AnnotationUtil {
      */
     private static final Set<Class<? extends Annotation>> knownCyclicAnnotationTypes =
             Collections.newSetFromMap(new MapMaker().weakKeys().makeMap());
+    private static final ImmutableSet<FindOption> findOptionsForDescription = ImmutableSet.copyOf(
+            EnumSet.of(FindOption.LOOKUP_SUPER_CLASSES,
+                       FindOption.LOOKUP_META_ANNOTATIONS,
+                       FindOption.LOOKUP_SUPER_METHODS,
+                       FindOption.LOOKUP_SUPER_PARAMETERS));
 
     static {
         // Add well known JDK annotations with cyclic dependencies which will always be blocklisted.
@@ -139,11 +145,7 @@ public final class AnnotationUtil {
      */
     @Nullable
     public static Description findFirstDescription(AnnotatedElement element) {
-        final EnumSet<FindOption> options = EnumSet.of(FindOption.LOOKUP_SUPER_CLASSES,
-                                                       FindOption.LOOKUP_META_ANNOTATIONS,
-                                                       FindOption.LOOKUP_SUPER_METHODS,
-                                                       FindOption.LOOKUP_SUPER_PARAMETERS);
-        final List<Description> found = find(element, Description.class, options);
+        final List<Description> found = find(element, Description.class, findOptionsForDescription);
         return found.isEmpty() ? null : found.get(0);
     }
 
@@ -251,7 +253,7 @@ public final class AnnotationUtil {
      * @param findOptions the options to be applied when finding annotations
      */
     static <T extends Annotation> List<T> find(AnnotatedElement element, Class<T> annotationType,
-                                               EnumSet<FindOption> findOptions) {
+                                               Set<FindOption> findOptions) {
         requireNonNull(element, "element");
         requireNonNull(annotationType, "annotationType");
 
@@ -441,7 +443,7 @@ public final class AnnotationUtil {
      * Collects the list of {@link AnnotatedElement}s which are to be used to find annotations.
      */
     private static List<AnnotatedElement> resolveTargetElements(AnnotatedElement element,
-                                                                EnumSet<FindOption> findOptions) {
+                                                                Set<FindOption> findOptions) {
         if (!findOptions.contains(FindOption.LOOKUP_SUPER_CLASSES)) {
             return ImmutableList.of(element);
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -69,17 +69,6 @@ public final class AnnotationUtil {
          */
         LOOKUP_SUPER_CLASSES,
         /**
-         * Get additional annotations from the meta-annotations which annotate the annotations specified
-         * on the given {@link AnnotatedElement}.
-         */
-        LOOKUP_META_ANNOTATIONS,
-        /**
-         * Collect the annotations specified in the super classes first, the annotations specified on the
-         * given {@link AnnotatedElement} will be collected at last. This option will work only with
-         * the {@link #LOOKUP_SUPER_CLASSES}.
-         */
-        COLLECT_SUPER_CLASSES_FIRST,
-        /**
          * Get annotations from methods in super classes of the given {@link AnnotatedElement} if the element
          * is a {@link Method}. Otherwise, this option will be ignored.
          * This option will work only with the {@link #LOOKUP_SUPER_CLASSES}.
@@ -90,7 +79,18 @@ public final class AnnotationUtil {
          * is a {@link Parameter}. Otherwise, this option will be ignored.
          * This option will work only with the {@link #LOOKUP_SUPER_CLASSES}.
          */
-        LOOKUP_SUPER_PARAMETERS
+        LOOKUP_SUPER_PARAMETERS,
+        /**
+         * Get additional annotations from the meta-annotations which annotate the annotations specified
+         * on the given {@link AnnotatedElement}.
+         */
+        LOOKUP_META_ANNOTATIONS,
+        /**
+         * Collect the annotations specified in the super classes first, the annotations specified on the
+         * given {@link AnnotatedElement} will be collected at last. This option will work only with
+         * the {@link #LOOKUP_SUPER_CLASSES}.
+         */
+        COLLECT_SUPER_CLASSES_FIRST,
     }
 
     /**
@@ -452,29 +452,27 @@ public final class AnnotationUtil {
         if (element instanceof Class) {
             final List<Class<?>> classes = collectClasses((Class<?>) element, collectSuperClassFirst);
             return convertToAnnotatedElements(classes);
-
-        } else if (element instanceof Method && findOptions.contains(FindOption.LOOKUP_SUPER_METHODS)) {
+        }
+        if (element instanceof Method && findOptions.contains(FindOption.LOOKUP_SUPER_METHODS)) {
             final Method method = (Method) element;
             final Class<?> clazz = method.getDeclaringClass();
             final List<Method> methods = collectMethods(clazz, method, collectSuperClassFirst);
             return convertToAnnotatedElements(methods);
-
-        } else if (element instanceof Parameter && findOptions.contains(FindOption.LOOKUP_SUPER_PARAMETERS)) {
+        }
+        if (element instanceof Parameter && findOptions.contains(FindOption.LOOKUP_SUPER_PARAMETERS)) {
             final Parameter parameter = (Parameter) element;
             final Executable executable = parameter.getDeclaringExecutable();
             final Class<?> clazz = executable.getDeclaringClass();
             final List<Parameter> parameters = collectParameters(clazz, executable, parameter,
                                                                  collectSuperClassFirst);
             return convertToAnnotatedElements(parameters);
-
-        } else {
-            return ImmutableList.of(element);
         }
+        return ImmutableList.of(element);
     }
 
     private static <T extends AnnotatedElement> List<AnnotatedElement> convertToAnnotatedElements(
             List<T> elements) {
-        return elements.stream().map(element -> (AnnotatedElement)element).collect(Collectors.toList());
+        return elements.stream().map(element -> (AnnotatedElement) element).collect(toImmutableList());
     }
 
     private static List<Parameter> collectParameters(Class<?> clazz, Executable executable,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -472,7 +472,7 @@ public final class AnnotationUtil {
 
     private static <T extends AnnotatedElement> List<AnnotatedElement> convertToAnnotatedElements(
             List<T> elements) {
-        return elements.stream().map(element -> (AnnotatedElement) element).collect(toImmutableList());
+        return (List<AnnotatedElement>) elements;
     }
 
     private static List<Parameter> collectParameters(Class<?> clazz, Executable executable,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -37,7 +37,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotationUtil.java
@@ -472,8 +472,9 @@ public final class AnnotationUtil {
         }
     }
 
-    private static <T extends AnnotatedElement> List<AnnotatedElement> convertToAnnotatedElements(List<T> list) {
-        return list.stream().map(element -> (AnnotatedElement)element).collect(Collectors.toList());
+    private static <T extends AnnotatedElement> List<AnnotatedElement> convertToAnnotatedElements(
+            List<T> elements) {
+        return elements.stream().map(element -> (AnnotatedElement)element).collect(Collectors.toList());
     }
 
     private static List<Parameter> collectParameters(Class<?> clazz, Executable executable,

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedBeanFactoryRegistryTest.noopDependencyInjector;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceFactory.create;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceFactory.find;
+import static com.linecorp.armeria.internal.server.annotation.AnnotatedServiceFactory.findDescription;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,6 +57,7 @@ class AnnotatedServiceFactoryTest {
 
     private static final String HOME_PATH_PREFIX = "/home";
     private static final String ANNOTATED_DESCRIPTION = "This is a description from the annotation";
+    private static final String ANNOTATED_DESCRIPTION_SUPER = "This is a super description from the annotation";
 
     @Test
     void testFindAnnotatedServiceElementsWithPathPrefixAnnotation() {
@@ -199,7 +201,7 @@ class AnnotatedServiceFactoryTest {
     void testDescriptionLoadingPriority() throws NoSuchMethodException {
         final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod1", String.class)
                                                                        .getParameters()[0];
-        final DescriptionInfo descriptionInfo = AnnotatedServiceFactory.findDescription(parameter);
+        final DescriptionInfo descriptionInfo = findDescription(parameter);
         assertThat(descriptionInfo.docString()).isEqualTo(ANNOTATED_DESCRIPTION);
     }
 
@@ -207,12 +209,82 @@ class AnnotatedServiceFactoryTest {
     void testDescriptionLoadFromFile() throws NoSuchMethodException {
         final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod2", String.class)
                                                                        .getParameters()[0];
-        final DescriptionInfo descriptionInfo = AnnotatedServiceFactory.findDescription(parameter);
+        final DescriptionInfo descriptionInfo = findDescription(parameter);
         assertThat(descriptionInfo.docString())
                 .isEqualTo("This is a description from the properties file");
     }
 
-    private static class DescriptionAnnotatedTestClass {
+    @Test
+    void testParameterDescriptionLoad() throws NoSuchMethodException {
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod3", String.class)
+                                                                       .getParameters()[0];
+        final DescriptionInfo descriptionInfo = findDescription(parameter);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a description from the annotation");
+    }
+
+    @Test
+    void testParameterDescriptionLoadByParentClass() throws NoSuchMethodException {
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod4", String.class)
+                                                                       .getParameters()[0];
+        final DescriptionInfo descriptionInfo = findDescription(parameter);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a super description from the annotation");
+    }
+
+    @Test
+    void testParameterDescriptionLoadByChildClass() throws NoSuchMethodException {
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod5", String.class)
+                                                                       .getParameters()[0];
+        final DescriptionInfo descriptionInfo = findDescription(parameter);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a description from the annotation");
+    }
+
+    @Test
+    void testMethodDescriptionLoad() throws NoSuchMethodException {
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod3", String.class);
+        final DescriptionInfo descriptionInfo = findDescription(method);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a description from the annotation");
+    }
+
+    @Test
+    void testMethodDescriptionLoadByParentClass() throws NoSuchMethodException {
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod4", String.class);
+        final DescriptionInfo descriptionInfo = findDescription(method);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a super description from the annotation");
+    }
+
+    @Test
+    void testMethodDescriptionLoadByChildClass() throws NoSuchMethodException {
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod5", String.class);
+        final DescriptionInfo descriptionInfo = findDescription(method);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a description from the annotation");
+    }
+
+    @Test
+    void testClassDescriptionLoadByParentClass() {
+        final Class<DescriptionAnnotatedTestClass> clazz = DescriptionAnnotatedTestClass.class;
+        final DescriptionInfo descriptionInfo = findDescription(clazz);
+        assertThat(descriptionInfo.docString())
+                .isEqualTo("This is a super description from the annotation");
+    }
+
+    @Description(ANNOTATED_DESCRIPTION_SUPER)
+    private interface DescriptionAnnotatedTestInterface {
+        void testMethod3(String param);
+
+        @Description(ANNOTATED_DESCRIPTION_SUPER)
+        void testMethod4(@Description(ANNOTATED_DESCRIPTION_SUPER) String param);
+
+        @Description(ANNOTATED_DESCRIPTION_SUPER)
+        void testMethod5(@Description(ANNOTATED_DESCRIPTION_SUPER) String param);
+    }
+
+    private static class DescriptionAnnotatedTestClass implements DescriptionAnnotatedTestInterface {
         // Resource file from JavaDoc was already created
         @Get("/some/path")
         public void testMethod1(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param) {}
@@ -220,6 +292,20 @@ class AnnotatedServiceFactoryTest {
         // Resource file from JavaDoc was already created
         @Get("/some/path")
         public void testMethod2(@Param("param") String param) {}
+
+        @Override
+        @Description(ANNOTATED_DESCRIPTION)
+        @Get("/some/path")
+        public void testMethod3(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param) {}
+
+        @Override
+        @Get("/some/path")
+        public void testMethod4(@Param("param") String param) {}
+
+        @Override
+        @Description(ANNOTATED_DESCRIPTION)
+        @Get("/some/path")
+        public void testMethod5(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param) {}
     }
 
     private static List<AnnotatedServiceElement> getServiceElements(

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactoryTest.java
@@ -216,7 +216,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testParameterDescriptionLoad() throws NoSuchMethodException {
-        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod3", String.class)
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod3",
+                                                                                  String.class, String.class)
                                                                        .getParameters()[0];
         final DescriptionInfo descriptionInfo = findDescription(parameter);
         assertThat(descriptionInfo.docString())
@@ -225,7 +226,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testParameterDescriptionLoadByParentClass() throws NoSuchMethodException {
-        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod4", String.class)
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod4",
+                                                                                  String.class, String.class)
                                                                        .getParameters()[0];
         final DescriptionInfo descriptionInfo = findDescription(parameter);
         assertThat(descriptionInfo.docString())
@@ -234,7 +236,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testParameterDescriptionLoadByChildClass() throws NoSuchMethodException {
-        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod5", String.class)
+        final Parameter parameter = DescriptionAnnotatedTestClass.class.getMethod("testMethod5",
+                                                                                  String.class, String.class)
                                                                        .getParameters()[0];
         final DescriptionInfo descriptionInfo = findDescription(parameter);
         assertThat(descriptionInfo.docString())
@@ -243,7 +246,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testMethodDescriptionLoad() throws NoSuchMethodException {
-        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod3", String.class);
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod3",
+                                                                            String.class, String.class);
         final DescriptionInfo descriptionInfo = findDescription(method);
         assertThat(descriptionInfo.docString())
                 .isEqualTo("This is a description from the annotation");
@@ -251,7 +255,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testMethodDescriptionLoadByParentClass() throws NoSuchMethodException {
-        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod4", String.class);
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod4",
+                                                                            String.class, String.class);
         final DescriptionInfo descriptionInfo = findDescription(method);
         assertThat(descriptionInfo.docString())
                 .isEqualTo("This is a super description from the annotation");
@@ -259,7 +264,8 @@ class AnnotatedServiceFactoryTest {
 
     @Test
     void testMethodDescriptionLoadByChildClass() throws NoSuchMethodException {
-        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod5", String.class);
+        final Method method = DescriptionAnnotatedTestClass.class.getMethod("testMethod5", String.class,
+                                                                            String.class);
         final DescriptionInfo descriptionInfo = findDescription(method);
         assertThat(descriptionInfo.docString())
                 .isEqualTo("This is a description from the annotation");
@@ -275,13 +281,13 @@ class AnnotatedServiceFactoryTest {
 
     @Description(ANNOTATED_DESCRIPTION_SUPER)
     private interface DescriptionAnnotatedTestInterface {
-        void testMethod3(String param);
+        void testMethod3(String param1, String param2);
 
         @Description(ANNOTATED_DESCRIPTION_SUPER)
-        void testMethod4(@Description(ANNOTATED_DESCRIPTION_SUPER) String param);
+        void testMethod4(@Description(ANNOTATED_DESCRIPTION_SUPER) String param1, String param2);
 
         @Description(ANNOTATED_DESCRIPTION_SUPER)
-        void testMethod5(@Description(ANNOTATED_DESCRIPTION_SUPER) String param);
+        void testMethod5(@Description(ANNOTATED_DESCRIPTION_SUPER) String param1, String param2);
     }
 
     private static class DescriptionAnnotatedTestClass implements DescriptionAnnotatedTestInterface {
@@ -296,16 +302,18 @@ class AnnotatedServiceFactoryTest {
         @Override
         @Description(ANNOTATED_DESCRIPTION)
         @Get("/some/path")
-        public void testMethod3(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param) {}
+        public void testMethod3(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param1,
+                                String param2) {}
 
         @Override
         @Get("/some/path")
-        public void testMethod4(@Param("param") String param) {}
+        public void testMethod4(@Param("param") String param1, String param2) {}
 
         @Override
         @Description(ANNOTATED_DESCRIPTION)
         @Get("/some/path")
-        public void testMethod5(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param) {}
+        public void testMethod5(@Description(ANNOTATED_DESCRIPTION) @Param("param") String param1,
+                                String param2) {}
     }
 
     private static List<AnnotatedServiceElement> getServiceElements(


### PR DESCRIPTION
Motivation:
- The annotation `@Description` is used to give a description for `Class`, `Method`, and `Method parameter` at Doc-service.
- The annotation `@Description` could only exist at Super class or Interface in order to give a common desecription for multiple other class which extend or implmenet them. (First initiative: https://github.com/line/armeria/discussions/5192)
- However, the `@Description` at Super class or Interface is ignored at Doc-service. Let's make it effective.

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- Make `resolveTargetElements#AnnotationUtil` returns all `AnnotatedElement` not only for specific one but also for all in Super class and Interface when the given specific one is `Parameter`or `Method` type.

Result:

- Closes #5195.
- `@Description` annotation which is only annotated on `Parameter` or `Method` at Super class or Interface will be effective at Doc-service.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
