### PR TITLE
Allow `{Service,Server}ErrorHandler.renderStatus()` to access `ServiceRequestContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -212,7 +212,7 @@ abstract class AbstractHttpResponseHandler {
         final Throwable cause0 = firstNonNull(cause.getCause(), cause);
         final ServiceConfig serviceConfig = reqCtx.config();
         final AggregatedHttpResponse response = serviceConfig.errorHandler()
-                                                             .renderStatus(serviceConfig, req.headers(), status,
+                                                             .renderStatus(reqCtx, req.headers(), status,
                                                                            null, cause0);
         assert response != null;
         return response;

--- a/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ExceptionReportingServiceErrorHandler.java
@@ -52,9 +52,9 @@ final class ExceptionReportingServiceErrorHandler implements ServiceErrorHandler
 
     @Nullable
     @Override
-    public AggregatedHttpResponse renderStatus(ServiceConfig config, @Nullable RequestHeaders headers,
+    public AggregatedHttpResponse renderStatus(ServiceRequestContext ctx, RequestHeaders headers,
                                                HttpStatus status, @Nullable String description,
                                                @Nullable Throwable cause) {
-        return delegate.renderStatus(config, headers, status, description, cause);
+        return delegate.renderStatus(ctx, headers, status, description, cause);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/FallbackService.java
@@ -92,7 +92,7 @@ final class FallbackService implements HttpService {
 
     private static HttpResponse newFallbackResponse(ServiceRequestContext ctx, HttpStatus status) {
         final ServiceErrorHandler errorHandler = ctx.config().errorHandler();
-        final AggregatedHttpResponse rendered = errorHandler.renderStatus(ctx.config(),
+        final AggregatedHttpResponse rendered = errorHandler.renderStatus(ctx,
                                                                           ctx.request().headers(),
                                                                           status,
                                                                           null,

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceErrorHandler.java
@@ -88,7 +88,7 @@ public interface ServiceErrorHandler {
      * in the invocation chain will be used as a fallback (See {@link #orElse(ServiceErrorHandler)}
      * for more information).
      *
-     * @param config the {@link ServiceConfig} that provides the configuration properties.
+     * @param ctx the {@link ServiceRequestContext} of the request being handled.
      * @param headers the received {@link RequestHeaders}.
      * @param status the desired {@link HttpStatus} of the error response.
      * @param description an optional human-readable description of the error.
@@ -99,7 +99,7 @@ public interface ServiceErrorHandler {
      *         {@link #orElse(ServiceErrorHandler)} handle the event.
      */
     @Nullable
-    default AggregatedHttpResponse renderStatus(ServiceConfig config,
+    default AggregatedHttpResponse renderStatus(ServiceRequestContext ctx,
                                                 RequestHeaders headers,
                                                 HttpStatus status,
                                                 @Nullable String description,

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceErrorHandlerTest.java
@@ -49,7 +49,7 @@ class ServiceErrorHandlerTest {
             sb.service("/baz", (ctx, req) -> {
                 throw new RuntimeException();
             });
-            sb.errorHandler(((ctx, cause) -> HttpResponse.of(HttpStatus.NO_CONTENT)));
+            sb.errorHandler((ctx, cause) -> HttpResponse.of(HttpStatus.NO_CONTENT));
         }
     };
 


### PR DESCRIPTION
Motivation:

A user sometimes needs to access the `ServiceRequestContext` of the currently request in their `ServiceErrorHandler` or `ServerErrorHandler`, but `renderStatus()` doesn't provide the current context.

Modifications:

- Changed the method signature of `renderStatus()` so that a user can access the current `ServiceRequestContext`.
  - Note that the nullability of the context parameter differs between `ServiceRequestContext` and `ServerRequestContext`, because the context is not always available in case of protocol violation. Because the context can be null, `ServiceConfig` is provided as an additional parameter.

Result:

- A user's `{Service,Server}ErrorHandler.renderStatus()` implementation can now access the current `ServiceRequestContext` if available.