### PR TITLE
Add option to respect the marshaller specified in gRPC MethodDescriptor

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -27,6 +27,7 @@ import static com.linecorp.armeria.client.grpc.GrpcClientOptions.INTERCEPTORS;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_INBOUND_MESSAGE_SIZE_BYTES;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES;
 import static com.linecorp.armeria.client.grpc.GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS;
+import static com.linecorp.armeria.client.grpc.GrpcClientOptions.USE_METHOD_MARSHALLER;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
@@ -81,6 +82,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 
@@ -285,6 +287,15 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     @UnstableApi
     public GrpcClientBuilder enableUnsafeWrapResponseBuffers(boolean enableUnsafeWrapResponseBuffers) {
         return option(UNSAFE_WRAP_RESPONSE_BUFFERS.newValue(enableUnsafeWrapResponseBuffers));
+    }
+
+    /**
+     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}
+     * If not set, will use the default(false), which use more efficient way that reduce copy operation.
+     */
+    @UnstableApi
+    public GrpcClientBuilder useMethodMarshaller(boolean useMethodMarshaller) {
+        return option(USE_METHOD_MARSHALLER.newValue(useMethodMarshaller));
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -413,7 +413,7 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
         final ClientOptions options = buildOptions();
         if (options.get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS) && options.get(USE_METHOD_MARSHALLER)) {
             throw new IllegalStateException(
-                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive"
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
             );
         }
 

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -290,8 +290,9 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     }
 
     /**
-     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}
-     * If not set, will use the default(false), which use more efficient way that reduce copy operation.
+     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}.
+     * If disabled, the default marshaller will be used, which is more efficient.
+     * This property is disabled by default.
      */
     @UnstableApi
     public GrpcClientBuilder useMethodMarshaller(boolean useMethodMarshaller) {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -286,6 +286,12 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
      */
     @UnstableApi
     public GrpcClientBuilder enableUnsafeWrapResponseBuffers(boolean enableUnsafeWrapResponseBuffers) {
+        final ClientOptions options = buildOptions();
+        if (options.get(USE_METHOD_MARSHALLER)) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
+            );
+        }
         return option(UNSAFE_WRAP_RESPONSE_BUFFERS.newValue(enableUnsafeWrapResponseBuffers));
     }
 
@@ -296,6 +302,12 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
      */
     @UnstableApi
     public GrpcClientBuilder useMethodMarshaller(boolean useMethodMarshaller) {
+        final ClientOptions options = buildOptions();
+        if (options.get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS)) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
+            );
+        }
         return option(USE_METHOD_MARSHALLER.newValue(useMethodMarshaller));
     }
 
@@ -411,12 +423,6 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
 
         final Object client;
         final ClientOptions options = buildOptions();
