### PR TITLE
Fix `CorsServerErrorHandler` to work with dynamic `CorsService`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
@@ -54,7 +54,7 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
             return serverErrorHandler.renderStatus(null, serviceConfig, headers, status, description, cause);
         }
 
-        final CorsService corsService = serviceConfig.service().as(CorsService.class);
+        final CorsService corsService = ctx.findService(CorsService.class);
         if (corsService == null) {
             return serverErrorHandler.renderStatus(ctx, serviceConfig, headers, status, description, cause);
         }
@@ -80,7 +80,7 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
             if (oldRes == null) {
                 return null;
             }
-            final CorsService corsService = ctx.config().service().as(CorsService.class);
+            final CorsService corsService = ctx.findService(CorsService.class);
             if (corsService == null) {
                 return oldRes;
             }

--- a/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
@@ -69,8 +69,8 @@ class CorsServerErrorHandlerTest {
                            .preflightResponseHeader("x-preflight-cors", "Hello CORS")
                            .newDecorator();
         if (useRouteDecorator) {
-            sb.decorator(corsService);
-            sb.decorator((delegate, ctx, req) -> {
+            sb.decorator(pathPattern, corsService);
+            sb.decorator(pathPattern, (delegate, ctx, req) -> {
                 throw exception;
             });
         } else {


### PR DESCRIPTION
Motivation:

This PR is follow-up of https://github.com/line/armeria/pull/5632#discussion_r1595038769 and #5670 that `ctx.findService()` should be used to find `CorsService` added with route decorators.

Modifications:

- Use `ctx.findService()` to find `CorsService` in the service chain of a request

Result:

CorsServerErrorHandler now correctly handles response exceptions even if `CorsService` is added as a route decorator.
(Not need to be mentioned in the release notes)

