### PR TITLE
Respect user-provided `serviceLevelObjectives` in timer histogram metrics

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/MoreMeters.java
@@ -30,7 +30,6 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.common.Flags;
 
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.DistributionSummary.Builder;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -45,7 +44,7 @@ public final class MoreMeters {
     private static final boolean MICROMETER_1_5;
 
     static {
-        MICROMETER_1_5 = Stream.of(Builder.class.getMethods())
+        MICROMETER_1_5 = Stream.of(DistributionSummary.Builder.class.getMethods())
                                .anyMatch(method -> method != null &&
                                                    "serviceLevelObjectives".equals(method.getName()));
     }


### PR DESCRIPTION
Motivation:

Armeria allows overriding its default distribution metric config but `servieLevelObjectives` config is not respected in its timer metrics

Modification:

Made Armeria respect user-provided `serviceLevelObjectives` in its timer histogram metrics.

Result:

- Timer histogram metrics exposed by Armeria repects user-provided `serviceLevelObjectives`.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