-        if (options.get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS) && options.get(USE_METHOD_MARSHALLER)) {
-            throw new IllegalStateException(
-                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
-            );
-        }
-
         final ClientFactory factory = options.factory();
         URI uri = this.uri;
         if (uri != null) {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -411,6 +411,12 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
 
         final Object client;
         final ClientOptions options = buildOptions();
+        if (options.get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS) && options.get(USE_METHOD_MARSHALLER)) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive"
+            );
+        }
+
         final ClientFactory factory = options.factory();
         URI uri = this.uri;
         if (uri != null) {

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -178,8 +178,9 @@ public final class GrpcClientOptions {
                                 (ctx, cause, metadata) -> GrpcStatus.fromThrowable(cause));
 
     /**
-     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}
-     * If not set, will use the default(false), which use more efficient way that reduce copy operation.
+     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}.
+     * If disabled, the default marshaller will be used, which is more efficient.
+     * This option is disabled by default.
      */
     public static final ClientOption<Boolean> USE_METHOD_MARSHALLER =
             ClientOption.define("USE_METHOD_MARSHALLER", false);

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientOptions.java
@@ -45,6 +45,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Codec;
 import io.grpc.Compressor;
 import io.grpc.DecompressorRegistry;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 
@@ -175,6 +176,13 @@ public final class GrpcClientOptions {
     public static final ClientOption<GrpcExceptionHandlerFunction> EXCEPTION_HANDLER =
             ClientOption.define("EXCEPTION_HANDLER",
                                 (ctx, cause, metadata) -> GrpcStatus.fromThrowable(cause));
+
+    /**
+     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}
+     * If not set, will use the default(false), which use more efficient way that reduce copy operation.
+     */
+    public static final ClientOption<Boolean> USE_METHOD_MARSHALLER =
+            ClientOption.define("USE_METHOD_MARSHALLER", false);
 
     private GrpcClientOptions() {}
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -107,8 +107,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                    SessionProtocol sessionProtocol,
                    SerializationFormat serializationFormat,
                    @Nullable GrpcJsonMarshaller jsonMarshaller,
-                   Map<MethodDescriptor<?, ?>, String> simpleMethodNames,
-                   boolean useMethodMarshaller) {
+                   Map<MethodDescriptor<?, ?>, String> simpleMethodNames) {
         this.params = params;
         this.httpClient = httpClient;
         this.meterRegistry = meterRegistry;
@@ -116,12 +115,12 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
         this.serializationFormat = serializationFormat;
         this.jsonMarshaller = jsonMarshaller;
         this.simpleMethodNames = simpleMethodNames;
-        this.useMethodMarshaller = useMethodMarshaller;
 
         final ClientOptions options = options();
         maxOutboundMessageSizeBytes = options.get(GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES);
         maxInboundMessageSizeBytes = maxInboundMessageSizeBytes(options);
         unsafeWrapResponseBuffers = options.get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS);
+        useMethodMarshaller = options.get(GrpcClientOptions.USE_METHOD_MARSHALLER);
         compressor = options.get(GrpcClientOptions.COMPRESSOR);
         decompressorRegistry = options.get(GrpcClientOptions.DECOMPRESSOR_REGISTRY);
         credentials0 = options.get(GrpcClientOptions.CALL_CREDENTIALS);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -99,6 +99,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
     private final DecompressorRegistry decompressorRegistry;
     private final CallCredentials credentials0;
     private final GrpcExceptionHandlerFunction exceptionHandler;
+    private final boolean useMethodMarshaller;
 
     ArmeriaChannel(ClientBuilderParams params,
                    HttpClient httpClient,
@@ -106,7 +107,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                    SessionProtocol sessionProtocol,
                    SerializationFormat serializationFormat,
                    @Nullable GrpcJsonMarshaller jsonMarshaller,
-                   Map<MethodDescriptor<?, ?>, String> simpleMethodNames) {
+                   Map<MethodDescriptor<?, ?>, String> simpleMethodNames,
+                   boolean useMethodMarshaller) {
         this.params = params;
         this.httpClient = httpClient;
         this.meterRegistry = meterRegistry;
@@ -114,6 +116,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
         this.serializationFormat = serializationFormat;
         this.jsonMarshaller = jsonMarshaller;
         this.simpleMethodNames = simpleMethodNames;
+        this.useMethodMarshaller = useMethodMarshaller;
 
         final ClientOptions options = options();
         maxOutboundMessageSizeBytes = options.get(GrpcClientOptions.MAX_OUTBOUND_MESSAGE_SIZE_BYTES);
@@ -180,7 +183,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 serializationFormat,
                 jsonMarshaller,
                 unsafeWrapResponseBuffers,
-                exceptionHandler);
+                exceptionHandler,
+                useMethodMarshaller);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -160,7 +160,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             SerializationFormat serializationFormat,
             @Nullable GrpcJsonMarshaller jsonMarshaller,
             boolean unsafeWrapResponseBuffers,
-            GrpcExceptionHandlerFunction exceptionHandler) {
+            GrpcExceptionHandlerFunction exceptionHandler,
+            boolean useMethodMarshaller) {
         this.ctx = ctx;
         this.endpointGroup = endpointGroup;
         this.httpClient = httpClient;
@@ -184,7 +185,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
         requestFramer = new ArmeriaMessageFramer(ctx.alloc(), maxOutboundMessageSizeBytes, grpcWebText);
         marshaller = new GrpcMessageMarshaller<>(ctx.alloc(), serializationFormat, method, jsonMarshaller,
-                                                 unsafeWrapResponseBuffers);
+                                                 unsafeWrapResponseBuffers, useMethodMarshaller);
 
         if (callOptions.getExecutor() == null) {
             executor = MoreExecutors.directExecutor();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -162,10 +162,11 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         } else {
             jsonMarshaller = null;
         }
