### PR TITLE
`failOnPassedAfterRetry` is `true` by default

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -136,7 +136,7 @@ jobs:
           ${{ matrix.blockhound && '-Pblockhound' || '' }} \
           -PnoLint \
           -PflakyTests=false \
-          -Pretry=true \
+          -Pretry=true -PfailOnPassedAfterRetry=true \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
@@ -300,7 +300,7 @@ jobs:
       - name: Run flaky tests
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=2 --parallel check \
-          -PnoLint -PflakyTests=true -Pretry=true \
+          -PnoLint -PflakyTests=true -Pretry=true -PfailOnPassedAfterRetry=true \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ env.BUILD_JDK_VERSION }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}

--- a/.github/workflows/gradle-enterprise-postjob.yml
+++ b/.github/workflows/gradle-enterprise-postjob.yml
@@ -135,6 +135,6 @@ jobs:
           ./gradlew --no-daemon --stacktrace --build-cache build \
           --max-workers=2 --parallel \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
-          -Pretry=true -PfailOnPassedAfterRetry=false \
+          -Pretry=true \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }}
         shell: bash

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PflakyTests=false \
-          -Pretry=true -PfailOnPassedAfterRetry=false \
+          -Pretry=true \
           build
         shell: bash
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ allprojects {
         retry {
             if (rootProject.findProperty('retry') == 'true') {
                 maxRetries = 3
-                failOnPassedAfterRetry = rootProject.findProperty('failOnPassedAfterRetry') != 'false'
+                failOnPassedAfterRetry = rootProject.findProperty('failOnPassedAfterRetry') == 'true'
             }
         }
 


### PR DESCRIPTION
Motivation:

When I run builds locally, I often don't care about flakiness and run the following command:
```java
./gradlew clean build --parallel -Pretry=true -PfailOnPassedAfterRetry=false
```

However, it's difficult to remember `failOnPassedAfterRetry` and I end up copy/pasting this every time.
I propose that `failOnPassedAfterRetry` is `false` if unspecified.
To prevent our CI from ignoring such failures, our workflows are updated to set `failOnPassedAfterRetry=true`

Modifications:

- The condition for determining `failOnPassedAfterRetry` is inverted

Result:

- Users can now easily run builds ignoring flaky test failures

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
