### PR TITLE
Support LbSubsetFallbackPolicy.NO_FALLBACK

### DIFF
--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterEntry.java
@@ -16,10 +16,13 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -71,5 +74,15 @@ final class ClusterEntry implements Consumer<List<Endpoint>>, AsyncCloseable {
     @Override
     public void close() {
         endpointGroup.close();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("endpointGroup", endpointGroup)
+                          .add("loadBalancer", loadBalancer)
+                          .add("numEndpoints", endpoints.size())
+                          .add("endpoints", truncate(endpoints, 10))
+                          .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ClusterManager.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.xds.client.endpoint;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,6 +34,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -232,6 +234,16 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
         closeAsync().join();
     }
 
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("eventLoop", eventLoop)
+                          .add("clusterEntries", clusterEntries)
+                          .add("listenerSnapshot", listenerSnapshot)
+                          .add("closed", closed)
+                          .toString();
+    }
+
     static final class State {
 
         static final State INITIAL_STATE = new State(null, ImmutableList.of());
@@ -268,6 +280,15 @@ final class ClusterManager implements SnapshotWatcher<ListenerSnapshot>, AsyncCl
         @Override
         public int hashCode() {
             return Objects.hashCode(listenerSnapshot, endpoints);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).omitNullValues()
+                              .add("listenerSnapshot", listenerSnapshot)
+                              .add("numEndpoints", endpoints.size())
+                              .add("endpoints", truncate(endpoints, 10))
+                              .toString();
         }
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.Lock;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.client.ClientRequestContext;
@@ -192,6 +193,17 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>> i
     @Override
     public void close() {
         closeAsync().join();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("selectionStrategy", selectionStrategy)
+                          .add("allowEmptyEndpoints", allowEmptyEndpoints)
+                          .add("initialized", initialEndpointsFuture.isDone())
+                          .add("state", state)
+                          .add("clusterManager", clusterManager)
+                          .toString();
     }
 
     private static class XdsEndpointSelectionStrategy implements EndpointSelectionStrategy {

--- a/xds/src/test/java/com/linecorp/armeria/xds/XdsTestResources.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/XdsTestResources.java
@@ -335,7 +335,11 @@ public final class XdsTestResources {
     }
 
     public static Listener staticResourceListener(Metadata metadata) {
-        final RouteAction.Builder routeActionBuilder = RouteAction.newBuilder().setCluster("cluster");
+        return staticResourceListener(metadata, "cluster");
+    }
+
+    public static Listener staticResourceListener(Metadata metadata, String clusterName) {
+        final RouteAction.Builder routeActionBuilder = RouteAction.newBuilder().setCluster(clusterName);
         if (metadata != Metadata.getDefaultInstance()) {
             routeActionBuilder.setMetadataMatch(metadata);
         }

--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/XdsConverterUtilTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/XdsConverterUtilTest.java
@@ -83,7 +83,7 @@ class XdsConverterUtilTest {
         return Struct.newBuilder().putAllFields(structMap).build();
     }
 
-    static ClusterLoadAssignment sampleClusterLoadAssignment() {
+    static ClusterLoadAssignment sampleClusterLoadAssignment(String clusterName) {
         final Metadata metadata1 =
                 Metadata.newBuilder()
                         .putFilterMetadata(SUBSET_LOAD_BALANCING_FILTER_NAME,
@@ -118,7 +118,7 @@ class XdsConverterUtilTest {
                                    .addLbEndpoints(endpoint3)
                                    .build();
         return ClusterLoadAssignment.newBuilder()
-                            .setClusterName("cluster")
+                            .setClusterName(clusterName)
                             .addEndpoints(lbEndpoints)
                             .build();
     }


### PR DESCRIPTION
Motivation
The default subset policy, `LbSubsetFallbackPolicy.NO_FALLBACK`, should be supported.

Modifications:
- Support `LbSubsetFallbackPolicy.NO_FALLBACK`
- Add `toString` methods for xDS classes
Result:
- `XdsEndpointGroup` now adheres to the `LbSubsetFallbackPolicy.NO_FALLBACK` policy.