+        final boolean useMethodMarshaller = options.get(GrpcClientOptions.USE_METHOD_MARSHALLER);
 
         final ArmeriaChannel armeriaChannel =
                 new ArmeriaChannel(newParams, httpClient, meterRegistry(), scheme.sessionProtocol(),
-                                   serializationFormat, jsonMarshaller, simpleMethodNames);
+                                   serializationFormat, jsonMarshaller, simpleMethodNames, useMethodMarshaller);
         final Iterable<? extends ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
         final Channel channel;
         if (!Iterables.isEmpty(interceptors)) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -162,11 +162,9 @@ final class GrpcClientFactory extends DecoratingClientFactory {
         } else {
             jsonMarshaller = null;
         }
-        final boolean useMethodMarshaller = options.get(GrpcClientOptions.USE_METHOD_MARSHALLER);
-
         final ArmeriaChannel armeriaChannel =
                 new ArmeriaChannel(newParams, httpClient, meterRegistry(), scheme.sessionProtocol(),
-                                   serializationFormat, jsonMarshaller, simpleMethodNames, useMethodMarshaller);
+                                   serializationFormat, jsonMarshaller, simpleMethodNames);
         final Iterable<? extends ClientInterceptor> interceptors = options.get(GrpcClientOptions.INTERCEPTORS);
         final Channel channel;
         if (!Iterables.isEmpty(interceptors)) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
