### PR TITLE
Add lenient strictness to k8s test

### DIFF
--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpHttpLoggingInterceptorTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpHttpLoggingInterceptorTest.java
@@ -15,10 +15,17 @@
  */
 package com.linecorp.armeria.client.kubernetes;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
 import io.fabric8.kubernetes.client.http.AbstractHttpLoggingInterceptorTest;
 import io.fabric8.kubernetes.client.http.HttpClient;
 
 @SuppressWarnings("JUnitTestCaseWithNoTests")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class ArmeriaHttpHttpLoggingInterceptorTest extends AbstractHttpLoggingInterceptorTest {
     @Override
     protected HttpClient.Factory getHttpClientFactory() {


### PR DESCRIPTION
Motivation:

We're seeing the following error and I don't think there's much we can do about it.
I propose that we just adjust the lenient setting - the original purpose of mockito strictness is probably not relevant here since we use a 3rd party's test anyways.
https://ge.armeria.dev/scans/tests?search.relativeStartTime=P28D&search.tags=CI%2Cnot:PR&search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.client.kubernetes.ArmeriaHttpHttpLoggingInterceptorTest&tests.sortField=FLAKY&tests.test=responseBodyIsNotConsumed()

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
