### PR TITLE
[ISSUE-5715] Apply circuit breaker per connection

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/AbstractCircuitBreakerMappingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/AbstractCircuitBreakerMappingBuilder.java
@@ -29,6 +29,7 @@ public abstract class AbstractCircuitBreakerMappingBuilder
     private boolean perHost;
     private boolean perMethod;
     private boolean perPath;
+    private boolean perConnection;
 
     /**
      * Creates an empty builder where all mapping keys are disabled by default.
@@ -68,6 +69,14 @@ public abstract class AbstractCircuitBreakerMappingBuilder
     }
 
     /**
+     * Adds connection dimension to the mapping Key.
+     */
+    public SELF perConnection() {
+        perConnection = true;
+        return self();
+    }
+
+    /**
      * Returns whether the host dimension is enabled for the mapping.
      */
     protected final boolean isPerHost() {
@@ -89,10 +98,17 @@ public abstract class AbstractCircuitBreakerMappingBuilder
     }
 
     /**
+     * Returns whether the connection dimension is enabled for the mapping.
+     */
+    protected final boolean isPerConnection() {
+        return perConnection;
+    }
+
+    /**
      * Returns whether the set dimensions are valid.
      * At least one mapping key must be set.
      */
     protected final boolean validateMappingKeys() {
-        return perHost || perMethod || perPath;
+        return perHost || perMethod || perPath || perConnection;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClient.java
@@ -247,6 +247,37 @@ public final class CircuitBreakerClient extends AbstractCircuitBreakerClient<Htt
     }
 
     /**
+     * Creates a new decorator that binds one {@link CircuitBreaker} per connection with the specified
+     * {@link CircuitBreakerRule}.
+     *
+     * <p>Since {@link CircuitBreaker} is a unit of failure detection, don't reuse the same instance for
+     * unrelated services.
+     *
+     * @param factory a function that takes a connection id and creates a new {@link CircuitBreaker}.
+     */
+    @UnstableApi
+    public static Function<? super HttpClient, CircuitBreakerClient>
+    newPerConnectionDecorator(Function<String, ? extends CircuitBreaker> factory, CircuitBreakerRule rule) {
+        return newDecorator(CircuitBreakerMapping.perConnection(factory), rule);
+    }
+
+    /**
+     * Creates a new decorator that binds one {@link CircuitBreaker} per connection with the specified
+     * {@link CircuitBreakerRuleWithContent}.
+     *
+     * <p>Since {@link CircuitBreaker} is a unit of failure detection, don't reuse the same instance for
+     * unrelated services.
+     *
+     * @param factory a function that takes a connection id and creates a new {@link CircuitBreaker}.
+     */
+    @UnstableApi
+    public static Function<? super HttpClient, CircuitBreakerClient>
+    newPerConnectionDecorator(Function<String, ? extends CircuitBreaker> factory,
+                              CircuitBreakerRuleWithContent<HttpResponse> ruleWithContent) {
+        return newDecorator(CircuitBreakerMapping.perConnection(factory), ruleWithContent);
+    }
+
+    /**
      * Returns a new {@link CircuitBreakerClientBuilder} with the specified {@link CircuitBreakerRule}.
      */
     public static CircuitBreakerClientBuilder builder(CircuitBreakerRule rule) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerFactory.java
