### PR TITLE
Fix a bug where the unary and response streaming requests aren't timed out

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -65,6 +65,8 @@ public interface CancellationScheduler {
 
     void init(EventExecutor eventLoop);
 
+    void start();
+
     void start(CancellationTask task);
 
     void clearTimeout();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
@@ -127,6 +127,12 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
     }
 
     @Override
+    public void start() {
+        // The noopCancellationTask will be replaced by the actual task when start(CancellationTask) is called.
+        start(noopCancellationTask);
+    }
+
+    @Override
     public void start(CancellationTask task) {
         assert eventLoop != null;
         assert eventLoop.inEventLoop();
@@ -514,6 +520,7 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
                 cause = ResponseTimeoutException.get();
             }
         }
+        this.cause = cause;
 
         // Set FINISHING to preclude executing other timeout operations from the callbacks of `whenCancelling()`
         state = State.FINISHING;
@@ -527,7 +534,6 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
         if (task.canSchedule()) {
             task.run(cause);
         }
-        this.cause = cause;
         ((CancellationFuture) whenCancelled()).doComplete(cause);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NoopCancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NoopCancellationScheduler.java
@@ -45,6 +45,10 @@ final class NoopCancellationScheduler implements CancellationScheduler {
     }
 
     @Override
+    public void start() {
+    }
+
+    @Override
     public void start(CancellationTask task) {
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbstractFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbstractFixedStreamMessage.java
@@ -151,7 +151,7 @@ abstract class AbstractFixedStreamMessage<T> extends FixedStreamMessage<T> {
     }
 
     @Override
-    public final void abort() {
+    public void abort() {
         if (isDone()) {
             return;
         }
@@ -160,7 +160,7 @@ abstract class AbstractFixedStreamMessage<T> extends FixedStreamMessage<T> {
     }
 
     @Override
-    public final void abort(Throwable cause) {
+    public void abort(Throwable cause) {
         if (isDone()) {
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/AggregatingStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/AggregatingStreamMessage.java
@@ -80,6 +80,18 @@ public class AggregatingStreamMessage<T> extends AbstractFixedStreamMessage<T> i
     }
 
     @Override
+    public void abort() {
+        closed = true;
+        super.abort();
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        closed = true;
+        super.abort(cause);
+    }
+
+    @Override
     T get(int index) {
         return objs.get(index);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -67,6 +67,7 @@ abstract class AbstractHttpResponseHandler {
         this.reqCtx = reqCtx;
         this.req = req;
         this.completionFuture = completionFuture;
+        setTimeoutCancellationTask();
     }
 
     /**
@@ -244,10 +245,9 @@ abstract class AbstractHttpResponseHandler {
     }
 
     /**
-     * Schedules a request timeout.
+     * Set timeout cancellation task. The CancellationScheduler already starts in the HttpRequestDecoder.
      */
-    final void scheduleTimeout() {
-        // Schedule the initial request timeout with the timeoutNanos in the CancellationScheduler
+    final void setTimeoutCancellationTask() {
         reqCtx.requestCancellationScheduler().start(newCancellationTask());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
@@ -98,8 +98,6 @@ abstract class AbstractHttpResponseSubscriber extends AbstractHttpResponseHandle
             return;
         }
 
-        scheduleTimeout();
-
         // Start consuming.
         subscription.request(1);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatedHttpResponseHandler.java
@@ -52,7 +52,6 @@ final class AggregatedHttpResponseHandler extends AbstractHttpResponseHandler
                                   DefaultServiceRequestContext reqCtx, DecodedHttpRequest req,
                                   CompletableFuture<Void> completionFuture) {
         super(ctx, responseEncoder, reqCtx, req, completionFuture);
-        scheduleTimeout();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -20,9 +20,9 @@ import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
@@ -71,18 +71,15 @@ interface DecodedHttpRequest extends HttpRequest {
      */
     boolean isKeepAlive();
 
-    void init(ServiceRequestContext ctx);
+    void setServiceRequestContext(DefaultServiceRequestContext ctx);
 
-    boolean isInitialized();
+    DefaultServiceRequestContext serviceRequestContext();
+
+    void fireChannelRead(ChannelHandlerContext ctx);
+
+    boolean isFired();
 
     RoutingContext routingContext();
-
-    /**
-     * Returns the {@link ServiceConfig} mapped by {@link Routed}. {@code null} if a request path is invalid
-     * or an {@code OPTION * HTTP/1.1} request.
-     */
-    @Nullable
-    Routed<ServiceConfig> route();
 
     void close();
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandlerBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.server;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandlerBuilder;
 
 import io.micrometer.core.instrument.Timer;
@@ -32,14 +33,18 @@ final class Http2ServerConnectionHandlerBuilder
     private final Timer keepAliveTimer;
     private final GracefulShutdownSupport gracefulShutdownSupport;
     private final AsciiString scheme;
+    @Nullable
+    private final ProxiedAddresses proxiedAddresses;
 
     Http2ServerConnectionHandlerBuilder(Channel ch, ServerConfig config, Timer keepAliveTimer,
-                                        GracefulShutdownSupport gracefulShutdownSupport, AsciiString scheme) {
+                                        GracefulShutdownSupport gracefulShutdownSupport, AsciiString scheme,
+                                        @Nullable ProxiedAddresses proxiedAddresses) {
         super(ch);
         this.config = config;
         this.keepAliveTimer = keepAliveTimer;
         this.gracefulShutdownSupport = gracefulShutdownSupport;
         this.scheme = scheme;
+        this.proxiedAddresses = proxiedAddresses;
         // Disable graceful shutdown timeout in a super class. Server-side HTTP/2 graceful shutdown is
         // handled by Armeria's HTTP/2 server handler.
         gracefulShutdownTimeoutMillis(-1);
@@ -52,6 +57,7 @@ final class Http2ServerConnectionHandlerBuilder
                                                  Http2ConnectionEncoder encoder,
                                                  Http2Settings initialSettings) throws Exception {
         return new Http2ServerConnectionHandler(decoder, encoder, initialSettings, channel(),
-                                                config, keepAliveTimer, gracefulShutdownSupport, scheme);
+                                                config, keepAliveTimer, gracefulShutdownSupport, scheme,
+                                                proxiedAddresses);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpRequestDecoderContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpRequestDecoderContext.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.internal.common.RequestContextUtil.NOOP_CONTEXT_HOOK;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.armeria.internal.common.util.ChannelUtil;
+import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+
+final class HttpRequestDecoderContext {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestDecoderContext.class);
+
+    private static boolean warnedNullRequestId;
+
+    private static boolean warnedRequestIdGenerateFailure;
+
+    private static final InetSocketAddress UNKNOWN_ADDR;
+
+    static {
+        InetAddress unknownAddr;
+        try {
+            unknownAddr = InetAddress.getByAddress("<unknown>", new byte[] { 0, 0, 0, 0 });
+        } catch (Exception e1) {
+            // Just in case a certain JRE implementation doesn't accept the hostname '<unknown>'
+            try {
+                unknownAddr = InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 });
+            } catch (Exception e2) {
+                // Should never reach here.
+                final Error err = new Error(e2);
+                err.addSuppressed(e1);
+                throw err;
+            }
+        }
+        UNKNOWN_ADDR = new InetSocketAddress(unknownAddr, 1);
+    }
+
+    private final ServerConfig config;
+
+    private SessionProtocol protocol;
+
+    @Nullable
+    private final ProxiedAddresses proxiedAddresses;
+
+    @Nullable
+    private SSLSession sslSession;
+
+    @Nullable
+    private InetSocketAddress remoteAddress;
+    @Nullable
+    private InetSocketAddress localAddress;
+
+    HttpRequestDecoderContext(ServerConfig config, SessionProtocol protocol,
+                              @Nullable ProxiedAddresses proxiedAddresses) {
+        this.config = config;
+        this.protocol = protocol;
+        this.proxiedAddresses = proxiedAddresses;
+    }
+
+    void setProtocol(SessionProtocol protocol) {
+        this.protocol = protocol;
+    }
+
+    SessionProtocol protocol() {
+        return protocol;
+    }
+
+    void setSslSession(SSLSession sslSession) {
+        this.sslSession = sslSession;
+    }
+
+    DefaultServiceRequestContext newServiceRequestContext(Channel channel, Routed<ServiceConfig> routed,
+                                                          DecodedHttpRequest req) {
+        final RoutingResult routingResult = routed.routingResult();
+        final ServiceConfig serviceCfg = routed.value();
+        final EventLoop serviceEventLoop;
+        final EventLoopGroup serviceWorkerGroup = serviceCfg.serviceWorkerGroup();
+        if (serviceWorkerGroup == config.workerGroup()) {
+            serviceEventLoop = channel.eventLoop();
+        } else {
+            serviceEventLoop = serviceWorkerGroup.next();
+        }
+        final MeterRegistry meterRegistry = config.meterRegistry();
+        final Supplier<AutoCloseable> contextHook = serviceCfg.contextHook();
+
+        return newServiceRequestContext(channel, req, routingResult, serviceCfg, serviceEventLoop,
+                                        meterRegistry, contextHook);
+    }
+
+    private DefaultServiceRequestContext newServiceRequestContext(
+            Channel channel,
+            DecodedHttpRequest req,
+            RoutingResult routingResult,
+            ServiceConfig serviceCfg,
+            EventLoop serviceEventLoop,
+            MeterRegistry meterRegistry,
+            Supplier<AutoCloseable> contextHook) {
+        final InetSocketAddress remoteAddress = firstNonNull(remoteAddress(channel), UNKNOWN_ADDR);
+        final InetSocketAddress localAddress = firstNonNull(localAddress(channel), UNKNOWN_ADDR);
+        final ProxiedAddresses proxiedAddresses = determineProxiedAddresses(remoteAddress, req.headers());
+        final InetAddress clientAddress = config.clientAddressMapper().apply(proxiedAddresses).getAddress();
+
+        final DefaultServiceRequestContext ctx = new DefaultServiceRequestContext(
+                serviceCfg, channel, serviceEventLoop, meterRegistry, protocol,
+                nextRequestId(req.routingContext(), serviceCfg), req.routingContext(), routingResult,
+                req.exchangeType(), req, sslSession, proxiedAddresses, clientAddress, remoteAddress,
+                localAddress,
+                req.requestStartTimeNanos(), req.requestStartTimeMicros(), contextHook);
+        req.setServiceRequestContext(ctx);
+        return ctx;
+    }
+
+    DefaultServiceRequestContext newOptionsRequestContext(Channel channel, DecodedHttpRequest req) {
+        final RoutingContext routingCtx = req.routingContext();
+        final ServiceConfig serviceCfg = routingCtx.virtualHost().fallbackServiceConfig();
+        final RoutingResult routingResult = RoutingResult.builder()
+                                                         .path(routingCtx.path())
+                                                         .build();
+        return newServiceRequestContext(channel, req, routingResult, serviceCfg, channel.eventLoop(),
+                                        NoopMeterRegistry.get(), NOOP_CONTEXT_HOOK);
+    }
+
+    private ProxiedAddresses determineProxiedAddresses(InetSocketAddress remoteAddress,
+                                                       RequestHeaders headers) {
+        if (config.clientAddressTrustedProxyFilter().test(remoteAddress.getAddress())) {
+            return HttpHeaderUtil.determineProxiedAddresses(
+                    headers, config.clientAddressSources(), proxiedAddresses,
+                    remoteAddress, config.clientAddressFilter());
+        } else {
+            return proxiedAddresses != null ? proxiedAddresses : ProxiedAddresses.of(remoteAddress);
+        }
+    }
+
+    @Nullable
+    private InetSocketAddress remoteAddress(Channel ch) {
+        final InetSocketAddress remoteAddress = this.remoteAddress;
+        if (remoteAddress != null) {
+            return remoteAddress;
+        }
+
+        final InetSocketAddress newRemoteAddress = ChannelUtil.remoteAddress(ch);
+        this.remoteAddress = newRemoteAddress;
+        return newRemoteAddress;
+    }
+
+    @Nullable
+    private InetSocketAddress localAddress(Channel ch) {
+        final InetSocketAddress localAddress = this.localAddress;
+        if (localAddress != null) {
+            return localAddress;
+        }
+
+        final InetSocketAddress newLocalAddress = ChannelUtil.localAddress(ch);
+        this.localAddress = newLocalAddress;
+        return newLocalAddress;
+    }
+
+    private static RequestId nextRequestId(RoutingContext routingCtx, ServiceConfig serviceConfig) {
+        try {
+            final RequestId id = serviceConfig.requestIdGenerator().apply(routingCtx);
+            if (id != null) {
+                return id;
+            }
+
+            if (!warnedNullRequestId) {
+                warnedNullRequestId = true;
+                logger.warn("requestIdGenerator.apply(routingCtx) returned null; using RequestId.random()");
+            }
+            return RequestId.random();
+        } catch (Exception e) {
+            if (!warnedRequestIdGenerateFailure) {
+                warnedRequestIdGenerateFailure = true;
+                logger.warn("requestIdGenerator.apply(routingCtx) threw an exception; using RequestId.random()",
+                            e);
+            }
+            return RequestId.random();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class AggregatingRequestTimeoutTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.requestTimeoutMillis(100)
+              .service("/timeout", new HttpService() {
+                  @Override
+                  public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.of(200);
+                  }
+
+                  @Override
+                  public ExchangeType exchangeType(RoutingContext routingContext) {
+                      return ExchangeType.UNARY;
+                  }
+              });
+        }
+    };
+
+    @ParameterizedTest
+    @CsvSource({ "H1C", "H2C", "HTTP" })
+    void setRequestTimeoutAfter(SessionProtocol protocol) {
+        final HttpRequest request = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/timeout"),
+                                                   StreamMessage.streaming()); // Do not send body.
+        assertThat(WebClient.of(protocol, server.endpoint(protocol))
+                            .execute(request).aggregate().join().status())
+                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
@@ -28,6 +28,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
+import com.linecorp.armeria.internal.testing.ImmediateEventLoop;
 
 import reactor.test.StepVerifier;
 
@@ -100,7 +102,9 @@ class StreamingDecodedHttpRequestTest {
 
     private static StreamingDecodedHttpRequest decodedHttpRequest() {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
-        final ServiceRequestContext sctx = ServiceRequestContext.of(HttpRequest.of(headers));
+        final ServiceRequestContext sctx = ServiceRequestContext.builder(HttpRequest.of(headers))
+                                                                .eventLoop(ImmediateEventLoop.INSTANCE)
+                                                                .build();
         return decodedHttpRequest(headers, sctx);
     }
 
@@ -112,7 +116,7 @@ class StreamingDecodedHttpRequestTest {
                                                           InboundTrafficController.disabled(),
                                                           sctx.maxRequestLength(), sctx.routingContext(),
                                                           ExchangeType.BIDI_STREAMING, 0, 0, false, false);
-        request.init(sctx);
+        request.setServiceRequestContext((DefaultServiceRequestContext) sctx);
         return request;
     }
 }


### PR DESCRIPTION
Motivation:
Unary and response streaming requests were not being timed out when they failed to receive the body within the specified timeout.

Modifications:
- Refactored `Http1RequestDecoder`, `Http2RequestDecoder`, and `HttpServerHandler`:
  - Created `ServiceRequestContext` in the request decoders. - Timeout for a request now initiates in the request decoders upon header creation. - `ServiceRequestContext` is immediately set to the `DecodedHttpRequest` in the decoder.
  - Extracted the logic for handling Netty objects in `Http1RequestDecoder` into methods.

Result:
- Unary and response streaming requests are now properly timed out if they fail to receive the body within the designated timeout period.