### PR TITLE
Fix a bug that `FallbackService` doesn't respect `Flags.allowSemicolonInPathComponent()`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -149,9 +150,14 @@ public interface RoutingContext {
      */
     default RoutingContext withPath(String path) {
         requireNonNull(path, "path");
-        final String pathWithoutMatrixVariables = removeMatrixVariables(path);
-        checkArgument(pathWithoutMatrixVariables != null,
-                      "path with invalid matrix variables: %s", path);
+        final String pathWithoutMatrixVariables;
+        if (Flags.allowSemicolonInPathComponent()) {
+            pathWithoutMatrixVariables = path;
+        } else {
+            pathWithoutMatrixVariables = removeMatrixVariables(path);
+            checkArgument(pathWithoutMatrixVariables != null,
+                          "path with invalid matrix variables: %s", path);
+        }
 
         final RequestTarget oldReqTarget = requestTarget();
         final RequestTarget newReqTarget =

--- a/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/FallbackServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 import com.google.common.base.Strings;
 
@@ -44,6 +45,7 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+@SetSystemProperty(key = "com.linecorp.armeria.allowSemicolonInPathComponent", value = "true")
 class FallbackServiceTest {
 
     @Nullable
@@ -126,6 +128,13 @@ class FallbackServiceTest {
         assertThat(res.headers().status()).isSameAs(HttpStatus.FORBIDDEN);
         assertThat(lastRouteWasFallback).isTrue();
         assertThat(res.headers().get("x-trace-id")).isEqualTo("foo");
+    }
+
+    @Test
+    void fallbackServiceShouldNotRaiseExceptionWhenPathContainsSemicolon() {
+        // See https://github.com/line/armeria/issues/5726 for more information.
+        assertThat(webClient.get("/;").status()).isSameAs(HttpStatus.NOT_FOUND);
+        assertThat(lastRouteWasFallback).isTrue();
     }
 
     @ValueSource(strings = { "H1C", "H2C" })


### PR DESCRIPTION
Motivation:
`FallbackService` creates a new `RoutingContext` with appending `/` to the old path to check if a service is bound to the path.
https://github.com/line/armeria/blob/94151152f27df5c8ad61d7d3b840fc47ca2c0161/core/src/main/java/com/linecorp/armeria/server/FallbackService.java#L72 However, it doesn't respect `Flags.allowSemicolonInPathComponent()` when creating the new `RoutingContext` which results in an exception.

Modification:
- Respect `Flags.allowSemicolonInPathComponent()` in `RoutingContext.withPath()`.

Result:
- `FallbackService` doesn't raise an exception anymore when `Flags.allowSemicolonInPathComponent()` is `true` and the request path contains a semicolon.