### PR TITLE
Fix to propagate `ServiceRequestContext` to `ServerErrorHandler`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerErrorHandler.java
@@ -19,9 +19,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 import javax.annotation.Nonnull;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.ContentTooLargeException;
 import com.linecorp.armeria.common.HttpData;
@@ -49,8 +46,6 @@ import com.linecorp.armeria.server.annotation.AnnotatedService;
 enum DefaultServerErrorHandler implements ServerErrorHandler {
 
     INSTANCE;
-
-    private static final Logger logger = LoggerFactory.getLogger(DefaultServerErrorHandler.class);
 
     /**
      * Converts the specified {@link Throwable} to an {@link HttpResponse}.

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -407,7 +407,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         res = res.recover(cause -> {
             reqCtx.logBuilder().responseCause(cause);
             // Recover the failed response with the error handler.
-            return serviceCfg.errorHandler().onServiceException(reqCtx, cause);
+            try (SafeCloseable ignored = reqCtx.push()) {
+                return serviceCfg.errorHandler().onServiceException(reqCtx, cause);
+            }
         });
 
         // Keep track of the number of unfinished requests and

--- a/core/src/test/java/com/linecorp/armeria/server/ServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerErrorHandlerTest.java
@@ -42,11 +42,17 @@ class ServerErrorHandlerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.route()
               .get("/foo")
-              .errorHandler((ctx, cause) -> null)
+              .errorHandler((ctx, cause) -> {
+                  assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+                  return null;
+              })
               .build((ctx, req) -> {
                   throw new RuntimeException();
               });
-            sb.errorHandler((ctx, cause) -> HttpResponse.of(HttpStatus.BAD_REQUEST));
+            sb.errorHandler((ctx, cause) -> {
+                assertThat(ServiceRequestContext.current()).isSameAs(ctx);
+                return HttpResponse.of(HttpStatus.BAD_REQUEST);
+            });
         }
     };
 


### PR DESCRIPTION
Motivation:

An event loop of the `Channel` of a request is used to subscribe to a returned `HttpResponse`.
https://github.com/line/armeria/blob/3112b50cb6d2bd0cd31bac17796c5e6a01cc347c/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L453-L457
The channel event loop is not a context-aware event loop, so `ServiceRequestContext` is not available in the thread local. As a result, request-scoped MDC won't work.

Modifications:

- Push `ServiceRequestContext` before calling `ServerErrorHandler.onServiceException()`

Result:

`ServiceRequestContext` is now correctly propagated to `ServerErrorHandler`.