### PR TITLE
Close k8s client explicitly to avoid leak

### DIFF
--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpHttpLoggingInterceptorTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpHttpLoggingInterceptorTest.java
@@ -15,11 +15,24 @@
  */
 package com.linecorp.armeria.client.kubernetes;
 
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.AfterEach;
+
 import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("JUnitTestCaseWithNoTests")
 class ArmeriaHttpHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
+
+    @AfterEach
+    void afterEach() throws Exception {
+        final Field field = AbstractHttpLoggingInterceptorTest.class.getDeclaredField("httpClient");
+        field.setAccessible(true);
+        final HttpClient httpClient = (HttpClient) field.get(this);
+        httpClient.close();
+    }
+
     @Override
     protected HttpClient.Factory getHttpClientFactory() {
         return new ArmeriaHttpClientFactory();

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -23,7 +23,6 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -76,11 +75,6 @@ class KubernetesEndpointGroupMockServerTest {
         // A workaround for the issue that the static client is leaked.
         // Remove once https://github.com/fabric8io/kubernetes-client/pull/5854 is released.
         staticClient.close();
-    }
-
-    @AfterEach
-    void afterEach() {
-        client.close();
     }
 
     @Test

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -23,6 +23,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -75,6 +76,11 @@ class KubernetesEndpointGroupMockServerTest {
         // A workaround for the issue that the static client is leaked.
         // Remove once https://github.com/fabric8io/kubernetes-client/pull/5854 is released.
         staticClient.close();
+    }
+
+    @AfterEach
+    void afterEach() {
+        client.close();
     }
 
     @Test
@@ -160,7 +166,6 @@ class KubernetesEndpointGroupMockServerTest {
                     Endpoint.of("4.4.4.4", nodePort)
             );
         });
-        client.close();
     }
 
     @Test
@@ -227,7 +232,6 @@ class KubernetesEndpointGroupMockServerTest {
                         Endpoint.of("3.3.3.3", httpNodePort));
             });
         }
-        client.close();
     }
 
     @Test
@@ -270,7 +274,6 @@ class KubernetesEndpointGroupMockServerTest {
             );
         });
         endpointGroup.close();
-        client.close();
     }
 
     private static Node newNode(String ip, String type) {

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -160,6 +160,7 @@ class KubernetesEndpointGroupMockServerTest {
                     Endpoint.of("4.4.4.4", nodePort)
             );
         });
+        client.close();
     }
 
     @Test
@@ -226,6 +227,7 @@ class KubernetesEndpointGroupMockServerTest {
                         Endpoint.of("3.3.3.3", httpNodePort));
             });
         }
+        client.close();
     }
 
     @Test
@@ -268,6 +270,7 @@ class KubernetesEndpointGroupMockServerTest {
             );
         });
         endpointGroup.close();
+        client.close();
     }
 
     private static Node newNode(String ip, String type) {


### PR DESCRIPTION
Motivation:

####  leak number 1
```
05:53:28.204 [Test worker] ERROR io.netty.util.ResourceLeakDetector - LEAK: ClientFactory.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
Created at:
        com.linecorp.armeria.client.DefaultClientFactory.<init>(DefaultClientFactory.java:101)
        com.linecorp.armeria.client.ClientFactoryBuilder.build(ClientFactoryBuilder.java:964)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientBuilder$ClientFactoryBuilderHolder.maybeBuild(ArmeriaHttpClientBuilder.java:168)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientBuilder.clientFactory(ArmeriaHttpClientBuilder.java:146)
        com.linecorp.armeria.client.kubernetes.ArmeriaWebSocketClient.webSocketClient(ArmeriaWebSocketClient.java:73)
        com.linecorp.armeria.client.kubernetes.ArmeriaWebSocketClient.execute(ArmeriaWebSocketClient.java:107)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClient.buildWebSocketDirect(ArmeriaHttpClient.java:70)
        io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocketOnce(StandardHttpClient.java:257)
        io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$buildWebSocket$12(StandardHttpClient.java:231)
        io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:75)
        io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:68)
        io.fabric8.kubernetes.client.http.StandardHttpClient.retryWithExponentialBackoff(StandardHttpClient.java:165)
        io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocket(StandardHttpClient.java:229)
        io.fabric8.kubernetes.client.http.StandardWebSocketBuilder.buildAsync(StandardWebSocketBuilder.java:44)
        io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest.wsRequestHeadersLogged(AbstractHttpLoggingInterceptorTest.java:271)
```

ref: https://github.com/line/armeria/actions/runs/8642064674/job/23692539440?pr=5591

#### leak number 2

```
07:44:56.673 [Test worker] ERROR io.netty.util.ResourceLeakDetector - LEAK: ClientFactory.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
Created at:
        com.linecorp.armeria.client.DefaultClientFactory.<init>(DefaultClientFactory.java:101)
        com.linecorp.armeria.client.ClientFactoryBuilder.build(ClientFactoryBuilder.java:964)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientBuilder$ClientFactoryBuilderHolder.maybeBuild(ArmeriaHttpClientBuilder.java:168)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientBuilder.clientFactory(ArmeriaHttpClientBuilder.java:146)
        com.linecorp.armeria.client.kubernetes.ArmeriaWebSocketClient.webSocketClient(ArmeriaWebSocketClient.java:73)
        com.linecorp.armeria.client.kubernetes.ArmeriaWebSocketClient.execute(ArmeriaWebSocketClient.java:107)
        com.linecorp.armeria.client.kubernetes.ArmeriaHttpClient.buildWebSocketDirect(ArmeriaHttpClient.java:70)
        io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocketOnce(StandardHttpClient.java:257)
        io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$buildWebSocket$12(StandardHttpClient.java:231)
        io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:75)
        io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:68)
        io.fabric8.kubernetes.client.http.StandardHttpClient.retryWithExponentialBackoff(StandardHttpClient.java:165)
        io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocket(StandardHttpClient.java:229)
        io.fabric8.kubernetes.client.http.StandardWebSocketBuilder.buildAsync(StandardWebSocketBuilder.java:44)
        io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest.wsResponseStatusLogged(AbstractHttpLoggingInterceptorTest.java:288)
```

ref: https://github.com/line/armeria/actions/runs/8643129605/job/23695542018

While we could wait for the next release which fixes this issue, for the time being I don't think closing the client explicitly is a bad idea

Modifications:

- Close the kubernetes client in tests that reported a leak

Result:

- Less noise and failure from builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
