### PR TITLE
Fix self-signed certificate generation failure

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -218,7 +218,11 @@ if (tasks.findByName('trimShadedJar')) {
         // Do not optimize the dependencies that access some fields via sun.misc.Unsafe or reflection only.
         keep "class com.linecorp.armeria.internal.shaded.caffeine.** { *; }"
         keep "class com.linecorp.armeria.internal.shaded.jctools.** { *; }"
-
+        // Keep the Bouncy Castle classes dynamically accessed by MinifiedBouncyCastleProvider.
+        keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.dsa.** { *; }"
+        keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.ec.** { *; }"
+        keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.rsa.** { *; }"
+        keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.x509.** { *; }"
         dontnote
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
@@ -151,7 +151,7 @@ public final class MinifiedBouncyCastleProvider extends Provider implements Conf
         // depending on how and what relocation tool we use, so this `assert` will help us
         // notice when the relocation did not work as expected.
         checkArgument(className.startsWith(BC_PACKAGE_PREFIX),
-                      "Unexpected BouncyCastle class name: %s", className);
+                      "Unexpected Bouncy Castle class name: %s", className);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.security.AccessController;
@@ -132,24 +133,25 @@ public final class MinifiedBouncyCastleProvider extends Provider implements Conf
         checkState(!containsKey(key), "duplicate algorithm: %s", key);
         if (value.contains(".bouncycastle.")) {
             // Very likely to be a class name.
-            assertClassName(value);
+            checkClassName(value);
         }
         put(key, value);
     }
 
     @Override
     public void addAlgorithm(String type, ASN1ObjectIdentifier oid, String className) {
-        assertClassName(className);
+        checkClassName(className);
         addAlgorithm(type + '.' + oid, className);
         addAlgorithm(type + ".OID." + oid, className);
     }
 
