### PR TITLE
[Issue-5578] make ContentTooLargeException extend HttpStatusException

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ContentTooLargeException.java
@@ -18,11 +18,12 @@ package com.linecorp.armeria.common;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
+import com.linecorp.armeria.server.HttpStatusException;
 
 /**
  * A {@link RuntimeException} raised when the length of request or response content exceeds its limit.
  */
-public final class ContentTooLargeException extends RuntimeException {
+public final class ContentTooLargeException extends HttpStatusException {
 
     private static final long serialVersionUID = 4901614315474105954L;
 
@@ -56,7 +57,7 @@ public final class ContentTooLargeException extends RuntimeException {
     }
 
     private ContentTooLargeException(boolean neverSample) {
-        super(null, null, !neverSample, !neverSample);
+        super(HttpStatus.REQUEST_ENTITY_TOO_LARGE, !neverSample, null);
 
         this.neverSample = neverSample;
         maxContentLength = -1;
@@ -66,7 +67,8 @@ public final class ContentTooLargeException extends RuntimeException {
 
     ContentTooLargeException(long maxContentLength, long contentLength, long transferred,
                              @Nullable Throwable cause) {
-        super(toString(maxContentLength, contentLength, transferred), cause);
+        super(HttpStatus.REQUEST_ENTITY_TOO_LARGE,
+              toString(maxContentLength, contentLength, transferred), cause);
 
         neverSample = false;
         this.transferred = transferred;

--- a/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpStatusException.java
@@ -59,7 +59,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
  *
  * @see HttpResponseException
  */
-public final class HttpStatusException extends RuntimeException {
+public class HttpStatusException extends RuntimeException {
 
     private static final HttpStatusException[] EXCEPTIONS = new HttpStatusException[1000];
 
@@ -120,9 +120,17 @@ public final class HttpStatusException extends RuntimeException {
     /**
      * Creates a new instance.
      */
-    private HttpStatusException(HttpStatus httpStatus, boolean withStackTrace, @Nullable Throwable cause) {
+    protected HttpStatusException(HttpStatus httpStatus, boolean withStackTrace, @Nullable Throwable cause) {
         super(requireNonNull(httpStatus, "httpStatus").toString(), cause, withStackTrace, withStackTrace);
         this.httpStatus = httpStatus;
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected HttpStatusException(HttpStatus httpStatus, @Nullable String message, @Nullable Throwable cause) {
+        super(message == null ? requireNonNull(httpStatus, "httpStatus").toString() : message, cause);
+        this.httpStatus = requireNonNull(httpStatus, "httpStatus");
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/common/ContentTooLargeExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/ContentTooLargeExceptionTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.server.HttpStatusException;
+
+class ContentTooLargeExceptionTest {
+    @Test
+    void instanceOfHttpStatusException() {
+
+        final ContentTooLargeException cause = ContentTooLargeException.get();
+        assertInstanceOf(HttpStatusException.class, cause);
+        assertEquals(HttpStatus.REQUEST_ENTITY_TOO_LARGE, cause.httpStatus());
+    }
+}


### PR DESCRIPTION
Motivation:

Make `ContentTooLargeException` extend `HttpStatusException`
Issue #5578

Modifications:

- Make HttpStatusException not final class
- Make ContentTooLargeException extend HttpStatusException

Result:

- Closes #5578. (If this resolves the issue.)
- User can handle `ContentTooLargeException` by `HttpStatusException`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
