### PR TITLE
Add /info URL to provide information about server application

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import com.linecorp.armeria.server.management.AppInfo;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
@@ -121,6 +122,9 @@ final class DefaultServerConfig implements ServerConfig {
     private final Mapping<String, SslContext> sslContexts;
 
     @Nullable
+    private final AppInfo appInfo;
+
+    @Nullable
     private String strVal;
 
     DefaultServerConfig(
@@ -151,7 +155,8 @@ final class DefaultServerConfig implements ServerConfig {
             DependencyInjector dependencyInjector,
             Function<? super String, String> absoluteUriTransformer,
             long unhandledExceptionsReportIntervalMillis,
-            List<ShutdownSupport> shutdownSupports) {
+            List<ShutdownSupport> shutdownSupports,
+            AppInfo appInfo) {
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
         requireNonNull(virtualHosts, "virtualHosts");
@@ -271,6 +276,7 @@ final class DefaultServerConfig implements ServerConfig {
         this.absoluteUriTransformer = castAbsoluteUriTransformer;
         this.unhandledExceptionsReportIntervalMillis = unhandledExceptionsReportIntervalMillis;
         this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
+        this.appInfo = appInfo;
     }
 
     private static Int2ObjectMap<Mapping<String, VirtualHost>> buildDomainAndPortMapping(
@@ -674,6 +680,12 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public long unhandledExceptionsReportIntervalMillis() {
         return unhandledExceptionsReportIntervalMillis;
+    }
+
+    @Override
+    @Nullable
+    public AppInfo appInfo() {
+        return appInfo;
     }
 
     List<ShutdownSupport> shutdownSupports() {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -104,6 +104,7 @@ import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.server.management.AppInfo;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelHandler;
@@ -237,6 +238,8 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     private final List<ShutdownSupport> shutdownSupports = new ArrayList<>();
     private int http2MaxResetFramesPerWindow = Flags.defaultServerHttp2MaxResetFramesPerMinute();
     private int http2MaxResetFramesWindowSeconds = 60;
+    @Nullable
+    private AppInfo appInfo;
 
     ServerBuilder() {
         // Set the default host-level properties.
@@ -452,6 +455,12 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
             port(new ServerPort(new InetSocketAddress(NetUtil.LOCALHOST6, port), protocols, portGroup));
         }
 
+        return this;
+    }
+
+    public ServerBuilder setAppInfo(AppInfo appInfo) {
+        requireNonNull(appInfo, "appInfo");
+        this.appInfo = appInfo;
         return this;
     }
 
@@ -2182,6 +2191,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
         final Mapping<String, SslContext> sslContexts;
         final SslContext defaultSslContext = findDefaultSslContext(defaultVirtualHost, virtualHosts);
         final Collection<ServerPort> ports;
+        final AppInfo appInfo = this.appInfo;
 
         for (ServerPort port : this.ports) {
             checkState(port.protocols().stream().anyMatch(p -> p != PROXY),
@@ -2283,7 +2293,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
                 clientAddressSources, clientAddressTrustedProxyFilter, clientAddressFilter, clientAddressMapper,
                 enableServerHeader, enableDateHeader, errorHandler, sslContexts,
                 http1HeaderNaming, dependencyInjector, absoluteUriTransformer,
-                unhandledExceptionsReportIntervalMillis, ImmutableList.copyOf(shutdownSupports));
+                unhandledExceptionsReportIntervalMillis, ImmutableList.copyOf(shutdownSupports), appInfo);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -105,6 +105,7 @@ import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.server.management.AppInfo;
+import com.linecorp.armeria.server.management.ManagementService;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelHandler;
@@ -458,6 +459,15 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
         return this;
     }
 
+    /**
+     * Adds the specified {@link AppInfo} that represents information about a deployed application via
+     * {@link ManagementService}.
+     * <pre>{@code
+     * ServerBuilder sb = Server.builder();
+     * sb.setAppInfo(new AppInfo("1.0.0", "name", "description"));
+     * }
+     * </pre>
+     */
     public ServerBuilder setAppInfo(AppInfo appInfo) {
         requireNonNull(appInfo, "appInfo");
         this.appInfo = appInfo;

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -30,8 +30,10 @@ import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import com.linecorp.armeria.server.management.AppInfo;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
@@ -339,4 +341,7 @@ public interface ServerConfig {
      * Returns the interval between reporting unhandled exceptions in milliseconds.
      */
     long unhandledExceptionsReportIntervalMillis();
+
+    @Nullable
+    AppInfo appInfo();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -342,6 +342,9 @@ public interface ServerConfig {
      */
     long unhandledExceptionsReportIntervalMillis();
 
+    /**
+     * Returns the {@link AppInfo} that represents application information.
+     */
     @Nullable
     AppInfo appInfo();
 }

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import com.linecorp.armeria.server.management.AppInfo;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
@@ -313,6 +314,11 @@ final class UpdatableServerConfig implements ServerConfig {
     @Override
     public long unhandledExceptionsReportIntervalMillis() {
         return delegate.unhandledExceptionsReportIntervalMillis();
+    }
+
+    @Override
+    public AppInfo appInfo() {
+        return delegate.appInfo();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/management/AppInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/management/AppInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server.management;
+
+public class AppInfo {
+    String version;
+    String name;
+    String description;
+
+    public AppInfo(String version, String name, String description) {
+        this.version = version;
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/management/AppInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/management/AppInfo.java
@@ -16,11 +16,24 @@
 
 package com.linecorp.armeria.server.management;
 
-public class AppInfo {
-    String version;
-    String name;
-    String description;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServerBuilder;
 
+/**
+ * A class that represents application information, which can be configured through
+ * {@link ServerBuilder#setAppInfo(AppInfo)}.
+ */
+public class AppInfo {
+    @Nullable final String version;
+    @Nullable final String name;
+    @Nullable final String description;
+
+    /**
+     * Creates a new {@link AppInfo} that holds information about an application.
+     * @param version A version of an application e.g. "1.0.0"
+     * @param name A name of an application
+     * @param description A description of application
+     */
     public AppInfo(String version, String name, String description) {
         this.version = version;
         this.name = name;

--- a/core/src/main/java/com/linecorp/armeria/server/management/AppInfoService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/management/AppInfoService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.armeria.server.management;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Version;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+public enum AppInfoService implements HttpService {
+
+    INSTANCE;
+
+    @Nullable
+    private AppInfo appInfo;
+
+    public static AppInfoService of() {
+        return INSTANCE;
+    }
+
+    void setAppInfo(@Nullable AppInfo appInfo) {
+        this.appInfo = appInfo;
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        final Version versionInfo = Version.get("armeria", Server.class.getClassLoader());
+
+        final ImmutableMap<String, ImmutableMap<String, String>> appInfoMap;
+        if (appInfo != null) {
+            appInfoMap = ImmutableMap.of(
+                    "app", ImmutableMap.of(
+                            "version", appInfo.version,
+                            "name", appInfo.name,
+                            "description", appInfo.description
+                    )
+            );
+        } else {
+            appInfoMap = ImmutableMap.of();
+        }
+
+        final ImmutableMap<String, ImmutableMap<String, String>> armeriaInfoMap = ImmutableMap.of(
+                "armeria", ImmutableMap.of(
+                        "version", versionInfo.artifactVersion(),
+                        "commit", versionInfo.longCommitHash(),
+                        "repositoryStatus", versionInfo.repositoryStatus()
+                )
+        );
+
+        final ImmutableMap<Object, Object> infoMap = ImmutableMap.builder()
+                                                                 .putAll(appInfoMap)
+                                                                 .putAll(armeriaInfoMap)
+                                                                 .build();
+        return HttpResponse.ofJson(infoMap);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/management/AppInfoService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/management/AppInfoService.java
@@ -26,16 +26,18 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
+/**
+ * An {@link HttpService} that provides additional information about configured server.
+ * This functionality is can be used by binding {@link ManagementService}
+ * It provides information about not only deployed application information, which can be specified by user,
+ * but also one about Armeria artifact itself.
+ */
 public enum AppInfoService implements HttpService {
 
     INSTANCE;
 
     @Nullable
     private AppInfo appInfo;
-
-    public static AppInfoService of() {
-        return INSTANCE;
-    }
 
     void setAppInfo(@Nullable AppInfo appInfo) {
         this.appInfo = appInfo;

--- a/core/src/test/java/com/linecorp/armeria/server/management/ManagementServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/management/ManagementServiceTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.linecorp.armeria.client.WebClient;
@@ -43,6 +45,9 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class ManagementServiceTest {
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final AppInfo TEST_APP_INFO = new AppInfo(
+            "1.0.0", "test-app-name", "test-app-description"
+    );
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -50,6 +55,7 @@ class ManagementServiceTest {
         protected void configure(ServerBuilder sb) {
             sb.requestTimeout(Duration.ofSeconds(45)); // Heap dump can take time.
             sb.serviceUnder("/internal/management", ManagementService.of());
+            sb.setAppInfo(TEST_APP_INFO);
         }
     };
 
@@ -102,5 +108,23 @@ class ManagementServiceTest {
 
         // Make sure that the returned file has a valid hprof format
         assertThat(Arrays.copyOf(actual, fileHeader.length)).isEqualTo(fileHeader);
+    }
+
+    @Test
+    void appInfo() throws JsonProcessingException {
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .build();
+
+        final AggregatedHttpResponse response = client.get("/internal/management/info").aggregate().join();
+        final String content = response.contentUtf8();
+        final JsonNode jsonNode = mapper.readTree(content).path("app");
+
+        final String actualVersion = jsonNode.path("version").textValue();
+        final String actualName = jsonNode.path("name").textValue();
+        final String actualDescription = jsonNode.path("description").textValue();
+
+        assertThat(actualVersion).isEqualTo(TEST_APP_INFO.version);
+        assertThat(actualName).isEqualTo(TEST_APP_INFO.name);
+        assertThat(actualDescription).isEqualTo(TEST_APP_INFO.description);
     }
 }


### PR DESCRIPTION
Motivation:

Please refer https://github.com/line/armeria/issues/5605 for motivation.
If it's required to provide more information about this PR, please let me know, then I'll supplement it 🙇 

Modifications:

- Implement `AppInfo` class that represents additional information about deployed application.
- Implement `AppInfoService` as one of `HttpService` that serves information about deployed application itself, as well as one about Armeria artifact itself.
- Add a new branch `/info` for `ManagementService` so that requests is routed to `AppInfoService`
- Make `AppInfo` as one of property of `ServerConfig`
- Add `setAppInfo` API in `ServerBuilder` so user can specify `AppInfo` when they configure Armeria server

Result:

- Closes #5605 (If this resolves the issue.)
- User can specify information about their application, which can be exposed to via /info URL of `ManagementService`
