### PR TITLE
Make AnnotatedService public

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -32,7 +32,11 @@ public final class ServiceNamingUtil {
                 continue;
             }
             if (delegate instanceof AnnotatedService) {
-                return ((AnnotatedService) delegate).name();
+                final AnnotatedService annotatedService = (AnnotatedService) delegate;
+                if (annotatedService.name() != null) {
+                    return annotatedService.name();
+                }
+                return annotatedService.serviceClass().getName();
             } else {
                 return delegate.getClass().getName();
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -32,7 +32,7 @@ public final class ServiceNamingUtil {
                 continue;
             }
             if (delegate instanceof AnnotatedService) {
-                return ((AnnotatedService) delegate).serviceName();
+                return ((AnnotatedService) delegate).name();
             } else {
                 return delegate.getClass().getName();
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -16,8 +16,8 @@
 package com.linecorp.armeria.internal.common.util;
 
 import com.linecorp.armeria.common.util.Unwrappable;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 
 public final class ServiceNamingUtil {
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ServiceNamingUtil.java
@@ -33,8 +33,9 @@ public final class ServiceNamingUtil {
             }
             if (delegate instanceof AnnotatedService) {
                 final AnnotatedService annotatedService = (AnnotatedService) delegate;
-                if (annotatedService.name() != null) {
-                    return annotatedService.name();
+                final String serviceName = annotatedService.name();
+                if (serviceName != null) {
+                    return serviceName;
                 }
                 return annotatedService.serviceClass().getName();
             } else {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -143,7 +143,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
         final Map<Class<?>, DescriptionInfo> serviceDescription = new HashMap<>();
         serviceConfigs.forEach(sc -> {
-            final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
+            final AnnotatedService service = sc.service().as(AnnotatedService.class);
             if (service != null) {
                 final Class<?> serviceClass = service.serviceClass();
                 final String className = serviceClass.getName();

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -145,7 +145,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         serviceConfigs.forEach(sc -> {
             final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
             if (service != null) {
-                final Class<?> serviceClass = ClassUtil.getUserClass(service.serviceObject().getClass());
+                final Class<?> serviceClass = service.serviceClass();
                 final String className = serviceClass.getName();
                 final String methodName = service.methodName();
                 if (!filter.test(name(), className, methodName)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -165,9 +165,10 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     }
 
     private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos,
-                                      String hostnamePattern, DefaultAnnotatedService service,
+                                      String hostnamePattern, AnnotatedService service0,
                                       Class<?> serviceClass) {
 
+        final DefaultAnnotatedService service = service0.as(DefaultAnnotatedService.class);
         final Route route = service.route();
         final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
         final Method method = service.method();

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -147,7 +147,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
             if (service != null) {
                 final Class<?> serviceClass = ClassUtil.getUserClass(service.serviceObject().getClass());
                 final String className = serviceClass.getName();
-                final String methodName = service.method().getName();
+                final String methodName = service.methodName();
                 if (!filter.test(name(), className, methodName)) {
                     return;
                 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -143,7 +143,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
         final Map<Class<?>, DescriptionInfo> serviceDescription = new HashMap<>();
         serviceConfigs.forEach(sc -> {
-            final AnnotatedService service = sc.service().as(AnnotatedService.class);
+            final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
             if (service != null) {
                 final Class<?> serviceClass = ClassUtil.getUserClass(service.serviceObject().getClass());
                 final String className = serviceClass.getName();
@@ -165,15 +165,15 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     }
 
     private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos,
-                                      String hostnamePattern, AnnotatedService service,
+                                      String hostnamePattern, DefaultAnnotatedService service,
                                       Class<?> serviceClass) {
+
         final Route route = service.route();
         final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
         final Method method = service.method();
         final int overloadId = service.overloadId();
         final TypeSignature returnTypeSignature = getReturnTypeSignature(method);
-        final List<FieldInfo> fieldInfos = fieldInfos(service.as(DefaultAnnotatedService.class)
-                                                             .annotatedValueResolvers());
+        final List<FieldInfo> fieldInfos = fieldInfos(service.annotatedValueResolvers());
         route.methods().forEach(
                 httpMethod -> {
                     final MethodInfo methodInfo = new MethodInfo(

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -143,7 +143,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
         final Map<Class<?>, DescriptionInfo> serviceDescription = new HashMap<>();
         serviceConfigs.forEach(sc -> {
-            final AnnotatedService service = sc.service().as(AnnotatedService.class);
+            final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
             if (service != null) {
                 final Class<?> serviceClass = service.serviceClass();
                 final String className = serviceClass.getName();
@@ -165,10 +165,9 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     }
 
     private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos,
-                                      String hostnamePattern, AnnotatedService service0,
+                                      String hostnamePattern, DefaultAnnotatedService service,
                                       Class<?> serviceClass) {
 
-        final DefaultAnnotatedService service = service0.as(DefaultAnnotatedService.class);
         final Route route = service.route();
         final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
         final Method method = service.method();

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -62,6 +62,7 @@ import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.RoutePathType;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.Header;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.RequestObject;
@@ -144,7 +145,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         serviceConfigs.forEach(sc -> {
             final AnnotatedService service = sc.service().as(AnnotatedService.class);
             if (service != null) {
-                final Class<?> serviceClass = ClassUtil.getUserClass(service.object().getClass());
+                final Class<?> serviceClass = ClassUtil.getUserClass(service.serviceObject().getClass());
                 final String className = serviceClass.getName();
                 final String methodName = service.method().getName();
                 if (!filter.test(name(), className, methodName)) {
@@ -171,7 +172,8 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         final Method method = service.method();
         final int overloadId = service.overloadId();
         final TypeSignature returnTypeSignature = getReturnTypeSignature(method);
-        final List<FieldInfo> fieldInfos = fieldInfos(service.annotatedValueResolvers());
+        final List<FieldInfo> fieldInfos = fieldInfos(service.as(DefaultAnnotatedService.class)
+                                                             .annotatedValueResolvers());
         route.methods().forEach(
                 httpMethod -> {
                     final MethodInfo methodInfo = new MethodInfo(

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceElement.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceElement.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 
 /**
  * Details of an annotated HTTP service method.
@@ -78,7 +79,8 @@ public final class AnnotatedServiceElement {
         HttpService decoratedService = decorator.apply(service);
         // Apply localDecorator passed in through method parameter
         decoratedService = decoratedService.decorate(localDecorator);
-        return service.withExceptionHandler(decoratedService);
+        return service.as(DefaultAnnotatedService.class)
+                      .withExceptionHandler(decoratedService);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceElement.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceElement.java
@@ -33,12 +33,12 @@ public final class AnnotatedServiceElement {
 
     private final Route route;
 
-    private final AnnotatedService service;
+    private final DefaultAnnotatedService service;
 
     private final Function<? super HttpService, ? extends HttpService> decorator;
 
     AnnotatedServiceElement(Route route,
-                            AnnotatedService service,
+                            DefaultAnnotatedService service,
                             Function<? super HttpService, ? extends HttpService> decorator) {
         this.route = requireNonNull(route, "route");
         this.service = requireNonNull(service, "service");
@@ -79,8 +79,7 @@ public final class AnnotatedServiceElement {
         HttpService decoratedService = decorator.apply(service);
         // Apply localDecorator passed in through method parameter
         decoratedService = decoratedService.decorate(localDecorator);
-        return service.as(DefaultAnnotatedService.class)
-                      .withExceptionHandler(decoratedService);
+        return service.withExceptionHandler(decoratedService);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -291,8 +291,10 @@ public final class AnnotatedServiceFactory {
                                                queryDelimiter);
             return new AnnotatedServiceElement(
                     route,
-                    new AnnotatedService(object, method, overloadId, resolvers, eh, res, route, defaultStatus,
-                                         responseHeaders, responseTrailers, needToUseBlockingTaskExecutor),
+                    new DefaultAnnotatedService(object, method, overloadId,
+                                                resolvers, eh, res, route, defaultStatus,
+                                                responseHeaders, responseTrailers,
+                                                needToUseBlockingTaskExecutor),
                     decorator(method, clazz, dependencyInjector));
         }).collect(toImmutableList());
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceFactory.java
@@ -80,6 +80,7 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.annotation.AdditionalHeader;
 import com.linecorp.armeria.server.annotation.AdditionalTrailer;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.Blocking;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Decorator;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -84,6 +84,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.server.FileAggregatedMultipart;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedBeanFactoryRegistry.BeanFactoryId;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.ByteArrayRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Delimiter;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -110,7 +110,6 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     private final boolean useBlockingTaskExecutor;
     @Nullable
     private String name;
-    private final boolean serviceNameSetByAnnotation;
 
     DefaultAnnotatedService(Object object, Method method,
                             int overloadId, List<AnnotatedValueResolver> resolvers,
@@ -170,9 +169,6 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         }
         if (serviceName != null) {
             this.name = serviceName.value();
-            serviceNameSetByAnnotation = true;
-        } else {
-            serviceNameSetByAnnotation = false;
         }
 
         this.method.setAccessible(true);
@@ -225,14 +221,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
 
     @Override
     public String name() {
-        if (name == null) {
-            return serviceClass().getName();
-        }
         return name;
-    }
-
-    public boolean serviceNameSetByAnnotation() {
-        return serviceNameSetByAnnotation;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -124,7 +124,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         this.method = requireNonNull(method, "method");
         checkArgument(overloadId >= 0, "overloadId: %s (expected: >= 0)", overloadId);
         this.overloadId = overloadId;
-        this.serviceClass = ClassUtil.getUserClass(object.getClass());
+        serviceClass = ClassUtil.getUserClass(object.getClass());
 
         checkArgument(!method.isVarArgs(), "%s#%s declared to take a variable number of arguments",
                       method.getDeclaringClass().getSimpleName(), method.getName());
@@ -168,9 +168,9 @@ public final class DefaultAnnotatedService implements AnnotatedService {
             serviceName = AnnotationUtil.findFirst(object.getClass(), ServiceName.class);
         }
         if (serviceName != null) {
-            this.name = serviceName.value();
+            name = serviceName.value();
         } else {
-            this.name = null;
+            name = null;
         }
 
         this.method.setAccessible(true);
@@ -241,7 +241,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         return method;
     }
 
-    public int overloadId() {
+    int overloadId() {
         return overloadId;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -109,7 +109,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     private final ResponseType responseType;
     private final boolean useBlockingTaskExecutor;
     @Nullable
-    private String serviceName;
+    private String name;
     private final boolean serviceNameSetByAnnotation;
 
     DefaultAnnotatedService(Object object, Method method,
@@ -169,7 +169,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
             serviceName = AnnotationUtil.findFirst(object.getClass(), ServiceName.class);
         }
         if (serviceName != null) {
-            this.serviceName = serviceName.value();
+            this.name = serviceName.value();
             serviceNameSetByAnnotation = true;
         } else {
             serviceNameSetByAnnotation = false;
@@ -225,10 +225,10 @@ public final class DefaultAnnotatedService implements AnnotatedService {
 
     @Override
     public String name() {
-        if (serviceName == null) {
+        if (name == null) {
             return serviceClass().getName();
         }
-        return serviceName;
+        return name;
     }
 
     public boolean serviceNameSetByAnnotation() {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -239,10 +239,6 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         return method;
     }
 
-    @Override
-    public String methodName() {
-        return method.getName();
-    }
 
     public int overloadId() {
         return overloadId;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -233,7 +233,7 @@ final class DefaultAnnotatedService implements AnnotatedService {
 
     @Override
     public Class<?> serviceClass() {
-        return this.serviceClass;
+        return serviceClass;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -86,6 +86,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
             NO_AGGREGATION_FUTURE = UnmodifiableFuture.completedFuture(AggregatedResult.EMPTY);
 
     private final Object object;
+    private final Class<?> serviceClass;
     private final Method method;
     private final int overloadId;
     private final MethodHandle methodHandle;
@@ -124,6 +125,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         this.method = requireNonNull(method, "method");
         checkArgument(overloadId >= 0, "overloadId: %s (expected: >= 0)", overloadId);
         this.overloadId = overloadId;
+        this.serviceClass = ClassUtil.getUserClass(object.getClass());
 
         checkArgument(!method.isVarArgs(), "%s#%s declared to take a variable number of arguments",
                       method.getDeclaringClass().getSimpleName(), method.getName());
@@ -221,7 +223,8 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         }
     }
 
-    public String serviceName() {
+    @Override
+    public String name() {
         if (serviceName == null) {
             return serviceClass().getName();
         }
@@ -233,18 +236,13 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     }
 
     @Override
-    public String methodName() {
-        return method.getName();
-    }
-
-    @Override
     public Object serviceObject() {
         return object;
     }
 
     @Override
     public Class<?> serviceClass() {
-        return ClassUtil.getUserClass(object.getClass());
+        return this.serviceClass;
     }
 
     @Override
@@ -253,6 +251,10 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     }
 
     @Override
+    public String methodName() {
+        return method.getName();
+    }
+
     public int overloadId() {
         return overloadId;
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -77,7 +77,7 @@ import com.linecorp.armeria.server.annotation.ServiceName;
  * This class is not supposed to be instantiated by a user. Please check out the documentation
  * <a href="https://armeria.dev/docs/server-annotated-service">Annotated HTTP Service</a> to use this.
  */
-public final class DefaultAnnotatedService implements AnnotatedService {
+final class DefaultAnnotatedService implements AnnotatedService {
     private static final Logger logger = LoggerFactory.getLogger(DefaultAnnotatedService.class);
 
     private static final MethodHandles.Lookup lookup = MethodHandles.lookup();

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -109,7 +109,7 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     private final ResponseType responseType;
     private final boolean useBlockingTaskExecutor;
     @Nullable
-    private String name;
+    private final String name;
 
     DefaultAnnotatedService(Object object, Method method,
                             int overloadId, List<AnnotatedValueResolver> resolvers,
@@ -169,6 +169,8 @@ public final class DefaultAnnotatedService implements AnnotatedService {
         }
         if (serviceName != null) {
             this.name = serviceName.value();
+        } else {
+            this.name = null;
         }
 
         this.method.setAccessible(true);
@@ -238,7 +240,6 @@ public final class DefaultAnnotatedService implements AnnotatedService {
     public Method method() {
         return method;
     }
-
 
     public int overloadId() {
         return overloadId;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/HttpResultUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/HttpResultUtil.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.HttpResult;
 
 final class HttpResultUtil {

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathAnnotatedServiceConfigSetters.java
@@ -27,7 +27,7 @@ import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
@@ -33,7 +33,7 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 
 /**
  * The default {@link ServerErrorHandler} that is used when a user didn't specify one.

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -338,7 +338,7 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         } else {
             // Set the default service name only when the service name is set using @ServiceName.
             // If it's not, the global defaultServiceNaming is used.
-            if (annotatedService != null && annotatedService.serviceNameSetByAnnotation()) {
+            if (annotatedService != null && annotatedService.name() != null) {
                 serviceConfigBuilder.defaultServiceName(annotatedService.name());
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -338,8 +338,13 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         } else {
             // Set the default service name only when the service name is set using @ServiceName.
             // If it's not, the global defaultServiceNaming is used.
-            if (annotatedService != null && annotatedService.name() != null) {
-                serviceConfigBuilder.defaultServiceName(annotatedService.name());
+            if (annotatedService != null) {
+                final String serivceName = annotatedService.name();
+                if (serviceName != null) {
+                   
+ serviceConfigBuilder.defaultServiceName(serviceName);
+                }
+            }
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -324,7 +324,7 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         final ServiceConfigBuilder serviceConfigBuilder =
                 new ServiceConfigBuilder(route, contextPath, service);
 
-        final DefaultAnnotatedService annotatedService;
+        final AnnotatedService annotatedService;
         if (defaultServiceNaming == null || defaultLogName == null) {
             annotatedService = service.as(AnnotatedService.class);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -42,7 +42,7 @@ import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.EventLoopGroups;
-import com.linecorp.armeria.internal.server.annotation.DefaultAnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.netty.channel.EventLoopGroup;

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -326,7 +326,7 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
 
         final DefaultAnnotatedService annotatedService;
         if (defaultServiceNaming == null || defaultLogName == null) {
-            annotatedService = service.as(DefaultAnnotatedService.class);
+            annotatedService = service.as(AnnotatedService.class);
         } else {
             annotatedService = null;
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -42,7 +42,8 @@ import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.EventLoopGroups;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.internal.server.annotation.DefaultAnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.netty.channel.EventLoopGroup;
@@ -338,7 +339,8 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         } else {
             // Set the default service name only when the service name is set using @ServiceName.
             // If it's not, the global defaultServiceNaming is used.
-            if (annotatedService != null && annotatedService.serviceNameSetByAnnotation()) {
+            if (annotatedService != null && annotatedService.as(DefaultAnnotatedService.class)
+                                                            .serviceNameSetByAnnotation()) {
                 serviceConfigBuilder.defaultServiceName(annotatedService.serviceName());
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -339,12 +339,10 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
             // Set the default service name only when the service name is set using @ServiceName.
             // If it's not, the global defaultServiceNaming is used.
             if (annotatedService != null) {
-                final String serivceName = annotatedService.name();
+                final String serviceName = annotatedService.name();
                 if (serviceName != null) {
-                   
- serviceConfigBuilder.defaultServiceName(serviceName);
+                    serviceConfigBuilder.defaultServiceName(serviceName);
                 }
-            }
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServiceConfigSetters.java
@@ -43,7 +43,6 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 import com.linecorp.armeria.common.util.EventLoopGroups;
 import com.linecorp.armeria.internal.server.annotation.DefaultAnnotatedService;
-import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 
 import io.netty.channel.EventLoopGroup;
@@ -325,9 +324,9 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         final ServiceConfigBuilder serviceConfigBuilder =
                 new ServiceConfigBuilder(route, contextPath, service);
 
-        final AnnotatedService annotatedService;
+        final DefaultAnnotatedService annotatedService;
         if (defaultServiceNaming == null || defaultLogName == null) {
-            annotatedService = service.as(AnnotatedService.class);
+            annotatedService = service.as(DefaultAnnotatedService.class);
         } else {
             annotatedService = null;
         }
@@ -339,9 +338,8 @@ final class DefaultServiceConfigSetters implements ServiceConfigSetters {
         } else {
             // Set the default service name only when the service name is set using @ServiceName.
             // If it's not, the global defaultServiceNaming is used.
-            if (annotatedService != null && annotatedService.as(DefaultAnnotatedService.class)
-                                                            .serviceNameSetByAnnotation()) {
-                serviceConfigBuilder.defaultServiceName(annotatedService.serviceName());
+            if (annotatedService != null && annotatedService.serviceNameSetByAnnotation()) {
+                serviceConfigBuilder.defaultServiceName(annotatedService.name());
             }
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostContextPathAnnotatedServiceConfigSetters.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -59,7 +59,7 @@ public interface AnnotatedService extends HttpService {
     }
 
     /**
-     * Returns {@link Route} for this {@link AnnotatedService}.
+     * Returns the {@link Route} for this {@link AnnotatedService}.
      */
     Route route();
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -34,12 +34,7 @@ public interface AnnotatedService extends HttpService {
     /**
      * Returns service name for this {@link AnnotatedService}.
      */
-    String serviceName();
-
-    /**
-     * Returns method name which is annotated in {@link AnnotatedService}.
-     */
-    String methodName();
+    String name();
 
     /**
      * Returns the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
@@ -57,10 +52,11 @@ public interface AnnotatedService extends HttpService {
     Method method();
 
     /**
-     * Returns a unique ID to distinguish overloaded methods.
-     * If the method is not overloaded, it should return 0.
+     * Returns method name which is annotated in {@link AnnotatedService}.
      */
-    int overloadId();
+    default String methodName() {
+        return method().getName();
+    }
 
     /**
      * Returns {@link Route} for this {@link AnnotatedService}.

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.server.annotation;
 import java.lang.reflect.Method;
 
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -44,7 +45,8 @@ public interface AnnotatedService extends HttpService {
     Object serviceObject();
 
     /**
-     * Returns the {@link Class} of the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
+     * Returns the {@link Class} of the annotated service object specified
+     * with {@link ServerBuilder#annotatedService(Object)}.
      */
     Class<?> serviceClass();
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -49,7 +49,7 @@ public interface AnnotatedService extends HttpService {
     Class<?> serviceClass();
 
     /**
-     * Returns the target {@link Method} invoked when the request is received.
+     * Returns the target {@link Method} invoked when a request is received.
      */
     Method method();
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -26,7 +26,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 
 /**
  * An {@link HttpService} which is defined by a {@link Path} or HTTP method annotations.
- * This class is designed to provide a common interface for {@link AnnotatedService}.
+ * This class is designed to provide a common interface and expose as public for Annotated HTTP Service.
  * Please check out the documentation at
  * <a href="https://armeria.dev/docs/server-annotated-service">Annotated HTTP Service</a> to use this.
  */

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.server.ServerBuilder;
  * Please check out the documentation at
  * <a href="https://armeria.dev/docs/server-annotated-service">Annotated HTTP Service</a> to use this.
  */
+@Nullable
 public interface AnnotatedService extends HttpService {
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.annotation;
+
+import java.lang.reflect.Method;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.ServerBuilder;
+
+/**
+ * An {@link HttpService} which is defined by a {@link Path} or HTTP method annotations.
+ * This class is designed to provide a common interface for {@link AnnotatedService}
+ * internally. Please check out the documentation at
+ * <a href="https://armeria.dev/docs/server-annotated-service">Annotated HTTP Service</a> to use this.
+ */
+public interface AnnotatedService extends HttpService {
+
+    /**
+     * Returns service name for this {@link AnnotatedService}.
+     */
+    String serviceName();
+
+    /**
+     * Returns method name which is annotated in {@link AnnotatedService}.
+     */
+    String methodName();
+
+    /**
+     * Returns the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
+     */
+    Object serviceObject();
+
+    /**
+     * Returns the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
+     */
+    Class<?> serviceClass();
+
+    /**
+     * Returns the target {@link Method} invoked when the request is received.
+     */
+    Method method();
+
+    /**
+     * Returns a unique ID to distinguish overloaded methods.
+     * If the method is not overloaded, it should return 0.
+     */
+    int overloadId();
+
+    /**
+     * Returns {@link Route} for this {@link AnnotatedService}.
+     */
+    Route route();
+
+    /**
+     * Returns the default {@link HttpStatus} specified with {@link StatusCode}.
+     * If {@link StatusCode} is not given, {@link HttpStatus#OK} is returned by default.
+     * If the method returns a void type such as {@link Void} or Kotlin Unit, {@link HttpStatus#NO_CONTENT} is
+     * returned.
+     */
+    HttpStatus defaultStatus();
+}

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -25,8 +25,8 @@ import com.linecorp.armeria.server.ServerBuilder;
 
 /**
  * An {@link HttpService} which is defined by a {@link Path} or HTTP method annotations.
- * This class is designed to provide a common interface for {@link AnnotatedService}
- * internally. Please check out the documentation at
+ * This class is designed to provide a common interface for {@link AnnotatedService}.
+ * Please check out the documentation at
  * <a href="https://armeria.dev/docs/server-annotated-service">Annotated HTTP Service</a> to use this.
  */
 public interface AnnotatedService extends HttpService {

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -44,7 +44,7 @@ public interface AnnotatedService extends HttpService {
     Object serviceObject();
 
     /**
-     * Returns the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
+     * Returns the {@link Class} of the annotated service object specified with {@link ServerBuilder#annotatedService(Object)}.
      */
     Class<?> serviceClass();
 

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -54,7 +54,7 @@ public interface AnnotatedService extends HttpService {
     Method method();
 
     /**
-     * Returns method name which is annotated in {@link AnnotatedService}.
+     *  Returns the name of the target method invoked when a request is received.
      */
     default String methodName() {
         return method().getName();

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -34,6 +34,7 @@ public interface AnnotatedService extends HttpService {
     /**
      * Returns service name for this {@link AnnotatedService}.
      */
+    @Nullable
     String name();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/AnnotatedService.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.server.ServerBuilder;
 public interface AnnotatedService extends HttpService {
 
     /**
-     * Returns service name for this {@link AnnotatedService}.
+     * Returns the name of this annotated service specified with {@link ServiceName}.
      */
     @Nullable
     String name();

--- a/kotlin/src/main/java/com/linecorp/armeria/common/kotlin/CoroutineContexts.java
+++ b/kotlin/src/main/java/com/linecorp/armeria/common/kotlin/CoroutineContexts.java
@@ -20,7 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.internal.server.annotation.AnnotatedService;
+import com.linecorp.armeria.server.annotation.AnnotatedService;
 import com.linecorp.armeria.server.kotlin.CoroutineContextService;
 
 import io.netty.util.AttributeKey;


### PR DESCRIPTION
Motivation:

- Related issue: #5382
- It'd be nice if a user can access the information provided by `AnnotatredService`, but it is not part of the public API.

### Modifications:

- Split `AnnotatedService` into `AnnotatedService` (interface) and 
  `DefaultAnnotatedService` (implementation).

### Result:
- Closes #5382

Before:
```java
        ServiceRequestContext serviceRequestContext = ServiceRequestContext.current();
        AnnotatedService service = serviceRequestContext.config().service().as(AnnotatedService.class);

        // This doesn't compile.
        // service.method(); 
        // service.defaultStatus();
```

After:
```java
        ServiceRequestContext serviceRequestContext = ServiceRequestContext.current();
        AnnotatedService service = serviceRequestContext.config().service().as(AnnotatedService.class);

        // This compiles and provides useful properties.
        service.method(); 
        service.defaultStatus();
```