### PR TITLE
Add a graceful shutdown timeout before closing the default `ClientFactory`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -97,6 +97,7 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final String DNS_CACHE_SPEC = "maximumSize=4096";
     static final long DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = 10000;
     static final long DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS = 3000;
+    static final long DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS = 10000;
 
     private DefaultFlagsProvider() {}
 
@@ -502,5 +503,10 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Long defaultHttp1ConnectionCloseDelayMillis() {
         return DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS;
+    }
+
+    @Override
+    public Long defaultClientFactoryGracefulShutdownTimeoutMillis() {
+        return DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -43,6 +43,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.DnsResolverGroupBuilder;
 import com.linecorp.armeria.client.Endpoint;
@@ -434,6 +435,9 @@ public final class Flags {
             getValue(FlagsProvider::defaultHttp1ConnectionCloseDelayMillis,
                     "defaultHttp1ConnectionCloseDelayMillis", value -> value >= 0);
 
+    private static final long DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS =
+            getValue(FlagsProvider::defaultClientFactoryGracefulShutdownTimeoutMillis,
+                    "defaultClientFactoryGracefulShutdownTimeoutMillis", value -> value >= 0);
     /**
      * Returns the specification of the {@link Sampler} that determines whether to retain the stack
      * trace of the exceptions that are thrown frequently by Armeria. A sampled exception will have the stack
@@ -1619,6 +1623,25 @@ public final class Flags {
     @UnstableApi
     public static long defaultHttp1ConnectionCloseDelayMillis() {
         return DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS;
+    }
+
+    /**
+     * Returns the default time in milliseconds to wait before closing the
+     * {@linkplain ClientFactory#ofDefault() default ClientFactory} that is closed by JVM
+     * {@linkplain Runtime#addShutdownHook(Thread) shutdown hook}.
+     *
+     * <p>This option is ignored if you manually close the default {@linkplain ClientFactory} with
+     * {@link ClientFactory#closeDefault()} or you disable the shutdown hook with
+     * {@link ClientFactory#disableShutdownHook()}.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultClientFactoryGracefulShutdownTimeoutMillis=<long>} JVM option to
+     * override the default value. {@code 0} closes the default {@link ClientFactory} immediately.
+     */
+    @UnstableApi
+    public static long defaultClientFactoryGracefulShutdownTimeoutMillis() {
+        return DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLException;
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
 
 import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.DnsResolverGroupBuilder;
 import com.linecorp.armeria.client.retry.Backoff;
@@ -1215,6 +1216,26 @@ public interface FlagsProvider {
     @Nullable
     @UnstableApi
     default Long defaultHttp1ConnectionCloseDelayMillis() {
+        return null;
+    }
+
+    /**
+     * Returns the default time in milliseconds to wait before closing the
+     * {@linkplain ClientFactory#ofDefault() default ClientFactory} that is closed by JVM
+     * {@linkplain Runtime#addShutdownHook(Thread) shutdown hook}.
+     *
+     * <p>This option is ignored if you manually close the default {@linkplain ClientFactory} with
+     * {@link ClientFactory#closeDefault()} or you disable the shutdown hook with
+     * {@link ClientFactory#disableShutdownHook()}.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_CLIENT_FACTORY_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS}. Specify the
+     * {@code -Dcom.linecorp.armeria.defaultClientFactoryGracefulShutdownTimeoutMillis=<long>} JVM option to
+     * override the default value. {@code 0} closes the default {@link ClientFactory} immediately.
+     */
+    @Nullable
+    @UnstableApi
+    default Long defaultClientFactoryGracefulShutdownTimeoutMillis() {
         return null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -69,6 +69,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 
+import com.linecorp.armeria.client.Client;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.common.Flags;
@@ -899,6 +900,10 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder {
     /**
      * Sets the amount of time to wait after calling {@link Server#stop()} for
      * requests to go away before actually shutting down.
+     *
+     * <p>When setting this value, it is recommended to appropriately adjust
+     * {@link Flags#defaultClientFactoryGracefulShutdownTimeoutMillis()} to prevent {@link Client}s from
+     * terminating during processing requests.
      *
      * @param quietPeriod the number of milliseconds to wait for active
      *                    requests to go end before shutting down. {@link Duration#ZERO} means

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceFinderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceFinderTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria;
+package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,11 +28,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.cors.CorsService;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.server.logging.LoggingService;

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TestFlagsProvider.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/TestFlagsProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.testing;
+
+import com.linecorp.armeria.common.FlagsProvider;
+
+public final class TestFlagsProvider implements FlagsProvider {
+    @Override
+    public int priority() {
+        return 0;
+    }
+
+    @Override
+    public Long defaultClientFactoryGracefulShutdownTimeoutMillis() {
+        // Disable the graceful shutdown timeout for faster tests.
+        // It's not recommended to disable the graceful shutdown timeout in production.
+        return 0L;
+    }
+}

--- a/testing-internal/src/main/resources/META-INF/services/com.linecorp.armeria.common.FlagsProvider
+++ b/testing-internal/src/main/resources/META-INF/services/com.linecorp.armeria.common.FlagsProvider
@@ -1,0 +1,1 @@
+com.linecorp.armeria.internal.testing.TestFlagsProvider


### PR DESCRIPTION
Motivation:

The default `ClientFactory` closes immediately when a JVM shuts down. The closed `ClientFactory` prevents all clients using the default factory from processing requests.

This is not a problem when the client is used alone. However, many clients are used in a server to fetch or deliver data when the server receives a request. If the `ClientFactory` is closed while the server is still in graceful shutdown mode, all requests will fail.  This behavior cannot be called a graceful shutdown.

In this case, an `EndpointSelectionTimeoutException` is raised by `HealthCheckedEndointGroup` due to the termination of the default `ClientFactory` used by `HttpHealthChecker`.
```java
com.linecorp.armeria.client.UnprocessedRequestException: com.linecorp.armeria.client.endpoint.EndpointSelectionTimeoutException:
  Failed to select within 6400 ms an endpoint from: HealthCheckedEndpointGroup{endpoints=[], numEndpoints=0, candidates=[Endpoint{example.com, ipAddr=x.x.x.x, weight=1000}, ...], numCandidates=8, ...,
  initialized=true, initialSelectionTimeoutMillis=10000, selectionTimeoutMillis=6400, contextGroupChain=[]}
    at com.linecorp.armeria.client.UnprocessedRequestException.of(UnprocessedRequestException.java:45)
    at com.linecorp.armeria.client.HttpClientDelegate.earlyFailedResponse(HttpClientDelegate.java:228)
...
Caused by: com.linecorp.armeria.client.endpoint.EndpointSelectionTimeoutException:
  Failed to select within 6400 ms an endpoint from: HealthCheckedEndpointGroup{endpoints=[], numEndpoints=0, candidates=[Endpoint{example.com, ipAddr=x.x.x.x, weight=1000}, ...], numCandidates=8, ...,
  initialized=true, initialSelectionTimeoutMillis=10000, selectionTimeoutMillis=6400, contextGroupChain=[]}
    at com.linecorp.armeria.client.endpoint.EndpointSelectionTimeoutException.get(EndpointSelectionTimeoutException.java:48)
    at com.linecorp.armeria.client.endpoint.AbstractEndpointSelector.lambda$select$0(AbstractEndpointSelector.java:117)
    at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
    at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:153)
    ...
    8 common frames omitted
```

I propose to add a delay before closing the default `ClientFactory` so that the server handles the request during graceful shutdown.

Modifications:

- Add `Flags.defaultClientFactoryGracefulShutdownTimeoutMillis()` that indicates the default time to wait before closing the default `ClientFactory`.
- Add `TestFlagsProvider` to override `defaultClientFactoryGracefulShutdownTimeoutMillis` for rapid iterative testing.

Result:

- `HealthCheckedEndpointGroup` no longer raises `EndpointSelectionTimeoutException` when a server is stopped by the JVM shutdown hook.
- You can now set a delay before the default `ClientFactory` shuts down via `Flags.defaultClientFactoryGracefulShutdownTimeoutMillis()`. If not set, 10 seconds is used by default.
