### PR TITLE
Add recovery hook to outermost HttpResponse and fix DeferredStreamMessage

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
@@ -269,7 +269,8 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
                 }
             } else {
                 try {
-                    if (subscription.shouldNotifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
+                    if (subscription.shouldNotifyCancellation() ||
+                        !(cause instanceof CancelledSubscriptionException)) {
                         subscriber.onError(cause);
                     }
                     completionFuture.completeExceptionally(cause);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
@@ -154,7 +154,7 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
         private final EventExecutor executor;
         private final SubscriptionOption[] options;
         private final boolean withPooledObjects;
-        private final boolean notifyCancellation;
+        private final boolean shouldNotifyCancellation;
 
         private volatile boolean cancelRequested;
 
@@ -166,7 +166,7 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
             this.executor = executor;
             this.options = options;
             withPooledObjects = containsWithPooledObjects(options);
-            notifyCancellation = containsNotifyCancellation(options);
+            shouldNotifyCancellation = containsNotifyCancellation(options);
         }
 
         Subscriber<Object> subscriber() {
@@ -195,8 +195,8 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
             return withPooledObjects;
         }
 
-        boolean notifyCancellation() {
-            return notifyCancellation;
+        boolean shouldNotifyCancellation() {
+            return shouldNotifyCancellation;
         }
 
         boolean cancelRequested() {
@@ -269,7 +269,7 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
                 }
             } else {
                 try {
-                    if (subscription.notifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
+                    if (subscription.shouldNotifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
                         subscriber.onError(cause);
                     }
                     completionFuture.completeExceptionally(cause);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
@@ -195,6 +195,10 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
             return withPooledObjects;
         }
 
+        boolean notifyCancellation() {
+            return notifyCancellation;
+        }
+
         boolean cancelRequested() {
             return cancelRequested;
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -440,7 +440,7 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
         } catch (Throwable t) {
             final Exception composite = new CompositeException(t, cause);
             throwIfFatal(t);
-            logger.warn("Subscriber.onError() should not raise an exception. subscriber: {}",
+            logger.warn("Subscriber.onSubscribe() or onError() should not raise an exception. subscriber: {}",
                         subscriber, composite);
         }
         whenComplete().completeExceptionally(cause);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -391,7 +391,7 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
             return;
         }
 
-        // Downstream was already set but upstream wasn't set yet.
+        // Downstream was already set but upstream wasn't set yet or wouldn't be subscribed by the downstream.
 
         //noinspection unchecked
         final CompletableFuture<List<?>> collectingFuture =

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -369,8 +369,8 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
 
         if (!subscribedToUpstreamUpdater.compareAndSet(this, 0, 1)) {
             // Already subscribed to upstream so just abort upstream.
-            // upstream.abort(cause) might be as well in delegate(StreamMessage<T> upstream) method which is
-            // perfectly fine.
+            // upstream.abort(cause) might be called as well in delegate(StreamMessage<T> upstream) method
+            // which is perfectly fine.
             final StreamMessage<T> upstream = this.upstream;
             assert upstream != null;
             upstream.abort(cause);
@@ -391,7 +391,7 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
             return;
         }
 
-        // Downstream was already subscribed but upstream wasn't set yet.
+        // Downstream was already set but upstream wasn't set yet.
 
         //noinspection unchecked
         final CompletableFuture<List<?>> collectingFuture =

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -413,7 +413,7 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
     private void downstreamOnError(Throwable cause, SubscriptionImpl downstreamSubscription) {
         final Subscriber<Object> subscriber = downstreamSubscription.subscriber();
         try {
-            if (downstreamSubscription.notifyCancellation() ||
+            if (downstreamSubscription.shouldNotifyCancellation() ||
                 !(cause instanceof CancelledSubscriptionException)) {
                 subscriber.onError(cause);
             }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseHandler.java
@@ -274,7 +274,12 @@ abstract class AbstractHttpResponseHandler {
                     // A stream or connection was already closed by a client
                     fail(cause);
                 } else {
-                    req.setShouldResetOnlyIfRemoteIsOpen(true);
+                    if (reqCtx.sessionProtocol().isMultiplex()) {
+                        req.setShouldResetOnlyIfRemoteIsOpen(true);
+                    } else if (req.isOpen()) {
+                        disconnectWhenFinished();
+                    }
+
                     req.abortResponse(cause, false);
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -389,15 +389,15 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         if (whenAggregated != null) {
             res = HttpResponse.of(req.whenAggregated().thenApply(ignored -> {
                 if (serviceEventLoop.inEventLoop()) {
-                    return serve0(req, serviceCfg, service, reqCtx);
+                    return serve0(req, service, reqCtx);
                 }
-                return serveInServiceEventLoop(req, serviceCfg, service, reqCtx, serviceEventLoop);
+                return serveInServiceEventLoop(req, service, reqCtx, serviceEventLoop);
             }));
         } else {
             if (serviceEventLoop.inEventLoop()) {
-                res = serve0(req, serviceCfg, service, reqCtx);
+                res = serve0(req, service, reqCtx);
             } else {
-                res = serveInServiceEventLoop(req, serviceCfg, service, reqCtx, serviceEventLoop);
+                res = serveInServiceEventLoop(req, service, reqCtx, serviceEventLoop);
             }
         }
         res = res.recover(cause -> {
@@ -455,9 +455,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         }
     }
 
-    private static HttpResponse serve0(HttpRequest req,
-                                       ServiceConfig serviceCfg,
-                                       HttpService service,
+    private static HttpResponse serve0(HttpRequest req, HttpService service,
                                        DefaultServiceRequestContext reqCtx) {
         try (SafeCloseable ignored = reqCtx.push()) {
             HttpResponse serviceResponse;
@@ -478,11 +476,10 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private static HttpResponse serveInServiceEventLoop(DecodedHttpRequest req,
-                                                        ServiceConfig serviceCfg,
                                                         HttpService service,
                                                         DefaultServiceRequestContext reqCtx,
                                                         EventLoop serviceEventLoop) {
-        return HttpResponse.of(() -> serve0(req.subscribeOn(serviceEventLoop), serviceCfg, service, reqCtx),
+        return HttpResponse.of(() -> serve0(req.subscribeOn(serviceEventLoop), service, reqCtx),
                                serviceEventLoop)
                            .subscribeOn(serviceEventLoop);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/RequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RequestTimeoutTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RequestTimeoutTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    private static class TimeoutNowInServeArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+            for (SessionProtocol protocol : ImmutableList.of(SessionProtocol.H1C, SessionProtocol.H2C)) {
+                for (ExchangeType value : ExchangeType.values()) {
+                    for (boolean clientSendsOneBody : ImmutableList.of(true, false)) {
+                        for (boolean useServiceEventLoop : ImmutableList.of(true, false)) {
+                            for (HttpResponse httpResponse : ImmutableList.of(
+                                    HttpResponse.of(200),
+                                    HttpResponse.delayed(HttpResponse.of(200), Duration.ofMillis(100)),
+                                    HttpResponse.streaming())) {
+                                builder.add(arguments(protocol, value, clientSendsOneBody,
+                                                      useServiceEventLoop, httpResponse));
+                            }
+                        }
+                    }
+                }
+            }
+            return builder.build().stream();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TimeoutNowInServeArgumentsProvider.class)
+    void timeoutNowInServe(SessionProtocol protocol, ExchangeType exchangeType,
+                           boolean clientSendsOneBody, boolean useServiceEventLoop, HttpResponse httpResponse) {
+        server.server().reconfigure(sb -> {
+            if (useServiceEventLoop) {
+                sb.serviceWorkerGroup(2);
+            }
+            sb.service("/", new HttpService() {
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    ctx.timeoutNow();
+                    return httpResponse;
+                }
+
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    return exchangeType;
+                }
+            });
+        });
+        final HttpRequestWriter request = HttpRequest.streaming(RequestHeaders.of(HttpMethod.POST, "/"));
+        if (clientSendsOneBody) {
+            // AbstractHttpResponseHandler.scheduleTimeout(); is called before ctx.timeoutNow(); is called.
+            request.write(HttpData.ofUtf8("foo"));
+        }
+        request.close();
+        assertThat(WebClient.of(protocol, server.endpoint(protocol))
+                            .execute(request).aggregate().join().status())
+                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    private static class TimeoutByTimerArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            final ImmutableList.Builder<Arguments> builder = ImmutableList.builder();
+            for (SessionProtocol protocol : ImmutableList.of(SessionProtocol.H1C, SessionProtocol.H2C)) {
+                for (ExchangeType value : ExchangeType.values()) {
+                    for (boolean useServiceEventLoop : ImmutableList.of(true, false)) {
+                        for (boolean clientCloseRequest : ImmutableList.of(true, false)) {
+                            builder.add(arguments(protocol, value, useServiceEventLoop, clientCloseRequest));
+                        }
+                    }
+                }
+            }
+            return builder.build().stream();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TimeoutByTimerArgumentsProvider.class)
+    void timeoutByTimer(SessionProtocol protocol, ExchangeType exchangeType,
+                        boolean useServiceEventLoop, boolean clientCloseRequest) {
+        server.server().reconfigure(sb -> {
+            sb.requestTimeoutMillis(10);
+            if (useServiceEventLoop) {
+                sb.serviceWorkerGroup(2);
+            }
+            sb.service("/", new HttpService() {
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    return HttpResponse.streaming();
+                }
+
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    return exchangeType;
+                }
+            });
+        });
+        final HttpRequestWriter request = HttpRequest.streaming(RequestHeaders.of(HttpMethod.POST, "/"));
+        if (clientCloseRequest) {
+            request.close();
+        }
+        assertThat(WebClient.builder(protocol, server.endpoint(protocol))
+                            .build()
+                            .execute(request).aggregate().join().status())
+                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
Motivation:
A hook needs to be added to the `HttpResponse` returned from an `HttpService` to allow recovery when the `HttpResponse` is aborted. This hook must be added to the outermost `HttpResponse` to effectively handle exceptions raised in any layer.

Additionally, `DeferredHttpResponse` contains a bug that causes `Subscriber.onError()` to be called twice under certain conditions. This occurs when:
- A `downstreamSubscription` is set and the `DeferredHttpResponse` is aborted, causing downstream onError to be called. https://github.com/line/armeria/blob/armeria-1.28.3/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java#L311 https://github.com/line/armeria/blob/armeria-1.28.3/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java#L390
- `upstream` is set and subscribed by the downstream, which subsequently gets aborted and triggers a second call to downstream onError. https://github.com/line/armeria/blob/armeria-1.28.3/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java#L353

Modifications:
- Added a recovery hook to the outermost `HttpResponse` in `HttpServerHandler` to enable proper handling of abort scenarios.
- Modified `DeferredStreamMessage` to prevent calling `Subscriber.onError()` twice.
- Closed HTTP/1.1 connections when the request times out and the server does not receive the request fully.

Result:
- The `HttpResponse` returned from an `HttpService` is now correctly recovered from the exception.
- Aborted `DeferredStreamMessage` doesn't call `Subscriber.onError()` multiple times anymore.