-    private static void assertClassName(String className) {
+    private static void checkClassName(String className) {
         // Bouncy Castle sometimes uses a hard-coded class name when configuring itself.
         // Such hard-coded names may or may not be updated during the class relocation process
         // depending on how and what relocation tool we use, so this `assert` will help us
         // notice when the relocation did not work as expected.
-        assert className.startsWith(BC_PACKAGE_PREFIX) : "Unexpected BouncyCastle class name: " + className;
+        checkArgument(className.startsWith(BC_PACKAGE_PREFIX),
+                      "Unexpected BouncyCastle class name: %s", className);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
@@ -30,12 +30,15 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi.EC;
-import org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory;
-import org.bouncycastle.jcajce.provider.asymmetric.x509.KeyFactory;
+import org.bouncycastle.jcajce.provider.asymmetric.DSA;
+import org.bouncycastle.jcajce.provider.asymmetric.EC;
+import org.bouncycastle.jcajce.provider.asymmetric.RSA;
+import org.bouncycastle.jcajce.provider.asymmetric.X509;
 import org.bouncycastle.jcajce.provider.config.ConfigurableProvider;
 import org.bouncycastle.jcajce.provider.util.AsymmetricKeyInfoConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * A downsized version of {@link BouncyCastleProvider} which provides only RSA/DSA/EC {@link KeyFactorySpi}s
@@ -44,6 +47,15 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 public final class MinifiedBouncyCastleProvider extends Provider implements ConfigurableProvider {
 
     private static final long serialVersionUID = -834653615603942658L;
+
+    /**
+     * The relocated Bouncy Castle package prefix. If relocated, it will be:
+     * {@code com.linecorp.armeria.internal.shaded.bouncycastle}.
+     */
+    @VisibleForTesting
+    @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
+    static final String BC_PACKAGE_PREFIX =
+            BouncyCastleProvider.class.getName().replaceFirst("\\.bouncycastle\\..*$", ".bouncycastle.");
 
     private static final String PROVIDER_NAME = "ArmeriaBC";
 
@@ -101,31 +113,10 @@ public final class MinifiedBouncyCastleProvider extends Provider implements Conf
     }
 
     private void addFactories() {
-        // KeyFactories
-        addKeyFactory(org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyFactorySpi.class, "RSA");
-        addKeyFactory(org.bouncycastle.jcajce.provider.asymmetric.dsa.KeyFactorySpi.class, "DSA");
-        addKeyFactory(EC.class, "EC");
-        addKeyFactory(KeyFactory.class, "X.509", "X509");
-
-        // CertificateFactories
-        addCertificateFactory(CertificateFactory.class, "X.509", "X509");
-    }
-
-    private void addKeyFactory(
-            Class<? extends KeyFactorySpi> factoryType, String name, String... aliases) {
-        addFactory("KeyFactory.", factoryType, name, aliases);
-    }
-
-    private void addCertificateFactory(
-            Class<? extends CertificateFactorySpi> factoryType, String name, String... aliases) {
-        addFactory("CertificateFactory.", factoryType, name, aliases);
-    }
-
-    private void addFactory(String prefix, Class<?> factoryType, String name, String... aliases) {
-        addAlgorithm(prefix + name, factoryType.getName());
-        for (String alias : aliases) {
-            addAlgorithm("Alg.Alias." + prefix + alias, name);
-        }
+        new RSA.Mappings().configure(this);
+        new DSA.Mappings().configure(this);
+        new EC.Mappings().configure(this);
+        new X509.Mappings().configure(this);
     }
 
     @Override
@@ -139,13 +130,26 @@ public final class MinifiedBouncyCastleProvider extends Provider implements Conf
     @Override
     public void addAlgorithm(String key, String value) {
         checkState(!containsKey(key), "duplicate algorithm: %s", key);
+        if (value.contains(".bouncycastle.")) {
+            // Very likely to be a class name.
+            assertClassName(value);
+        }
         put(key, value);
     }
 
     @Override
     public void addAlgorithm(String type, ASN1ObjectIdentifier oid, String className) {
+        assertClassName(className);
         addAlgorithm(type + '.' + oid, className);
         addAlgorithm(type + ".OID." + oid, className);
+    }
+
+    private static void assertClassName(String className) {
+        // Bouncy Castle sometimes uses a hard-coded class name when configuring itself.
+        // Such hard-coded names may or may not be updated during the class relocation process
+        // depending on how and what relocation tool we use, so this `assert` will help us
+        // notice when the relocation did not work as expected.
+        assert className.startsWith(BC_PACKAGE_PREFIX) : "Unexpected BouncyCastle class name: " + className;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
@@ -68,6 +68,8 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.util.Exceptions;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.base64.Base64;
@@ -87,9 +89,6 @@ import io.netty.util.internal.SystemPropertyUtil;
  * An X.509 certificate file and a EC/RSA private key file are generated in a system's temporary directory using
  * {@link File#createTempFile(String, String)}, and they are deleted when the JVM exits using
  * {@link File#deleteOnExit()}.
- * </p><p>
- * At first, this method tries to use OpenJDK's X.509 implementation (the {@code sun.security.x509} package).
- * If it fails, it tries to use <a href="https://www.bouncycastle.org/">Bouncy Castle</a> as a fallback.
  * </p>
  */
 public final class SelfSignedCertificate {
@@ -99,7 +98,7 @@ public final class SelfSignedCertificate {
     // https://github.com/netty/netty/blob/11e6a77fba9ec7184a558d869373d0ce506d7236/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleSelfSignedCertGenerator.java
     //
     // Changes:
-    // - Always use shaded BouncyCastle instead of JDK so it works on Java 16+.
+    // - Always use shaded BouncyCastle instead of JDK, so it works on Java 16+.
     //   See https://github.com/line/armeria/issues/3673 for more information.
     // - Accept `Random` instead of `SecureRandom`.
     // - Inline `BouncyCastleSelfSignedCertGenerator`.
@@ -280,15 +279,16 @@ public final class SelfSignedCertificate {
             throw new Error(e);
         }
 
-        final String[] paths;
-        try {
-            // Try Bouncy Castle if the current JVM didn't have sun.security.x509.
-            paths = generate(
-                    fqdn, keypair, random, notBefore, notAfter, algorithm);
-        } catch (Throwable cause) {
-            throw new CertificateException(
-                    "Failed to generate a self-signed X.509 certificate using Bouncy Castle: " + cause, cause);
-        }
+        final String[] paths = MinifiedBouncyCastleProvider.call(() -> {
+            try {
+                return generate(
+                        fqdn, keypair, random, notBefore, notAfter, algorithm);
+            } catch (Throwable cause) {
+                return Exceptions.throwUnsafely(new CertificateException(
+                        "Failed to generate a self-signed X.509 certificate: " + cause,
+                        cause));
+            }
+        });
 
         certificate = new File(paths[0]);
         privateKey = new File(paths[1]);
@@ -306,7 +306,7 @@ public final class SelfSignedCertificate {
                     certificateInput.close();
                 } catch (IOException e) {
                     if (logger.isWarnEnabled()) {
-                        logger.warn("Failed to close a file: " + certificate, e);
+                        logger.warn("Failed to close a file: {}", certificate, e);
                     }
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
@@ -98,7 +98,7 @@ public final class SelfSignedCertificate {
     // https://github.com/netty/netty/blob/11e6a77fba9ec7184a558d869373d0ce506d7236/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleSelfSignedCertGenerator.java
     //
     // Changes:
-    // - Always use shaded BouncyCastle instead of JDK, so it works on Java 16+.
+    // - Always use shaded Bouncy Castle instead of JDK, so it works on Java 16+.
     //   See https://github.com/line/armeria/issues/3673 for more information.
     // - Accept `Random` instead of `SecureRandom`.
     // - Inline `BouncyCastleSelfSignedCertGenerator`.

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
@@ -48,7 +48,7 @@ class MinifiedBouncyCastleProviderTest {
     void classNameShouldBeChecked() {
         final MinifiedBouncyCastleProvider provider = new MinifiedBouncyCastleProvider();
         assertThatThrownBy(() -> provider.addAlgorithm("foo", "incorrect.bouncycastle.class.name"))
-                .isInstanceOf(AssertionError.class)
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Unexpected BouncyCastle class name");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
@@ -15,16 +15,60 @@
  */
 package com.linecorp.armeria.internal.common.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.security.Security;
-import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.netty.handler.ssl.SslContextBuilder;
 
 class MinifiedBouncyCastleProviderTest {
+
+    @BeforeEach
+    void ensureNoBouncyCastle() {
+        assertThat(Security.getProviders()).doesNotHaveAnyElementsOfTypes(BouncyCastleProvider.class,
+                                                                          MinifiedBouncyCastleProvider.class);
+    }
+
+    @Test
+    void relocatedPackagePrefix() {
+        //noinspection ConstantValue - The assumption will meet when the test is run with shading enabled.
+        assumeThat(BouncyCastleProvider.class.getName().contains(".internal.shaded.")).isTrue();
+        assertThat(MinifiedBouncyCastleProvider.BC_PACKAGE_PREFIX)
+                .isEqualTo("com.linecorp.armeria.internal.shaded.bouncycastle.");
+    }
+
+    @Test
+    void classNameShouldBeChecked() {
+        final MinifiedBouncyCastleProvider provider = new MinifiedBouncyCastleProvider();
+        assertThatThrownBy(() -> provider.addAlgorithm("foo", "incorrect.bouncycastle.class.name"))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Unexpected BouncyCastle class name");
+    }
+
+    @Test
+    void callIsCalled() {
+        final AtomicBoolean called = new AtomicBoolean();
+
+        // Test call(Runnable):
+        MinifiedBouncyCastleProvider.call(() -> {
+            assertMinifiedBouncyCastleProviderExists();
+            called.set(true);
+        });
+        assertThat(called).isTrue();
+
+        // Test call(Callable):
+        assertThat(MinifiedBouncyCastleProvider.call(() -> {
+            assertMinifiedBouncyCastleProviderExists();
+            return 42;
+        })).isEqualTo(42);
+    }
 
     /**
      * Tests if a SSLeay PKCS#5 private key is accepted.
@@ -47,9 +91,6 @@ class MinifiedBouncyCastleProviderTest {
      */
     @Test
     void bouncyCastlePreInstalled() {
-        Assumptions.assumeTrue(Arrays.stream(Security.getProviders())
-                                     .noneMatch(p -> BouncyCastleProvider.PROVIDER_NAME.equals(p.getName())));
-
         Security.addProvider(new BouncyCastleProvider());
         try {
             MinifiedBouncyCastleProvider.call(this::loadPkcs5);
@@ -76,5 +117,9 @@ class MinifiedBouncyCastleProviderTest {
         SslContextBuilder.forServer(getClass().getResourceAsStream("/testing/core/ServerBuilderTest/cert.pem"),
                                     getClass().getResourceAsStream(privateKeyPath),
                                     null);
+    }
+
+    private static void assertMinifiedBouncyCastleProviderExists() {
+        assertThat(Security.getProviders()).hasAtLeastOneElementOfType(MinifiedBouncyCastleProvider.class);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProviderTest.java
@@ -49,7 +49,7 @@ class MinifiedBouncyCastleProviderTest {
         final MinifiedBouncyCastleProvider provider = new MinifiedBouncyCastleProvider();
         assertThatThrownBy(() -> provider.addAlgorithm("foo", "incorrect.bouncycastle.class.name"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unexpected BouncyCastle class name");
+                .hasMessageContaining("Unexpected Bouncy Castle class name");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`SelfSignedCertificate` fails to generate a self-signed certificate and throws a
`NullPointerException` when all of the following conditions are met:

- DEBUG-level logging of JDK security event is enabled; and
- A user has no Bouncy Castle dependency.

JDK security event logging and the absence of Bouncy Castle interact with each other in the following way:

- With logging enabled, JDK tries to retrieve the `PublicKey` for logging via `java.security.cert.Certificate#getPublicKey()`, but it returns `null`.
- `Certificate.getPublicKey()` returns `null` because Armeria internally relies on a minimal version of Bouncy Castle that doesn't have all the necessary algorithms.

Modifications:

- Updated ProGuard settings so that all the necessary classes are included in the shaded JAR.
- `MinifiedBouncyCastleProvider` is now configured by the `Mappings.configure()` methods, so that all the necessary algorithms are registered as intended by the Bouncy Castle authors.
- Added some protection mechanism and test cases against the potential situation where our shading tool fails to relocate Bouncy Castle properly.
- Made sure `SelfSignedCertificate` has access to all the necessary algorithms required for generating a self-signed certificate.
- Overall clean-up of `MinifiedBouncyCastleProviderTest`

Result:

- (defect) A user doesn't get a `NullPointerException` when running Armeria with a self-signed certificate when the following conditions are all met:
  - DEBUG-level logging of JDK security event is enabled; and
  - A user has no Bouncy Castle dependency.