### PR TITLE
CORS origin is checked in a case-insensitive manner

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/websocket/DefaultWebSocketService.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
 import com.google.common.net.HostAndPort;
 
@@ -289,17 +290,18 @@ public final class DefaultWebSocketService implements WebSocketService, WebSocke
                                    "missing the origin header");
         }
 
+        final String lowerCaseOrigin = Ascii.toLowerCase(origin);
         if (originPredicate == null) {
             // Only the same-origin is allowed.
-            if (!isSameOrigin(ctx, headers, origin)) {
+            if (!isSameOrigin(ctx, headers, lowerCaseOrigin)) {
                 return HttpResponse.of(HttpStatus.FORBIDDEN, MediaType.PLAIN_TEXT_UTF_8,
-                                       "not allowed origin: " + origin);
+                                       "not allowed origin: " + lowerCaseOrigin);
             }
             return null;
         }
-        if (!originPredicate.test(origin)) {
+        if (!originPredicate.test(lowerCaseOrigin)) {
             return HttpResponse.of(HttpStatus.FORBIDDEN, MediaType.PLAIN_TEXT_UTF_8,
-                                   "not allowed origin: " + origin);
+                                   "not allowed origin: " + lowerCaseOrigin);
         }
         return null;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java
@@ -106,7 +106,7 @@ public final class CorsConfig {
                 isPathMatched(policy, routingContext)) {
                 return policy;
             } else if (!isNullOrigin && isPathMatched(policy, routingContext)) {
-                if (policy.originPredicate().test(origin)) {
+                if (policy.originPredicate().test(lowerCaseOrigin)) {
                     return policy;
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/websocket/WebSocketServiceBuilder.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.server.websocket;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -184,7 +186,10 @@ public final class WebSocketServiceBuilder {
 
     private static Set<String> validateOrigins(Iterable<String> allowedOrigins) {
         //TODO(minwoox): Dedup the same logic in cors service.
-        final Set<String> copied = ImmutableSet.copyOf(requireNonNull(allowedOrigins, "allowedOrigins"));
+        final Set<String> copied = ImmutableSet.copyOf(requireNonNull(allowedOrigins, "allowedOrigins"))
+                                               .stream()
+                                               .map(Ascii::toLowerCase)
+                                               .collect(toImmutableSet());
         checkArgument(!copied.isEmpty(), "allowedOrigins is empty. (expected: non-empty)");
         if (copied.contains(ANY_ORIGIN)) {
             if (copied.size() > 1) {

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -868,9 +868,7 @@ class HttpServerCorsTest {
     @Test
     void caseInsensitiveOriginCheck() {
         final WebClient client = client();
-        AggregatedHttpResponse res;
-
-        res = preflightRequest(client, "/cors", "http://EXAMPLE.com", "GET");
+        final AggregatedHttpResponse res = preflightRequest(client, "/cors", "http://EXAMPLE.com", "GET");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
                 .isEqualTo("http://EXAMPLE.com");
     }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/HttpServerCorsTest.java
@@ -864,4 +864,14 @@ class HttpServerCorsTest {
         res = preflightRequest(client, "/cors19/index3", "http://invalid.com", "DELETE");
         assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS)).isNull();
     }
+
+    @Test
+    void caseInsensitiveOriginCheck() {
+        final WebClient client = client();
+        AggregatedHttpResponse res;
+
+        res = preflightRequest(client, "/cors", "http://EXAMPLE.com", "GET");
+        assertThat(res.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .isEqualTo("http://EXAMPLE.com");
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceCorsTest.java
@@ -104,6 +104,15 @@ class WebSocketServiceCorsTest {
     }
 
     @Test
+    void caseInsensitiveOrigin() {
+        final WebClient client = WebClient.builder(server2.uri(SessionProtocol.H1C))
+                                          .responseTimeoutMillis(0)
+                                          .build();
+        assertThat(sendRequestAndRetrieveResponseHeaders(client, "http://ARMERIA.com").status())
+                .isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+    }
+
+    @Test
     void testWhenAllowedOriginsAreMatchedByPredicate() {
         final WebClient client = WebClient.builder(server3.uri(SessionProtocol.H1C))
                                           .responseTimeoutMillis(0)


### PR DESCRIPTION
Motivation:

We are lowercasing origins we would like to check:
https://github.com/line/armeria/blob/d31dc60bb080a51915e528473c6d8c96d5c699eb/core/src/main/java/com/linecorp/armeria/server/cors/AbstractCorsPolicyBuilder.java#L79

However, we use the non-normalized origin in the request header to find the correct CORS policy to apply:
https://github.com/line/armeria/blob/d31dc60bb080a51915e528473c6d8c96d5c699eb/core/src/main/java/com/linecorp/armeria/server/cors/CorsConfig.java#L109

Detailed logs can be found here: https://github.com/line/centraldogma/pull/940

Modifications:

- Use the lowercased request origin header to find the correct CORS policy

Result:

- Previous behavior is revived

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
