### PR TITLE
Add headers and MediaTypes for Git HTTP

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -56,6 +56,7 @@ public final class HttpHeaderNames {
     // - Added pseudo headers
     // - Added Accept-Patch
     // - Added Content-Base
+    // - Added Git-Protocol
     // - Added Prefer
     // - Removed the ancient CSP headers
     //   - X-Content-Security-Policy
@@ -232,6 +233,11 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString FOLLOW_ONLY_WHEN_PRERENDER_SHOWN =
             create("Follow-Only-When-Prerender-Shown");
+    /**
+     * The HTTP {@code "Git-Protocol"} header field name, as described in
+     * <a href="https://git-scm.com/docs/protocol-v2#_http_transport">HTTP Transport</a>.
+     */
+    public static final AsciiString GIT_PROTOCOL = create("Git-Protocol");
     /**
      * The HTTP {@code "Host"} header field name.
      */

--- a/core/src/main/java/com/linecorp/armeria/common/MediaType.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaType.java
@@ -492,6 +492,29 @@ public final class MediaType {
      */
     public static final MediaType GEO_JSON = createConstant(APPLICATION_TYPE, "geo+json");
 
+    /**
+     * This constant is used for advertising the capabilities of a Git server,
+     * as described in <a href="https://git-scm.com/docs/http-protocol/2.34.0#_smart_clients">Smart Clients</a>.
+     */
+    public static final MediaType GIT_UPLOAD_PACK_ADVERTISEMENT =
+            createConstant(APPLICATION_TYPE, "x-git-upload-pack-advertisement");
+
+    /**
+     * This constant is used for requesting a Git packfile from a Git server, as described in
+     * <a href="https://git-scm.com/docs/http-protocol/2.34.0#_smart_service_git_upload_pack">
+     * Smart Service git-upload-pack</a>.
+     */
+    public static final MediaType GIT_UPLOAD_PACK_REQUEST =
+            createConstant(APPLICATION_TYPE, "x-git-upload-pack-request");
+
+    /**
+     * This constant is used for responding with a Git packfile from a Git server, as described in
+     * <a href="https://git-scm.com/docs/http-protocol/2.34.0#_smart_service_git_upload_pack">
+     * Smart Service git-upload-pack</a>.
+     */
+    public static final MediaType GIT_UPLOAD_PACK_RESULT =
+            createConstant(APPLICATION_TYPE, "x-git-upload-pack-result");
+
     public static final MediaType GZIP = createConstant(APPLICATION_TYPE, "x-gzip");
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/MediaTypeNames.java
@@ -346,6 +346,18 @@ public final class MediaTypeNames {
      */
     public static final String GEO_JSON = "application/geo+json";
     /**
+     * {@value #GIT_UPLOAD_PACK_ADVERTISEMENT}.
+     */
+    public static final String GIT_UPLOAD_PACK_ADVERTISEMENT = "application/x-git-upload-pack-advertisement";
+    /**
+     * {@value #GIT_UPLOAD_PACK_REQUEST}.
+     */
+    public static final String GIT_UPLOAD_PACK_REQUEST = "application/x-git-upload-pack-request";
+    /**
+     * {@value #GIT_UPLOAD_PACK_RESULT}.
+     */
+    public static final String GIT_UPLOAD_PACK_RESULT = "application/x-git-upload-pack-result";
+    /**
      * {@value #GZIP}.
      */
     public static final String GZIP = "application/x-gzip";


### PR DESCRIPTION
Motivation:
Added necessary headers and MediaTypes for Git HTTP, as a follow-up to https://github.com/line/centraldogma/pull/954.
