### PR TITLE
Always use HTTP/2 preface for H2C

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -208,6 +208,12 @@ public final class ClientFactoryOptions
     /**
      * Whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
      * the protocol version of a cleartext HTTP connection.
+     *
+     * <p>Note that this option is only effective when the {@link SessionProtocol} of the {@link Endpoint} is
+     * {@link SessionProtocol#HTTP}.
+     * If the {@link SessionProtocol} is {@link SessionProtocol#HTTPS} or {@link SessionProtocol#H2}, ALPN will
+     * be used. If the {@link SessionProtocol} is {@link SessionProtocol#H2C}, the client will
+     * always use HTTP/2 connection preface.
      */
     public static final ClientFactoryOption<Boolean> USE_HTTP2_PREFACE =
             ClientFactoryOption.define("USE_HTTP2_PREFACE", Flags.defaultUseHttp2Preface());
@@ -527,6 +533,12 @@ public final class ClientFactoryOptions
     /**
      * Returns whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
      * the protocol version of a cleartext HTTP connection.
+     *
+     * <p>Note that this option is only effective when the {@link SessionProtocol} of the {@link Endpoint} is
+     * {@link SessionProtocol#HTTP}.
+     * If the {@link SessionProtocol} is {@link SessionProtocol#HTTPS} or {@link SessionProtocol#H2}, ALPN will
+     * be used. If the {@link SessionProtocol} is {@link SessionProtocol#H2C}, the client will always use
+     * HTTP/2 connection preface.
      */
     public boolean useHttp2Preface() {
         return get(USE_HTTP2_PREFACE);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -359,7 +359,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
     private void configureUpgradeCodec(Channel ch, Consumer<ChannelHandler> pipelineCustomizer) {
         final Http2ClientConnectionHandler http2Handler = newHttp2ConnectionHandler(ch, http2);
-        if (clientFactory.useHttp2Preface()) {
+        // - h2c: HTTP/2 preface is always used.
+        // - http: Either HTTP/1.1 upgrade or HTTP/2 preface is used depending on 'useHttp2Preface()'.
+        final boolean shouldUsePreface = httpPreference == HttpPreference.HTTP2_REQUIRED ||
+                                         clientFactory.useHttp2Preface();
+        if (shouldUsePreface) {
             pipelineCustomizer.accept(new DowngradeHandler());
             pipelineCustomizer.accept(http2Handler);
         } else {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -45,6 +45,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.DnsResolverGroupBuilder;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
@@ -870,8 +871,11 @@ public final class Flags {
      * If disabled, the {@code OPTIONS * HTTP/1.1} request with {@code "Upgrade: h2c"} header is sent for
      * a cleartext HTTP/2 connection. Consider disabling this flag if your HTTP servers have issues
      * handling or rejecting the HTTP/2 connection preface without a upgrade request.
-     * Note that this option does not affect ciphertext HTTP/2 connections, which use ALPN for protocol
-     * negotiation, and it has no effect if a user specified the value explicitly via
+     *
+     * <p>Note that this option is only effective when the {@link SessionProtocol} of the {@link Endpoint} is
+     * {@link SessionProtocol#HTTP}. This option does not affect ciphertext HTTP/2 connections, which use ALPN
+     * for protocol negotiation, or {@link SessionProtocol#H2C}, which will always use HTTP/2 connection
+     * preface. This option is ignored if a user specified the value explicitly via
      * {@link ClientFactoryBuilder#useHttp2Preface(boolean)}.
      *
      * <p>This flag is enabled by default. Specify the

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientPrefaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientPrefaceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.testing.NettyServerExtension;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2ConnectionEncoder;
+import io.netty.handler.codec.http2.Http2Settings;
+
+class Http2ClientPrefaceTest {
+
+    @RegisterExtension
+    static NettyServerExtension h2cServer = new NettyServerExtension() {
+        @Override
+        protected void configure(Channel ch) throws Exception {
+            ch.pipeline().addLast(new H2CHandlerBuilder().build());
+        }
+    };
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void shouldAlwaysUseConnectionPrefaceForH2C(boolean useHttp2Preface) {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp2Preface(useHttp2Preface)
+                                                  .build()) {
+            final BlockingWebClient client = WebClient.builder(h2cServer.endpoint().toUri(SessionProtocol.H2C))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            final AggregatedHttpResponse response = client.get("/");
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void shouldUseConnectionPrefaceOrUpgradeForHttp(boolean useHttp2Preface) {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp2Preface(useHttp2Preface)
+                                                  .build()) {
+            final BlockingWebClient client = WebClient.builder(h2cServer.endpoint().toUri(SessionProtocol.HTTP))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            if (useHttp2Preface) {
+                final AggregatedHttpResponse response = client.get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+            } else {
+                // Upgrade HTTP/1.1 to HTTP/2 fails because the server only supports H2C.
+                assertThatThrownBy(() -> client.get("/"))
+                        .isInstanceOf(UnprocessedRequestException.class)
+                        .hasCauseInstanceOf(ClosedSessionException.class);
+            }
+        }
+    }
+
+    private static final class H2CHandler extends SimpleH2CServerHandler {
+
+        H2CHandler(Http2ConnectionDecoder decoder,
+                   Http2ConnectionEncoder encoder,
+                   Http2Settings initialSettings) {
+            super(decoder, encoder, initialSettings);
+        }
+    }
+
+    private static final class H2CHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<
+            H2CHandler, H2CHandlerBuilder> {
+
+        @Override
+        public H2CHandler build() {
+            return super.build();
+        }
+
+        @Override
+        public H2CHandler build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                Http2Settings initialSettings) {
+            final H2CHandler handler =
+                    new H2CHandler(decoder, encoder, initialSettings);
+            frameListener(handler);
+            return handler;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

There are two modes to negotiate cleartext HTTP/2 connections. They are HTTP/2 connection preface and HTTP/1 upgrade requests. The default behavior is determined by `ClientFactoryOptions.useHttp2Preface()`. This option affects' http' and `h2c`, so even if a user uses `h2c` with prior knowledge, an upgrade request will be sent if `useHttp2Preface() == false`.

With prior knowledge, it is an unwanted behavior for `useHttp2Preface()` option to affect `h2c` scheme. `h2c` is an explicit scheme whose negotiation should be fixed to the HTTP/2 connection preface. Its endpoint may not understand the HTTP/1 upgrade.

So it would make more sense to apply to `useHttp2Preface()` option to adjust the default behavior of `http`.  If both `http` and `h2c` follow `useHttp2Preface()`, there is no difference in behavior between them.

Modifications:

- Always use HTTP/2 connection preface for `h2c`
- `useHttp2Preface()` option now affects only `http`.

Result:

Armeria client always uses HTTP/2 connection preface for `h2c`, regardless of the value of `useHttp2Preface()`.

