### PR TITLE
Handle flaky `RampingUpTest` tests

### DIFF
--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RampingUpTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RampingUpTest.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -176,8 +177,8 @@ class RampingUpTest {
     private static Set<Endpoint> selectEndpoints(int weight, EndpointGroup xdsEndpointGroup) {
         final Set<Endpoint> selectedEndpoints = new HashSet<>();
         for (int i = 0; i < weight * 2; i++) {
-            selectedEndpoints.add(xdsEndpointGroup.selectNow(ctx()));
-            selectedEndpoints.add(xdsEndpointGroup.selectNow(ctx()));
+            selectedEndpoints.add(xdsEndpointGroup.select(ctx(), CommonPools.workerGroup()).join());
+            selectedEndpoints.add(xdsEndpointGroup.select(ctx(), CommonPools.workerGroup()).join());
         }
         return selectedEndpoints;
     }


### PR DESCRIPTION
Motivation:

This PR handles the following flaky test

https://ge.armeria.dev/s/p7k6qi4mxuzu4/tests/task/:xds:shadedTest/details/com.linecorp.armeria.xds.client.endpoint.RampingUpTest/checkEndpointsAreRampedUp()

Following the change of https://github.com/line/armeria/pull/5693, now calling `EndpointGroup#selectNow` may return `null` if the `RampingUpEndpointWeightSelector#updateEndpoints` is not completed yet since updates are already scheduled on the event loop.

https://github.com/line/armeria/blob/8bad3305a8e1843c049537395368266215245df6/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L149

For this reason, although `XdsEndpointGroup` is in the correct state, `EndpointGroup#selectNow` may return `null`.

I propose that we just call `EndpointGroup#select` instead of `EndpointGroup#selectNow` so that we don't have to worry about the state of `WeightRampingUpStrategy`. It will probably match the user behavior more closely anyways as well.

Modifications:

- Call `EndpointGroup#select` instead of `EndpointGroup#selectNow`

Result:

- Closes #5749

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
