### PR TITLE
Migrate gradle enterprise plugin to develocity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
           timezone: "Asia/Seoul"
       open-pull-requests-limit: 10
       allow:
-          - dependency-name: "com.gradle.enterprise"
+          - dependency-name: "com.gradle.develocity"
             dependency-type: "production"
           - dependency-name: "com.gradle.common-custom-user-data-gradle-plugin"
             dependency-type: "production"

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -22,7 +22,7 @@ env:
   GH_TOKEN: ${{ github.token }}
   RUN_ID: ${{ github.run_id }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   choose-self-hosted:

--- a/.github/workflows/e2e-chaos-tests.yml
+++ b/.github/workflows/e2e-chaos-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CHAOS_MESH_VERSION: 2.6.2
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   chaos-tests:

--- a/.github/workflows/gradle-cache-check.yml
+++ b/.github/workflows/gradle-cache-check.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   LC_ALL: "en_US.UTF-8"
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   build-cache-check:

--- a/.github/workflows/gradle-enterprise-postjob.yml
+++ b/.github/workflows/gradle-enterprise-postjob.yml
@@ -9,7 +9,7 @@ on:
 env:
   LC_ALL: "en_US.UTF-8"
   BUILD_JDK_VERSION: "19"
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
   RUN_ID: ${{ github.event.workflow_run.id }}
   COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
   # Used by Octokit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   LC_ALL: "en_US.UTF-8"
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   publish:

--- a/build.gradle
+++ b/build.gradle
@@ -121,15 +121,17 @@ allprojects {
             })
         }
 
-        retry {
-            if (rootProject.findProperty('retry') == 'true') {
-                maxRetries = 3
-                failOnPassedAfterRetry = rootProject.findProperty('failOnPassedAfterRetry') != 'false'
+        develocity {
+            testRetry {
+                if (rootProject.findProperty('retry') == 'true') {
+                    maxRetries = 3
+                    failOnPassedAfterRetry = rootProject.findProperty('failOnPassedAfterRetry') != 'false'
+                }
             }
-        }
 
-        predictiveSelection {
-            enabled.set(!isCi)
+            predictiveTestSelection {
+                enabled.set(!isCi)
+            }
         }
     }
 }
@@ -439,7 +441,7 @@ configure(relocatedProjects) {
 }
 
 // additional configuration that can't be done at settings.gradle
-gradleEnterprise {
+develocity {
     buildScan {
         // maintain a allowList so that sensitive information (credentials) aren't accidentally published.
         Set<String> allowList = ['coverage', 'leak', 'blockhound', 'noLint', 'flakyTests', 'buildJdkVersion',

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,20 +6,19 @@ plugins {
     // automatically download one based on the foojay Disco API.
     // https://docs.gradle.org/8.1.1/userguide/toolchains.html#sec:provisioning
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.6.0'
-    id 'com.gradle.enterprise' version '3.17.2'
+    id 'com.gradle.develocity' version '3.17.2'
     // adds additional metadata to build scans
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
 }
 
-import com.gradle.scan.plugin.PublishedBuildScan
+import com.gradle.develocity.agent.gradle.scan.PublishedBuildScan
 
 def isCi = System.getenv("CI") != null
 
-gradleEnterprise {
+develocity {
     server = "https://ge.armeria.dev"
     buildScan {
-        publishIfAuthenticated()
-        publishAlways()
+        publishing.onlyIf { it.authenticated }
         uploadInBackground = !isCi
         if (isCi) {
             buildScanPublished { PublishedBuildScan scan ->
@@ -53,10 +52,6 @@ gradleEnterprise {
                 tag jobName
             }
         }
-
-        capture {
-            taskInputFiles = true
-        }
     }
 }
 
@@ -64,7 +59,7 @@ buildCache {
     local {
         enabled = true
     }
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = true
         // also check access key to avoid warning logs
         def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,7 +62,7 @@ buildCache {
     remote(develocity.buildCache) {
         enabled = true
         // also check access key to avoid warning logs
-        def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+        def accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
         push = isCi && accessKey != null && !accessKey.isEmpty()
     }
 }


### PR DESCRIPTION
Motivation:

Gradle enterprise plugin is rebranded as "Develocity" since 3.17 and several core functionalities have been deprecated, and will be removed in a future plugin version.

Modification:

- Migrate gradle enterprise plugin to the develocity plugin ([migration guide](https://docs.gradle.com/develocity/gradle-plugin/legacy/#develocity_migration))
  - Simple renames.
  - Remove explicit `taskInputFiles` setting. Since 3.17, hashes of inputs of tasks will be captured by default.
  - Remove `buildScan.publishAlways`. The updated Develocity `buildScan.publishing` publishes a Build Scan by default.

Result:

Gradle enterprise plugin is migrated to the Develocity plugin.

---
> WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.
> - The deprecated "GRADLE_ENTERPRISE_ACCESS_KEY" environment variable has been replaced by "DEVELOCITY_ACCESS_KEY"

Note: Access key environment variable name should be also renamed(`GRADLE_ENTERPRISE_ACCESS_KEY` -> `DEVELOCITY_ACCESS_KEY`) but I don't have permission to update secrets, so I need help on this.