### PR TITLE
Add `webSocketClient` in `ServerExtension`

### DIFF
--- a/junit4/src/main/java/com/linecorp/armeria/testing/junit4/server/ServerRule.java
+++ b/junit4/src/main/java/com/linecorp/armeria/testing/junit4/server/ServerRule.java
@@ -31,6 +31,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -67,6 +69,12 @@ public abstract class ServerRule extends ExternalResource {
             @Override
             public void configureWebClient(WebClientBuilder wcb) throws Exception {
                 ServerRule.this.configureWebClient(wcb);
+            }
+
+            @Override
+            public void configureWebSocketClient(WebSocketClientBuilder wscb)
+                    throws Exception {
+                ServerRule.this.configureWebSocketClient(wscb);
             }
         };
     }
@@ -108,6 +116,12 @@ public abstract class ServerRule extends ExternalResource {
      * You can get the configured {@link WebClient} using {@link #webClient()}.
      */
     protected void configureWebClient(WebClientBuilder webClientBuilder) throws Exception {}
+
+    /**
+     * Configures the {@link WebSocketClient} with the given {@link WebSocketClientBuilder}.
+     * You can get the configured {@link WebSocketClient} using {@link #webSocketClient()}.
+     */
+    protected void configureWebSocketClient(WebSocketClientBuilder webSocketClientBuilder) throws Exception {}
 
     /**
      * Stops the {@link Server} asynchronously.
@@ -343,5 +357,14 @@ public abstract class ServerRule extends ExternalResource {
     public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
         requireNonNull(webClientCustomizer, "webClientCustomizer");
         return delegate.restClient(webClientCustomizer);
+    }
+
+    /**
+     * Returns the {@link WebSocketClient} configured
+     * by {@link #configureWebSocketClient(WebSocketClientBuilder)}.
+     */
+    @UnstableApi
+    public WebSocketClient webSocketClient() {
+        return delegate.webSocketClient();
     }
 }

--- a/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
+++ b/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
@@ -455,8 +455,8 @@ public abstract class ServerRuleDelegate {
 
     private WebSocketClientBuilder webSocketClientBuilder() {
         final boolean hasHttps = hasHttps();
-        final String hostAndPort = hasHttps ? "wss://" + httpsUri().getHost() + ":" + httpsUri().getPort()
-                                            : "ws://" + httpUri().getHost() + ":" + httpUri().getPort();
+        final String hostAndPort = hasHttps ? "wss://" + httpsUri().getAuthority()
+                                            : "ws://" + httpUri().getAuthority();
         final WebSocketClientBuilder webSocketClientBuilder = WebSocketClient.builder(hostAndPort);
         if (hasHttps) {
             webSocketClientBuilder.factory(ClientFactory.insecure());

--- a/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
+++ b/junit5/src/main/java/com/linecorp/armeria/internal/testing/ServerRuleDelegate.java
@@ -32,6 +32,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -49,6 +51,7 @@ public abstract class ServerRuleDelegate {
     private final boolean autoStart;
 
     private final AtomicReference<WebClient> webClient = new AtomicReference<>();
+    private final AtomicReference<WebSocketClient> webSocketClient = new AtomicReference<>();
 
     /**
      * Creates a new instance.
@@ -113,6 +116,14 @@ public abstract class ServerRuleDelegate {
      * You can get the configured {@link WebClient} using {@link #webClient()}.
      */
     public abstract void configureWebClient(WebClientBuilder webClientBuilder) throws Exception;
+
+    /**
+     * Configures the {@link WebSocketClient} with the given {@link WebSocketClientBuilder}.
+     * You can get the configured {@link WebSocketClient} using {@link #webSocketClient()}.
+     */
+    @UnstableApi
+    public abstract void configureWebSocketClient(WebSocketClientBuilder webSocketClientBuilder)
+            throws Exception;
 
     /**
      * Stops the {@link Server} asynchronously.
@@ -404,6 +415,25 @@ public abstract class ServerRuleDelegate {
         return webClient(webClientCustomizer).asRestClient();
     }
 
+    /**
+     * Returns the {@link WebSocketClient} configured
+     * by {@link #configureWebSocketClient(WebSocketClientBuilder)}.
+     */
+    @UnstableApi
+    public WebSocketClient webSocketClient() {
+        final WebSocketClient webSocketClient = this.webSocketClient.get();
+        if (webSocketClient != null) {
+            return webSocketClient;
+        }
+
+        final WebSocketClient newWebSocketClient = webSocketClientBuilder().build();
+        if (this.webSocketClient.compareAndSet(null, newWebSocketClient)) {
+            return newWebSocketClient;
+        } else {
+            return this.webSocketClient.get();
+        }
+    }
+
     private void ensureStarted() {
         // This will ensure that the server has started.
         server();
@@ -421,5 +451,22 @@ public abstract class ServerRuleDelegate {
             throw new IllegalStateException("failed to configure a WebClient", e);
         }
         return webClientBuilder;
+    }
+
+    private WebSocketClientBuilder webSocketClientBuilder() {
+        final boolean hasHttps = hasHttps();
+        final String hostAndPort = hasHttps ? "wss://" + httpsUri().getHost() + ":" + httpsUri().getPort()
+                                            : "ws://" + httpUri().getHost() + ":" + httpUri().getPort();
+        final WebSocketClientBuilder webSocketClientBuilder = WebSocketClient.builder(hostAndPort);
+        if (hasHttps) {
+            webSocketClientBuilder.factory(ClientFactory.insecure());
+        }
+
+        try {
+            configureWebSocketClient(webSocketClientBuilder);
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to configure a WebSocketClient", e);
+        }
+        return webSocketClientBuilder;
     }
 }

--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/ServerExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/ServerExtension.java
@@ -31,6 +31,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RestClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -74,6 +76,12 @@ public abstract class ServerExtension extends AbstractAllOrEachExtension {
             @Override
             public void configureWebClient(WebClientBuilder wcb) throws Exception {
                 ServerExtension.this.configureWebClient(wcb);
+            }
+
+            @Override
+            public void configureWebSocketClient(WebSocketClientBuilder wscb)
+                    throws Exception {
+                ServerExtension.this.configureWebSocketClient(wscb);
             }
         };
     }
@@ -125,6 +133,12 @@ public abstract class ServerExtension extends AbstractAllOrEachExtension {
      * You can get the configured {@link WebClient} using {@link #webClient()}.
      */
     protected void configureWebClient(WebClientBuilder webClientBuilder) throws Exception {}
+
+    /**
+     * Configures the {@link WebSocketClient} with the given {@link WebSocketClientBuilder}.
+     * You can get the configured {@link WebSocketClient} using {@link #webSocketClient()}.
+     */
+    protected void configureWebSocketClient(WebSocketClientBuilder webSocketClientBuilder) throws Exception {}
 
     /**
      * Stops the {@link Server} asynchronously.
@@ -368,6 +382,15 @@ public abstract class ServerExtension extends AbstractAllOrEachExtension {
     public RestClient restClient(Consumer<WebClientBuilder> webClientCustomizer) {
         requireNonNull(webClientCustomizer, "webClientCustomizer");
         return delegate.restClient(webClientCustomizer);
+    }
+
+    /**
+     * Returns the {@link WebSocketClient} configured
+     * by {@link #configureWebSocketClient(WebSocketClientBuilder)}.
+     */
+    @UnstableApi
+    public WebSocketClient webSocketClient() {
+        return delegate.webSocketClient();
     }
 
     /**

--- a/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/ServerExtensionWithWebSocketClientTest.java
+++ b/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/ServerExtensionWithWebSocketClientTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.testing.junit5.server;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketSession;
+import com.linecorp.armeria.common.websocket.WebSocket;
+import com.linecorp.armeria.common.websocket.WebSocketFrame;
+import com.linecorp.armeria.common.websocket.WebSocketWriter;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.websocket.WebSocketService;
+import com.linecorp.armeria.server.websocket.WebSocketServiceHandler;
+
+public class ServerExtensionWithWebSocketClientTest {
+    private static final int MAX_FRAME_LENGTH = 4 * 1024;
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/chat", WebSocketService.builder(new WebSocketEchoHandler())
+                                                .maxFramePayloadLength(MAX_FRAME_LENGTH)
+                                                .build());
+        }
+    };
+
+    @Test
+    void webSocketClient() {
+        final WebSocketClient client = server.webSocketClient();
+        final WebSocketSession session = client.connect("/chat").join();
+
+        assertThat(session).isNotNull();
+        final WebSocketWriter outbound = session.outbound();
+        outbound.write("hello");
+        outbound.write("world");
+        outbound.close();
+        final List<String> responses = session.inbound().collect().join().stream().map(WebSocketFrame::text)
+                                              .collect(toImmutableList());
+        assertThat(responses).contains("hello", "world");
+    }
+
+    static final class WebSocketEchoHandler implements WebSocketServiceHandler {
+
+        @Override
+        public WebSocket handle(ServiceRequestContext ctx, WebSocket in) {
+            final WebSocketWriter writer = WebSocket.streaming();
+            in.subscribe(new Subscriber<WebSocketFrame>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(WebSocketFrame webSocketFrame) {
+                    writer.write(webSocketFrame);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    writer.close(t);
+                }
+
+                @Override
+                public void onComplete() {
+                    writer.close();
+                }
+            });
+            return writer;
+        }
+    }
+}

--- a/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/ServerExtensionWithWebSocketClientTest.java
+++ b/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/ServerExtensionWithWebSocketClientTest.java
@@ -21,11 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.linecorp.armeria.client.websocket.WebSocketClient;
 import com.linecorp.armeria.client.websocket.WebSocketSession;
 import com.linecorp.armeria.common.websocket.WebSocket;
 import com.linecorp.armeria.common.websocket.WebSocketFrame;

--- a/sangria/sangria_2.13/src/test/scala/com/linecorp/armeria/server/sangria/ServerSuite.scala
+++ b/sangria/sangria_2.13/src/test/scala/com/linecorp/armeria/server/sangria/ServerSuite.scala
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.server.sangria
 
-import com.linecorp.armeria.client.{WebClient, WebClientBuilder}
-import com.linecorp.armeria.client.logging.LoggingClient
+import com.linecorp.armeria.client.WebClientBuilder
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder
 import com.linecorp.armeria.internal.testing.ServerRuleDelegate
 import com.linecorp.armeria.server.ServerBuilder
 import munit.Suite
@@ -33,6 +33,8 @@ trait ServerSuite {
 
   protected def configureWebClient: WebClientBuilder => Unit = _ => ()
 
+  protected def configureWebSocketClient: WebSocketClientBuilder => Unit = _ => ()
+
   protected def server: ServerRuleDelegate = delegate
 
   /**
@@ -46,6 +48,9 @@ trait ServerSuite {
       override def configure(sb: ServerBuilder): Unit = configureServer(sb)
 
       override def configureWebClient(wcb: WebClientBuilder): Unit = self.configureWebClient(wcb)
+
+      override def configureWebSocketClient(webSocketClientBuilder: WebSocketClientBuilder): Unit =
+        self.configureWebSocketClient(webSocketClientBuilder)
     }
 
     if (!runServerForEachTest) {

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ServerSuite.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/server/ServerSuite.scala
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server
 
 import com.linecorp.armeria.client.WebClientBuilder
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder
 import com.linecorp.armeria.internal.testing.ServerRuleDelegate
 import munit.Suite
 
@@ -28,6 +29,8 @@ trait ServerSuite {
   protected def configureServer: ServerBuilder => Unit
 
   protected def configureWebClient: WebClientBuilder => Unit = _ => ()
+
+  protected def configureWebSocketClient: WebSocketClientBuilder => Unit = _ => ()
 
   protected def server: ServerRuleDelegate = delegate
 
@@ -42,6 +45,9 @@ trait ServerSuite {
       override def configure(sb: ServerBuilder): Unit = configureServer(sb)
 
       override def configureWebClient(wcb: WebClientBuilder): Unit = self.configureWebClient(wcb)
+
+      override def configureWebSocketClient(wscb: WebSocketClientBuilder): Unit =
+        self.configureWebSocketClient(wscb)
     }
 
     if (!runServerForEachTest) {

--- a/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ServerSuite.scala
+++ b/scalapb/scalapb_2.13/src/test/scala/com/linecorp/armeria/server/scalapb/ServerSuite.scala
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.scalapb
 
 import com.linecorp.armeria.client.WebClientBuilder
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder
 import com.linecorp.armeria.internal.testing.ServerRuleDelegate
 import com.linecorp.armeria.server.ServerBuilder
 import munit.Suite
@@ -29,6 +30,8 @@ trait ServerSuite {
   protected def configureServer: ServerBuilder => Unit
 
   protected def configureWebClient: WebClientBuilder => Unit = _ => ()
+
+  protected def configureWebSocketClient: WebSocketClientBuilder => Unit = _ => ()
 
   protected def server: ServerRuleDelegate = delegate
 
@@ -43,6 +46,9 @@ trait ServerSuite {
       override def configure(sb: ServerBuilder): Unit = configureServer(sb)
 
       override def configureWebClient(wcb: WebClientBuilder): Unit = self.configureWebClient(wcb)
+
+      override def configureWebSocketClient(webSocketClientBuilder: WebSocketClientBuilder): Unit =
+        self.configureWebSocketClient(webSocketClientBuilder)
     }
 
     if (!runServerForEachTest) {


### PR DESCRIPTION
Motivation:

Added `webSocketClient` which directly connects to `ServerExtension` 

Modifications:

- `ServerExtension`: Added `webSocketClient` method which users can easily use to retrieve a webSocketClient which connects to `ServerExtension` 
- `ServerRuleDelegate`: Added `webSocketClient` 

Result:

- Closes #<https://github.com/line/armeria/issues/5538>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