@@ -256,7 +256,12 @@ public final class GrpcMessageMarshaller<I, O> {
                 stream = CodedInputStream.newInstance(buf.nioBuffer());
             }
             try {
-                final Message msg = prototype.getParserForType().parseFrom(stream);
+                final Message msg;
+                if (useMethodMarshaller) {
+                    msg = (Message) marshaller.parse(new ByteBufInputStream(buf));
+                } else {
+                    msg = prototype.getParserForType().parseFrom(stream);
+                }
                 try {
                     stream.checkLastTagWas(0);
                 } catch (InvalidProtocolBufferException e) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshaller.java
@@ -248,25 +248,25 @@ public final class GrpcMessageMarshaller<I, O> {
             if (!buf.isReadable()) {
                 return prototype.getDefaultInstanceForType();
             }
-            final CodedInputStream stream;
-            if (unsafeWrapDeserializedBuffer) {
-                stream = UnsafeByteOperations.unsafeWrap(buf.nioBuffer()).newCodedInput();
-                stream.enableAliasing(true);
-            } else {
-                stream = CodedInputStream.newInstance(buf.nioBuffer());
-            }
             try {
                 final Message msg;
                 if (useMethodMarshaller) {
                     msg = (Message) marshaller.parse(new ByteBufInputStream(buf));
                 } else {
+                    final CodedInputStream stream;
+                    if (unsafeWrapDeserializedBuffer) {
+                        stream = UnsafeByteOperations.unsafeWrap(buf.nioBuffer()).newCodedInput();
+                        stream.enableAliasing(true);
+                    } else {
+                        stream = CodedInputStream.newInstance(buf.nioBuffer());
+                    }
                     msg = prototype.getParserForType().parseFrom(stream);
-                }
-                try {
-                    stream.checkLastTagWas(0);
-                } catch (InvalidProtocolBufferException e) {
-                    e.setUnfinishedMessage(msg);
-                    throw e;
+                    try {
+                        stream.checkLastTagWas(0);
+                    } catch (InvalidProtocolBufferException e) {
+                        e.setUnfinishedMessage(msg);
+                        throw e;
+                    }
                 }
                 return msg;
             } catch (InvalidProtocolBufferException e) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -151,7 +151,8 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                                  ResponseHeaders defaultHeaders,
                                  @Nullable GrpcExceptionHandlerFunction exceptionHandler,
                                  @Nullable Executor blockingExecutor,
-                                 boolean autoCompression) {
+                                 boolean autoCompression,
+                                 boolean useMethodMarshaller) {
         requireNonNull(req, "req");
         this.method = requireNonNull(method, "method");
         this.simpleMethodName = requireNonNull(simpleMethodName, "simpleMethodName");
@@ -170,7 +171,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         clientAcceptEncoding = req.headers().get(GrpcHeaderNames.GRPC_ACCEPT_ENCODING, "");
         this.autoCompression = autoCompression;
         marshaller = new GrpcMessageMarshaller<>(alloc, serializationFormat, method, jsonMarshaller,
-                                                 unsafeWrapRequestBuffers);
+                                                 unsafeWrapRequestBuffers, useMethodMarshaller);
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         this.blockingExecutor = blockingExecutor;
         defaultResponseHeaders = defaultHeaders;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -133,6 +133,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
     private final boolean useBlockingTaskExecutor;
     private final boolean unsafeWrapRequestBuffers;
     private final boolean useClientTimeoutHeader;
+    private final boolean useMethodMarshaller;
     private final String advertisedEncodingsHeader;
     private final Map<SerializationFormat, ResponseHeaders> defaultHeaders;
     @Nullable
@@ -154,7 +155,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                       boolean useClientTimeoutHeader,
                       boolean lookupMethodFromAttribute,
                       @Nullable GrpcHealthCheckService grpcHealthCheckService,
-                      boolean autoCompression) {
+                      boolean autoCompression, boolean useMethodMarshaller) {
         this.registry = requireNonNull(registry, "registry");
         routes = ImmutableSet.copyOf(registry.methodsByRoute().keySet());
         exchangeTypes = registry.methods().entrySet().stream()
@@ -173,6 +174,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         this.lookupMethodFromAttribute = lookupMethodFromAttribute;
         this.autoCompression = autoCompression;
+        this.useMethodMarshaller = useMethodMarshaller;
 
         advertisedEncodingsHeader = String.join(",", decompressorRegistry.getAdvertisedMessageEncodings());
 
@@ -356,7 +358,8 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     defaultHeaders.get(serializationFormat),
                     exceptionHandler,
                     blockingExecutor,
-                    autoCompression);
+                    autoCompression,
+                    useMethodMarshaller);
         } else {
             return new StreamingServerCall<>(
                     req,
@@ -374,7 +377,8 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     defaultHeaders.get(serializationFormat),
                     exceptionHandler,
                     blockingExecutor,
-                    autoCompression);
+                    autoCompression,
+                    useMethodMarshaller);
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -981,7 +981,7 @@ public final class GrpcServiceBuilder {
         }
         if (unsafeWrapRequestBuffers && useMethodMarshaller) {
             throw new IllegalStateException(
-                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive"
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
             );
         }
         if (enableHealthCheckService) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -751,6 +751,11 @@ public final class GrpcServiceBuilder {
      * {@link GrpcSerializationFormats#PROTO_WEB_TEXT}.
      */
     public GrpcServiceBuilder unsafeWrapRequestBuffers(boolean unsafeWrapRequestBuffers) {
+        if (unsafeWrapRequestBuffers && useMethodMarshaller) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
+            );
+        }
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
         return this;
     }
@@ -832,6 +837,11 @@ public final class GrpcServiceBuilder {
      */
     @UnstableApi
     public GrpcServiceBuilder useMethodMarshaller(boolean useMethodMarshaller) {
+        if (unsafeWrapRequestBuffers && useMethodMarshaller) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
+            );
+        }
         this.useMethodMarshaller = useMethodMarshaller;
         return this;
     }
