### PR TITLE
Fix incorrect indentation in dependabot npm strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,4 +34,4 @@ updates:
       directory: "/"
       schedule:
         interval: "monthly"
-        versioning-strategy: increase
+      versioning-strategy: increase


### PR DESCRIPTION
Motivation:

In #5378, I'd followed the following [post](https://stackoverflow.com/questions/60201543/dependabot-only-updates-lock-file) to prevent [PR](https://github.com/line/armeria/pull/5541)s that only updates the `package-lock.json` file.

I hadn't realized that the indentation was off though 😅 

Modifications:

- Fixed indentation for npm versioning strategy

Result:

- Less noisy npm dependency updates

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