@@ -29,7 +29,9 @@ public interface CircuitBreakerFactory {
      * @param host the host of the context endpoint.
      * @param method the method of the context request.
      * @param path the path of the context request.
+     * @param connectionId the connectionId of the channel of the context request.
      * @return the {@link CircuitBreaker} instance corresponding to this combination.
      */
-    CircuitBreaker apply(@Nullable String host, @Nullable String method, @Nullable String path);
+    CircuitBreaker apply(@Nullable String host, @Nullable String method,
+                         @Nullable String path, @Nullable String connectionId);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMapping.java
@@ -51,7 +51,7 @@ public interface CircuitBreakerMapping extends ClientCircuitBreakerGenerator<Cir
      */
     static CircuitBreakerMapping perMethod(Function<String, ? extends CircuitBreaker> factory) {
         requireNonNull(factory, "factory");
-        return builder().perMethod().build((host, method, path) -> factory.apply(method));
+        return builder().perMethod().build((host, method, path, connectionId) -> factory.apply(method));
     }
 
     /**
@@ -61,7 +61,7 @@ public interface CircuitBreakerMapping extends ClientCircuitBreakerGenerator<Cir
      */
     static CircuitBreakerMapping perHost(Function<String, ? extends CircuitBreaker> factory) {
         requireNonNull(factory, "factory");
-        return builder().perHost().build((host, method, path) -> factory.apply(host));
+        return builder().perHost().build((host, method, path, connectionId) -> factory.apply(host));
     }
 
     /**
@@ -71,7 +71,19 @@ public interface CircuitBreakerMapping extends ClientCircuitBreakerGenerator<Cir
      */
     static CircuitBreakerMapping perPath(Function<String, ? extends CircuitBreaker> factory) {
         requireNonNull(factory, "factory");
-        return builder().perPath().build((host, method, path) -> factory.apply(path));
+        return builder().perPath()
+                        .build((host, method, path, connectionId) -> factory.apply(path));
+    }
+
+    /**
+     * Creates a new {@link CircuitBreakerMapping} which maps {@link CircuitBreaker}s with the connection id.
+     *
+     * @param factory the function that takes a connection id and creates a new {@link CircuitBreaker}
+     */
+    static CircuitBreakerMapping perConnection(Function<String, ? extends CircuitBreaker> factory) {
+        requireNonNull(factory, "factory");
+        return builder().perConnection()
+                        .build((host, method, path, connectionId) -> factory.apply(connectionId));
     }
 
     /**
@@ -84,7 +96,8 @@ public interface CircuitBreakerMapping extends ClientCircuitBreakerGenerator<Cir
     static CircuitBreakerMapping perHostAndMethod(
             BiFunction<String, String, ? extends CircuitBreaker> factory) {
         requireNonNull(factory, "factory");
-        return builder().perHost().perMethod().build((host, method, path) -> factory.apply(host, method));
+        return builder().perHost().perMethod().build((host, method, path, connectionId) ->
+                                                             factory.apply(host, method));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMappingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMappingBuilder.java
@@ -30,6 +30,7 @@ public final class CircuitBreakerMappingBuilder
         if (!validateMappingKeys()) {
             throw new IllegalStateException("A CircuitBreakerMapping must be per host, method and/or path");
         }
-        return new KeyedCircuitBreakerMapping(isPerHost(), isPerMethod(), isPerPath(), factory);
+        return new KeyedCircuitBreakerMapping(isPerHost(), isPerMethod(), isPerPath(), isPerConnection(),
+                                              factory);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/circuitbreaker/CircuitBreakerMappingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/circuitbreaker/CircuitBreakerMappingUtil.java
@@ -16,10 +16,14 @@
 
 package com.linecorp.armeria.internal.common.circuitbreaker;
 
+import java.util.Objects;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
 
 public final class CircuitBreakerMappingUtil {
 
@@ -45,6 +49,15 @@ public final class CircuitBreakerMappingUtil {
     public static String path(ClientRequestContext ctx) {
         final HttpRequest request = ctx.request();
         return request == null ? "" : request.path();
+    }
+
+    @Nullable
+    public static String connectionId(ClientRequestContext ctx) {
+        if (ctx.log().isAvailable(RequestLogProperty.SESSION)) {
+            return Objects.requireNonNull(ctx.log().partial().channel()).id().asLongText();
+        }
+
+        return null;
     }
 
     private CircuitBreakerMappingUtil() {}

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerClientTest.java
@@ -169,7 +169,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -180,7 +180,7 @@ class CircuitBreakerClientTest {
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
-                .apply("dummyhost:8080", null, "/dummy-path");
+                .apply("dummyhost:8080", null, "/dummy-path", null);
     }
 
     @Test
@@ -189,7 +189,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -201,7 +201,7 @@ class CircuitBreakerClientTest {
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
-                .apply("dummyhost:8080", null, "/dummy-path");
+                .apply("dummyhost:8080", null, "/dummy-path", null);
     }
 
     @Test
@@ -210,7 +210,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -220,7 +220,8 @@ class CircuitBreakerClientTest {
                 COUNT);
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
-        verify(factory, times(1)).apply(null, "GET", "/dummy-path");
+        verify(factory, times(1))
+                .apply(null, "GET", "/dummy-path", null);
     }
 
     @Test
@@ -229,7 +230,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -241,7 +242,7 @@ class CircuitBreakerClientTest {
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
-                .apply(null, "GET", "/dummy-path");
+                .apply(null, "GET", "/dummy-path", null);
     }
 
     @Test
@@ -250,7 +251,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -262,7 +263,7 @@ class CircuitBreakerClientTest {
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
-                .apply("dummyhost:8080", "GET", "/dummy-path");
+                .apply("dummyhost:8080", "GET", "/dummy-path", null);
     }
 
     @Test
@@ -271,7 +272,7 @@ class CircuitBreakerClientTest {
         when(circuitBreaker.tryRequest()).thenReturn(false);
 
         final CircuitBreakerFactory factory = mock(CircuitBreakerFactory.class);
-        when(factory.apply(any(), any(), any())).thenReturn(circuitBreaker);
+        when(factory.apply(any(), any(), any(), any())).thenReturn(circuitBreaker);
 
         final int COUNT = 2;
         failFastInvocation(
@@ -283,7 +284,39 @@ class CircuitBreakerClientTest {
 
         verify(circuitBreaker, times(COUNT)).tryRequest();
         verify(factory, times(1))
-                .apply("dummyhost:8080", "GET", "/dummy-path");
+                .apply("dummyhost:8080", "GET", "/dummy-path", null);
+    }
+
+    @Test
+    void testPerConnectionDecorator() {
+        final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
+
+        final Function<String, CircuitBreaker> factory = mock(Function.class);
+        when(factory.apply(any())).thenReturn(circuitBreaker);
+
+        final int COUNT = 2;
+        failFastInvocation(CircuitBreakerClient.newPerConnectionDecorator(factory, rule()), HttpMethod.GET,
+                           COUNT);
+
+        verify(circuitBreaker, times(COUNT)).tryRequest();
+        verify(factory, times(1)).apply(any());
+    }
+
+    @Test
+    void testPerConnectionDecoratorWithContent() {
+        final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+        when(circuitBreaker.tryRequest()).thenReturn(false);
+
+        final Function<String, CircuitBreaker> factory = mock(Function.class);
+        when(factory.apply(any())).thenReturn(circuitBreaker);
+
+        final int COUNT = 2;
+        failFastInvocation(CircuitBreakerClient.newPerConnectionDecorator(factory, ruleWithResponse()),
+                           HttpMethod.GET, COUNT);
+
+        verify(circuitBreaker, times(COUNT)).tryRequest();
+        verify(factory, times(1)).apply(any());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Add feature to allow finer-grained control of circuit breaker strategy on a connection level. 

Modifications:

Add connection related arguments in `CircuitBreaker` related classes. 

Result:

- Closes #<https://github.com/line/armeria/issues/5717>. (If this resolves the issue.)
- Users will be able to control circuit breaker on a connection level. 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
