### PR TITLE
update check-style setting for LY corp copyright

### DIFF
--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -31,7 +31,7 @@
   <!-- Copyright headers -->
   <module name="RegexpSingleline">
     <property name="id" value="CopyrightHeader"/>
-    <property name="format" value="^(?:\s|\*)*Copyright\s+[0-9]+\s+LINE Corporation\s*$"/>
+    <property name="format" value="^(?:\s|\*)*Copyright\s+[0-9]+\s+(LINE|LY) Corporation\s*$"/>
     <property name="minimum" value="1"/>
     <property name="maximum" value="1"/>
     <property name="message" value="missing copyright header"/>


### PR DESCRIPTION
Motivation:
In the latest developer guide, it is recommended to use `Copyright $today.year LY Corporation`, but the check-style settings have not been adapted accordingly. When this copyright notice is used, a check-style warning occurs.
Modifications:

- Updated check-style setting for LY corp copyright

Result:

- Using either LINE copyright or LY copyright will pass the check-style test.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
