### PR TITLE
Remove `RequestLog` dependency in `RetryingClient`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/limit/AbstractConcurrencyLimitingClient.java
@@ -108,7 +108,7 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
                                 // Wrap the exception with UnprocessedRequestException.
                                 final UnprocessedRequestException t =
                                         UnprocessedRequestException.of(throwable);
-                                completeExceptionally(ctx, resFuture, t);
+                                resFuture.completeExceptionally(t);
                                 return null;
                             }
                             numActiveRequests.incrementAndGet();
@@ -124,19 +124,12 @@ public abstract class AbstractConcurrencyLimitingClient<I extends Request, O ext
                                 } catch (Throwable t) {
                                     permit.close();
                                     numActiveRequests.decrementAndGet();
-                                    completeExceptionally(ctx, resFuture, t);
+                                    resFuture.completeExceptionally(t);
                                 }
                             }
                             return null;
                         }, ctx.eventLoop().withoutContext());
         return deferred;
-    }
-
-    private static void completeExceptionally(ClientRequestContext ctx,
-                                              CompletableFuture<?> resFuture, Throwable t) {
-        resFuture.completeExceptionally(t);
-        ctx.logBuilder().endRequest(t);
-        ctx.logBuilder().endResponse(t);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/limit/ConcurrencyLimitingClientTest.java
@@ -177,7 +177,6 @@ class ConcurrencyLimitingClientTest {
         await().untilAsserted(() -> assertThat(res.isOpen()).isFalse());
         assertThatThrownBy(() -> res.whenComplete().get()).hasCauseInstanceOf(Exception.class);
         await().untilAsserted(() -> assertThat(client.numActiveRequests()).isZero());
-        await().untilAsserted(() -> assertThat(ctx.log().isComplete()).isTrue());
     }
 
     @Test

--- a/oauth2/src/test/java/com/linecorp/armeria/client/auth/oauth2/OAuth2ClientRetryTest.java
+++ b/oauth2/src/test/java/com/linecorp/armeria/client/auth/oauth2/OAuth2ClientRetryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.auth.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.auth.oauth2.GrantedOAuth2AccessToken;
+import com.linecorp.armeria.common.auth.oauth2.UnsupportedResponseException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class OAuth2ClientRetryTest {
+
+    private static AtomicInteger tokenCounter = new AtomicInteger();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/token", (ctx, req) -> {
+                if (tokenCounter.incrementAndGet() < 2) {
+                    return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+                final GrantedOAuth2AccessToken token = GrantedOAuth2AccessToken.builder("token")
+                                                                               .build();
+                return HttpResponse.of(HttpStatus.OK, MediaType.JSON, token.rawResponse());
+            });
+            sb.service("/resource", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+        }
+    };
+
+    @Test
+    void retryOnFailure() {
+        final AccessTokenRequest accessTokenRequest =
+                AccessTokenRequest.ofClientCredentials("client_id", "client_secret");
+        final WebClient authClient = server.webClient();
+        final OAuth2AuthorizationGrant grant =
+                OAuth2AuthorizationGrant.builder(authClient, "/token")
+                                        .accessTokenRequest(accessTokenRequest)
+                                        .build();
+
+        // INTERNAL_SERVER_ERROR from the token server will raise UnsupportedMediaTypeException
+        final RetryRule retryRule = RetryRule.onException(UnsupportedResponseException.class);
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .decorator(OAuth2Client.newDecorator(grant))
+                                          .decorator(RetryingClient.newDecorator(retryRule))
+                                          .build();
+        final AggregatedHttpResponse response =
+                client.prepare()
+                      .get("/resource")
+                      // Response streaming type uses RequestLog in which RetryingClient is used triggered a
+                      // deadlock.
+                      .exchangeType(ExchangeType.RESPONSE_STREAMING)
+                      .execute()
+                      .aggregate()
+                      .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
Motivation:

Related: #5708, #4834

If a decorator directly returns a response, the `RequestLog` for the request won't be complete. Because the `RequestLog` is automatically completed when it starts to be written to the wire by `AbstractRequestHandler`.

In the case of `RetryingClient`, `RequestLog`'s events are used to get exceptions to apply `RetryRule`. If the `RequestLog` events aren't complete, `RetryingClient` will fall into a deadlock.

Typically, `RequestLog` is automatically completed so it is difficult for the user to recognize that `RequestLog` must be completed. Consequently, it is easy to miss.

I propose two changes in this PR to solve the problem.

1. If `RequestLog.requestFirstBytesTransferredTimeNanos` isn't logged when a response completes, we can assume that the response is returned by a decorator. So a hook is added to a response completion event to complete the log manually for that case.

2. `RetryingClient` is refactored not to retry on `RequestLog` but to use `SplitHttpResponse` and subscribe to headers. An exception when headers are received is used to apply `RetryRule`.

Modifications:

- Add a hook that completes `RequestLog` if it is written to wire to `ClientUtil`
- Split `handleResponse` into `handleAggregatedResponse` and `handleStreamingResponse` in `RetryingClient`
  - Remove `RequestLog` usage in `handleStreamingResponse` and use `SplitHttpRequest` to check if an exception is raised in the response.

Result:

- Fixed deadlock that could occur in `RetryingClient` due to `RequestLog` not being completed.
