### PR TITLE
Call `UnloggedExceptionsReporter.report` after calling `ServiceErrorH…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -92,7 +92,7 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final String CACHED_HEADERS = ":authority,:scheme,:method,accept-encoding,content-type";
     static final String FILE_SERVICE_CACHE_SPEC = "maximumSize=1024";
     static final String DNS_CACHE_SPEC = "maximumSize=4096";
-    static final long DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = 10000;
+    static final long DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = 10000;
 
     private DefaultFlagsProvider() {}
 
@@ -472,7 +472,12 @@ final class DefaultFlagsProvider implements FlagsProvider {
 
     @Override
     public Long defaultUnhandledExceptionsReportIntervalMillis() {
-        return DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
+        return DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
+    }
+
+    @Override
+    public Long defaultUnloggedExceptionsReportIntervalMillis() {
+        return DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -116,6 +116,8 @@ public final class Flags {
 
     private static final String VERBOSE_EXCEPTION_SAMPLER_SPEC;
 
+    private static final long DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
+
     static {
         final String strSpec = getNormalized("verboseExceptions",
                                              DefaultFlagsProvider.VERBOSE_EXCEPTION_SAMPLER_SPEC, val -> {
@@ -133,6 +135,17 @@ public final class Flags {
             VERBOSE_EXCEPTION_SAMPLER_SPEC = "never";
         } else {
             VERBOSE_EXCEPTION_SAMPLER_SPEC = strSpec;
+        }
+
+        final Long intervalMillis = getUserValue(
+                FlagsProvider::defaultUnloggedExceptionsReportIntervalMillis,
+                "defaultUnloggedExceptionsReportIntervalMillis", value -> value >= 0);
+        if (intervalMillis != null) {
+            DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = intervalMillis;
+        } else {
+            DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS =
+                    getValue(FlagsProvider::defaultUnhandledExceptionsReportIntervalMillis,
+                             "defaultUnhandledExceptionsReportIntervalMillis", value -> value >= 0);
         }
     }
 
@@ -404,10 +417,6 @@ public final class Flags {
 
     private static final MeterRegistry METER_REGISTRY =
             getValue(FlagsProvider::meterRegistry, "meterRegistry");
-
-    private static final long DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS =
-            getValue(FlagsProvider::defaultUnhandledExceptionsReportIntervalMillis,
-                     "defaultUnhandledExceptionsReportIntervalMillis", value -> value >= 0);
 
     private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG =
             getValue(FlagsProvider::distributionStatisticConfig, "distributionStatisticConfig");
@@ -1503,16 +1512,31 @@ public final class Flags {
     }
 
     /**
-     * Returns the default interval in milliseconds between the reports on unhandled exceptions.
+     * Returns the default interval in milliseconds between the reports on unlogged exceptions.
      *
      * <p>The default value of this flag is
-     * {@value DefaultFlagsProvider#DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
+     * {@value DefaultFlagsProvider#DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
      * {@code -Dcom.linecorp.armeria.defaultUnhandledExceptionsReportIntervalMillis=<long>} JVM option to
+     * override the default value.</p>
+     *
+     * @deprecated Use {@link #defaultUnloggedExceptionsReportIntervalMillis()} instead.
+     */
+    @Deprecated
+    public static long defaultUnhandledExceptionsReportIntervalMillis() {
+        return DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
+    }
+
+    /**
+     * Returns the default interval in milliseconds between the reports on unlogged exceptions.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultUnloggedExceptionsReportIntervalMillis=<long>} JVM option to
      * override the default value.</p>
      */
     @UnstableApi
-    public static long defaultUnhandledExceptionsReportIntervalMillis() {
-        return DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
+    public static long defaultUnloggedExceptionsReportIntervalMillis() {
+        return DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1126,13 +1126,29 @@ public interface FlagsProvider {
      * Returns the default interval in milliseconds between the reports on unhandled exceptions.
      *
      * <p>The default value of this flag is
-     * {@value DefaultFlagsProvider#DEFAULT_UNHANDLED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
+     * {@value DefaultFlagsProvider#DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
      * {@code -Dcom.linecorp.armeria.defaultUnhandledExceptionsReportIntervalMillis=<long>} JVM option to
+     * override the default value.</p>
+     *
+     * @deprecated Use {@link #defaultUnloggedExceptionsReportIntervalMillis()} instead.
+     */
+    @Nullable
+    @Deprecated
+    default Long defaultUnhandledExceptionsReportIntervalMillis() {
+        return null;
+    }
+
+    /**
+     * Returns the default interval in milliseconds between the reports on unhandled exceptions.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultUnloggedExceptionsReportIntervalMillis=<long>} JVM option to
      * override the default value.</p>
      */
     @Nullable
     @UnstableApi
-    default Long defaultUnhandledExceptionsReportIntervalMillis() {
+    default Long defaultUnloggedExceptionsReportIntervalMillis() {
         return null;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -492,6 +492,11 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return getLong("defaultUnhandledExceptionsReportIntervalMillis");
     }
 
+    @Override
+    public @Nullable Long defaultUnloggedExceptionsReportIntervalMillis() {
+        return getLong("defaultUnloggedExceptionsReportIntervalMillis");
+    }
+
     @Nullable
     private static Long getLong(String name) {
         return getAndParse(name, Long::parseLong);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -105,7 +105,7 @@ public final class DefaultServiceRequestContext
     private final InetSocketAddress remoteAddress;
     private final InetSocketAddress localAddress;
 
-    private boolean shouldReportUnhandledExceptions = true;
+    private boolean shouldReportUnloggedExceptions = true;
 
     private final RequestLogBuilder log;
 
@@ -469,12 +469,22 @@ public final class DefaultServiceRequestContext
 
     @Override
     public boolean shouldReportUnhandledExceptions() {
-        return shouldReportUnhandledExceptions;
+        return shouldReportUnloggedExceptions;
     }
 
     @Override
     public void setShouldReportUnhandledExceptions(boolean value) {
-        shouldReportUnhandledExceptions = value;
+        shouldReportUnloggedExceptions = value;
+    }
+
+    @Override
+    public boolean shouldReportUnloggedExceptions() {
+        return shouldReportUnloggedExceptions;
+    }
+
+    @Override
+    public void setShouldReportUnloggedExceptions(boolean value) {
+        shouldReportUnloggedExceptions = value;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -114,7 +114,7 @@ final class DefaultServerConfig implements ServerConfig {
     private final Http1HeaderNaming http1HeaderNaming;
     private final DependencyInjector dependencyInjector;
     private final Function<String, String> absoluteUriTransformer;
-    private final long unhandledExceptionsReportIntervalMillis;
+    private final long unloggedExceptionsReportIntervalMillis;
     private final List<ShutdownSupport> shutdownSupports;
 
     @Nullable
@@ -150,7 +150,7 @@ final class DefaultServerConfig implements ServerConfig {
             Http1HeaderNaming http1HeaderNaming,
             DependencyInjector dependencyInjector,
             Function<? super String, String> absoluteUriTransformer,
-            long unhandledExceptionsReportIntervalMillis,
+            long unloggedExceptionsReportIntervalMillis,
             List<ShutdownSupport> shutdownSupports) {
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
@@ -269,7 +269,7 @@ final class DefaultServerConfig implements ServerConfig {
         final Function<String, String> castAbsoluteUriTransformer =
                 (Function<String, String>) requireNonNull(absoluteUriTransformer, "absoluteUriTransformer");
         this.absoluteUriTransformer = castAbsoluteUriTransformer;
-        this.unhandledExceptionsReportIntervalMillis = unhandledExceptionsReportIntervalMillis;
+        this.unloggedExceptionsReportIntervalMillis = unloggedExceptionsReportIntervalMillis;
         this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
     }
 
@@ -673,7 +673,12 @@ final class DefaultServerConfig implements ServerConfig {
 
     @Override
     public long unhandledExceptionsReportIntervalMillis() {
-        return unhandledExceptionsReportIntervalMillis;
+        return unloggedExceptionsReportIntervalMillis;
+    }
+
+    @Override
+    public long unloggedExceptionsReportIntervalMillis() {
+        return unloggedExceptionsReportIntervalMillis;
     }
 
     List<ShutdownSupport> shutdownSupports() {
@@ -697,7 +702,7 @@ final class DefaultServerConfig implements ServerConfig {
                     clientAddressSources(), clientAddressTrustedProxyFilter(), clientAddressFilter(),
                     clientAddressMapper(),
                     isServerHeaderEnabled(), isDateHeaderEnabled(),
-                    dependencyInjector(), absoluteUriTransformer(), unhandledExceptionsReportIntervalMillis());
+                    dependencyInjector(), absoluteUriTransformer(), unloggedExceptionsReportIntervalMillis());
         }
 
         return strVal;
@@ -722,7 +727,7 @@ final class DefaultServerConfig implements ServerConfig {
             boolean serverHeaderEnabled, boolean dateHeaderEnabled,
             @Nullable DependencyInjector dependencyInjector,
             Function<? super String, String> absoluteUriTransformer,
-            long unhandledExceptionsReportIntervalMillis) {
+            long unloggedExceptionsReportIntervalMillis) {
 
         final StringBuilder buf = new StringBuilder();
         if (type != null) {
@@ -821,8 +826,8 @@ final class DefaultServerConfig implements ServerConfig {
         }
         buf.append(", absoluteUriTransformer: ");
         buf.append(absoluteUriTransformer);
-        buf.append(", unhandledExceptionsReportIntervalMillis: ");
-        buf.append(unhandledExceptionsReportIntervalMillis);
+        buf.append(", unloggedExceptionsReportIntervalMillis: ");
+        buf.append(unloggedExceptionsReportIntervalMillis);
         buf.append(')');
 
         return buf.toString();

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
@@ -31,11 +31,11 @@ import com.linecorp.armeria.common.util.TextFormatter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-final class PeriodicUnloggedExceptionsReporter implements UnloggedExceptionsReporter {
+final class DefaultUnloggedExceptionsReporter implements UnloggedExceptionsReporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(PeriodicUnloggedExceptionsReporter.class);
-    private static final AtomicIntegerFieldUpdater<PeriodicUnloggedExceptionsReporter> scheduledUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(PeriodicUnloggedExceptionsReporter.class,
+    private static final Logger logger = LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
+    private static final AtomicIntegerFieldUpdater<DefaultUnloggedExceptionsReporter> scheduledUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(DefaultUnloggedExceptionsReporter.class,
                                                  "scheduled");
 
     private final long intervalMillis;
@@ -52,9 +52,9 @@ final class PeriodicUnloggedExceptionsReporter implements UnloggedExceptionsRepo
     @Nullable
     private Throwable thrownException;
 
-    PeriodicUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
+    DefaultUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
         this.intervalMillis = intervalMillis;
-        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unlogged");
+        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unhandled");
         counter = new LongAdder();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
@@ -54,7 +54,7 @@ final class DefaultUnloggedExceptionsReporter implements UnloggedExceptionsRepor
 
     DefaultUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
         this.intervalMillis = intervalMillis;
-        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unhandled");
+        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unlogged");
         counter = new LongAdder();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultUnloggedExceptionsReporter.java
@@ -31,11 +31,11 @@ import com.linecorp.armeria.common.util.TextFormatter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-final class DefaultUnhandledExceptionsReporter implements UnhandledExceptionsReporter {
+final class DefaultUnloggedExceptionsReporter implements UnloggedExceptionsReporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultUnhandledExceptionsReporter.class);
-    private static final AtomicIntegerFieldUpdater<DefaultUnhandledExceptionsReporter> scheduledUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(DefaultUnhandledExceptionsReporter.class,
+    private static final Logger logger = LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
+    private static final AtomicIntegerFieldUpdater<DefaultUnloggedExceptionsReporter> scheduledUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(DefaultUnloggedExceptionsReporter.class,
                                                  "scheduled");
 
     private final long intervalMillis;
@@ -52,7 +52,7 @@ final class DefaultUnhandledExceptionsReporter implements UnhandledExceptionsRep
     @Nullable
     private Throwable thrownException;
 
-    DefaultUnhandledExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
+    DefaultUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
         this.intervalMillis = intervalMillis;
         micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unhandled");
         counter = new LongAdder();

--- a/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
@@ -26,9 +26,9 @@ import com.linecorp.armeria.common.util.Exceptions;
 final class ExceptionReportingServiceErrorHandler implements ServiceErrorHandler {
 
     private final ServiceErrorHandler delegate;
-    private final UnhandledExceptionsReporter reporter;
+    private final UnloggedExceptionsReporter reporter;
 
-    ExceptionReportingServiceErrorHandler(ServiceErrorHandler delegate, UnhandledExceptionsReporter reporter) {
+    ExceptionReportingServiceErrorHandler(ServiceErrorHandler delegate, UnloggedExceptionsReporter reporter) {
         this.delegate = delegate;
         this.reporter = reporter;
     }
@@ -36,10 +36,11 @@ final class ExceptionReportingServiceErrorHandler implements ServiceErrorHandler
     @Nullable
     @Override
     public HttpResponse onServiceException(ServiceRequestContext ctx, Throwable cause) {
-        if (ctx.shouldReportUnhandledExceptions() && !isIgnorableException(cause)) {
+        final HttpResponse httpResponse = delegate.onServiceException(ctx, cause);
+        if (ctx.shouldReportUnloggedExceptions() && !isIgnorableException(cause)) {
             reporter.report(cause);
         }
-        return delegate.onServiceException(ctx, cause);
+        return httpResponse;
     }
 
     private static boolean isIgnorableException(Throwable cause) {

--- a/core/src/main/java/com/linecorp/armeria/server/PeriodicUnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/PeriodicUnloggedExceptionsReporter.java
@@ -31,11 +31,11 @@ import com.linecorp.armeria.common.util.TextFormatter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-final class DefaultUnloggedExceptionsReporter implements UnloggedExceptionsReporter {
+final class PeriodicUnloggedExceptionsReporter implements UnloggedExceptionsReporter {
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
-    private static final AtomicIntegerFieldUpdater<DefaultUnloggedExceptionsReporter> scheduledUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(DefaultUnloggedExceptionsReporter.class,
+    private static final Logger logger = LoggerFactory.getLogger(PeriodicUnloggedExceptionsReporter.class);
+    private static final AtomicIntegerFieldUpdater<PeriodicUnloggedExceptionsReporter> scheduledUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(PeriodicUnloggedExceptionsReporter.class,
                                                  "scheduled");
 
     private final long intervalMillis;
@@ -52,9 +52,9 @@ final class DefaultUnloggedExceptionsReporter implements UnloggedExceptionsRepor
     @Nullable
     private Throwable thrownException;
 
-    DefaultUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
+    PeriodicUnloggedExceptionsReporter(MeterRegistry meterRegistry, long intervalMillis) {
         this.intervalMillis = intervalMillis;
-        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unhandled");
+        micrometerCounter = meterRegistry.counter("armeria.server.exceptions.unlogged");
         counter = new LongAdder();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -232,8 +232,8 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     @Nullable
     private DependencyInjector dependencyInjector;
     private Function<? super String, String> absoluteUriTransformer = Function.identity();
-    private long unhandledExceptionsReportIntervalMillis =
-            Flags.defaultUnhandledExceptionsReportIntervalMillis();
+    private long unloggedExceptionsReportIntervalMillis =
+            Flags.defaultUnloggedExceptionsReportIntervalMillis();
     private final List<ShutdownSupport> shutdownSupports = new ArrayList<>();
     private int http2MaxResetFramesPerWindow = Flags.defaultServerHttp2MaxResetFramesPerMinute();
     private int http2MaxResetFramesWindowSeconds = 60;
@@ -2106,32 +2106,60 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     }
 
     /**
-     * Sets the interval between reporting exceptions which is not handled or logged
+     * Sets the interval between reporting exceptions which is not logged
      * by any decorators or services such as {@link LoggingService}.
      * @param unhandledExceptionsReportInterval the interval between reports,
      *        or {@link Duration#ZERO} to disable this feature
      * @throws IllegalArgumentException if specified {@code interval} is negative.
+     *
+     * @deprecated Use {@link #unloggedExceptionsReportInterval(Duration)} instead.
      */
-    @UnstableApi
+    @Deprecated
     public ServerBuilder unhandledExceptionsReportInterval(Duration unhandledExceptionsReportInterval) {
-        requireNonNull(unhandledExceptionsReportInterval, "unhandledExceptionsReportInterval");
-        checkArgument(!unhandledExceptionsReportInterval.isNegative());
-        return unhandledExceptionsReportIntervalMillis(unhandledExceptionsReportInterval.toMillis());
+        return unloggedExceptionsReportInterval(unhandledExceptionsReportInterval);
     }
 
     /**
-     * Sets the interval between reporting exceptions which is not handled or logged
+     * Sets the interval between reporting exceptions which is not logged
      * by any decorators or services such as {@link LoggingService}.
      * @param unhandledExceptionsReportIntervalMillis the interval between reports in milliseconds,
      *        or {@code 0} to disable this feature
      * @throws IllegalArgumentException if specified {@code interval} is negative.
+     *
+     * @deprecated Use {@link #unloggedExceptionsReportIntervalMillis(long)} instead.
+     */
+    @Deprecated
+    public ServerBuilder unhandledExceptionsReportIntervalMillis(long unhandledExceptionsReportIntervalMillis) {
+        return unloggedExceptionsReportIntervalMillis(unhandledExceptionsReportIntervalMillis);
+    }
+
+    /**
+     * Sets the interval between reporting exceptions which is not logged
+     * by any decorators or services such as {@link LoggingService}.
+     * @param unloggedExceptionsReportInterval the interval between reports,
+     *        or {@link Duration#ZERO} to disable this feature
+     * @throws IllegalArgumentException if specified {@code interval} is negative.
      */
     @UnstableApi
-    public ServerBuilder unhandledExceptionsReportIntervalMillis(long unhandledExceptionsReportIntervalMillis) {
-        checkArgument(unhandledExceptionsReportIntervalMillis >= 0,
-                      "unhandledExceptionsReportIntervalMillis: %s (expected: >= 0)",
-                      unhandledExceptionsReportIntervalMillis);
-        this.unhandledExceptionsReportIntervalMillis = unhandledExceptionsReportIntervalMillis;
+    public ServerBuilder unloggedExceptionsReportInterval(Duration unloggedExceptionsReportInterval) {
+        requireNonNull(unloggedExceptionsReportInterval, "unloggedExceptionsReportInterval");
+        checkArgument(!unloggedExceptionsReportInterval.isNegative());
+        return unloggedExceptionsReportIntervalMillis(unloggedExceptionsReportInterval.toMillis());
+    }
+
+    /**
+     * Sets the interval between reporting exceptions which is not logged
+     * by any decorators or services such as {@link LoggingService}.
+     * @param unloggedExceptionsReportIntervalMillis the interval between reports in milliseconds,
+     *        or {@code 0} to disable this feature
+     * @throws IllegalArgumentException if specified {@code interval} is negative.
+     */
+    @UnstableApi
+    public ServerBuilder unloggedExceptionsReportIntervalMillis(long unloggedExceptionsReportIntervalMillis) {
+        checkArgument(unloggedExceptionsReportIntervalMillis >= 0,
+                      "unloggedExceptionsReportIntervalMillis: %s (expected: >= 0)",
+                      unloggedExceptionsReportIntervalMillis);
+        this.unloggedExceptionsReportIntervalMillis = unloggedExceptionsReportIntervalMillis;
         return this;
     }
 
@@ -2154,13 +2182,13 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
         assert extensions != null;
         final DependencyInjector dependencyInjector = dependencyInjectorOrReflective();
 
-        final UnhandledExceptionsReporter unhandledExceptionsReporter;
-        if (unhandledExceptionsReportIntervalMillis > 0) {
-            unhandledExceptionsReporter = UnhandledExceptionsReporter.of(
-                    meterRegistry, unhandledExceptionsReportIntervalMillis);
-            serverListeners.add(unhandledExceptionsReporter);
+        final UnloggedExceptionsReporter unloggedExceptionsReporter;
+        if (unloggedExceptionsReportIntervalMillis > 0) {
+            unloggedExceptionsReporter = UnloggedExceptionsReporter.of(
+                    meterRegistry, unloggedExceptionsReportIntervalMillis);
+            serverListeners.add(unloggedExceptionsReporter);
         } else {
-            unhandledExceptionsReporter = null;
+            unloggedExceptionsReporter = null;
         }
 
         final ServerErrorHandler errorHandler;
@@ -2172,11 +2200,11 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
         }
         final VirtualHost defaultVirtualHost =
                 defaultVirtualHostBuilder.build(virtualHostTemplate, dependencyInjector,
-                                                unhandledExceptionsReporter, errorHandler);
+                                                unloggedExceptionsReporter, errorHandler);
         final List<VirtualHost> virtualHosts =
                 virtualHostBuilders.stream()
                                    .map(vhb -> vhb.build(virtualHostTemplate, dependencyInjector,
-                                                         unhandledExceptionsReporter, errorHandler))
+                                                         unloggedExceptionsReporter, errorHandler))
                                    .collect(toImmutableList());
         // Pre-populate the domain name mapping for later matching.
         final Mapping<String, SslContext> sslContexts;
@@ -2283,7 +2311,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, errorHandler, sslContexts,
                 http1HeaderNaming, dependencyInjector, absoluteUriTransformer,
-                unhandledExceptionsReportIntervalMillis, ImmutableList.copyOf(shutdownSupports));
+                unloggedExceptionsReportIntervalMillis, ImmutableList.copyOf(shutdownSupports));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -336,7 +336,15 @@ public interface ServerConfig {
     Function<String, String> absoluteUriTransformer();
 
     /**
-     * Returns the interval between reporting unhandled exceptions in milliseconds.
+     * Returns the interval between reporting unlogged exceptions in milliseconds.
+     *
+     * @deprecated Use {@link #unloggedExceptionsReportIntervalMillis()} instead.
      */
+    @Deprecated
     long unhandledExceptionsReportIntervalMillis();
+
+    /**
+     * Returns the interval between reporting unlogged exceptions in milliseconds.
+     */
+    long unloggedExceptionsReportIntervalMillis();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -333,14 +333,14 @@ final class ServiceConfigBuilder implements ServiceConfigSetters {
                         HttpHeaders virtualHostDefaultHeaders,
                         Function<? super RoutingContext, ? extends RequestId> defaultRequestIdGenerator,
                         ServiceErrorHandler defaultServiceErrorHandler,
-                        @Nullable UnhandledExceptionsReporter unhandledExceptionsReporter,
+                        @Nullable UnloggedExceptionsReporter unloggedExceptionsReporter,
                         String baseContextPath, Supplier<AutoCloseable> contextHook) {
         ServiceErrorHandler errorHandler =
                 serviceErrorHandler != null ? serviceErrorHandler.orElse(defaultServiceErrorHandler)
                                             : defaultServiceErrorHandler;
-        if (unhandledExceptionsReporter != null) {
+        if (unloggedExceptionsReporter != null) {
             errorHandler = new ExceptionReportingServiceErrorHandler(errorHandler,
-                                                                     unhandledExceptionsReporter);
+                                                                     unloggedExceptionsReporter);
         }
 
         final boolean webSocket = service.as(DefaultWebSocketService.class) != null;

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -600,15 +600,33 @@ public interface ServiceRequestContext extends RequestContext {
 
     /**
      * Returns whether exceptions should be reported.
-     * When {@link LoggingService} handles exceptions, this is set to false.
+     * When {@link LoggingService} logs exceptions, this is set to false.
+     *
+     * @deprecated Use {@link #shouldReportUnloggedExceptions()} instead.
      */
+    @Deprecated
     boolean shouldReportUnhandledExceptions();
 
     /**
      * Sets whether to report exceptions.
-     * @param value whether to report unhandled exceptions
+     * @param value whether to report unlogged exceptions
+     *
+     * @deprecated Use {@link #setShouldReportUnloggedExceptions(boolean)} instead.
      */
+    @Deprecated
     void setShouldReportUnhandledExceptions(boolean value);
+
+    /**
+     * Returns whether exceptions should be reported.
+     * When {@link LoggingService} logs exceptions, this is set to false.
+     */
+    boolean shouldReportUnloggedExceptions();
+
+    /**
+     * Sets whether to report exceptions.
+     * @param value whether to report unlogged exceptions
+     */
+    void setShouldReportUnloggedExceptions(boolean value);
 
     /**
      * Initiates graceful connection shutdown with a given drain duration in microseconds and returns

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -244,6 +244,16 @@ public class ServiceRequestContextWrapper
     }
 
     @Override
+    public boolean shouldReportUnloggedExceptions() {
+        return unwrap().shouldReportUnloggedExceptions();
+    }
+
+    @Override
+    public void setShouldReportUnloggedExceptions(boolean value) {
+        unwrap().setShouldReportUnloggedExceptions(value);
+    }
+
+    @Override
     public CompletableFuture<Void> initiateConnectionShutdown(long drainDurationMicros) {
         return unwrap().initiateConnectionShutdown(drainDurationMicros);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
@@ -21,7 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 interface UnloggedExceptionsReporter extends ServerListener {
 
     static UnloggedExceptionsReporter of(MeterRegistry meterRegistry, long intervalMillis) {
-        return new DefaultUnloggedExceptionsReporter(meterRegistry, intervalMillis);
+        return new PeriodicUnloggedExceptionsReporter(meterRegistry, intervalMillis);
     }
 
     void report(Throwable cause);

--- a/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
@@ -21,7 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 interface UnloggedExceptionsReporter extends ServerListener {
 
     static UnloggedExceptionsReporter of(MeterRegistry meterRegistry, long intervalMillis) {
-        return new PeriodicUnloggedExceptionsReporter(meterRegistry, intervalMillis);
+        return new DefaultUnloggedExceptionsReporter(meterRegistry, intervalMillis);
     }
 
     void report(Throwable cause);

--- a/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UnloggedExceptionsReporter.java
@@ -18,10 +18,10 @@ package com.linecorp.armeria.server;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-interface UnhandledExceptionsReporter extends ServerListener {
+interface UnloggedExceptionsReporter extends ServerListener {
 
-    static UnhandledExceptionsReporter of(MeterRegistry meterRegistry, long intervalMillis) {
-        return new DefaultUnhandledExceptionsReporter(meterRegistry, intervalMillis);
+    static UnloggedExceptionsReporter of(MeterRegistry meterRegistry, long intervalMillis) {
+        return new DefaultUnloggedExceptionsReporter(meterRegistry, intervalMillis);
     }
 
     void report(Throwable cause);

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -316,6 +316,11 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
+    public long unloggedExceptionsReportIntervalMillis() {
+        return delegate.unloggedExceptionsReportIntervalMillis();
+    }
+
+    @Override
     public String toString() {
         return delegate.toString();
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -1279,7 +1279,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
      * added to this builder.
      */
     VirtualHost build(VirtualHostBuilder template, DependencyInjector dependencyInjector,
-                      @Nullable UnhandledExceptionsReporter unhandledExceptionsReporter,
+                      @Nullable UnloggedExceptionsReporter unloggedExceptionsReporter,
                       ServerErrorHandler serverErrorHandler) {
         requireNonNull(template, "template");
 
@@ -1403,7 +1403,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                                             successFunction, requestAutoAbortDelayMillis,
                                             multipartUploadsLocation, serviceWorkerGroup, defaultHeaders,
                                             requestIdGenerator, defaultErrorHandler,
-                                            unhandledExceptionsReporter, baseContextPath, contextHook);
+                                            unloggedExceptionsReporter, baseContextPath, contextHook);
                 }).collect(toImmutableList());
 
         final ServiceConfig fallbackServiceConfig =
@@ -1412,7 +1412,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                                accessLogWriter, blockingTaskExecutor, successFunction,
                                requestAutoAbortDelayMillis, multipartUploadsLocation, serviceWorkerGroup,
                                defaultHeaders, requestIdGenerator,
-                               defaultErrorHandler, unhandledExceptionsReporter, "/", contextHook);
+                               defaultErrorHandler, unloggedExceptionsReporter, "/", contextHook);
 
         final ImmutableList.Builder<ShutdownSupport> builder = ImmutableList.builder();
         builder.addAll(shutdownSupports);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/LoggingService.java
@@ -77,7 +77,7 @@ public final class LoggingService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        ctx.setShouldReportUnhandledExceptions(false);
+        ctx.setShouldReportUnloggedExceptions(false);
         ctx.log().whenComplete().thenAccept(requestLog -> {
             if (sampler.isSampled(requestLog)) {
                 log(ctx, requestLog, logWriter);

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
@@ -41,7 +41,7 @@ class DefaultUnhandledExceptionReporterTest {
     @Spy
     final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
     final Logger errorHandlerLogger =
-            (Logger) LoggerFactory.getLogger(DefaultUnhandledExceptionsReporter.class);
+            (Logger) LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
     private static final long reportIntervalMillis = 1000;
     private static final long awaitIntervalMillis = 2000;
     private static volatile boolean throwNonIgnorableException;
@@ -87,7 +87,7 @@ class DefaultUnhandledExceptionReporterTest {
               .build((ctx, req) -> {
                   throw HttpStatusException.of(HttpStatus.BAD_REQUEST);
               });
-            sb.unhandledExceptionsReportInterval(Duration.ofMillis(reportIntervalMillis));
+            sb.unloggedExceptionsReportInterval(Duration.ofMillis(reportIntervalMillis));
         }
     };
 

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
@@ -41,7 +41,7 @@ class DefaultUnhandledExceptionReporterTest {
     @Spy
     final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
     final Logger errorHandlerLogger =
-            (Logger) LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
+            (Logger) LoggerFactory.getLogger(PeriodicUnloggedExceptionsReporter.class);
     private static final long reportIntervalMillis = 1000;
     private static final long awaitIntervalMillis = 2000;
     private static volatile boolean throwNonIgnorableException;

--- a/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DefaultUnhandledExceptionReporterTest.java
@@ -41,7 +41,7 @@ class DefaultUnhandledExceptionReporterTest {
     @Spy
     final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
     final Logger errorHandlerLogger =
-            (Logger) LoggerFactory.getLogger(PeriodicUnloggedExceptionsReporter.class);
+            (Logger) LoggerFactory.getLogger(DefaultUnloggedExceptionsReporter.class);
     private static final long reportIntervalMillis = 1000;
     private static final long awaitIntervalMillis = 2000;
     private static volatile boolean throwNonIgnorableException;

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -677,19 +677,19 @@ class ServerBuilderTest {
     void exceptionReportInterval() {
         final Server server1 = Server.builder()
                                      .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
-                                     .unhandledExceptionsReportInterval(Duration.ofMillis(1000))
+                                     .unloggedExceptionsReportInterval(Duration.ofMillis(1000))
                                      .build();
-        assertThat(server1.config().unhandledExceptionsReportIntervalMillis()).isEqualTo(1000);
+        assertThat(server1.config().unloggedExceptionsReportIntervalMillis()).isEqualTo(1000);
 
         final Server server2 = Server.builder()
-                                     .unhandledExceptionsReportInterval(Duration.ofMillis(0))
+                                     .unloggedExceptionsReportInterval(Duration.ofMillis(0))
                                      .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                                      .build();
-        assertThat(server2.config().unhandledExceptionsReportIntervalMillis()).isZero();
+        assertThat(server2.config().unloggedExceptionsReportIntervalMillis()).isZero();
 
         assertThrows(IllegalArgumentException.class, () ->
                 Server.builder()
-                      .unhandledExceptionsReportInterval(Duration.ofMillis(-1000))
+                      .unloggedExceptionsReportInterval(Duration.ofMillis(-1000))
                       .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                       .build());
     }
@@ -697,20 +697,20 @@ class ServerBuilderTest {
     @Test
     void exceptionReportIntervalMilliSeconds() {
         final Server server1 = Server.builder()
-                                     .unhandledExceptionsReportIntervalMillis(1000)
+                                     .unloggedExceptionsReportIntervalMillis(1000)
                                      .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                                      .build();
-        assertThat(server1.config().unhandledExceptionsReportIntervalMillis()).isEqualTo(1000);
+        assertThat(server1.config().unloggedExceptionsReportIntervalMillis()).isEqualTo(1000);
 
         final Server server2 = Server.builder()
-                                     .unhandledExceptionsReportIntervalMillis(0)
+                                     .unloggedExceptionsReportIntervalMillis(0)
                                      .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                                      .build();
-        assertThat(server2.config().unhandledExceptionsReportIntervalMillis()).isZero();
+        assertThat(server2.config().unloggedExceptionsReportIntervalMillis()).isZero();
 
         assertThrows(IllegalArgumentException.class, () ->
                 Server.builder()
-                      .unhandledExceptionsReportIntervalMillis(-1000)
+                      .unloggedExceptionsReportIntervalMillis(-1000)
                       .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
                       .build());
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceRequestContextTest.java
@@ -198,7 +198,7 @@ class ServiceRequestContextTest {
     @Test
     void defaultServiceRequestContextShouldLogExceptions() {
         final ServiceRequestContext sctx = serviceRequestContext();
-        assertThat(sctx.shouldReportUnhandledExceptions()).isTrue();
+        assertThat(sctx.shouldReportUnloggedExceptions()).isTrue();
     }
 
     private static void assertUnwrapAllCurrentCtx(@Nullable RequestContext ctx) {


### PR DESCRIPTION
…andler` and rename `UnhandledExceptions` to `UnloggedExceptions`.