@@ -977,11 +987,6 @@ public final class GrpcServiceBuilder {
                 GrpcSerializationFormats.JSON)) {
             throw new IllegalStateException(
                     "'GrpcSerializationFormats.JSON' must be set if 'enableHttpJsonTranscoding' is set"
-            );
-        }
-        if (unsafeWrapRequestBuffers && useMethodMarshaller) {
-            throw new IllegalStateException(
-                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive."
             );
         }
         if (enableHealthCheckService) {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -147,6 +147,8 @@ public final class GrpcServiceBuilder {
 
     private boolean useClientTimeoutHeader = true;
 
+    private boolean useMethodMarshaller;
+
     private boolean enableHealthCheckService;
 
     private boolean autoCompression;
@@ -825,6 +827,16 @@ public final class GrpcServiceBuilder {
     }
 
     /**
+     * Sets whether to respect the marshaller specified in gRPC {@link MethodDescriptor}
+     * If not set, will use the default(false), which use more efficient way that reduce copy operation.
+     */
+    @UnstableApi
+    public GrpcServiceBuilder useMethodMarshaller(boolean useMethodMarshaller) {
+        this.useMethodMarshaller = useMethodMarshaller;
+        return this;
+    }
+
+    /**
      * Sets the specified {@link GrpcExceptionHandlerFunction} that maps a {@link Throwable}
      * to a gRPC {@link Status}.
      *
@@ -1016,7 +1028,8 @@ public final class GrpcServiceBuilder {
                 useClientTimeoutHeader,
                 enableHttpJsonTranscoding, // The method definition might be set when transcoding is enabled.
                 grpcHealthCheckService,
-                autoCompression);
+                autoCompression,
+                useMethodMarshaller);
         if (enableUnframedRequests) {
             grpcService = new UnframedGrpcService(
                     grpcService, handlerRegistry,

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -979,6 +979,11 @@ public final class GrpcServiceBuilder {
                     "'GrpcSerializationFormats.JSON' must be set if 'enableHttpJsonTranscoding' is set"
             );
         }
+        if (unsafeWrapRequestBuffers && useMethodMarshaller) {
+            throw new IllegalStateException(
+                    "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive"
+            );
+        }
         if (enableHealthCheckService) {
             grpcHealthCheckService = GrpcHealthCheckService.builder().build();
         }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -85,10 +85,11 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
                         @Nullable GrpcJsonMarshaller jsonMarshaller, boolean unsafeWrapRequestBuffers,
                         ResponseHeaders defaultHeaders,
                         @Nullable GrpcExceptionHandlerFunction exceptionHandler,
-                        @Nullable Executor blockingExecutor, boolean autoCompress) {
+                        @Nullable Executor blockingExecutor, boolean autoCompress,
+                        boolean useMethodMarshaller) {
         super(req, method, simpleMethodName, compressorRegistry, decompressorRegistry, res,
               maxResponseMessageLength, ctx, serializationFormat, jsonMarshaller, unsafeWrapRequestBuffers,
-              defaultHeaders, exceptionHandler, blockingExecutor, autoCompress);
+              defaultHeaders, exceptionHandler, blockingExecutor, autoCompress, useMethodMarshaller);
         requireNonNull(req, "req");
         this.method = requireNonNull(method, "method");
         this.ctx = requireNonNull(ctx, "ctx");

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -72,10 +72,11 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
                     ResponseHeaders defaultHeaders,
                     @Nullable GrpcExceptionHandlerFunction exceptionHandler,
                     @Nullable Executor blockingExecutor,
-                    boolean autoCompress) {
+                    boolean autoCompress,
+                    boolean useMethodMarshaller) {
         super(req, method, simpleMethodName, compressorRegistry, decompressorRegistry, res,
               maxResponseMessageLength, ctx, serializationFormat, jsonMarshaller, unsafeWrapRequestBuffers,
-              defaultHeaders, exceptionHandler, blockingExecutor, autoCompress);
+              defaultHeaders, exceptionHandler, blockingExecutor, autoCompress, useMethodMarshaller);
         requireNonNull(req, "req");
         this.ctx = requireNonNull(ctx, "ctx");
         final boolean grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -62,48 +62,6 @@ class GrpcClientBuilderTest {
         }
     };
 
-    private static class CustomMarshallerInterceptor implements ClientInterceptor {
-        private int spiedMarshallerCallCnt;
-
-        CustomMarshallerInterceptor() {
-        }
-
-        int getSpiedMarshallerCallCnt() {
-            return spiedMarshallerCallCnt;
-        }
-
-        @Override
-        public <I, O> ClientCall<I, O> interceptCall(MethodDescriptor<I, O> method, CallOptions callOptions,
-                                                     Channel next) {
-            final MethodDescriptor<I, O> methodDescriptor = method.toBuilder().setRequestMarshaller(
-                    new PrototypeMarshaller<I>() {
-                        @Nullable
-                        @Override
-                        public I getMessagePrototype() {
-                            return null;
-                        }
-
-                        @Override
-                        public Class<I> getMessageClass() {
-                            return null;
-                        }
-
-                        @Override
-                        public InputStream stream(I value) {
-                            spiedMarshallerCallCnt++;
-                            return method.getRequestMarshaller().stream(value);
-                        }
-
-                        @Override
-                        public I parse(InputStream inputStream) {
-                            return null;
-                        }
-                    }
-            ).build();
-            return next.newCall(methodDescriptor, callOptions);
-        }
-    }
-
     @Test
     void defaultSerializationFormat() {
         TestServiceBlockingStub client =
@@ -242,5 +200,47 @@ class GrpcClientBuilderTest {
         final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
         assertThat(clientParams.options().get(GrpcClientOptions.INTERCEPTORS))
                 .containsExactly(interceptorA, interceptorB);
+    }
+
+    private static class CustomMarshallerInterceptor implements ClientInterceptor {
+        private int spiedMarshallerCallCnt;
+
+        CustomMarshallerInterceptor() {
+        }
+
+        int getSpiedMarshallerCallCnt() {
+            return spiedMarshallerCallCnt;
+        }
+
+        @Override
+        public <I, O> ClientCall<I, O> interceptCall(MethodDescriptor<I, O> method, CallOptions callOptions,
+                                                     Channel next) {
+            final MethodDescriptor<I, O> methodDescriptor = method.toBuilder().setRequestMarshaller(
+                    new PrototypeMarshaller<I>() {
+                        @Nullable
+                        @Override
+                        public I getMessagePrototype() {
+                            return null;
+                        }
+
+                        @Override
+                        public Class<I> getMessageClass() {
+                            return null;
+                        }
+
+                        @Override
+                        public InputStream stream(I value) {
+                            spiedMarshallerCallCnt++;
+                            return method.getRequestMarshaller().stream(value);
+                        }
+
+                        @Override
+                        public I parse(InputStream inputStream) {
+                            return null;
+                        }
+                    }
+            ).build();
+            return next.newCall(methodDescriptor, callOptions);
+        }
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static testing.grpc.Messages.PayloadType.COMPRESSABLE;
 
 import java.io.InputStream;
-import java.util.concurrent.Executors;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -34,6 +33,7 @@ import com.google.protobuf.ByteString;
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.internal.common.grpc.TestServiceImpl;
@@ -57,7 +57,7 @@ class GrpcClientBuilderTest {
         @Override
         protected void configure(ServerBuilder sb) {
             sb.service(GrpcService.builder()
-                                  .addService(new TestServiceImpl(Executors.newSingleThreadScheduledExecutor()))
+                                  .addService(new TestServiceImpl(CommonPools.blockingTaskExecutor()))
                                   .build());
         }
     };
@@ -160,7 +160,7 @@ class GrpcClientBuilderTest {
                                             .build(TestServiceBlockingStub.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive");
+                        "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive.");
     }
 
     @ParameterizedTest

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -127,6 +127,16 @@ class GrpcClientBuilderTest {
     }
 
     @Test
+    void useMethodMarshaller() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder("http://foo.com")
+                           .useMethodMarshaller(true)
+                           .build(TestServiceBlockingStub.class);
+        final ClientBuilderParams clientParams = Clients.unwrap(client, ClientBuilderParams.class);
+        assertThat(clientParams.options().get(GrpcClientOptions.USE_METHOD_MARSHALLER)).isTrue();
+    }
+
+    @Test
     void intercept() {
         final ClientInterceptor interceptorA = new ClientInterceptor() {
             @Override

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -152,6 +152,17 @@ class GrpcClientBuilderTest {
         assertThat(clientParams.options().get(GrpcClientOptions.UNSAFE_WRAP_RESPONSE_BUFFERS)).isTrue();
     }
 
+    @Test
+    void canNotSetUseMethodMarshallerAndUnsafeWrapDeserializedBufferAtTheSameTime() {
+        assertThatThrownBy(() -> GrpcClients.builder(server.httpUri())
+                                            .enableUnsafeWrapResponseBuffers(true)
+                                            .useMethodMarshaller(true)
+                                            .build(TestServiceBlockingStub.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive");
+    }
+
     @ParameterizedTest
     @CsvSource({"true, 1", "false, 0"})
     void useMethodMarshaller(boolean useMethodMarshaller, int expectedCallCnt) {
@@ -204,9 +215,6 @@ class GrpcClientBuilderTest {
 
     private static class CustomMarshallerInterceptor implements ClientInterceptor {
         private int spiedMarshallerCallCnt;
-
-        CustomMarshallerInterceptor() {
-        }
 
         int getSpiedMarshallerCallCnt() {
             return spiedMarshallerCallCnt;

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -157,8 +157,7 @@ class GrpcClientBuilderTest {
     void canNotSetUseMethodMarshallerAndUnsafeWrapDeserializedBufferAtTheSameTime() {
         assertThatThrownBy(() -> GrpcClients.builder(server.httpUri())
                                             .enableUnsafeWrapResponseBuffers(true)
-                                            .useMethodMarshaller(true)
-                                            .build(TestServiceBlockingStub.class))
+                                            .useMethodMarshaller(true))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
                         "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive.");

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshallerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/GrpcMessageMarshallerTest.java
@@ -58,6 +58,7 @@ class GrpcMessageMarshallerTest {
                                            GrpcSerializationFormats.PROTO,
                                            TestServiceGrpc.getUnaryCallMethod(),
                                            grpcJsonMarshaller,
+                                           false,
                                            false);
     }
 
@@ -66,8 +67,23 @@ class GrpcMessageMarshallerTest {
                                          .map(Arguments::of);
     }
 
+    static GrpcMessageMarshaller<SimpleRequest, SimpleResponse> messageMarshallerWithMethodMarshaller(
+            GrpcJsonMarshaller grpcJsonMarshaller) {
+        return new GrpcMessageMarshaller<>(ByteBufAllocator.DEFAULT,
+                                           GrpcSerializationFormats.PROTO,
+                                           TestServiceGrpc.getUnaryCallMethod(),
+                                           grpcJsonMarshaller,
+                                           false,
+                                           true);
+    }
+
+    private static Stream<Arguments> messageMarshallerArgsWithMethodMarshaller() {
+        return grpcJsonMarshallerStream().map(GrpcMessageMarshallerTest::messageMarshallerWithMethodMarshaller)
+                                         .map(Arguments::of);
+    }
+
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void serializeRequest(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller) throws Exception {
         final ByteBuf serialized = marshaller.serializeRequest(GrpcTestUtil.REQUEST_MESSAGE);
         assertThat(ByteBufUtil.getBytes(serialized))
@@ -76,7 +92,7 @@ class GrpcMessageMarshallerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void deserializeRequest_byteBuf(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller)
             throws Exception {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
@@ -95,7 +111,8 @@ class GrpcMessageMarshallerTest {
                                             GrpcSerializationFormats.PROTO,
                                             TestServiceGrpc.getUnaryCallMethod(),
                                             grpcJsonMarshaller,
-                                            true);
+                                            true,
+                                            false);
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.REQUEST_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
         buf.writeBytes(GrpcTestUtil.REQUEST_MESSAGE.toByteArray());
@@ -106,7 +123,7 @@ class GrpcMessageMarshallerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void deserializeRequest_stream(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller)
             throws Exception {
         final SimpleRequest request = marshaller.deserializeRequest(
@@ -116,7 +133,7 @@ class GrpcMessageMarshallerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void serializeResponse(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller) throws Exception {
         final ByteBuf serialized = marshaller.serializeResponse(GrpcTestUtil.RESPONSE_MESSAGE);
         assertThat(ByteBufUtil.getBytes(serialized))
@@ -125,7 +142,7 @@ class GrpcMessageMarshallerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void deserializeResponse_bytebuf(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller)
             throws Exception {
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
@@ -144,6 +161,7 @@ class GrpcMessageMarshallerTest {
                                             GrpcSerializationFormats.PROTO,
                                             TestServiceGrpc.getUnaryCallMethod(),
                                             grpcJsonMarshaller,
+                                            true,
                                             true);
         final ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(GrpcTestUtil.RESPONSE_MESSAGE.getSerializedSize());
         assertThat(buf.refCnt()).isEqualTo(1);
@@ -155,7 +173,7 @@ class GrpcMessageMarshallerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("messageMarshallerArgs")
+    @MethodSource({"messageMarshallerArgs", "messageMarshallerArgsWithMethodMarshaller"})
     void deserializeResponse_stream(GrpcMessageMarshaller<SimpleRequest, SimpleResponse> marshaller)
             throws Exception {
         final SimpleResponse response = marshaller.deserializeResponse(

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -112,7 +112,7 @@ class DeferredListenerTest {
                                      DecompressorRegistry.getDefaultInstance(),
                                      HttpResponse.streaming(), new CompletableFuture<>(), 0, 0, ctx,
                                      GrpcSerializationFormats.PROTO, null, false,
-                                     ResponseHeaders.of(200), null, blockingTaskExecutor, false);
+                                     ResponseHeaders.of(200), null, blockingTaskExecutor, false, false);
     }
 
     private static class TestListener extends ServerCall.Listener<SimpleRequest> {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -285,7 +285,7 @@ class GrpcServiceBuilderTest {
                                             .build())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive");
+                        "'unsafeWrapRequestBuffers' and 'useMethodMarshaller' are mutually exclusive.");
     }
 
     @ParameterizedTest

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -260,6 +260,13 @@ class GrpcServiceBuilderTest {
                 .hasMessageContaining("enableHttpJsonTranscoding");
     }
 
+    @Test
+    void setUseMethodMarshaller() {
+        assertDoesNotThrow(() -> GrpcService.builder()
+                                            .useMethodMarshaller(true)
+                                            .build());
+    }
+
     private static class MetricsServiceImpl extends MetricsServiceImplBase {}
 
     private static class ReconnectServiceImpl extends ReconnectServiceImplBase {}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
@@ -298,6 +298,7 @@ class StreamingServerCallTest {
                                        .build(),
                         /* exceptionMappings */ null,
                         /* blockingExecutor */ null,
+                        false,
                         false);
 
         final AtomicReference<Subscription> subscriptionRef = new AtomicReference<>();
@@ -367,6 +368,7 @@ class StreamingServerCallTest {
                                .build(),
                 /* exceptionMappings */ null,
                 /* blockingExecutor */ null,
+                false,
                 false);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -331,7 +331,8 @@ class UnaryServerCallTest {
                                        .build(),
                         /* exceptionMappings */ null,
                         /* blockingExecutor */ null,
-                        /* autoCompress */ false);
+                        /* autoCompress */ false,
+                        /* useMethodMarshaller */false);
 
         final AtomicReference<SimpleRequest> requestCaptor = new AtomicReference<>();
         final AtomicBoolean completed = new AtomicBoolean();
