### PR TITLE
Provide a way to configure the `maxClientHelloLength` that a server allows

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -60,6 +60,8 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final long DEFAULT_CONNECT_TIMEOUT_MILLIS = 3200; // 3.2 seconds
     static final long DEFAULT_WRITE_TIMEOUT_MILLIS = 1000; // 1 second
 
+    static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH = 4096; // 4KiB
+
     // Use slightly greater value than the default request timeout so that clients have a higher chance of
     // getting proper 503 Service Unavailable response when server-side timeout occurs.
     static final long DEFAULT_RESPONSE_TIMEOUT_MILLIS = 15 * 1000; // 15 seconds
@@ -435,6 +437,11 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Boolean tlsAllowUnsafeCiphers() {
         return false;
+    }
+
+    @Override
+    public Integer defaultMaxClientHelloLength() {
+        return DEFAULT_MAX_CLIENT_HELLO_LENGTH;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -60,7 +60,8 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final long DEFAULT_CONNECT_TIMEOUT_MILLIS = 3200; // 3.2 seconds
     static final long DEFAULT_WRITE_TIMEOUT_MILLIS = 1000; // 1 second
 
-    static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH = 4096; // 4KiB
+    // Use the fragmentation size as the default. https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
+    static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH = 16384; // 16KiB
 
     // Use slightly greater value than the default request timeout so that clients have a higher chance of
     // getting proper 503 Service Unavailable response when server-side timeout occurs.

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -400,6 +400,11 @@ public final class Flags {
     private static final boolean TLS_ALLOW_UNSAFE_CIPHERS =
             getValue(FlagsProvider::tlsAllowUnsafeCiphers, "tlsAllowUnsafeCiphers");
 
+    // Maximum 16KiB https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
+    private static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH =
+            getValue(FlagsProvider::defaultMaxClientHelloLength, "defaultMaxClientHelloLength",
+                     value -> value >= 0 && value <= 16384);
+
     private static final Set<TransientServiceOption> TRANSIENT_SERVICE_OPTIONS =
             getValue(FlagsProvider::transientServiceOptions, "transientServiceOptions");
 
@@ -1424,6 +1429,19 @@ public final class Flags {
      */
     public static boolean tlsAllowUnsafeCiphers() {
         return TLS_ALLOW_UNSAFE_CIPHERS;
+    }
+
+    /**
+     * Returns the default maximum client hello length that a server allows.
+     * The length shouldn't exceed 16KiB as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1">Fragmentation</a>.
+     *
+     * <p>The default value of this flag is {@value DefaultFlagsProvider#DEFAULT_MAX_CLIENT_HELLO_LENGTH}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientHelloLength=<integer>} JVM option to
+     * override the default value.
+     */
+    public static int defaultMaxClientHelloLength() {
+        return DEFAULT_MAX_CLIENT_HELLO_LENGTH;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -400,10 +400,10 @@ public final class Flags {
     private static final boolean TLS_ALLOW_UNSAFE_CIPHERS =
             getValue(FlagsProvider::tlsAllowUnsafeCiphers, "tlsAllowUnsafeCiphers");
 
-    // Maximum 16KiB https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1
+    // Maximum 16MiB https://datatracker.ietf.org/doc/html/rfc5246#section-7.4
     private static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH =
             getValue(FlagsProvider::defaultMaxClientHelloLength, "defaultMaxClientHelloLength",
-                     value -> value >= 0 && value <= 16384);
+                     value -> value >= 0 && value <= 16777216); // 16MiB
 
     private static final Set<TransientServiceOption> TRANSIENT_SERVICE_OPTIONS =
             getValue(FlagsProvider::transientServiceOptions, "transientServiceOptions");
@@ -1433,8 +1433,8 @@ public final class Flags {
 
     /**
      * Returns the default maximum client hello length that a server allows.
-     * The length shouldn't exceed 16KiB as described in
-     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1">Fragmentation</a>.
+     * The length shouldn't exceed 16MiB as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-7.4">Handshake Protocol</a>.
      *
      * <p>The default value of this flag is {@value DefaultFlagsProvider#DEFAULT_MAX_CLIENT_HELLO_LENGTH}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientHelloLength=<integer>} JVM option to

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1014,8 +1014,8 @@ public interface FlagsProvider {
 
     /**
      * Returns the default maximum client hello length that a server allows.
-     * The length shouldn't exceed 16KiB as described in
-     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1">Fragmentation</a>.
+     * The length shouldn't exceed 16MiB as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-7.4">Handshake Protocol</a>.
      *
      * <p>The default value of this flag is {@value DefaultFlagsProvider#DEFAULT_MAX_CLIENT_HELLO_LENGTH}.
      * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientHelloLength=<integer>} JVM option to

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1013,6 +1013,20 @@ public interface FlagsProvider {
     }
 
     /**
+     * Returns the default maximum client hello length that a server allows.
+     * The length shouldn't exceed 16KiB as described in
+     * <a href="https://datatracker.ietf.org/doc/html/rfc5246#section-6.2.1">Fragmentation</a>.
+     *
+     * <p>The default value of this flag is {@value DefaultFlagsProvider#DEFAULT_MAX_CLIENT_HELLO_LENGTH}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultMaxClientHelloLength=<integer>} JVM option to
+     * override the default value.
+     */
+    @Nullable
+    default Integer defaultMaxClientHelloLength() {
+        return null;
+    }
+
+    /**
      * Returns the {@link Set} of {@link TransientServiceOption}s that are enabled for a
      * {@link TransientService}.
      *

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -443,6 +443,11 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     }
 
     @Override
+    public Integer defaultMaxClientHelloLength() {
+        return getInt("defaultMaxClientHelloLength");
+    }
+
+    @Override
     public Set<TransientServiceOption> transientServiceOptions() {
         final String val = getNormalized("transientServiceOptions");
         if (val == null) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MoreMeters;
@@ -109,7 +110,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private static final Logger logger = LoggerFactory.getLogger(HttpServerPipelineConfigurator.class);
 
     private static final int SSL_RECORD_HEADER_LENGTH = 5;
-    private static final int MAX_CLIENT_HELLO_LENGTH = 4096; // 4KiB should be more than enough.
 
     static final AsciiString SCHEME_HTTP = AsciiString.cached("http");
     static final AsciiString SCHEME_HTTPS = AsciiString.cached("https");
@@ -232,7 +232,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private void configureHttps(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
         final Mapping<String, SslContext> sslContexts =
                 requireNonNull(config.sslContextMapping(), "config.sslContextMapping() returned null");
-        p.addLast(new SniHandler(sslContexts, MAX_CLIENT_HELLO_LENGTH, config.idleTimeoutMillis()));
+        p.addLast(new SniHandler(sslContexts, Flags.defaultMaxClientHelloLength(), config.idleTimeoutMillis()));
         p.addLast(TrafficLoggingHandler.SERVER);
         p.addLast(new Http2OrHttpHandler(proxiedAddresses));
     }


### PR DESCRIPTION
Motivation:
The `maxClientHelloLength` was hardcoded to 4KiB in https://github.com/line/armeria/pull/4974. However, this value does not cover all cases, so we need to provide a way for users to change this value to suit their needs.

Modifications:
- Added `Flags.defaultMaxClientHelloLength()` which allows users to configure the value.

Result:
- You can now configure the maximum length of a TLS client hello message that a server allows by using the `-Dcom.linecorp.armeria.defaultMaxClientHelloLength=<integer>` JVM option.
- The default value of `defaultMaxClientHelloLength` is now 16KiB.