### PR TITLE
Prevents the connection from being used immediately when `WriteTimeoutException` occurs.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -329,6 +329,10 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
     }
 
     final void failAndReset(Throwable cause) {
+        // Mark the session as unhealthy so that subsequent requests do not use it.
+        final HttpSession session = HttpSession.get(ch);
+        session.deactivate();
+
         if (cause instanceof ProxyConnectException || cause instanceof ResponseCompleteException) {
             // - ProxyConnectException is handled by HttpSessionHandler.exceptionCaught().
             // - ResponseCompleteException means the response is successfully received.

--- a/core/src/test/java/com/linecorp/armeria/client/WriteTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/WriteTimeoutTest.java
@@ -16,7 +16,11 @@
 
 package com.linecorp.armeria.client;
 
+import static com.linecorp.armeria.internal.client.HttpSession.get;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -29,6 +33,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -63,12 +68,20 @@ class WriteTimeoutTest {
         headersBuilder.add("header1", Strings.repeat("a", 2048)); // set a header over 1KB
 
         // using h1c since http2 compresses headers
-        assertThatThrownBy(() -> WebClient.builder(SessionProtocol.H1C, server.httpEndpoint())
-                                          .factory(clientFactory)
-                                          .writeTimeoutMillis(1000)
-                                          .build()
-                                          .blocking()
-                                          .execute(headersBuilder.build(), "content"))
-                .isInstanceOf(WriteTimeoutException.class);
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final HttpResponse res = WebClient.builder(SessionProtocol.H1C, server.httpEndpoint())
+                                              .factory(clientFactory)
+                                              .writeTimeoutMillis(1000)
+                                              .build()
+                                              .execute(headersBuilder.build(), "content");
+            final ClientRequestContext ctx = captor.get();
+            assertThatThrownBy(() -> res.aggregate().join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(WriteTimeoutException.class);
+
+            final RequestLog log = ctx.log().whenComplete().join();
+            // Make sure that the session is deactivated after the write timeout.
+            assertThat(get(log.channel()).isAcquirable()).isFalse();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

I got a report from LINE internally where the connection was not terminated but hung when the VM instance was shut down due to maintenance of the underlying hypervisor.

`operationComplete()` was not called for `Channel.write()` for this abnormal connection. There was neither a normal response nor a failure response.
https://github.com/line/armeria/blob/f0ec7cb729d1fb33d238c6ea8fb9af41460ab37d/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java#L126-L126 As a result, `WriteTimeoutException` occurred and tried to reset the connection.
https://github.com/line/armeria/blob/f0ec7cb729d1fb33d238c6ea8fb9af41460ab37d/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java#L331-L331

`failAndReset()` calls `Channel.write(Unpooled.EMPTY_BUFFER)` first and then calls `Channel.close()`. 
https://github.com/line/armeria/blob/f0ec7cb729d1fb33d238c6ea8fb9af41460ab37d/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java#L371-L374
Since `channel.write()` does not respond, the connection cannot be closed.

Modifications:

- Deactivate `HttpSession` first before proceeding with the reset process.
  - Unhealthy connections will be cleaned up eventually with `KeeyAliveHandler` by idle timeout.

Result:

Fixed a bug where a connection was reused after `WriteTimeoutException` occurred.
