### PR TITLE
Fix a bug when gRPC transcoding is used with parameterized paths

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -76,6 +76,7 @@ import io.grpc.Status.Code;
 import io.grpc.stub.StreamObserver;
 import testing.grpc.HttpJsonTranscodingTestServiceGrpc.HttpJsonTranscodingTestServiceBlockingStub;
 import testing.grpc.HttpJsonTranscodingTestServiceGrpc.HttpJsonTranscodingTestServiceImplBase;
+import testing.grpc.Transcoding.ConflictMessage;
 import testing.grpc.Transcoding.EchoAnyRequest;
 import testing.grpc.Transcoding.EchoAnyResponse;
 import testing.grpc.Transcoding.EchoFieldMaskRequest;
@@ -331,6 +332,13 @@ public class HttpJsonTranscodingTest {
                                            StreamObserver<EchoNestedMessageResponse> responseObserver) {
             responseObserver
                     .onNext(EchoNestedMessageResponse.newBuilder().setNested(request.getNested()).build());
+            responseObserver.onCompleted();
+        }
+
+        @Override
+        public void paramNameConflict(ConflictMessage request,
+                                      StreamObserver<ConflictMessage> responseObserver) {
+            responseObserver.onNext(request);
             responseObserver.onCompleted();
         }
     }
@@ -1077,6 +1085,14 @@ public class HttpJsonTranscodingTest {
         assertThat(response.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThat(nested).isNotNull().matches(v -> ((TreeNode) v).isObject());
         assertThat(nested.get("name").asText()).isEqualTo("Armeria");
+    }
+
+    @Test
+    void conflictingParamNamesReturnsCorrectly() {
+        final AggregatedHttpResponse res = server.blockingWebClient().get("/v1/conflict/hello/1/a/test");
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThatJson(res.contentUtf8()).node("id").isEqualTo("hello/1");
+        assertThatJson(res.contentUtf8()).node("p0").isEqualTo("a");
     }
 
     public static JsonNode findMethod(JsonNode methods, String name) {

--- a/grpc/src/test/proto/testing/grpc/transcoding.proto
+++ b/grpc/src/test/proto/testing/grpc/transcoding.proto
@@ -224,6 +224,12 @@ service HttpJsonTranscodingTestService {
       }
     };
   }
+
+  rpc ParamNameConflict(ConflictMessage) returns (ConflictMessage) {
+    option(google.api.http) = {
+      get: "/v1/conflict/{id=hello/*}/{p0}/test"
+    };
+  }
 }
 
 message GetMessageRequestV1 {
@@ -406,4 +412,9 @@ message EchoNestedMessageRequest {
 
 message EchoNestedMessageResponse {
   TopLevelMessage.NestedMessage nested = 1;
+}
+
+message ConflictMessage {
+  string p0 = 1;
+  string id = 2;
 }


### PR DESCRIPTION
Motivation:

This bug was found while analyzing the code for #5676.

Our gRPC-transcoding path parser contains logic which uses the parameter name when constructing the mapped path.
While doing so, we use an arbitrary name prefixed with a 'p' if we are unable to determine a suitable parameter name.

https://github.com/line/armeria/blob/1737482b82255d2ff4728927bdf91631bf1b23e9/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingPathParser.java#L385

This can be problematic since a path may be constructed in a different way from what the user expected.
e.g.
- path: `/v1/conflict/{id=hello/*}/{p0}/test`

The above path will currently be mapped to `/v1/conflict/hello/:p0/:p0/test`.
However, there is no guarantee that `id` and `p0` should be equal, and hence the following probably makes more sense:
`/v1/conflict/hello/:p0/:p1/test`.

I propose that we remove the logic to use parameter names. By doing so, we can 1) simplify the logic and 2) remove potential bugs going forward.

Modifications:

- Removed `WildcardPathSegment#parentFieldPath` and all code paths leading to it.

Result:

- There is no longer a bug when a user uses field `p{\d}` for gRPC transcoding.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
