### PR TITLE
Fix a possible deadlock when `OAuth2Client` is used with `RetryingClient`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -376,6 +376,11 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                 retryConfig.requiresResponseTrailers() ?
                 RequestLogProperty.RESPONSE_END_TIME : RequestLogProperty.RESPONSE_HEADERS;
 
+        // The RequestLog may be not complete when a decorator returns a response directly.
+        // The direct response typically occurs when an exception is raised from the decorator.
+        // The incomplete RequestLog may cause a deadlock when the response don't be completed
+        // until it times out.
+        // TODO(ikhoon): Find a way to apply RetryingRule without relying on the RequestLog.
         derivedCtx.log().whenAvailable(logProperty).thenAccept(log -> {
             final Throwable responseCause =
                     log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;

--- a/oauth2/src/test/java/com/linecorp/armeria/client/auth/oauth2/OAuth2ClientRetryTest.java
+++ b/oauth2/src/test/java/com/linecorp/armeria/client/auth/oauth2/OAuth2ClientRetryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.auth.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.auth.oauth2.GrantedOAuth2AccessToken;
+import com.linecorp.armeria.common.auth.oauth2.UnsupportedResponseException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class OAuth2ClientRetryTest {
+
+    private static AtomicInteger tokenCounter = new AtomicInteger();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/token", (ctx, req) -> {
+                if (tokenCounter.incrementAndGet() < 2) {
+                    return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+                final GrantedOAuth2AccessToken token = GrantedOAuth2AccessToken.builder("token")
+                                                                               .build();
+                return HttpResponse.of(HttpStatus.OK, MediaType.JSON, token.rawResponse());
+            });
+            sb.service("/resource", (ctx, req) -> {
+                return HttpResponse.of(HttpStatus.OK);
+            });
+        }
+    };
+
+    @Test
+    void retryOnFailure() {
+        final AccessTokenRequest accessTokenRequest =
+                AccessTokenRequest.ofClientCredentials("client_id", "client_secret");
+        final WebClient authClient = server.webClient();
+        final OAuth2AuthorizationGrant grant =
+                OAuth2AuthorizationGrant.builder(authClient, "/token")
+                                        .accessTokenRequest(accessTokenRequest)
+                                        .build();
+
+        // INTERNAL_SERVER_ERROR from the token server will raise UnsupportedMediaTypeException
+        final RetryRule retryRule = RetryRule.onException(UnsupportedResponseException.class);
+        final WebClient client = WebClient.builder(server.httpUri())
+                                          .decorator(OAuth2Client.newDecorator(grant))
+                                          .decorator(RetryingClient.newDecorator(retryRule))
+                                          .build();
+        final AggregatedHttpResponse response =
+                client.prepare()
+                      .get("/resource")
+                      // Response streaming type uses RequestLog in which RetryingClient is used triggered a
+                      // deadlock.
+                      .exchangeType(ExchangeType.RESPONSE_STREAMING)
+                      .execute()
+                      .aggregate()
+                      .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
Motivation:

When `OAuth2Client` fails to acquire a granted access token, it directly returns a failed response. As the response is returned, `RequestLog` is not completed.

`RetryingClient` waits for some properties of `RequestLog` to be completed. Therefore, the incomplete `RequestLog` causes `RetryingClient` to get stuck.

This PR is a temporary workaround to fix the problem. The deadlock phenomenon will occur easily if a decorator returns a response directly. I created #5714 in which I will try to solve this problem ultimately.

Modifications:

- If `getAccessToken()` completes exceptionally, completes the log and then returns a failed response.

Result:

Fixed a bug where `RetryingClient` gets to deadlock when `OAuth2Client` fails to obtain an access token.
