### PR TITLE
[Issue-5581] Change into transitive dependency(netty.transport.native.unix.common)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -112,12 +112,12 @@ dependencies {
 
     // Netty native libraries
     ['linux-x86_64', 'linux-aarch_64'].each { arch ->
-        implementation(variantOf(libs.netty.transport.native.unix.common) { classifier(arch) })
+        api(variantOf(libs.netty.transport.native.unix.common) { classifier(arch) })
         implementation(variantOf(libs.netty.transport.native.epoll) { classifier(arch) })
         optionalImplementation(variantOf(libs.netty.io.uring) { classifier(arch) })
     }
     ['osx-x86_64', 'osx-aarch_64'].each { arch ->
-        implementation(variantOf(libs.netty.transport.native.unix.common) { classifier(arch) })
+        api(variantOf(libs.netty.transport.native.unix.common) { classifier(arch) })
         implementation(variantOf(libs.netty.transport.native.kqueue) { classifier(arch) })
         implementation(variantOf(libs.netty.resolver.dns.native.macos) { classifier(arch) })
     }


### PR DESCRIPTION
Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

From issue #5581, the class is exposed in the public API.
> Class io.netty.channel.unix.DomainSocketAddress is used as public method parameter in core/src/main/java/com/linecorp/armeria/common/util/DomainSocketAddress.java

Result:

- Closes #5581. (If this resolves the issue.)
- User can use [core] com.linecorp.armeria.common.util.DomainSocketAddress#asNettyAddress without adding dependency

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