@@ -376,6 +377,7 @@ class UnaryServerCallTest {
                                .build(),
                 /* exceptionMappings */ null,
                 /* blockingExecutor */ null,
-                /* autoCompress */ false);
+                /* autoCompress */ false,
+                /* useMethodMarshaller */ false);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -332,7 +332,7 @@ class UnaryServerCallTest {
                         /* exceptionMappings */ null,
                         /* blockingExecutor */ null,
                         /* autoCompress */ false,
-                        /* useMethodMarshaller */false);
+                        /* useMethodMarshaller */ false);
 
         final AtomicReference<SimpleRequest> requestCaptor = new AtomicReference<>();
         final AtomicBoolean completed = new AtomicBoolean();


### PR DESCRIPTION
Motivation:

- This PR adds option to use marshaller that specified in gRPC `MethodDescriptor`
- Related Issue #5103
  - Partial solved: Option to use marshaller that specified in gRPC `MethodDescriptor`
  - Unsolved part: Provide way to add custom marshaller

Modifications:

- New option `useMethodMarshaller`
  - default value is `false`
- Add validate logic for `GrpcServiceBuilder` and `GrpcClientBuilder` to check that `unsafeWrapDeserializedBuffer` and `useMethodMarshaller` are mutually exclusive

Result:
- Have new option `useMethodMarshaller`
- Throw `IllegalStateException` when both `unsafeWrapDeserializedBuffer` and `useMethodMarshaller` are enabled
<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
