### PR TITLE
Close a WebSocket when it is idle

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -266,7 +266,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                             ((ServerHttp1ObjectEncoder) encoder).webSocketUpgrading();
                             final ChannelPipeline pipeline = ctx.pipeline();
                             pipeline.replace(this, null, new WebSocketServiceChannelHandler(
-                                    webSocketRequest, encoder, serviceConfig));
+                                    webSocketRequest, encoder, serviceConfig, cfg));
                             if (pipeline.get(HttpServerUpgradeHandler.class) != null) {
                                 pipeline.remove(HttpServerUpgradeHandler.class);
                             }

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketIdleTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketIdleTimeoutTest.java
@@ -1,23 +1,29 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.server.websocket;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.websocket.WebSocketClient;
-import com.linecorp.armeria.client.websocket.WebSocketInboundTestHandler;
 import com.linecorp.armeria.client.websocket.WebSocketSession;
-import com.linecorp.armeria.common.ClosedSessionException;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.websocket.WebSocketFrame;
-import com.linecorp.armeria.common.websocket.WebSocketWriter;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.websocket.WebSocketServiceTest.AbstractWebSocketHandler;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketIdleTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketIdleTimeoutTest.java
@@ -1,0 +1,47 @@
+package com.linecorp.armeria.server.websocket;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketInboundTestHandler;
+import com.linecorp.armeria.client.websocket.WebSocketSession;
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.websocket.WebSocketFrame;
+import com.linecorp.armeria.common.websocket.WebSocketWriter;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.websocket.WebSocketServiceTest.AbstractWebSocketHandler;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+public class WebSocketIdleTimeoutTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final WebSocketService service =
+                    WebSocketService.builder(new AbstractWebSocketHandler()).build();
+
+            sb.service("/idle", service);
+            sb.idleTimeout(Duration.ofMillis(1));
+        }
+    };
+
+    @Test
+    void shouldClosedConnection() throws Exception {
+        final WebSocketClient client = WebSocketClient.of(server.httpUri());
+        final WebSocketSession session = client.connect("/idle").join();
+
+        Thread.sleep(2000);
+        assertThat(session.outbound().isOpen()).isFalse();
+    }
+}


### PR DESCRIPTION
Related: #5696 

Motivation:

> WebSocket is mostly a long-running request, 
it is not easy to limit when it will end with a request timeout. 
It would make more sense to terminate the request when no messages are sent or received for a certain period of time.

>The existing idle timeout handler operates at the connection level so a new scheduler that can perform at the WebSocket level is necessary.

Modifications:

- WebSocketServiceChannelHandler
   - Add ServerConfig parameter to the constructor
   - Add a feature  closes channels using ScheduledFuture
- Http1RequestDecoder
  - Modify ```new WebSocketServiceChannelHandler()```  Parameter in  ```pipeline.replace()``` 

Result:

- Closes #5696 . 
- Set idleTimeoutMillis in ServerConfig to a non-zero value, WebSockets will close after the idle timeout period.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
