### PR TITLE
Collect timings related with TLS handshake

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -72,6 +72,7 @@ import io.netty.handler.proxy.ProxyHandler;
 import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.ssl.SslContext;
+import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import reactor.core.scheduler.NonBlocking;
@@ -80,6 +81,9 @@ final class HttpChannelPool implements AsyncCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpChannelPool.class);
     private static final Channel[] EMPTY_CHANNELS = new Channel[0];
+
+    static final AttributeKey<ClientConnectionTimingsBuilder> TIMINGS_BUILDER_KEY =
+            AttributeKey.valueOf(HttpChannelPool.class, "TIMINGS_BUILDER_KEY");
 
     private final HttpClientFactory clientFactory;
     private final EventLoop eventLoop;
@@ -350,7 +354,7 @@ final class HttpChannelPool implements AsyncCloseable {
 
         // Create a new connection.
         final Promise<Channel> sessionPromise = eventLoop.newPromise();
-        connect(remoteAddress, desiredProtocol, serializationFormat, key, sessionPromise);
+        connect(remoteAddress, desiredProtocol, serializationFormat, key, sessionPromise, timingsBuilder);
 
         if (sessionPromise.isDone()) {
             notifyConnect(desiredProtocol, key, sessionPromise, promise, timingsBuilder);
@@ -371,8 +375,8 @@ final class HttpChannelPool implements AsyncCloseable {
      */
     void connect(SocketAddress remoteAddress, SessionProtocol desiredProtocol,
                  SerializationFormat serializationFormat,
-                 PoolKey poolKey, Promise<Channel> sessionPromise) {
-
+                 PoolKey poolKey, Promise<Channel> sessionPromise,
+                 ClientConnectionTimingsBuilder timingsBuilder) {
         final Bootstrap bootstrap;
         try {
             bootstrap = bootstraps.get(remoteAddress, desiredProtocol, serializationFormat);
@@ -390,6 +394,18 @@ final class HttpChannelPool implements AsyncCloseable {
             try {
                 final Channel channel = registerFuture.channel();
                 configureProxy(channel, poolKey.proxyConfig, desiredProtocol);
+
+                if (desiredProtocol.isTls() && timingsBuilder != null) {
+                    channel.attr(TIMINGS_BUILDER_KEY).set(timingsBuilder);
+
+                    // If TCP fast open is enabled,
+                    // Should start the TLS handshake timer after` before connecting the TCP connection.
+                    final boolean fastOpen =
+                            Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
+                    if (fastOpen) {
+                        timingsBuilder.tlsHandshakeStart();
+                    }
+                }
 
                 // should be invoked right before channel.connect() is invoked as defined in javadocs
                 clientFactory.channelPipelineCustomizer().accept(channel.pipeline());

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -397,14 +397,6 @@ final class HttpChannelPool implements AsyncCloseable {
 
                 if (desiredProtocol.isTls() && timingsBuilder != null) {
                     channel.attr(TIMINGS_BUILDER_KEY).set(timingsBuilder);
-
-                    // If TCP fast open is enabled,
-                    // Should start the TLS handshake timer after before connecting the TCP connection.
-                    final boolean fastOpen =
-                            Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
-                    if (fastOpen) {
-                        timingsBuilder.tlsHandshakeStart();
-                    }
                 }
 
                 // should be invoked right before channel.connect() is invoked as defined in javadocs

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -376,7 +376,7 @@ final class HttpChannelPool implements AsyncCloseable {
     void connect(SocketAddress remoteAddress, SessionProtocol desiredProtocol,
                  SerializationFormat serializationFormat,
                  PoolKey poolKey, Promise<Channel> sessionPromise,
-                 ClientConnectionTimingsBuilder timingsBuilder) {
+                 @Nullable ClientConnectionTimingsBuilder timingsBuilder) {
         final Bootstrap bootstrap;
         try {
             bootstrap = bootstraps.get(remoteAddress, desiredProtocol, serializationFormat);
@@ -399,7 +399,7 @@ final class HttpChannelPool implements AsyncCloseable {
                     channel.attr(TIMINGS_BUILDER_KEY).set(timingsBuilder);
 
                     // If TCP fast open is enabled,
-                    // Should start the TLS handshake timer after` before connecting the TCP connection.
+                    // Should start the TLS handshake timer after before connecting the TCP connection.
                     final boolean fastOpen =
                             Boolean.TRUE.equals(channel.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
                     if (fastOpen) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -70,7 +70,6 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -230,20 +229,8 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             sslHandler = sslCtx.newHandler(ch.alloc());
         }
 
-        final boolean fastOpen = Boolean.TRUE.equals(ch.config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT));
-        if (!fastOpen) {
-            p.addLast(new ChannelInboundHandlerAdapter() {
-                @Override
-                public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                    final ClientConnectionTimingsBuilder timingsBuilder =
-                            ctx.channel().attr(TIMINGS_BUILDER_KEY).get();
-                    timingsBuilder.tlsHandshakeStart();
-                    super.channelActive(ctx);
-                    p.remove(this);
-                }
-            });
-        }
-        p.addLast(configureSslHandler(sslHandler));
+        final ClientConnectionTimingsBuilder timingsBuilder = ch.attr(TIMINGS_BUILDER_KEY).get();
+        p.addLast(configureSslHandler(new ClientSslHandler(sslCtx.newEngine(ch.alloc()), timingsBuilder)));
         p.addLast(TrafficLoggingHandler.CLIENT);
         p.addLast(new ChannelInboundHandlerAdapter() {
             @Nullable
@@ -256,13 +243,10 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                     return;
                 }
 
-                final ClientConnectionTimingsBuilder timingsBuilder =
-                        ctx.channel().attr(TIMINGS_BUILDER_KEY).get();
                 final SslHandshakeCompletionEvent handshakeEvent = (SslHandshakeCompletionEvent) evt;
                 handshakeFailed = !handshakeEvent.isSuccess();
                 if (handshakeFailed) {
                     // The connection will be closed automatically by SslHandler.
-                    timingsBuilder.tlsHandshakeEnd();
                     return;
                 }
 
@@ -273,7 +257,6 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                     // conclude protocol negotiation and start a new session.
                     return;
                 }
-                timingsBuilder.tlsHandshakeEnd();
 
                 final SessionProtocol protocol;
                 if (isHttp2Protocol(sslHandler)) {
@@ -475,6 +458,25 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
     private static boolean isHttp2Protocol(SslHandler sslHandler) {
         return ApplicationProtocolNames.HTTP_2.equals(sslHandler.applicationProtocol());
+    }
+
+    /**
+     * A handler that collects the ssl related metric.
+     */
+    private static final class ClientSslHandler extends SslHandler {
+        private final ClientConnectionTimingsBuilder timingsBuilder;
+
+        ClientSslHandler(SSLEngine engine, ClientConnectionTimingsBuilder timingsBuilder) {
+            super(engine);
+            this.timingsBuilder = timingsBuilder;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            timingsBuilder.tlsHandshakeStart();
+            super.channelActive(ctx);
+            handshakeFuture().addListener(future -> timingsBuilder.tlsHandshakeEnd());
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -218,19 +218,19 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         assert isHttps();
 
         final ChannelPipeline p = ch.pipeline();
-        final SslHandler sslHandler;
+        final SSLEngine sslEngine;
         if (remoteAddr instanceof InetSocketAddress) {
             final InetSocketAddress raddr = (InetSocketAddress) remoteAddr;
-            sslHandler = sslCtx.newHandler(ch.alloc(),
-                                           raddr.getHostString(),
-                                           raddr.getPort());
+            sslEngine = sslCtx.newEngine(ch.alloc(),
+                                         raddr.getHostString(),
+                                         raddr.getPort());
         } else {
             assert remoteAddr instanceof DomainSocketAddress : remoteAddr;
-            sslHandler = sslCtx.newHandler(ch.alloc());
+            sslEngine = sslCtx.newEngine(ch.alloc());
         }
-
         final ClientConnectionTimingsBuilder timingsBuilder = ch.attr(TIMINGS_BUILDER_KEY).get();
-        p.addLast(configureSslHandler(new ClientSslHandler(sslCtx.newEngine(ch.alloc()), timingsBuilder)));
+        final SslHandler sslHandler = new ClientSslHandler(sslEngine, timingsBuilder);
+        p.addLast(configureSslHandler(sslHandler));
         p.addLast(TrafficLoggingHandler.CLIENT);
         p.addLast(new ChannelInboundHandlerAdapter() {
             @Nullable

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -523,9 +523,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             }
             if (proxyDestinationAddress != null) {
                 channelPool.connect(proxyDestinationAddress, retryProtocol, serializationFormat,
-                                    poolKey, sessionPromise);
+                                    poolKey, sessionPromise, null);
             } else {
-                channelPool.connect(remoteAddress, retryProtocol, serializationFormat, poolKey, sessionPromise);
+                channelPool.connect(remoteAddress, retryProtocol, serializationFormat, poolKey, sessionPromise,
+                                    null);
             }
         } else {
             // Fail all pending responses.

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimings.java
@@ -41,6 +41,8 @@ public final class ClientConnectionTimings {
     private final long dnsResolutionDurationNanos;
     private final long socketConnectStartTimeMicros;
     private final long socketConnectDurationNanos;
+    private final long tlsHandshakeStartTimeMicros;
+    private final long tlsHandshakeDurationNanos;
     private final long pendingAcquisitionStartTimeMicros;
     private final long pendingAcquisitionDurationNanos;
 
@@ -54,6 +56,7 @@ public final class ClientConnectionTimings {
     ClientConnectionTimings(long connectionAcquisitionStartTimeMicros, long connectionAcquisitionDurationNanos,
                             long dnsResolutionStartTimeMicros, long dnsResolutionDurationNanos,
                             long socketConnectStartTimeMicros, long socketConnectDurationNanos,
+                            long tlsHandshakeStartTimeMicros, long tlsHandshakeDurationNanos,
                             long pendingAcquisitionStartTimeMicros, long pendingAcquisitionDurationNanos) {
         this.connectionAcquisitionStartTimeMicros = connectionAcquisitionStartTimeMicros;
         this.connectionAcquisitionDurationNanos = connectionAcquisitionDurationNanos;
@@ -61,6 +64,8 @@ public final class ClientConnectionTimings {
         this.dnsResolutionDurationNanos = dnsResolutionDurationNanos;
         this.socketConnectStartTimeMicros = socketConnectStartTimeMicros;
         this.socketConnectDurationNanos = socketConnectDurationNanos;
+        this.tlsHandshakeStartTimeMicros = tlsHandshakeStartTimeMicros;
+        this.tlsHandshakeDurationNanos = tlsHandshakeDurationNanos;
         this.pendingAcquisitionStartTimeMicros = pendingAcquisitionStartTimeMicros;
         this.pendingAcquisitionDurationNanos = pendingAcquisitionDurationNanos;
     }
@@ -86,6 +91,36 @@ public final class ClientConnectionTimings {
      */
     public long connectionAcquisitionDurationNanos() {
         return connectionAcquisitionDurationNanos;
+    }
+
+    /**
+     * Returns the time when the client started to TLS handshake, in microseconds since the epoch.
+     *
+     * @return the start time, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeStartTimeMicros() {
+        return tlsHandshakeStartTimeMicros;
+    }
+
+    /**
+     * Returns the time when the client started to TLS handshake, in milliseconds since the epoch.
+     *
+     * @return the start time, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeStartTimeMillis() {
+        if (tlsHandshakeStartTimeMicros >= 0) {
+            return TimeUnit.MICROSECONDS.toMillis(tlsHandshakeStartTimeMicros);
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the duration which was taken to TLS handshake, in nanoseconds.
+     *
+     * @return the duration, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeDurationNanos() {
+        return tlsHandshakeDurationNanos;
     }
 
     /**
@@ -203,6 +238,14 @@ public final class ClientConnectionTimings {
             buf.append(", socketConnectDuration=");
             TextFormatter.appendElapsed(buf, socketConnectDurationNanos);
         }
+
+        if (tlsHandshakeDurationNanos >= 0) {
+            buf.append(", tlsHandshakeStartTime=");
+            TextFormatter.appendEpochMicros(buf, tlsHandshakeStartTimeMicros);
+            buf.append(", tlsHandshakeDuration=");
+            TextFormatter.appendElapsed(buf, tlsHandshakeDurationNanos);
+        }
+
         if (pendingAcquisitionDurationNanos >= 0) {
             buf.append(", pendingAcquisitionStartTime=");
             TextFormatter.appendEpochMicros(buf, pendingAcquisitionStartTimeMicros);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimings.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimings.java
@@ -94,36 +94,6 @@ public final class ClientConnectionTimings {
     }
 
     /**
-     * Returns the time when the client started to TLS handshake, in microseconds since the epoch.
-     *
-     * @return the start time, or {@code -1} if there was no action to TLS handshake.
-     */
-    public long tlsHandshakeStartTimeMicros() {
-        return tlsHandshakeStartTimeMicros;
-    }
-
-    /**
-     * Returns the time when the client started to TLS handshake, in milliseconds since the epoch.
-     *
-     * @return the start time, or {@code -1} if there was no action to TLS handshake.
-     */
-    public long tlsHandshakeStartTimeMillis() {
-        if (tlsHandshakeStartTimeMicros >= 0) {
-            return TimeUnit.MICROSECONDS.toMillis(tlsHandshakeStartTimeMicros);
-        }
-        return -1;
-    }
-
-    /**
-     * Returns the duration which was taken to TLS handshake, in nanoseconds.
-     *
-     * @return the duration, or {@code -1} if there was no action to TLS handshake.
-     */
-    public long tlsHandshakeDurationNanos() {
-        return tlsHandshakeDurationNanos;
-    }
-
-    /**
      * Returns the time when the client started to resolve a domain name, in microseconds since the epoch.
      *
      * @return the start time, or {@code -1} if there was no action to resolve a domain name.
@@ -181,6 +151,36 @@ public final class ClientConnectionTimings {
      */
     public long socketConnectDurationNanos() {
         return socketConnectDurationNanos;
+    }
+
+    /**
+     * Returns the time when the client started to TLS handshake, in microseconds since the epoch.
+     *
+     * @return the start time, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeStartTimeMicros() {
+        return tlsHandshakeStartTimeMicros;
+    }
+
+    /**
+     * Returns the time when the client started to TLS handshake, in milliseconds since the epoch.
+     *
+     * @return the start time, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeStartTimeMillis() {
+        if (tlsHandshakeStartTimeMicros >= 0) {
+            return TimeUnit.MICROSECONDS.toMillis(tlsHandshakeStartTimeMicros);
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the duration which was taken to TLS handshake, in nanoseconds.
+     *
+     * @return the duration, or {@code -1} if there was no action to TLS handshake.
+     */
+    public long tlsHandshakeDurationNanos() {
+        return tlsHandshakeDurationNanos;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimingsBuilder.java
@@ -92,11 +92,8 @@ public final class ClientConnectionTimingsBuilder {
      * Sets the time when the client started to TLS handshake to a remote peer.
      */
     public ClientConnectionTimingsBuilder tlsHandshakeStart() {
-        final boolean alreadySet = tlsHandshakeStartTimeMicros > 0;
-        if (!alreadySet) {
-            tlsHandshakeStartTimeMicros = SystemInfo.currentTimeMicros();
-            tlsHandshakeStartNanos = System.nanoTime();
-        }
+        tlsHandshakeStartTimeMicros = SystemInfo.currentTimeMicros();
+        tlsHandshakeStartNanos = System.nanoTime();
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupport.java
@@ -126,6 +126,10 @@ public final class RequestMetricSupport {
             if (socketConnectDurationNanos >= 0) {
                 metrics.socketConnectDuration().record(socketConnectDurationNanos, TimeUnit.NANOSECONDS);
             }
+            final long tlsHandshakeDurationNanos = timings.tlsHandshakeDurationNanos();
+            if (tlsHandshakeDurationNanos >= 0) {
+                metrics.tlsHandshakeDuration().record(tlsHandshakeDurationNanos, TimeUnit.NANOSECONDS);
+            }
             final long pendingAcquisitionDurationNanos = timings.pendingAcquisitionDurationNanos();
             if (pendingAcquisitionDurationNanos >= 0) {
                 metrics.pendingAcquisitionDuration().record(pendingAcquisitionDurationNanos,
@@ -203,6 +207,8 @@ public final class RequestMetricSupport {
         Timer dnsResolutionDuration();
 
         Timer socketConnectDuration();
+
+        Timer tlsHandshakeDuration();
 
         Timer pendingAcquisitionDuration();
 
@@ -299,6 +305,7 @@ public final class RequestMetricSupport {
         private final Timer connectionAcquisitionDuration;
         private final Timer dnsResolutionDuration;
         private final Timer socketConnectDuration;
+        private final Timer tlsHandshakeDuration;
         private final Timer pendingAcquisitionDuration;
 
         private final Counter writeTimeouts;
@@ -327,6 +334,9 @@ public final class RequestMetricSupport {
                     distributionStatisticConfig);
             socketConnectDuration = newTimer(
                     parent, idPrefix.name("socket.connect.duration"), idPrefix.tags(),
+                    distributionStatisticConfig);
+            tlsHandshakeDuration = newTimer(
+                    parent, idPrefix.name("tls.handshake.duration"), idPrefix.tags(),
                     distributionStatisticConfig);
             pendingAcquisitionDuration = newTimer(
                     parent, idPrefix.name("pending.acquisition.duration"), idPrefix.tags(),
@@ -358,6 +368,11 @@ public final class RequestMetricSupport {
         @Override
         public Timer socketConnectDuration() {
             return socketConnectDuration;
+        }
+
+        @Override
+        public Timer tlsHandshakeDuration() {
+            return tlsHandshakeDuration;
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/client/TlsHandshakeTimingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TlsHandshakeTimingTest.java
@@ -32,7 +32,7 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.channel.ChannelOption;
 
-public class TlsHandshakeTimingTest {
+class TlsHandshakeTimingTest {
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {

--- a/core/src/test/java/com/linecorp/armeria/client/TlsHandshakeTimingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TlsHandshakeTimingTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.logging.ClientConnectionTimings;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.channel.ChannelOption;
+
+public class TlsHandshakeTimingTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.https(0);
+            sb.tlsSelfSigned();
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    @Test
+    void httpsServerConnectionWithTlsSelfSigned() {
+        final AtomicReference<ClientConnectionTimings> timingsHolder = new AtomicReference<>();
+        try (ClientFactory clientFactory = ClientFactory.builder().tlsNoVerify().build()) {
+            final AggregatedHttpResponse res =
+                    WebClient.builder(server.httpsUri())
+                             .factory(clientFactory)
+                             .decorator((delegate, ctx, req) -> {
+                                 ctx.log().whenAvailable(RequestLogProperty.SESSION)
+                                    .thenAccept(log -> timingsHolder.set(log.connectionTimings()));
+                                 return delegate.execute(ctx, req);
+                             })
+                             .build()
+                             .blocking()
+                             .get("/");
+            assertThat(res.status().code()).isEqualTo(200);
+            assertThat(timingsHolder.get().tlsHandshakeStartTimeMicros()).isPositive();
+            assertThat(timingsHolder.get().tlsHandshakeStartTimeMillis()).isPositive();
+            assertThat(timingsHolder.get().tlsHandshakeDurationNanos()).isPositive();
+        }
+    }
+
+    @Test
+    void httpsServerConnectionWithTlsSelfSignedByTFOOption() {
+        final AtomicReference<ClientConnectionTimings> timingsHolder = new AtomicReference<>();
+        try (ClientFactory clientFactory = ClientFactory.builder()
+                                                        .tlsNoVerify()
+                                                        .channelOption(ChannelOption.TCP_FASTOPEN_CONNECT, true)
+                                                        .build()) {
+            final AggregatedHttpResponse res =
+                    WebClient.builder(server.httpsUri())
+                             .factory(clientFactory)
+                             .decorator((delegate, ctx, req) -> {
+                                 ctx.log().whenAvailable(RequestLogProperty.SESSION)
+                                    .thenAccept(log -> timingsHolder.set(log.connectionTimings()));
+                                 return delegate.execute(ctx, req);
+                             })
+                             .build()
+                             .blocking()
+                             .get("/");
+            assertThat(res.status().code()).isEqualTo(200);
+            assertThat(timingsHolder.get().tlsHandshakeStartTimeMicros()).isPositive();
+            assertThat(timingsHolder.get().tlsHandshakeStartTimeMillis()).isPositive();
+            assertThat(timingsHolder.get().tlsHandshakeDurationNanos()).isPositive();
+        }
+    }
+
+    @Test
+    void serverConnectionWithoutTls() {
+        final AtomicReference<ClientConnectionTimings> timingsHolder = new AtomicReference<>();
+        final AggregatedHttpResponse res =
+                WebClient.builder(server.httpUri())
+                         .decorator((delegate, ctx, req) -> {
+                             ctx.log().whenAvailable(RequestLogProperty.SESSION)
+                                .thenAccept(log -> timingsHolder.set(log.connectionTimings()));
+                             return delegate.execute(ctx, req);
+                         })
+                         .build()
+                         .blocking()
+                         .get("/");
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(timingsHolder.get().tlsHandshakeStartTimeMicros()).isEqualTo(-1);
+        assertThat(timingsHolder.get().tlsHandshakeStartTimeMillis()).isEqualTo(-1);
+        assertThat(timingsHolder.get().tlsHandshakeDurationNanos()).isEqualTo(-1);
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/metric/RequestMetricSupportTest.java
@@ -83,6 +83,8 @@ class RequestMetricSupportTest {
                                "service=FooService}", 1.0)
                 .containsEntry("foo.socket.connect.duration#count{http.status=200,method=POST," +
                                "service=FooService}", 1.0)
+                .containsEntry("foo.tls.handshake.duration#count{http.status=200,method=POST," +
+                               "service=FooService}", 1.0)
                 .containsEntry("foo.pending.acquisition.duration#count{http.status=200,method=POST," +
                                "service=FooService}", 1.0)
                 .containsEntry("foo.request.length#count{http.status=200,method=POST," +
@@ -107,6 +109,8 @@ class RequestMetricSupportTest {
                                       .dnsResolutionEnd()
                                       .socketConnectStart()
                                       .socketConnectEnd()
+                                      .tlsHandshakeStart()
+                                      .tlsHandshakeEnd()
                                       .pendingAcquisitionStart()
                                       .pendingAcquisitionEnd()
                                       .build();
@@ -165,6 +169,8 @@ class RequestMetricSupportTest {
                 .containsEntry("foo.dns.resolution.duration#count{http.status=500,method=POST,service=none}",
                                1.0)
                 .containsEntry("foo.socket.connect.duration#count{http.status=500,method=POST,service=none}",
+                               1.0)
+                .containsEntry("foo.tls.handshake.duration#count{http.status=500,method=POST,service=none}",
                                1.0)
                 .containsEntry("foo.pending.acquisition.duration#count{http.status=500,method=POST," +
                                "service=none}", 1.0)

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ plugins {
     // automatically download one based on the foojay Disco API.
     // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.6.0'
-    id 'com.gradle.enterprise' version '3.16.2'
+    id 'com.gradle.enterprise' version '3.17'
     // adds additional metadata to build scans
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
 }


### PR DESCRIPTION
Motivation:

Collect the timings related with TLS handshake. If a request was the first in a connection, armeria could also provide it in a RequestLog to tell a user that the request timing has been affected by TLS handshake.

Modifications:

- Add TLS handshake related field in `ClientConnectionTimings`
- Add TLS handshake duration metric field at MetricCollectingClient
- Start collecting the TLS handshake timer in the case below.
  - ~~If the client is enabled as `TCP fast open` in the first request, start the timer before the TCP connection.~~
  - start the timer when netty calls `SslHandler.channelActive()`

Result:

- Closes #3647 
