### PR TITLE
Update the project version to 1.28.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.linecorp.armeria
-version=1.27.3-SNAPSHOT
+version=1.28.0-SNAPSHOT
 projectName=Armeria
 projectUrl=https://armeria.dev/
 projectDescription=Asynchronous HTTP/2 RPC/REST client/server library built on top of Java 8, Netty, Thrift and gRPC


### PR DESCRIPTION
Motivation:

Our project version should be greater than the latest release version, which is not the case at the moment.

Modifications:

- Update the project version from 1.27.3-SNAPSHOT to 1.28.0-SNAPSHOT.

Result:

- We now publish the SNAPSHOT JARs with the correct version.