### PR TITLE
Respond with 408 status when the server didn't receive the request fully

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -482,10 +482,8 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
     }
 
     private static SubscriptionImpl noopSubscription() {
-        final DefaultStreamMessage<?> streamMessage = new DefaultStreamMessage<>();
-        streamMessage.close();
-        return new SubscriptionImpl(streamMessage, NoopSubscriber.get(), ImmediateEventExecutor.INSTANCE,
-                                    EMPTY_OPTIONS);
+        return new SubscriptionImpl(NoopCancellableStreamMessage.INSTANCE, NoopSubscriber.get(),
+                                    ImmediateEventExecutor.INSTANCE, EMPTY_OPTIONS);
     }
 
     private final class ForwardingSubscriber implements Subscriber<T> {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/NoopCancellableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/NoopCancellableStreamMessage.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.stream;
+
+final class NoopCancellableStreamMessage extends CancellableStreamMessage<Object> {
+
+    static final NoopCancellableStreamMessage INSTANCE = new NoopCancellableStreamMessage();
+
+    @Override
+    SubscriptionImpl subscribe(SubscriptionImpl subscription) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void request(long n) {}
+
+    @Override
+    void cancel() {}
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public long demand() {
+        return 0;
+    }
+
+    @Override
+    public void abort() {}
+
+    @Override
+    public void abort(Throwable cause) {}
+
+    private NoopCancellableStreamMessage() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -56,6 +56,8 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     @Nullable
     private Throwable abortResponseCause;
 
+    private boolean isNormallyClosed;
+
     private final CompletableFuture<Void> aggregationFuture = new CompletableFuture<>();
 
     AggregatingDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
@@ -194,6 +196,7 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
 
     @Override
     public void close() {
+        isNormallyClosed = true;
         super.close();
         aggregationFuture.complete(null);
     }
@@ -202,6 +205,11 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     public void close(Throwable cause) {
         super.close(cause);
         aggregationFuture.complete(null);
+    }
+
+    @Override
+    public boolean isNormallyClosed() {
+        return isNormallyClosed;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AggregatingDecodedHttpRequest.java
@@ -208,7 +208,7 @@ final class AggregatingDecodedHttpRequest extends AggregatingStreamMessage<HttpO
     }
 
     @Override
-    public boolean isNormallyClosed() {
+    public boolean isClosedSuccessfully() {
         return isNormallyClosed;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -88,7 +88,7 @@ interface DecodedHttpRequest extends HttpRequest {
 
     void close(Throwable cause);
 
-    boolean isNormallyClosed();
+    boolean isClosedSuccessfully();
 
     /**
      * Sets the specified {@link HttpResponse} which responds to this request. This is always called

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -88,6 +88,8 @@ interface DecodedHttpRequest extends HttpRequest {
 
     void close(Throwable cause);
 
+    boolean isNormallyClosed();
+
     /**
      * Sets the specified {@link HttpResponse} which responds to this request. This is always called
      * by the {@link HttpServerHandler} after the handler gets the {@link HttpResponse} from an

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -96,10 +95,8 @@ enum DefaultServerErrorHandler implements ServerErrorHandler {
             } else {
                 final RequestContextExtension ctxExtension = ctx.as(RequestContextExtension.class);
                 assert ctxExtension != null;
-                final Request request = ctxExtension.originalRequest();
-
-                if (request instanceof DecodedHttpRequest &&
-                    ((DecodedHttpRequest) request).isNormallyClosed()) {
+                final DecodedHttpRequest request = (DecodedHttpRequest) ctxExtension.originalRequest();
+                if (request.isNormallyClosed()) {
                     status = HttpStatus.SERVICE_UNAVAILABLE;
                 } else {
                     // The server didn't receive the request fully yet.

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
@@ -96,7 +96,7 @@ enum DefaultServerErrorHandler implements ServerErrorHandler {
                 final RequestContextExtension ctxExtension = ctx.as(RequestContextExtension.class);
                 assert ctxExtension != null;
                 final DecodedHttpRequest request = (DecodedHttpRequest) ctxExtension.originalRequest();
-                if (request.isNormallyClosed()) {
+                if (request.isClosedSuccessfully()) {
                     status = HttpStatus.SERVICE_UNAVAILABLE;
                 } else {
                     // The server didn't receive the request fully yet.

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -193,7 +193,7 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     public void close(Throwable cause) {}
 
     @Override
-    public boolean isNormallyClosed() {
+    public boolean isClosedSuccessfully() {
         return true;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -193,6 +193,11 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     public void close(Throwable cause) {}
 
     @Override
+    public boolean isNormallyClosed() {
+        return true;
+    }
+
+    @Override
     public void setResponse(HttpResponse response) {
         // TODO(ikhoon): Dedup
         if (abortResponseCause != null) {

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -54,6 +54,8 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     @Nullable
     private Throwable abortResponseCause;
 
+    private boolean isNormallyClosed;
+
     StreamingDecodedHttpRequest(EventLoop eventLoop, int id, int streamId, RequestHeaders headers,
                                 boolean keepAlive, InboundTrafficController inboundTrafficController,
                                 long maxRequestLength, RoutingContext routingCtx, ExchangeType exchangeType,
@@ -163,6 +165,17 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
             final int length = ((HttpData) obj).length();
             inboundTrafficController.dec(length);
         }
+    }
+
+    @Override
+    public void close() {
+        isNormallyClosed = true;
+        super.close();
+    }
+
+    @Override
+    public boolean isNormallyClosed() {
+        return isNormallyClosed;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -174,7 +174,7 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     }
 
     @Override
-    public boolean isNormallyClosed() {
+    public boolean isClosedSuccessfully() {
         return isNormallyClosed;
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/AggregatingRequestTimeoutTest.java
@@ -91,6 +91,6 @@ class AggregatingRequestTimeoutTest {
         // The service waits for the full request body and then responds.
         assertThat(WebClient.of(protocol, server.endpoint(protocol))
                             .execute(request).aggregate().join().status())
-                .isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
+                .isSameAs(HttpStatus.REQUEST_TIMEOUT);
     }
 }


### PR DESCRIPTION
Motivation:
Currently, the server always responds with a 503 status if a `RequestTimeoutException` is raised. However, according to the RFC 9110, the correct response in this case should be a 408 status code. https://httpwg.org/specs/rfc9110.html#status.408
```
The 408 (Request Timeout) status code indicates that the server did not receive a complete request message within the time that it was prepared to wait.
```

Modification:
- Introduced `DecodedHttpRequest.isNormallyClosed()` to check if the request was received fully.
- Updated the server to send a 408 response when a request times out and the service didn't receive the request fully.

Result:
- The server now returns a 408 status if a service didn't receive the request fully and the request times out.
- Issue #5579 has been closed.