### PR TITLE
Fix client connection timing end check condition from '>= 0' to '> 0'

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimingsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ClientConnectionTimingsBuilder.java
@@ -77,7 +77,7 @@ public final class ClientConnectionTimingsBuilder {
      * @throws IllegalStateException if {@link #socketConnectStart()} is not invoked before calling this.
      */
     public ClientConnectionTimingsBuilder socketConnectEnd() {
-        checkState(socketConnectStartTimeMicros >= 0, "socketConnectStart() is not called yet.");
+        checkState(socketConnectStartTimeMicros > 0, "socketConnectStart() is not called yet.");
         checkState(!socketConnectEndSet, "socketConnectEnd() is already called.");
         socketConnectEndNanos = System.nanoTime();
         socketConnectEndSet = true;
@@ -103,7 +103,7 @@ public final class ClientConnectionTimingsBuilder {
      * @throws IllegalStateException if {@link #pendingAcquisitionStart()} is not invoked before calling this.
      */
     public ClientConnectionTimingsBuilder pendingAcquisitionEnd() {
-        checkState(pendingAcquisitionStartTimeMicros >= 0, "pendingAcquisitionStart() is not called yet.");
+        checkState(pendingAcquisitionStartTimeMicros > 0, "pendingAcquisitionStart() is not called yet.");
         pendingAcquisitionEndNanos = System.nanoTime();
         pendingAcquisitionEndSet = true;
         return this;


### PR DESCRIPTION
Motivation:

The ClientConnectionTimingsBuilder's `socketConnect`, `pendingAcquisition` timing end method check condition is incorrect.

Modifications:

- fix check condition `>=  0` to `> 0`

Result:

- Closes #5658

