### PR TITLE
Fixed bug where a request timeout is scheduled after receiving the entire body

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbstractFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/AbstractFixedStreamMessage.java
@@ -151,7 +151,7 @@ abstract class AbstractFixedStreamMessage<T> extends FixedStreamMessage<T> {
     }
 
     @Override
-    public final void abort() {
+    public void abort() {
         if (isDone()) {
             return;
         }
@@ -160,7 +160,7 @@ abstract class AbstractFixedStreamMessage<T> extends FixedStreamMessage<T> {
     }
 
     @Override
-    public final void abort(Throwable cause) {
+    public void abort(Throwable cause) {
         if (isDone()) {
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -274,6 +274,7 @@ abstract class AbstractHttpResponseHandler {
                     // A stream or connection was already closed by a client
                     fail(cause);
                 } else {
+                    req.setShouldResetOnlyIfRemoteIsOpen(true);
                     req.abortResponse(cause, false);
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.internal.common.InboundTrafficController;
 import com.linecorp.armeria.internal.common.stream.AggregatingStreamMessage;
 
 import io.netty.channel.EventLoop;
@@ -245,19 +244,5 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     @Override
     public RequestHeaders headers() {
         return headers;
-    }
-
-    @Override
-    public StreamingDecodedHttpRequest toAbortedStreaming(
-            InboundTrafficController inboundTrafficController,
-            Throwable cause, boolean shouldResetOnlyIfRemoteIsOpen) {
-        final StreamingDecodedHttpRequest streamingDecodedHttpRequest = new StreamingDecodedHttpRequest(
-                eventLoop, id, streamId, headers, keepAlive,
-                inboundTrafficController, maxRequestLength, routingCtx,
-                exchangeType, requestStartTimeNanos, requestStartTimeMicros,
-                false, shouldResetOnlyIfRemoteIsOpen);
-        abort(cause);
-        streamingDecodedHttpRequest.abortResponse(cause, true);
-        return streamingDecodedHttpRequest;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -206,6 +206,18 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     }
 
     @Override
+    public void abort() {
+        super.abort();
+        aggregationFuture.complete(null);
+    }
+
+    @Override
+    public void abort(Throwable cause) {
+        super.abort(cause);
+        aggregationFuture.complete(null);
+    }
+
+    @Override
     public boolean isResponseAborted() {
         return abortResponseCause != null;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -141,17 +141,6 @@ interface DecodedHttpRequest extends HttpRequest {
     }
 
     /**
-     * Returns a new {@link StreamingDecodedHttpRequest} whose corresponding response is aborted using the
-     * specified {@link Throwable}. This is called when an {@link AggregatingDecodedHttpRequest}
-     * needs to be passed to a service before it's closed.
-     */
-    default StreamingDecodedHttpRequest toAbortedStreaming(
-            InboundTrafficController inboundTrafficController,
-            Throwable cause, boolean shouldResetOnlyIfRemoteIsOpen) {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Sets whether to send an RST_STREAM after the response sending response when the peer is open state.
      */
     default void setShouldResetOnlyIfRemoteIsOpen(boolean shouldResetOnlyIfRemoteIsOpen) {

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server;
 
+import java.util.concurrent.CompletableFuture;
+
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -73,8 +75,6 @@ interface DecodedHttpRequest extends HttpRequest {
 
     void init(ServiceRequestContext ctx);
 
-    boolean isInitialized();
-
     RoutingContext routingContext();
 
     /**
@@ -106,11 +106,14 @@ interface DecodedHttpRequest extends HttpRequest {
      * Tells whether {@link #abortResponse(Throwable, boolean)} was called or not.
      */
     boolean isResponseAborted();
-
     /**
-     * Returns whether the request should be fully aggregated before passed to the {@link HttpServerHandler}.
+     * Returns a {@link CompletableFuture} that is completed the request is fully aggregated.
+     * {@code null} if the request does not need to be aggregated.
      */
-    boolean needsAggregation();
+    @Nullable
+    default CompletableFuture<Void> whenAggregated() {
+        return null;
+    }
 
     /**
      * Returns the {@link ExchangeType} that determines whether to stream an {@link HttpRequest} or

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -106,6 +106,7 @@ interface DecodedHttpRequest extends HttpRequest {
      * Tells whether {@link #abortResponse(Throwable, boolean)} was called or not.
      */
     boolean isResponseAborted();
+
     /**
      * Returns a {@link CompletableFuture} that is completed the request is fully aggregated.
      * {@code null} if the request does not need to be aggregated.

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -85,11 +85,6 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     }
 
     @Override
-    public boolean isInitialized() {
-        return ctx != null;
-    }
-
-    @Override
     public RoutingContext routingContext() {
         return routingContext;
     }
@@ -231,11 +226,6 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     @Override
     public boolean isResponseAborted() {
         return abortResponseCause != null;
-    }
-
-    @Override
-    public boolean needsAggregation() {
-        return false;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2RequestDecoder.java
@@ -207,10 +207,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             req = DecodedHttpRequest.of(endOfStream, eventLoop, id, streamId, headers, true,
                                         inboundTrafficController, routingCtx);
             requests.put(streamId, req);
-            // An aggregating request will be fired later after all objects are collected.
-            if (!req.needsAggregation()) {
-                ctx.fireChannelRead(req);
-            }
+            ctx.fireChannelRead(req);
         } else {
             if (!(req instanceof DecodedHttpRequestWriter)) {
                 // Silently ignore the following HEADERS Frames of non-DecodedHttpRequestWriter. The request
@@ -224,11 +221,6 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             try {
                 // Trailers is received. The decodedReq will be automatically closed.
                 decodedReq.write(trailers);
-                if (req.needsAggregation()) {
-                    assert !req.isInitialized();
-                    // An aggregated request can be fired now.
-                    ctx.fireChannelRead(req);
-                }
             } catch (Throwable t) {
                 decodedReq.close(t);
                 throw Http2Exception.streamError(streamId, INTERNAL_ERROR, t,
@@ -318,10 +310,6 @@ final class Http2RequestDecoder extends Http2EventAdapter {
             // Received an empty DATA frame
             if (endOfStream) {
                 req.close();
-                if (req.needsAggregation()) {
-                    assert !req.isInitialized();
-                    ctx.fireChannelRead(req);
-                }
             }
             return padding;
         }
@@ -344,26 +332,12 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
             final HttpStatusException httpStatusException =
                     HttpStatusException.of(HttpStatus.REQUEST_ENTITY_TOO_LARGE, cause);
-            if (!decodedReq.isInitialized()) {
-                assert decodedReq.needsAggregation();
-                final StreamingDecodedHttpRequest streamingReq =
-                        decodedReq.toAbortedStreaming(inboundTrafficController,
-                                                      httpStatusException, shouldReset);
-                requests.put(streamId, streamingReq);
-                ctx.fireChannelRead(streamingReq);
-            } else {
-                decodedReq.setShouldResetOnlyIfRemoteIsOpen(shouldReset);
-                decodedReq.abortResponse(httpStatusException, true);
-            }
+            decodedReq.setShouldResetOnlyIfRemoteIsOpen(shouldReset);
+            decodedReq.abortResponse(httpStatusException, true);
         } else if (decodedReq.isOpen()) {
             try {
                 // The decodedReq will be automatically closed if endOfStream is true.
                 decodedReq.write(HttpData.wrap(data.retain()).withEndOfStream(endOfStream));
-                if (endOfStream && decodedReq.needsAggregation()) {
-                    assert !decodedReq.isInitialized();
-                    // An aggregated request is now ready to be fired.
-                    ctx.fireChannelRead(decodedReq);
-                }
             } catch (Throwable t) {
                 decodedReq.close(t);
                 throw Http2Exception.streamError(streamId, INTERNAL_ERROR, t,
@@ -412,13 +386,7 @@ final class Http2RequestDecoder extends Http2EventAdapter {
 
         final ClosedStreamException cause =
                 new ClosedStreamException("received a RST_STREAM frame: " + Http2Error.valueOf(errorCode));
-        if (!req.isInitialized()) {
-            assert req.needsAggregation();
-            // Call fireChannelRead so that the cause is logged by LoggingService.
-            ctx.fireChannelRead(req.toAbortedStreaming(inboundTrafficController, cause, false));
-        } else {
-            req.abortResponse(cause, /* cancel */ true);
-        }
+        req.abortResponse(cause, /* cancel */ true);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -446,7 +446,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private static HttpResponse serve0(DecodedHttpRequest req, ServiceConfig serviceCfg, HttpService service,
-                                       DefaultServiceRequestContext reqCtx, EventLoop serviceEventLoop) {
+                                       DefaultServiceRequestContext reqCtx,
+                                       @Nullable EventLoop serviceEventLoop) {
         final CompletableFuture<Void> whenAggregated = req.whenAggregated();
         if (whenAggregated != null) {
             return HttpResponse.of(whenAggregated.thenApply(ignored -> {

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -82,11 +82,6 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     }
 
     @Override
-    public boolean isInitialized() {
-        return ctx != null;
-    }
-
-    @Override
     public RoutingContext routingContext() {
         return routingCtx;
     }
@@ -203,11 +198,6 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     @Override
     public boolean isResponseAborted() {
         return abortResponseCause != null;
-    }
-
-    @Override
-    public boolean needsAggregation() {
-        return false;
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class AggregatingRequestTimeoutTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.requestTimeoutMillis(100)
+              .service("/timeout/sync", new HttpService() {
+                  @Override
+                  public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      //
+                      return HttpResponse.of(200);
+                  }
+
+                  @Override
+                  public ExchangeType exchangeType(RoutingContext routingContext) {
+                      return ExchangeType.UNARY;
+                  }
+              })
+              .service("/timeout/async", new HttpService() {
+                  @Override
+                  public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                      return HttpResponse.of(req.aggregate().thenApply(agg -> {
+                          return HttpResponse.of(200);
+                      }));
+                  }
+
+                  @Override
+                  public ExchangeType exchangeType(RoutingContext routingContext) {
+                      return ExchangeType.UNARY;
+                  }
+              });
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    @ParameterizedTest
+    @CsvSource({ "H1C", "H2C", "HTTP" })
+    void synchronouslyHandleFailedRequest(SessionProtocol protocol) {
+        final HttpRequest request = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/timeout/sync"),
+                                                   StreamMessage.streaming()); // Do not send body.
+        // The service synchronously responds without aggregating the request body.
+        assertThat(WebClient.of(protocol, server.endpoint(protocol))
+                            .execute(request).aggregate().join().status())
+                .isSameAs(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "H1C", "H2C", "HTTP" })
+    void asynchronouslyHandleFailedRequest(SessionProtocol protocol) {
+        final HttpRequest request = HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/timeout/async"),
+                                                   StreamMessage.streaming()); // Do not send body.
+        // The service waits for the full request body and then responds.
+        assertThat(WebClient.of(protocol, server.endpoint(protocol))
+                            .execute(request).aggregate().join().status())
+                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
@@ -43,7 +43,6 @@ class AggregatingRequestTimeoutTest {
               .service("/timeout/sync", new HttpService() {
                   @Override
                   public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                      //
                       return HttpResponse.of(200);
                   }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ExceedingServiceMaxContentLengthTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ExceedingServiceMaxContentLengthTest.java
@@ -103,7 +103,9 @@ class ExceedingServiceMaxContentLengthTest {
             sb.service("/unary", new HttpService() {
                 @Override
                 public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-                    return HttpResponse.of("Hello, world!");
+                    return HttpResponse.of(req.aggregate().thenApply(agg -> {
+                        return HttpResponse.of("Hello, world!");
+                    }));
                 }
 
                 @Override

--- a/jetty/jetty11/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/jetty11/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -67,8 +67,11 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes;
+import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -228,8 +231,11 @@ public final class JettyService implements HttpService {
 
         req.aggregate().handle((aReq, cause) -> {
             if (cause != null) {
+                cause = Exceptions.peel(cause);
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
+                if (cause instanceof HttpStatusException || cause instanceof HttpResponseException) {
+                    res.close(cause);
+                } else if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
                     res.close();
                 }
                 return null;

--- a/jetty/jetty12/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/jetty12/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -66,8 +66,11 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.CompletionActions;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes;
+import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -209,8 +212,11 @@ public final class JettyService implements HttpService {
 
         req.aggregate().handle((aReq, cause) -> {
             if (cause != null) {
+                cause = Exceptions.peel(cause);
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
+                if (cause instanceof HttpStatusException || cause instanceof HttpResponseException) {
+                    res.close(cause);
+                } else if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
                     res.close();
                 }
                 return null;

--- a/jetty/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
+++ b/jetty/jetty9/src/main/java/com/linecorp/armeria/server/jetty/JettyService.java
@@ -64,7 +64,9 @@ import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.CompletionActions;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.server.servlet.ServletTlsAttributes;
+import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServerListenerAdapter;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -271,8 +273,11 @@ public final class JettyService implements HttpService {
 
         req.aggregate().handle((aReq, cause) -> {
             if (cause != null) {
+                cause = Exceptions.peel(cause);
                 logger.warn("{} Failed to aggregate a request:", ctx, cause);
-                if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
+                if (cause instanceof HttpStatusException || cause instanceof HttpResponseException) {
+                    res.close(cause);
+                } else if (res.tryWrite(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR))) {
                     res.close();
                 }
                 return null;

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -424,6 +424,10 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
         req.aggregate(AggregationOptions.usePooledObjects(ctx.alloc(), ctx.eventLoop()))
            .handle((aReq, cause) -> {
                if (cause != null) {
+                   cause = Exceptions.peel(cause);
+                   if (cause instanceof HttpStatusException) {
+                       return HttpResponse.ofFailure(cause);
+                   }
                    final HttpResponse errorRes;
                    if (ctx.config().verboseResponses()) {
                        errorRes = HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR,

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/server/thrift/THttpService.java
@@ -425,7 +425,7 @@ public final class THttpService extends DecoratingService<RpcRequest, RpcRespons
            .handle((aReq, cause) -> {
                if (cause != null) {
                    cause = Exceptions.peel(cause);
-                   if (cause instanceof HttpStatusException) {
+                   if (cause instanceof HttpStatusException || cause instanceof HttpResponseException) {
                        return HttpResponse.ofFailure(cause);
                    }
                    final HttpResponse errorRes;


### PR DESCRIPTION
Motivation:

If `ExchangeType` is `UNARY` or `RESPONSE_STREAMING` for a service, a timeout is scheduled after EOS is received. If it takes a long time to receive a full request body, the request will not end with 503 Service Unavailable even after the request timeout set by the user.

Modifications:

- Immediately fire a `DecodedHttpRequest` when request headers are received in `Http{1,2}RequestDecoder`
- `HttpServerHandler` uses `whenAggregated()` to wait for the unary request to be aggregated on behalf of `Http{1,2}RequestDecoder`
- Remove some methods specialized for `AggregatedDecodedHttpRequest` has been deleted

Result:

Unary and response streaming requests are now properly timed out if they fail to receive the body within the designated timeout period.