Motivation:
This PR addresses two main concerns:
1. Currently, `UnloggedExceptionsReporter` reports unlogged exceptions before calling `ServiceErrorHandler.onServiceException`. This order could conflict with user preferences if they want to handle exceptions in `ServiceErrorHandler` and avoid logging them through the reporter.
2. The term `UnhandledExceptions` might be misleading, as the exceptions are indeed handled but not logged. Renaming it to `UnloggedExceptions` provides clarity.

Modifications:
- Adjust the sequence to call `UnloggedExceptionsReporter.report` after invoking `ServiceErrorHandler`.
- Rename `UnhandledExceptions` to `UnloggedExceptions` throughout the codebase.

Result:
- This change enables users to control whether an exception should be logged by the `UnloggedExceptionsReporter` in a `ServiceErrorHandler` by invoking `ctx.setShouldReportUnloggedExceptions(false)`.
- (deprecation)
  - `Flags.defaultUnhandledExceptionsReportIntervalMillis` -> `Flags.defaultUnloggedExceptionsReportIntervalMillis`
  - `FlagsProvider.defaultUnhandledExceptionsReportIntervalMillis` -> `FlagsProvider.defaultUnloggedExceptionsReportIntervalMillis`
  - `ServerBuilder.unhandledExceptionsReportInterval` -> `ServerBuilder.unloggedExceptionsReportInterval`
  - `ServerConfig.unhandledExceptionsReportIntervalMillis` -> `ServerConfig.unloggedExceptionsReportIntervalMillis`
  - `ServiceRequestContext.shouldReportUnhandledExceptions` -> `ServiceRequestContext.shouldReportUnloggedExceptions`
  - `ServiceRequestContext.setShouldReportUnhandledExceptions` -> `ServiceRequestContext.setShouldReportUnloggedExceptions`