### PR TITLE
Quote the full URL in cURL commands

### DIFF
--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -297,29 +297,28 @@ const DebugPage: React.FunctionComponent<Props> = ({
         serviceType === ServiceType.HTTP ||
         serviceType === ServiceType.GRAPHQL
       ) {
-        const queries = additionalQueries;
+        const queries =
+          additionalQueries.length > 0 ? `?${additionalQueries}` : '';
+
         if (exactPathMapping) {
           endpoint = transport.getDebugMimeTypeEndpoint(method);
           mappedPath =
-            `'${escapeSingleQuote(
-              endpoint.pathMapping.substring('exact:'.length),
-            )}` +
-            `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
+            endpoint.pathMapping.substring('exact:'.length) + queries;
         } else {
           endpoint = transport.getDebugMimeTypeEndpoint(method, additionalPath);
-          mappedPath =
-            `'${escapeSingleQuote(additionalPath)}` +
-            `${queries.length > 0 ? `?${escapeSingleQuote(queries)}` : ''}'`;
+          mappedPath = additionalPath + queries;
         }
       } else if (additionalPath.length > 0) {
         endpoint = transport.getDebugMimeTypeEndpoint(method, additionalPath);
-        mappedPath = `'${escapeSingleQuote(additionalPath)}'`;
+        mappedPath = additionalPath;
       } else {
         endpoint = transport.getDebugMimeTypeEndpoint(method);
-        mappedPath = `'${escapeSingleQuote(endpoint.pathMapping)}'`;
+        mappedPath = endpoint.pathMapping;
       }
 
-      const uri = host + parseServerRootPath(docServiceRoute) + mappedPath;
+      const uri = `'${escapeSingleQuote(
+        host + parseServerRootPath(docServiceRoute) + mappedPath,
+      )}'`;
 
       const body = transport.getCurlBody(
         endpoint,


### PR DESCRIPTION
Motivation:

When copying a request as a cURL command in DocService, only the URL path is quoted. For example, `curl http://localhost:8080'/foo/bar'`. It would be better to quote the full URL, like `curl 'http://localhost:8080/foo/bar'`.

Modifications:

- Add quotes and call `escapeSingleQuote()` only when constructing the final URL

Result:

- The copied cURL command has the full URL quoted

Tested the following outputs:

- `curl [...] 'http://localhost:8080/foo/bar'`
- `curl [...] 'http://localhost:8080/foo/bar?qwe=asd'`
- `curl [...] 'http://localhost:8080/foo/bar?qwe="asd"'`
- `curl [...] 'http://localhost:8080/foo/bar?qwe='\''asd'\'''`