### PR TITLE
Disable output caching for jmh module

### DIFF
--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -82,7 +82,9 @@ jmh {
     }
 }
 
-tasks.jmh.outputs.upToDateWhen {false}
+tasks.jmh.outputs.upToDateWhen {
+    false
+}
 
 // Workaround a bug where the conflict of output path between 'benchmarks.jmh' and 'benchmarks.test' in IDEA
 project.afterEvaluate {

--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -82,6 +82,7 @@ jmh {
     }
 }
 
+// Disable output caching so that benchmarks are not skipped on the second run.
 tasks.jmh.outputs.upToDateWhen {
     false
 }

--- a/benchmarks/jmh/build.gradle
+++ b/benchmarks/jmh/build.gradle
@@ -82,6 +82,8 @@ jmh {
     }
 }
 
+tasks.jmh.outputs.upToDateWhen {false}
+
 // Workaround a bug where the conflict of output path between 'benchmarks.jmh' and 'benchmarks.test' in IDEA
 project.afterEvaluate {
     idea {


### PR DESCRIPTION
**Motivation**

We often run benchmarks several times without modifying the code.
However, with gradle up-to-date checks, we can often see that only the first run actually applies benchmarks.
I think it's reasonable that the jmh task output caching is always disabled

**Modifications**

Always disable output caching for jmh tasks

**Result**

It is easier to run benchmarks