### PR TITLE
[WIP] Enhance DefaultUnhandledExceptionsReporter for better exception repor…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
@@ -37,7 +37,7 @@ final class ExceptionReportingServiceErrorHandler implements ServiceErrorHandler
     @Override
     public HttpResponse onServiceException(ServiceRequestContext ctx, Throwable cause) {
         if (ctx.shouldReportUnhandledExceptions() && !isIgnorableException(cause)) {
-            reporter.report(cause);
+            reporter.report(ctx, cause);
         }
         return delegate.onServiceException(ctx, cause);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/UnhandledExceptionsReporter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UnhandledExceptionsReporter.java
@@ -24,5 +24,5 @@ interface UnhandledExceptionsReporter extends ServerListener {
         return new DefaultUnhandledExceptionsReporter(meterRegistry, intervalMillis);
     }
 
-    void report(Throwable cause);
+    void report(ServiceRequestContext ctx, Throwable cause);
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandlerTest.java
@@ -50,28 +50,28 @@ class ExceptionReportingServiceErrorHandlerTest {
     void onServiceExceptionShouldNotReportWhenShouldReportUnhandledExceptionsIsFalse() {
         when(ctx.shouldReportUnhandledExceptions()).thenReturn(false);
         serviceErrorHandler.onServiceException(ctx, new IllegalArgumentException("Test"));
-        verify(reporter, times(0)).report(any());
+        verify(reporter, times(0)).report(any(), any());
     }
 
     @Test
     void onServiceExceptionShouldNotReportWhenCauseIsExpected() {
         when(ctx.shouldReportUnhandledExceptions()).thenReturn(true);
         serviceErrorHandler.onServiceException(ctx, new ClosedChannelException());
-        verify(reporter, times(0)).report(any());
+        verify(reporter, times(0)).report(any(), any());
     }
 
     @Test
     void onServiceExceptionShouldReportWhenCauseIsNotExpected() {
         when(ctx.shouldReportUnhandledExceptions()).thenReturn(true);
         serviceErrorHandler.onServiceException(ctx, new IllegalArgumentException("Test"));
-        verify(reporter, times(1)).report(any());
+        verify(reporter, times(1)).report(any(), any());
     }
 
     @Test
     void onServiceExceptionShouldNotReportWhenCauseIsHttpStatusExceptionAndCauseNull() {
         when(ctx.shouldReportUnhandledExceptions()).thenReturn(true);
         serviceErrorHandler.onServiceException(ctx, HttpStatusException.of(500));
-        verify(reporter, times(0)).report(any());
+        verify(reporter, times(0)).report(any(), any());
     }
 
     @Test
@@ -79,6 +79,6 @@ class ExceptionReportingServiceErrorHandlerTest {
         when(ctx.shouldReportUnhandledExceptions()).thenReturn(true);
         serviceErrorHandler.onServiceException(
                 ctx, HttpStatusException.of(500, new IllegalArgumentException("test")));
-        verify(reporter, times(1)).report(any());
+        verify(reporter, times(1)).report(any(), any());
     }
 }


### PR DESCRIPTION
…ting

Motivation: https://github.com/line/armeria/issues/5567

> Currently, the DefaultUnhandledExceptionsReporter stores only one exception and the number of unhandled exceptions in an interval. However, this implementation lacks sufficient information for effective debugging and analysis. To address this limitation, we propose enhancing the reporter to provide more detailed information about unhandled exceptions.

> Proposed Changes:
> - Store Every Unique Exception and Its Count.
>   - Modify the reporter to store every unique exception encountered along with its occurrence count. A unique exception refers to instances where the class type and stack traces are identical.
> - Include Corresponding Context
>   - Enhance the reporting mechanism to include the corresponding context of each exception.

Modifications:

- Store Every Unique Exception and Its Count 
- Include Corresponding Context

Result:

- Closes #5567
- We can report the exceptions better. 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
