### PR TITLE
Update codecov-action to v4

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload the coverage report to Codecov
         if: ${{ matrix.coverage }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
       - name: Fail the run if any threads were blocked
         if: ${{ matrix.blockhound }}


### PR DESCRIPTION
codecov-action@v3 runs as node 16 which has reached end of life.

Also warning message is displayed in action summary like below
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.