### PR TITLE
Fix link in server access log docs

### DIFF
--- a/site/src/pages/docs/server-access-log.mdx
+++ b/site/src/pages/docs/server-access-log.mdx
@@ -158,7 +158,7 @@ Tokens for the log format are listed in the following table.
 |                                     |                   | %d/%b/%Y:%H:%M:%S %z.                                                   |
 |                                     |                   | (for example, `10/Oct/2000:13:55:36 -0700`)                             |
 |                                     |                   | Refer to                                                                |
-|                                     |                   | [Customizing timestamp format][#customizing-timestamp-format]           |
+|                                     |                   | [Customizing timestamp format](#customizing-timestamp-format)           |
 |                                     |                   | for more information.                                                   |
 +-------------------------------------+-------------------+-------------------------------------------------------------------------+
 | `%r`                                | Yes               | the request line from the client                                        |


### PR DESCRIPTION
Fix "Customizing timestamp format" link in server access log docs (https://armeria.dev/docs/server-access-log)

## as-is

<img width="776" alt="image" src="https://github.com/line/armeria/assets/11611397/b918f070-1f47-45c3-9330-8c14d64c188a">


## to-be

<img width="631" alt="image" src="https://github.com/line/armeria/assets/11611397/8629f479-1bab-4922-9268-5072884c908c">

(built locally)