### PR TITLE
Refactor messageContext initialization for enhanced scope availability in SamlAssertionConsumerFunction

### DIFF
--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
@@ -87,9 +87,10 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, AggregatedHttpRequest req,
                               String defaultHostname, SamlPortConfig portConfig) {
+        MessageContext<Response> messageContext = null;
+
         try {
             final SamlBindingProtocol bindingProtocol = cfg.endpoint().bindingProtocol();
-            final MessageContext<Response> messageContext;
             if (bindingProtocol == SamlBindingProtocol.HTTP_REDIRECT) {
                 messageContext = HttpRedirectBindingUtil.toSamlObject(req, SAML_RESPONSE,
                                                                       idpConfigs, defaultIdpConfig,
@@ -116,7 +117,7 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
 
             return ssoHandler.loginSucceeded(ctx, req, messageContext, sessionIndex, relayState);
         } catch (SamlException e) {
-            return ssoHandler.loginFailed(ctx, req, null, e);
+            return ssoHandler.loginFailed(ctx, req, messageContext, e);
         }
     }
 

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -294,7 +294,6 @@ class SamlServiceProviderTest {
         @Override
         public HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpRequest req,
                                         @Nullable MessageContext<Response> message, Throwable cause) {
-            System.err.println("message: " + message);
             messageContextHolder.set(message);
             // Handle as an error so that a test client can detect the failure.
             return HttpResponse.of(HttpStatus.BAD_REQUEST);

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -45,12 +45,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.joda.time.DateTime;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.opensaml.core.criterion.EntityIdCriterion;
@@ -114,6 +116,9 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 @GenerateNativeImageTrace
 class SamlServiceProviderTest {
+
+    private static final AtomicReference<MessageContext<Response>> messageContextHolder =
+            new AtomicReference<>();
 
     private static final String signatureAlgorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA;
 
@@ -289,6 +294,8 @@ class SamlServiceProviderTest {
         @Override
         public HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpRequest req,
                                         @Nullable MessageContext<Response> message, Throwable cause) {
+            System.err.println("message: " + message);
+            messageContextHolder.set(message);
             // Handle as an error so that a test client can detect the failure.
             return HttpResponse.of(HttpStatus.BAD_REQUEST);
         }
@@ -314,6 +321,11 @@ class SamlServiceProviderTest {
     }
 
     final WebClient client = WebClient.of(server.httpUri());
+
+    @BeforeEach
+    void setup() {
+        messageContextHolder.set(null);
+    }
 
     @Test
     void shouldRespondAuthnRequest_HttpRedirect() throws Exception {
@@ -436,6 +448,8 @@ class SamlServiceProviderTest {
     @Test
     void shouldNotConsumeAssertionWithoutSignature_HttpPost() throws Exception {
         shouldNotConsumeAssertion_HttpPost(null);
+        final MessageContext<Response> messageContext = messageContextHolder.get();
+        assertThat(messageContext.getMessage().getSignature()).isNull();
     }
 
     @Test

--- a/site/src/pages/docs/advanced-saml.mdx
+++ b/site/src/pages/docs/advanced-saml.mdx
@@ -56,14 +56,14 @@ attach it to your <type://Server>.
 ```java
 // Specify information about your keystore.
 // The keystore contains two key pairs, which are identified as 'signing' and 'encryption'.
-KeyStoreCredentialResolver credentialResolver =
+CredentialResolver credentialResolver =
         new KeyStoreCredentialResolverBuilder(ClassLoader.getSystemClassLoader(),
                                               "sample.jks")
                 .type("PKCS12")
                 .password("N5^X[hvG")
                 // You need to specify your key pair and its password here.
-                .addKeyPassword("signing", "N5^X[hvG")
-                .addKeyPassword("encryption", "N5^X[hvG")
+                .keyPassword("signing", "N5^X[hvG")
+                .keyPassword("encryption", "N5^X[hvG")
                 .build();
 
 SamlServiceProvider ssp =


### PR DESCRIPTION
Motivation:

This PR addresses a code enhancement in the SamlAssertionConsumerFunction by initializing the messageContext variable at the beginning of the method. This change is intended to streamline the assignment and handling of messageContext, ensuring that it can be consistently used throughout the method, particularly in exception handling scenarios.

Modifications:

Declared messageContext at the method start to allow its use across the entire method scope, including within try and catch blocks.

Result:

- Closes #5401 
- The refactor ensures messageContext is available for error handling.