### PR TITLE
Refactor `WeightRampingUpStrategy` to be timestamp based

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -263,7 +263,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         // Pre-generate the authority.
         authority = generateAuthority(type, host, port);
         // Pre-generate toString() value.
-        strVal = generateToString(type, authority, ipAddr, weight);
+        strVal = generateToString(type, authority, ipAddr, weight, attributes);
         this.attributes = attributes;
     }
 
@@ -290,14 +290,18 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
     }
 
     private static String generateToString(Type type, String authority, @Nullable String ipAddr,
-                                           int weight) {
+                                           int weight, @Nullable Attributes attributes) {
         try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tempThreadLocals.stringBuilder();
             buf.append("Endpoint{").append(authority);
             if (type == Type.HOSTNAME_AND_IP) {
                 buf.append(", ipAddr=").append(ipAddr);
             }
-            return buf.append(", weight=").append(weight).append('}').toString();
+            buf.append(", weight=").append(weight);
+            if (attributes != null) {
+                buf.append(", attributes=").append(attributes);
+            }
+            return buf.append('}').toString();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -172,7 +172,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         private void updateEndpoints(List<Endpoint> newEndpoints) {
 
             // clean up existing entries
-            for (EndpointsRampingUpEntry entry: rampingUpWindowsMap.values()) {
+            for (EndpointsRampingUpEntry entry : rampingUpWindowsMap.values()) {
                 entry.endpointAndSteps().clear();
             }
             endpointsFinishedRampingUp.clear();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -20,6 +20,9 @@ import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilde
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_RAMPING_UP_TASK_WINDOW_MILLIS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.DEFAULT_TOTAL_STEPS;
 import static com.linecorp.armeria.client.endpoint.WeightRampingUpStrategyBuilder.defaultTransition;
+import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.createTimestamp;
+import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.hasCreateTimestamp;
+import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.withCreateTimestamp;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayDeque;
@@ -38,14 +41,13 @@ import java.util.function.Supplier;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy.EndpointsRampingUpEntry.EndpointAndStep;
 import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 import com.linecorp.armeria.common.util.Ticker;
 
@@ -83,7 +85,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
     private final EndpointWeightTransition weightTransition;
     private final Supplier<EventExecutor> executorSupplier;
-    private final long rampingUpIntervalMillis;
+    private final long rampingUpIntervalNanos;
     private final int totalSteps;
     private final long rampingUpTaskWindowNanos;
     private final Ticker ticker;
@@ -103,7 +105,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         this.executorSupplier = requireNonNull(executorSupplier, "executorSupplier");
         checkArgument(rampingUpIntervalMillis > 0,
                       "rampingUpIntervalMillis: %s (expected: > 0)", rampingUpIntervalMillis);
-        this.rampingUpIntervalMillis = rampingUpIntervalMillis;
+        rampingUpIntervalNanos = TimeUnit.MILLISECONDS.toNanos(rampingUpIntervalMillis);
         checkArgument(totalSteps > 0, "totalSteps: %s (expected: > 0)", totalSteps);
         this.totalSteps = totalSteps;
         checkArgument(rampingUpTaskWindowMillis >= 0,
@@ -128,9 +130,9 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
         @VisibleForTesting
         final Deque<EndpointsRampingUpEntry> endpointsRampingUp = new ArrayDeque<>();
-
-        @Nullable
-        private Set<EndpointAndStep> unhandledNewEndpoints;
+        @VisibleForTesting
+        final Map<Long, EndpointsRampingUpEntry> rampingUpWindowsMap = new HashMap<>();
+        private Map<Endpoint, Long> endpointCreatedTimestamps = ImmutableMap.of();
 
         RampingUpEndpointWeightSelector(EndpointGroup endpointGroup, EventExecutor executor) {
             super(endpointGroup);
@@ -143,33 +145,17 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
         @Override
         protected void updateNewEndpoints(List<Endpoint> endpoints) {
-            if (endpointSelector == EMPTY_SELECTOR) {
-                final List<Endpoint> dedupEndpoints =
-                        new ArrayList<>(deduplicateEndpoints(endpoints).values());
-                endpointSelector = new WeightedRandomDistributionEndpointSelector(dedupEndpoints);
-                endpointsFinishedRampingUp.addAll(dedupEndpoints);
-            } else {
-                // Use the executor so the order of endpoints change is guaranteed.
-                executor.execute(() -> updateEndpoints(endpoints));
-            }
+            executor.execute(() -> updateEndpoints(endpoints));
         }
 
-        /**
-         * Removes the duplicate endpoints in the specified {@code newEndpoints} and returns a new map
-         * that contains unique endpoints.
-         * The value of the map is the {@link Endpoint} whose {@link Endpoint#weight()} is the summed weight of
-         * same {@link Endpoint}s.
-         */
-        private Map<Endpoint, Endpoint> deduplicateEndpoints(List<Endpoint> newEndpoints) {
-            final Map<Endpoint, Endpoint> newEndpointsMap = new HashMap<>(newEndpoints.size());
-
-            // The weight of the same endpoints are summed.
-            newEndpoints.forEach(
-                    newEndpoint -> newEndpointsMap.compute(newEndpoint, (key, v) -> {
-                        return v == null ? newEndpoint
-                                         : newEndpoint.withWeight(newEndpoint.weight() + v.weight());
-                    }));
-            return newEndpointsMap;
+        private long computeCreateTimestamp(Endpoint endpoint) {
+            if (hasCreateTimestamp(endpoint)) {
+                return createTimestamp(endpoint);
+            }
+            if (endpointCreatedTimestamps.containsKey(endpoint)) {
+                return endpointCreatedTimestamps.get(endpoint);
+            }
+            return ticker.read();
         }
 
         @Override
@@ -184,53 +170,62 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
         // Only executed by the executor.
         private void updateEndpoints(List<Endpoint> newEndpoints) {
-            unhandledNewEndpoints = null;
-            final Set<EndpointAndStep> newlyAddedEndpoints = filterOldEndpoints(newEndpoints);
-            if (rampingUpTaskWindowNanos > 0) {
-                // Check whether we can ramp up with the previous ramped up endpoints which are at the last
-                // of the rampingUpEndpointsEntries.
-                if (shouldRampUpWithPreviousRampedUpEntry()) {
-                    if (!newlyAddedEndpoints.isEmpty()) {
-                        updateWeightAndStep(newlyAddedEndpoints);
-                        endpointsRampingUp.getLast().addEndpoints(newlyAddedEndpoints);
-                    }
-                    buildEndpointSelector();
-                    return;
+
+            // clean up existing entries
+            for (EndpointsRampingUpEntry entry: rampingUpWindowsMap.values()) {
+                entry.endpointAndSteps().clear();
+            }
+            endpointsFinishedRampingUp.clear();
+
+            // We add the new endpoints from this point
+            final ImmutableMap.Builder<Endpoint, Long> createdTimestampsBuilder = ImmutableMap.builder();
+            for (Endpoint endpoint: newEndpoints) {
+                // Set the cached created timestamps for the next iteration
+                final long createTimestamp = computeCreateTimestamp(endpoint);
+                endpoint = withCreateTimestamp(endpoint, createTimestamp);
+                createdTimestampsBuilder.put(endpoint, createTimestamp);
+
+                // check if the endpoint is already finished ramping up
+                final int step = numStep(endpoint, rampingUpIntervalNanos, ticker);
+                if (step >= totalSteps) {
+                    endpointsFinishedRampingUp.add(endpoint);
+                    continue;
                 }
 
-                // Check whether we can ramp up with the next scheduled endpointsRampingUpEntry.
-                if (shouldRampUpWithNextScheduledEntry()) {
-                    // unhandledNewEndpoints will be ramped up when updateWeightAndStep() is executed.
-                    unhandledNewEndpoints = newlyAddedEndpoints;
-                    return;
+                // Create a EndpointsRampingUpEntry if there isn't one already
+                final long window = windowIndex(createTimestamp);
+                if (!rampingUpWindowsMap.containsKey(window)) {
+                    // align the schedule to execute at the start of each window
+                    final long initialDelayNanos = initialDelayNanos(window);
+                    final ScheduledFuture<?> scheduledFuture = executor.scheduleAtFixedRate(
+                            () -> updateWeightAndStep(window), initialDelayNanos,
+                            rampingUpIntervalNanos, TimeUnit.NANOSECONDS);
+                    final EndpointsRampingUpEntry entry = new EndpointsRampingUpEntry(
+                            new HashSet<>(), scheduledFuture, ticker, rampingUpIntervalNanos);
+                    rampingUpWindowsMap.put(window, entry);
                 }
-            }
+                final EndpointsRampingUpEntry rampingUpEntry = rampingUpWindowsMap.get(window);
 
-            if (newlyAddedEndpoints.isEmpty()) {
-                // newlyAddedEndpoints is empty which means that endpointsFinishedRampingUp are changed.
-                // So rebuild the endpoint selector.
-                buildEndpointSelector();
-                return;
-            }
+                final EndpointAndStep endpointAndStep = new EndpointAndStep(endpoint, step);
+                final int currentWeight = computeWeight(endpoint, step);
+                endpointAndStep.currentWeight(currentWeight);
 
-            updateWeightAndStep(newlyAddedEndpoints);
-
-            // Check again because newlyAddedEndpoints can be removed in the updateWeightAndStep method.
-            if (!newlyAddedEndpoints.isEmpty()) {
-                final ScheduledFuture<?> scheduledFuture = executor.scheduleAtFixedRate(
-                        this::updateWeightAndStep, rampingUpIntervalMillis,
-                        rampingUpIntervalMillis, TimeUnit.MILLISECONDS);
-                final EndpointsRampingUpEntry entry = new EndpointsRampingUpEntry(
-                        newlyAddedEndpoints, scheduledFuture, ticker, rampingUpIntervalMillis);
-                endpointsRampingUp.add(entry);
+                rampingUpEntry.addEndpoint(endpointAndStep);
             }
+            endpointCreatedTimestamps = createdTimestampsBuilder.buildKeepingLast();
+
             buildEndpointSelector();
+        }
+
+        private int computeWeight(Endpoint endpoint, int step) {
+            final int calculated = weightTransition.compute(endpoint, step, totalSteps);
+            return Ints.constrainToRange(calculated, 0, endpoint.weight());
         }
 
         private void buildEndpointSelector() {
             final ImmutableList.Builder<Endpoint> targetEndpointsBuilder = ImmutableList.builder();
             targetEndpointsBuilder.addAll(endpointsFinishedRampingUp);
-            for (EndpointsRampingUpEntry entry : endpointsRampingUp) {
+            for (EndpointsRampingUpEntry entry : rampingUpWindowsMap.values()) {
                 for (EndpointAndStep endpointAndStep : entry.endpointAndSteps()) {
                     targetEndpointsBuilder.add(
                             endpointAndStep.endpoint().withWeight(endpointAndStep.currentWeight()));
@@ -239,131 +234,29 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
             endpointSelector = new WeightedRandomDistributionEndpointSelector(targetEndpointsBuilder.build());
         }
 
-        private boolean shouldRampUpWithPreviousRampedUpEntry() {
-            final EndpointsRampingUpEntry lastEndpointsRampingUpEntry = endpointsRampingUp.peekLast();
-            return lastEndpointsRampingUpEntry != null &&
-                   ticker.read() - lastEndpointsRampingUpEntry.lastUpdatedTime <= rampingUpTaskWindowNanos;
+        @VisibleForTesting
+        long windowIndex(long timestamp) {
+            long window = timestamp % rampingUpIntervalNanos;
+            if (rampingUpTaskWindowNanos > 0) {
+                window /= rampingUpTaskWindowNanos;
+            }
+            return window;
         }
 
-        private boolean shouldRampUpWithNextScheduledEntry() {
-            final EndpointsRampingUpEntry nextEndpointsRampingUpEntry = endpointsRampingUp.peek();
-            return nextEndpointsRampingUpEntry != null &&
-                   nextEndpointsRampingUpEntry.nextUpdatingTime - ticker.read() <= rampingUpTaskWindowNanos;
+        private long initialDelayNanos(long windowIndex) {
+            final long timestamp = ticker.read();
+            final long base = (timestamp / rampingUpIntervalNanos + 1) * rampingUpIntervalNanos;
+            final long nextTimestamp = base + windowIndex * rampingUpTaskWindowNanos;
+            return nextTimestamp - timestamp;
         }
 
-        /**
-         * Removes endpoints in endpointsFinishedRampingUp and endpointsRampingUp that
-         * newEndpoints do not contain.
-         * This also returns the {@link Set} of {@link EndpointAndStep}s whose endpoints are not
-         * in endpointsFinishedRampingUp and endpointsRampingUp.
-         */
-        private Set<EndpointAndStep> filterOldEndpoints(List<Endpoint> newEndpoints) {
-            final Map<Endpoint, Endpoint> newEndpointsMap = deduplicateEndpoints(newEndpoints);
-
-            final List<Endpoint> replacedEndpoints = new ArrayList<>();
-            for (final Iterator<Endpoint> i = endpointsFinishedRampingUp.iterator(); i.hasNext();) {
-                final Endpoint endpointFinishedRampingUp = i.next();
-                final Endpoint newEndpoint = newEndpointsMap.remove(endpointFinishedRampingUp);
-                if (newEndpoint == null) {
-                    // newEndpoints does not have this endpoint so we remove it.
-                    i.remove();
-                    continue;
-                }
-
-                if (endpointFinishedRampingUp.weight() > newEndpoint.weight()) {
-                    // The weight of the new endpoint is lower than the endpoint so we just replace it
-                    // because we don't have to ramp up the weight.
-                    replacedEndpoints.add(newEndpoint);
-                    i.remove();
-                } else if (endpointFinishedRampingUp.weight() < newEndpoint.weight()) {
-                    // The weight of the new endpoint is greater than the endpoint so we remove the
-                    // endpointFinishedRampingUp and put the newEndpoint back.
-                    newEndpointsMap.put(newEndpoint, newEndpoint);
-                    i.remove();
-                } else {
-                    // The weights are same so we keep the endpointFinishedRampingUp.
-                }
-            }
-            if (!replacedEndpoints.isEmpty()) {
-                endpointsFinishedRampingUp.addAll(replacedEndpoints);
-            }
-
-            for (final Iterator<EndpointsRampingUpEntry> i = endpointsRampingUp.iterator();
-                 i.hasNext();) {
-                final EndpointsRampingUpEntry endpointsRampingUpEntry = i.next();
-
-                final Set<EndpointAndStep> endpointAndSteps = endpointsRampingUpEntry.endpointAndSteps();
-                filterOldEndpoints(endpointAndSteps, newEndpointsMap);
-                if (endpointAndSteps.isEmpty()) {
-                    // All endpointAndSteps are removed so remove the entry completely.
-                    i.remove();
-                    endpointsRampingUpEntry.scheduledFuture.cancel(true);
-                }
-            }
-
-            // At this point, newEndpointsMap only contains the new endpoints that have to be ramped up.
-            if (newEndpointsMap.isEmpty()) {
-                return ImmutableSet.of();
-            }
-            final Set<EndpointAndStep> newlyAddedEndpoints = new HashSet<>(newEndpointsMap.size());
-            newEndpointsMap.values().forEach(
-                    endpoint -> newlyAddedEndpoints.add(new EndpointAndStep(endpoint)));
-            return newlyAddedEndpoints;
-        }
-
-        private void filterOldEndpoints(Set<EndpointAndStep> endpointAndSteps,
-                                        Map<Endpoint, Endpoint> newEndpointsMap) {
-            final List<EndpointAndStep> replacedEndpoints = new ArrayList<>();
-            for (final Iterator<EndpointAndStep> i = endpointAndSteps.iterator(); i.hasNext();) {
-                final EndpointAndStep endpointAndStep = i.next();
-                final Endpoint rampingUpEndpoint = endpointAndStep.endpoint();
-                final Endpoint newEndpoint = newEndpointsMap.remove(rampingUpEndpoint);
-                if (newEndpoint == null) {
-                    // newEndpointsMap does not contain rampingUpEndpoint so just remove the endpoint.
-                    i.remove();
-                    continue;
-                }
-
-                if (rampingUpEndpoint.weight() == newEndpoint.weight()) {
-                    // Same weight so don't do anything. Ramping up happens as it is scheduled.
-                } else if (endpointAndStep.currentWeight() > newEndpoint.weight()) {
-                    // Don't need to update the weight anymore so we add the newEndpoint to
-                    // endpointsFinishedRampingUp and remove it from the iterator.
-                    endpointsFinishedRampingUp.add(newEndpoint);
-                    i.remove();
-                } else {
-                    // Should replace the existing endpoint with the new one.
-                    final int step = endpointAndStep.step();
-                    final EndpointAndStep replaced = new EndpointAndStep(newEndpoint, step);
-                    replaced.currentWeight(weightTransition.compute(newEndpoint, step, totalSteps));
-                    replacedEndpoints.add(replaced);
-                    i.remove();
-                }
-            }
-
-            if (!replacedEndpoints.isEmpty()) {
-                endpointAndSteps.addAll(replacedEndpoints);
-            }
-        }
-
-        private void updateWeightAndStep() {
-            if (unhandledNewEndpoints != null) {
-                final EndpointsRampingUpEntry entry = endpointsRampingUp.peek();
-                assert entry != null;
-                entry.addEndpoints(unhandledNewEndpoints);
-                unhandledNewEndpoints = null;
-            }
-            final EndpointsRampingUpEntry entry = endpointsRampingUp.poll();
+        private void updateWeightAndStep(long window) {
+            final EndpointsRampingUpEntry entry = rampingUpWindowsMap.get(window);
             assert entry != null;
-
             final Set<EndpointAndStep> endpointAndSteps = entry.endpointAndSteps();
             updateWeightAndStep(endpointAndSteps);
             if (endpointAndSteps.isEmpty()) {
-                entry.scheduledFuture.cancel(true);
-            } else {
-                // Add to the last of the entries.
-                endpointsRampingUp.add(entry);
-                entry.updateWindowTimestamps();
+                rampingUpWindowsMap.remove(window).scheduledFuture.cancel(true);
             }
             buildEndpointSelector();
         }
@@ -373,24 +266,26 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
                 final EndpointAndStep endpointAndStep = i.next();
                 final int step = endpointAndStep.incrementAndGetStep();
                 final Endpoint endpoint = endpointAndStep.endpoint();
-                if (step == totalSteps) {
+                if (step >= totalSteps) {
                     endpointsFinishedRampingUp.add(endpoint);
                     i.remove();
                 } else {
-                    final int calculated =
-                            weightTransition.compute(endpoint, step, totalSteps);
-                    final int currentWeight = Ints.constrainToRange(calculated, 0, endpoint.weight());
+                    final int currentWeight = computeWeight(endpoint, step);
                     endpointAndStep.currentWeight(currentWeight);
                 }
             }
         }
 
         private void close() {
-            EndpointsRampingUpEntry entry;
-            while ((entry = endpointsRampingUp.poll()) != null) {
-                entry.scheduledFuture.cancel(true);
-            }
+            rampingUpWindowsMap.values().forEach(e -> e.scheduledFuture.cancel(true));
         }
+    }
+
+    private static int numStep(Endpoint endpoint, long rampingUpIntervalNanos, Ticker ticker) {
+        final long timePassed = ticker.read() - createTimestamp(endpoint);
+        final int step = Ints.saturatedCast(timePassed / rampingUpIntervalNanos);
+        // there's no point in having an endpoint at step 0 (no weight), so we increment by 1
+        return step + 1;
     }
 
     @VisibleForTesting
@@ -401,8 +296,6 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         private final long rampingUpIntervalNanos;
 
         final ScheduledFuture<?> scheduledFuture;
-        long lastUpdatedTime;
-        long nextUpdatingTime;
 
         EndpointsRampingUpEntry(Set<EndpointAndStep> endpointAndSteps, ScheduledFuture<?> scheduledFuture,
                                 Ticker ticker, long rampingUpIntervalMillis) {
@@ -410,20 +303,14 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
             this.scheduledFuture = scheduledFuture;
             this.ticker = ticker;
             rampingUpIntervalNanos = TimeUnit.MILLISECONDS.toNanos(rampingUpIntervalMillis);
-            updateWindowTimestamps();
         }
 
         Set<EndpointAndStep> endpointAndSteps() {
             return endpointAndSteps;
         }
 
-        void addEndpoints(Set<EndpointAndStep> endpoints) {
-            endpointAndSteps.addAll(endpoints);
-        }
-
-        void updateWindowTimestamps() {
-            lastUpdatedTime = ticker.read();
-            nextUpdatingTime = lastUpdatedTime + rampingUpIntervalNanos;
+        void addEndpoint(EndpointAndStep endpoint) {
+            endpointAndSteps.add(endpoint);
         }
 
         @Override
@@ -433,8 +320,6 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
                               .add("ticker", ticker)
                               .add("rampingUpIntervalNanos", rampingUpIntervalNanos)
                               .add("scheduledFuture", scheduledFuture)
-                              .add("lastUpdatedTime", lastUpdatedTime)
-                              .add("nextUpdatingTime", nextUpdatingTime)
                               .toString();
         }
 
@@ -444,10 +329,6 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
             private final Endpoint endpoint;
             private int step;
             private int currentWeight;
-
-            EndpointAndStep(Endpoint endpoint) {
-                this(endpoint, 0);
-            }
 
             EndpointAndStep(Endpoint endpoint, int step) {
                 this.endpoint = endpoint;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -179,7 +179,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
 
             // We add the new endpoints from this point
             final Object2LongOpenHashMap<Endpoint> newCreatedTimestamps = new Object2LongOpenHashMap<>();
-            for (Endpoint endpoint: newEndpoints) {
+            for (Endpoint endpoint : newEndpoints) {
                 // Set the cached created timestamps for the next iteration
                 final long createTimestamp = computeCreateTimestamp(endpoint);
                 newCreatedTimestamps.put(endpoint, createTimestamp);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/RampingUpKeys.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/RampingUpKeys.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client.endpoint;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import io.netty.util.AttributeKey;
+
+public final class RampingUpKeys {
+
+    private static final AttributeKey<Long> endpointCreateTimestampNanos =
+            AttributeKey.valueOf(RampingUpKeys.class, "getCreateTimestamp");
+
+    public static long createTimestamp(Endpoint endpoint) {
+        final Long createdTimestamp = endpoint.attr(endpointCreateTimestampNanos);
+        checkState(createdTimestamp != null, "createdTimestamp doesn't exist for '%s'", endpoint);
+        return createdTimestamp;
+    }
+
+    public static Endpoint withCreateTimestamp(Endpoint endpoint, long timestamp) {
+        return endpoint.withAttr(endpointCreateTimestampNanos, timestamp);
+    }
+
+    public static boolean hasCreateTimestamp(Endpoint endpoint) {
+        return endpoint.attr(endpointCreateTimestampNanos) != null;
+    }
+
+    private RampingUpKeys() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/RampingUpKeys.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/RampingUpKeys.java
@@ -24,21 +24,21 @@ import io.netty.util.AttributeKey;
 
 public final class RampingUpKeys {
 
-    private static final AttributeKey<Long> endpointCreateTimestampNanos =
-            AttributeKey.valueOf(RampingUpKeys.class, "getCreateTimestamp");
+    private static final AttributeKey<Long> CREATED_AT_NANOS_KEY =
+            AttributeKey.valueOf(RampingUpKeys.class, "createdAtNanos");
 
-    public static long createTimestamp(Endpoint endpoint) {
-        final Long createdTimestamp = endpoint.attr(endpointCreateTimestampNanos);
-        checkState(createdTimestamp != null, "createdTimestamp doesn't exist for '%s'", endpoint);
-        return createdTimestamp;
+    public static long createdAtNanos(Endpoint endpoint) {
+        final Long createdAtNanos = endpoint.attr(CREATED_AT_NANOS_KEY);
+        checkState(createdAtNanos != null, "createdAtNanos doesn't exist for '%s'", endpoint);
+        return createdAtNanos;
     }
 
-    public static Endpoint withCreateTimestamp(Endpoint endpoint, long timestamp) {
-        return endpoint.withAttr(endpointCreateTimestampNanos, timestamp);
+    public static Endpoint withCreatedAtNanos(Endpoint endpoint, long timestampNanos) {
+        return endpoint.withAttr(CREATED_AT_NANOS_KEY, timestampNanos);
     }
 
-    public static boolean hasCreateTimestamp(Endpoint endpoint) {
-        return endpoint.attr(endpointCreateTimestampNanos) != null;
+    public static boolean hasCreatedAtNanos(Endpoint endpoint) {
+        return endpoint.attr(CREATED_AT_NANOS_KEY) != null;
     }
 
     private RampingUpKeys() {}

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -529,6 +529,11 @@ class EndpointTest {
         // ipAddr is omitted if hostname is an IP address.
         assertThat(Endpoint.of("127.0.0.1").toString()).isEqualTo("Endpoint{127.0.0.1, weight=1000}");
         assertThat(Endpoint.of("::1").toString()).isEqualTo("Endpoint{[::1], weight=1000}");
+
+        // attributes
+        final Endpoint endpointWithAttr = Endpoint.of("127.0.0.1").withAttr(AttributeKey.valueOf("test"), 1);
+        assertThat(endpointWithAttr.toString())
+                .isEqualTo("Endpoint{127.0.0.1, weight=1000, attributes=[test=1]}");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
@@ -16,7 +16,9 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static com.linecorp.armeria.client.endpoint.EndpointWeightTransition.linear;
+import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.withCreateTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,9 +30,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.ImmutableList;
 
@@ -50,11 +56,17 @@ final class WeightRampingUpStrategyTest {
     private static final AtomicLong ticker = new AtomicLong();
 
     private static final Queue<Runnable> scheduledJobs = new ConcurrentLinkedQueue<>();
+    private static final Queue<Long> initialDelayNanos = new ConcurrentLinkedQueue<>();
+    private static final Queue<Long> periodNanos = new ConcurrentLinkedQueue<>();
     private static final Queue<ScheduledFuture<?>> scheduledFutures = new ConcurrentLinkedQueue<>();
+    private static final long rampingUpIntervalNanos = TimeUnit.MILLISECONDS.toNanos(20000);
+    private static final long rampingUpTaskWindowNanos = TimeUnit.MILLISECONDS.toNanos(1000);
 
     @BeforeEach
     void setUp() {
         ticker.set(0);
+        initialDelayNanos.clear();
+        periodNanos.clear();
         scheduledJobs.clear();
         scheduledFutures.clear();
     }
@@ -63,7 +75,7 @@ final class WeightRampingUpStrategyTest {
     void endpointIsRemovedIfNotInNewEndpoints() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
         final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 2);
-        ticker.addAndGet(1);
+        ticker.addAndGet(rampingUpIntervalNanos);
         // Because we set only foo1.com, foo.com is removed.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo1.com")));
         final List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
@@ -77,10 +89,12 @@ final class WeightRampingUpStrategyTest {
     void rampingUpIsDoneAfterNumberOfSteps() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
         final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 2);
-        ticker.addAndGet(1);
+        ticker.addAndGet(rampingUpIntervalNanos);
+        final long windowIndex = selector.windowIndex(ticker.get());
         endpointGroup.addEndpoint(Endpoint.of("bar.com"));
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(windowIndex);
+        final Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(windowIndex).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE).containsExactly(
                 endpointAndStep(Endpoint.of("bar.com"), 1, 500));
         List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
@@ -90,7 +104,7 @@ final class WeightRampingUpStrategyTest {
                                               Endpoint.of("bar.com").withWeight(500)
                                       );
 
-        ticker.addAndGet(TimeUnit.SECONDS.toNanos(20));
+        ticker.addAndGet(rampingUpIntervalNanos);
         scheduledJobs.poll().run();
         // Ramping up is done because the step reached the numberOfSteps.
 
@@ -106,19 +120,20 @@ final class WeightRampingUpStrategyTest {
     @Test
     void endpointsAreAddedToPreviousEntry_IfTheyAreAddedWithinWindow() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
         addSecondEndpoints(endpointGroup, selector);
 
-        ticker.addAndGet(1);
+        ticker.addAndGet(rampingUpTaskWindowNanos - 1);
 
+        final long windowIndex = selector.windowIndex(ticker.get());
         endpointGroup.addEndpoint(Endpoint.of("baz.com"));
         endpointGroup.addEndpoint(Endpoint.of("baz1.com"));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps1 = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(windowIndex);
+        final Set<EndpointAndStep> endpointAndSteps1 =
+                selector.rampingUpWindowsMap.get(windowIndex).endpointAndSteps();
         assertThat(endpointAndSteps1).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                      .containsExactlyInAnyOrder(
                                              endpointAndStep(Endpoint.of("bar.com"), 1, 100),
@@ -139,18 +154,19 @@ final class WeightRampingUpStrategyTest {
     @Test
     void endpointsAreAddedToNewEntry_IfAllTheEntryAreRemoved() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
         addSecondEndpoints(endpointGroup, selector);
 
-        ticker.addAndGet(1);
+        ticker.addAndGet(steps * rampingUpIntervalNanos);
 
+        final long window = selector.windowIndex(ticker.get());
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("baz.com"), Endpoint.of("baz1.com")));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps1 = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps1 =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps1).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                      .containsExactlyInAnyOrder(
                                              endpointAndStep(Endpoint.of("baz.com"), 1, 100),
@@ -160,18 +176,18 @@ final class WeightRampingUpStrategyTest {
     @Test
     void endpointsAreAddedToNextEntry_IfTheyAreAddedWithinWindow() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
+        long window = selector.windowIndex(ticker.get());
         addSecondEndpoints(endpointGroup, selector);
 
         // Add 19 seconds so now it's within the window of second ramping up of bar.com and bar1.com.
         ticker.addAndGet(TimeUnit.SECONDS.toNanos(19));
 
-        // baz endpoint is not calculated and removed because it's overridden by the next setEndpoints() call.
-        endpointGroup.addEndpoint(Endpoint.of("baz.com"));
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps1 = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps1 =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps1).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                      .containsExactlyInAnyOrder(
                                              endpointAndStep(Endpoint.of("bar.com"), 1, 100),
@@ -184,15 +200,17 @@ final class WeightRampingUpStrategyTest {
                                               Endpoint.of("bar1.com").withWeight(100)
                                       );
 
+        ticker.addAndGet(TimeUnit.SECONDS.toNanos(1));
+        window = selector.windowIndex(ticker.get());
+
         // The weights of qux.com and qux1.com will be ramped up with bar.com and bar1.com.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com"), Endpoint.of("foo1.com"),
                                                     Endpoint.of("bar.com"), Endpoint.of("bar1.com"),
                                                     Endpoint.of("qux.com"), Endpoint.of("qux1.com")));
 
-        ticker.addAndGet(TimeUnit.SECONDS.toNanos(1));
-        scheduledJobs.poll().run();
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps2 = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps2 =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps2).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                      .containsExactlyInAnyOrder(
                                              endpointAndStep(Endpoint.of("bar.com"), 2, 200),
@@ -215,63 +233,63 @@ final class WeightRampingUpStrategyTest {
     @Test
     void setEndpointWithDifferentWeight() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
         // Set an endpoint with the weight which is lower than current weight so ramping up is
         // not happening for the endpoint.
         endpointGroup.setEndpoints(
                 ImmutableList.of(Endpoint.of("foo.com").withWeight(100), Endpoint.of("foo1.com")));
-        assertThat(selector.endpointsRampingUp).hasSize(0);
+        assertThat(selector.rampingUpWindowsMap).hasSize(0);
         List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
         assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
                                       .containsExactlyInAnyOrder(
                                               Endpoint.of("foo.com").withWeight(100), Endpoint.of("foo1.com")
                                       );
 
-        // Set an endpoint with the weight which is greater than current weight so ramping up is scheduled.
+        long window = selector.windowIndex(ticker.get());
+        // Set an endpoint with the weight which is greater than the current weight
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com").withWeight(3000),
                                                     Endpoint.of("foo1.com"),
                                                     Endpoint.of("bar.com")));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        Set<EndpointAndStep> endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                     .containsExactlyInAnyOrder(
-                                            endpointAndStep(Endpoint.of("foo.com").withWeight(3000), 1, 300),
                                             endpointAndStep(Endpoint.of("bar.com"), 1, 100));
         endpointsFromEntry = endpointsFromSelectorEntry(selector);
         assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
                                       .containsExactlyInAnyOrder(
-                                              Endpoint.of("foo.com").withWeight(300), Endpoint.of("foo1.com"),
+                                              Endpoint.of("foo.com").withWeight(3000), Endpoint.of("foo1.com"),
                                               Endpoint.of("bar.com").withWeight(100)
                                       );
 
-        // Execute the scheduled job so the weight is ramped up.
-        ticker.addAndGet(TimeUnit.SECONDS.toNanos(20));
+        // Execute a scheduled job
+        ticker.addAndGet(rampingUpIntervalNanos);
         scheduledJobs.poll().run();
+        window = selector.windowIndex(ticker.get());
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        endpointAndSteps = selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                     .containsExactlyInAnyOrder(
-                                            endpointAndStep(Endpoint.of("foo.com").withWeight(3000), 2, 600),
                                             endpointAndStep(Endpoint.of("bar.com"), 2, 200));
         endpointsFromEntry = endpointsFromSelectorEntry(selector);
-        assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
-                                      .containsExactlyInAnyOrder(
-                                              // 3000 * 2 / 10 = 600
-                                              Endpoint.of("foo.com").withWeight(600), Endpoint.of("foo1.com"),
-                                              Endpoint.of("bar.com").withWeight(200)
-                                      );
-
-        ticker.addAndGet(1);
+        assertThat(endpointsFromEntry)
+                .usingElementComparator(EndpointComparator.INSTANCE)
+                .containsExactlyInAnyOrder(
+                        // since rampingUpInterval has already passed, the full weight is used
+                        Endpoint.of("foo.com").withWeight(3000), Endpoint.of("foo1.com"),
+                        Endpoint.of("bar.com").withWeight(200)
+                );
 
         // Set an endpoint with the weight which is lower than current weight so scheduling is canceled.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com").withWeight(599),
                                                     Endpoint.of("foo1.com"),
                                                     Endpoint.of("bar.com")));
-        assertThat(selector.endpointsRampingUp).hasSize(1);
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE).containsExactly(
                 endpointAndStep(Endpoint.of("bar.com"), 2, 200));
         endpointsFromEntry = endpointsFromSelectorEntry(selector);
@@ -285,20 +303,19 @@ final class WeightRampingUpStrategyTest {
     @Test
     void rampingUpEndpointsAreRemoved() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
         addSecondEndpoints(endpointGroup, selector);
 
-        ticker.addAndGet(1);
-
+        final long window = selector.windowIndex(ticker.get());
         // bar1.com is removed and the weight of bar.com is ramped up.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com"), Endpoint.of("foo1.com"),
                                                     Endpoint.of("bar.com").withWeight(3000)));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE).containsExactly(
                 endpointAndStep(Endpoint.of("bar.com").withWeight(3000), 1, 300));
         List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
@@ -308,66 +325,104 @@ final class WeightRampingUpStrategyTest {
                                               Endpoint.of("bar.com").withWeight(300)
                                       );
 
-        ticker.addAndGet(1);
+        ticker.addAndGet(steps * rampingUpIntervalNanos);
         // bar.com is removed.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com"), Endpoint.of("foo1.com")));
-        assertThat(selector.endpointsRampingUp).isEmpty();
+        scheduledJobs.peek().run();
+
+        assertThat(selector.rampingUpWindowsMap).isEmpty();
         endpointsFromEntry = endpointsFromSelectorEntry(selector);
         assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
                                       .containsExactlyInAnyOrder(
                                               Endpoint.of("foo.com"), Endpoint.of("foo1.com")
                                       );
-        assertThat(scheduledFutures).hasSize(1);
-        verify(scheduledFutures.poll(), times(1)).cancel(true);
+        assertThat(scheduledFutures).hasSize(2);
+        verify(scheduledFutures.poll()).cancel(true);
     }
 
     @Test
-    void sameEndpointsAreSummed() {
+    void sameEndpointsAreProcessed() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
-
-        ticker.addAndGet(1);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
         addSecondEndpoints(endpointGroup, selector);
 
-        ticker.addAndGet(1);
-
+        final long window = selector.windowIndex(ticker.get());
         // The three bar.com are converted into onw bar.com with 3000 weight.
         endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com"), Endpoint.of("foo1.com"),
                                                     Endpoint.of("bar.com"), Endpoint.of("bar.com"),
                                                     Endpoint.of("bar.com"), Endpoint.of("bar1.com")));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                     .containsExactlyInAnyOrder(
-                                            endpointAndStep(Endpoint.of("bar.com").withWeight(3000), 1, 300),
+                                            endpointAndStep(Endpoint.of("bar.com"), 1, 100),
+                                            endpointAndStep(Endpoint.of("bar.com"), 1, 100),
+                                            endpointAndStep(Endpoint.of("bar.com"), 1, 100),
                                             endpointAndStep(Endpoint.of("bar1.com"), 1, 100)
                                     );
         final List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
         assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
                                       .containsExactlyInAnyOrder(
                                               Endpoint.of("foo.com"), Endpoint.of("foo1.com"),
-                                              Endpoint.of("bar.com").withWeight(300),
+                                              Endpoint.of("bar.com").withWeight(100),
+                                              Endpoint.of("bar.com").withWeight(100),
+                                              Endpoint.of("bar.com").withWeight(100),
                                               Endpoint.of("bar1.com").withWeight(100)
                                       );
     }
 
     @Test
+    void endpointTimestampsArePrioritized() {
+        final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
+
+        // The three bar.com are converted into onw bar.com with 3000 weight.
+        endpointGroup.setEndpoints(ImmutableList.of(Endpoint.of("foo.com")));
+
+        ticker.addAndGet(rampingUpIntervalNanos * steps);
+
+        assertThat(selector.rampingUpWindowsMap).isEmpty();
+        List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
+        assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
+                                      .containsExactlyInAnyOrder(Endpoint.of("foo.com"));
+
+        // as far as the selector is concerned, the endpoint is added at ticker#get now
+        final Endpoint endpoint = withCreateTimestamp(Endpoint.of("foo.com"), ticker.get());
+        endpointGroup.setEndpoints(ImmutableList.of(endpoint));
+
+        final long window = selector.windowIndex(ticker.get());
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(window);
+        final Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(window).endpointAndSteps();
+        assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE)
+                                    .containsExactlyInAnyOrder(
+                                            endpointAndStep(Endpoint.of("foo.com"), 1, 100));
+        endpointsFromEntry = endpointsFromSelectorEntry(selector);
+        assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
+                                      .containsExactlyInAnyOrder(Endpoint.of("foo.com").withWeight(100));
+    }
+
+    @Test
     void scheduledIsCanceledWhenEndpointGroupIsClosed() {
         final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
-        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, 10);
+        final int steps = 10;
+        final RampingUpEndpointWeightSelector selector = setInitialEndpoints(endpointGroup, steps);
 
-        ticker.addAndGet(1);
+        ticker.addAndGet(steps * rampingUpIntervalNanos);
 
         addSecondEndpoints(endpointGroup, selector);
-        assertThat(scheduledFutures).hasSize(1);
+        assertThat(scheduledFutures).hasSize(2);
 
-        ticker.addAndGet(TimeUnit.SECONDS.toNanos(10));
+        ticker.addAndGet(TimeUnit.SECONDS.toNanos(steps));
 
         endpointGroup.addEndpoint(Endpoint.of("baz.com"));
         endpointGroup.addEndpoint(Endpoint.of("baz1.com"));
-        assertThat(scheduledFutures).hasSize(2);
+        assertThat(scheduledFutures).hasSize(3);
 
         endpointGroup.close();
 
@@ -386,16 +441,65 @@ final class WeightRampingUpStrategyTest {
         assertThat(endpointSelector.selectNow(ctx)).isNull();
     }
 
+    private static Stream<Arguments> correctSchedulingParams() {
+        final int totalSteps = 5;
+        final long intervalNanos = TimeUnit.SECONDS.toNanos(5);
+        final long windowNanos = TimeUnit.SECONDS.toNanos(2);
+        final long numWindows = (long) Math.ceil(1.0 * intervalNanos / windowNanos);
+        return Stream.of(
+                Arguments.of(intervalNanos, windowNanos, totalSteps, 0, intervalNanos, 0),
+                Arguments.of(intervalNanos, windowNanos, totalSteps, windowNanos - 1,
+                             intervalNanos - windowNanos + 1, 0),
+                Arguments.of(intervalNanos, windowNanos, totalSteps, windowNanos, intervalNanos, 1),
+                Arguments.of(intervalNanos, windowNanos, totalSteps, windowNanos + 1, intervalNanos - 1, 1),
+                Arguments.of(intervalNanos, windowNanos, totalSteps, intervalNanos - 1,
+                             windowNanos * (numWindows - 1) + 1, numWindows - 1),
+                Arguments.of(intervalNanos, windowNanos, totalSteps, intervalNanos, intervalNanos, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("correctSchedulingParams")
+    void correctScheduling(long intervalNanos, long windowNanos, int totalSteps,
+                           long timePassed, long expectedInitialDelay, long expectedWindow) {
+        final DynamicEndpointGroup endpointGroup = new DynamicEndpointGroup();
+        final WeightRampingUpStrategy strategy =
+                new WeightRampingUpStrategy(
+                        linear(), ImmediateExecutor::new,
+                        TimeUnit.NANOSECONDS.toMillis(intervalNanos), totalSteps,
+                        TimeUnit.NANOSECONDS.toMillis(windowNanos), ticker::get);
+        final RampingUpEndpointWeightSelector selector =
+                (RampingUpEndpointWeightSelector) strategy.newSelector(endpointGroup);
+
+        ticker.addAndGet(timePassed);
+        endpointGroup.addEndpoint(Endpoint.of("baz.com"));
+        assertThat(periodNanos.poll()).isEqualTo(intervalNanos);
+        assertThat(initialDelayNanos.poll()).isEqualTo(expectedInitialDelay);
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(expectedWindow);
+    }
+
     private static RampingUpEndpointWeightSelector setInitialEndpoints(DynamicEndpointGroup endpointGroup,
                                                                        int numberOfSteps) {
         final WeightRampingUpStrategy strategy =
-                new WeightRampingUpStrategy(linear(), ImmediateExecutor::new,
-                                            20000, numberOfSteps, 1000, ticker::get);
+                new WeightRampingUpStrategy(
+                        linear(), ImmediateExecutor::new,
+                        TimeUnit.NANOSECONDS.toMillis(rampingUpIntervalNanos), numberOfSteps,
+                        TimeUnit.NANOSECONDS.toMillis(rampingUpTaskWindowNanos), ticker::get);
 
         final List<Endpoint> endpoints = ImmutableList.of(Endpoint.of("foo.com"), Endpoint.of("foo1.com"));
         endpointGroup.setEndpoints(endpoints);
         final RampingUpEndpointWeightSelector selector =
                 (RampingUpEndpointWeightSelector) strategy.newSelector(endpointGroup);
+
+        final ScheduledFuture<?> future = scheduledFutures.peek();
+        // We start out with step 1 so the scheduled jobs needs to run (n - 1) times
+        for (int i = 0; i < numberOfSteps - 1; i++) {
+            scheduledJobs.peek().run();
+        }
+        ticker.addAndGet(numberOfSteps * rampingUpIntervalNanos);
+        verify(future).cancel(anyBoolean());
+        periodNanos.clear();
+        initialDelayNanos.clear();
 
         final List<Endpoint> endpointsFromEntry = endpointsFromSelectorEntry(selector);
         assertThat(endpointsFromEntry).usingElementComparator(EndpointComparator.INSTANCE)
@@ -417,8 +521,10 @@ final class WeightRampingUpStrategyTest {
         endpointGroup.addEndpoint(Endpoint.of("bar.com"));
         endpointGroup.addEndpoint(Endpoint.of("bar1.com"));
 
-        assertThat(selector.endpointsRampingUp).hasSize(1);
-        final Set<EndpointAndStep> endpointAndSteps = selector.endpointsRampingUp.peek().endpointAndSteps();
+        final long windowIndex = selector.windowIndex(ticker.get());
+        assertThat(selector.rampingUpWindowsMap).containsOnlyKeys(windowIndex);
+        final Set<EndpointAndStep> endpointAndSteps =
+                selector.rampingUpWindowsMap.get(windowIndex).endpointAndSteps();
         assertThat(endpointAndSteps).usingElementComparator(EndpointAndStepComparator.INSTANCE)
                                     .containsExactlyInAnyOrder(
                                             endpointAndStep(Endpoint.of("bar.com"), 1, 100),
@@ -487,6 +593,8 @@ final class WeightRampingUpStrategyTest {
         public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
                                                       TimeUnit unit) {
             scheduledJobs.add(command);
+            initialDelayNanos.add(unit.toNanos(initialDelay));
+            periodNanos.add(unit.toNanos(period));
             final ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
             scheduledFutures.add(scheduledFuture);
             return scheduledFuture;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategyTest.java
@@ -16,7 +16,7 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static com.linecorp.armeria.client.endpoint.EndpointWeightTransition.linear;
-import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.withCreateTimestamp;
+import static com.linecorp.armeria.internal.client.endpoint.RampingUpKeys.withCreatedAtNanos;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -392,7 +392,7 @@ final class WeightRampingUpStrategyTest {
                                       .containsExactlyInAnyOrder(Endpoint.of("foo.com"));
 
         // as far as the selector is concerned, the endpoint is added at ticker#get now
-        final Endpoint endpoint = withCreateTimestamp(Endpoint.of("foo.com"), ticker.get());
+        final Endpoint endpoint = withCreatedAtNanos(Endpoint.of("foo.com"), ticker.get());
         endpointGroup.setEndpoints(ImmutableList.of(endpoint));
 
         final long window = selector.windowIndex(ticker.get());


### PR DESCRIPTION
Motivation:

The motivation for this PR stems from #5688.

The current `WeightRampingUpStrategy` internally maintains the ramping up status of endpoints. However, it is possible that although an `EndpointGroup` has just been created certain endpoints must be considered already ramped up. For instance, in xDS we newly create an `EndpointGroup` every time a `ClusterSnapshot` is updated. However, even if a `ClusterSnapshot` has changed, we need to retain an endpoint's ramping up status.

To resolve this, I propose a timestamp based solution. Specifically, I believe an `Endpoint` can maintain a state `createdAtNanos` and `WeightRampingUpStrategy` can refer to this value to determine the ramp-up status. We can also allow users to specify their own timestamp via an attribute if they are maintaining their own `Endpoint` pool like done in xDS.

While implementing a timestamp based solution, I found that the previous logic is probably simpler to manage if it were refactored. Specifically, I propose that a `rampingUpInterval` is divided into `rampingUpTaskWindow`s. Each `rampingUpTaskWindow` will be assigned a scheduler. If a scheduler doesn't have any more endpoints to ramp up, the scheduler is stopped. I've also removed the endpoint deduplication related logic to make the implementation simpler.

Modifications:

- Defined an attribute `createdAtNanos` which signifies when an `Endpoint` has been created.
- Refactored `WeightRampingUpStrategy` to refer to `createdAtNanos` when computing the initial ramping up step
- Refactored `WeightRampingUpStrategy` overall to always use the created timestamp when 1) determining the initial ramping up step 2) determining which ramping up scheduler to use
  - Removed deduplication logic for simplifying logic
  - Removed weight update logic for simplifying logic.

Result:

- We can prepare to support `WeightRampingUpStrategy` for xDS.
<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
