### PR TITLE
Add a stale bot

### DIFF
--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -1,0 +1,19 @@
+name: 'Mark inactive PRs as stale'
+on:
+  schedule:
+    # Update at 10:00 AM UTC+9
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
+          # Mark PRs as stale if they are open and inactive for 60 days.
+          days-before-pr-stale: 60
+          # Do not mark issues as stale.
+          days-before-issue-stale: -1
+          # Do not close PRs automatically.
+          days-before-close: -1

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity.'
           # Mark PRs as stale if they are open and inactive for 60 days.
-          days-before-pr-stale: 60
+          days-before-pr-stale: 30
+          # Do not leave a message when marking PRs as stale.
+          stale-pr-message: ''
           # Do not mark issues as stale.
           days-before-issue-stale: -1
           # Do not close PRs automatically.

--- a/.github/workflows/pr-stale.yml
+++ b/.github/workflows/pr-stale.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          # Mark PRs as stale if they are open and inactive for 60 days.
+          # Mark PRs as stale if they are open and inactive for 30 days.
           days-before-pr-stale: 30
           # Do not leave a message when marking PRs as stale.
           stale-pr-message: ''


### PR DESCRIPTION
Motivation:

There are many PRs that are open but stale. Possible reasons for the stale would be:
- An appropriate solution for a problem could not be found
- Maintainers or contributors are busy.
- A PR depends on other PRs or a library patch.

In order to separate and manage old PRs more systematically, it would be a good idea to add `stale` label to the PR.

For PRs marked as stale, maintainers will determine whether to close the PR or modify it themselves.

Modifications:

- Add a stale bot that marks inactive PRs for 30 days
- Auto-close is disabled.
- Don't mark issues as stale.

Result:

A stale bot is working in the Armeria repository on a daily basis.

