### PR TITLE
Fix flaky `AccessLoggerIntegrationTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
@@ -59,6 +59,7 @@ class AccessLoggerIntegrationTest {
         assertThat(server.blockingWebClient().get("/").status().code()).isEqualTo(200);
         assertThat(server.requestContextCaptor().size()).isEqualTo(1);
         final ServiceRequestContext ctx = server.requestContextCaptor().poll();
-        assertThat(CTX_REF).hasValue(ctx);
+        assertThat(ctx).isNotNull();
+        assertThat(CTX_REF).hasValueSatisfying(ctxRef -> assertThat(ctxRef.id()).isEqualTo(ctx.id()));
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/logging/AccessLoggerIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -60,6 +61,6 @@ class AccessLoggerIntegrationTest {
         assertThat(server.requestContextCaptor().size()).isEqualTo(1);
         final ServiceRequestContext ctx = server.requestContextCaptor().poll();
         assertThat(ctx).isNotNull();
-        assertThat(CTX_REF).hasValueSatisfying(ctxRef -> assertThat(ctxRef.id()).isEqualTo(ctx.id()));
+        await().untilAsserted(() -> assertThat(CTX_REF).hasValue(ctx));
     }
 }


### PR DESCRIPTION
Motivation:

`ServiceRequestContext` does not implement `equals()` which results in an intermittent failure due to comparing instance references.

ref: https://github.com/line/armeria/actions/runs/8655794720/job/23735309425?pr=5593#step:10:1210

Modifications:

- Compare the requestId instead

Result:

- Less flaky tests

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
