### PR TITLE
Fix deprecation warnings in native-image-config/build.gradle.kts

### DIFF
--- a/native-image-config/build.gradle.kts
+++ b/native-image-config/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     dependencies {
         // TODO(trustin): Use platform(libs.boms.jackson) once Gradle supports platform() for build dependencies.
         //                https://github.com/gradle/gradle/issues/21788
-        val jacksonDatabind = libs.jackson.databind.get()
+        val jacksonDatabind: Dependency = libs.jackson.databind.get()
         classpath(
             group = jacksonDatabind.group!!,
             name = jacksonDatabind.name,

--- a/native-image-config/build.gradle.kts
+++ b/native-image-config/build.gradle.kts
@@ -30,15 +30,9 @@ plugins {
 // otherwise, the previously generated config will be merged into the newly generated config.
 val shouldGenerateFromScratch = project.findProperty("scratch").let {
     when (it) {
-        null -> {
-            false
-        }
-        "" -> {
-            true
-        }
-        else -> {
-            throw IllegalArgumentException("-Pscratch option must be specified without any value.")
-        }
+        null -> false
+        "" -> true
+        else -> throw IllegalArgumentException("-Pscratch option must be specified without any value.")
     }
 }
 

--- a/native-image-config/build.gradle.kts
+++ b/native-image-config/build.gradle.kts
@@ -29,12 +29,16 @@ plugins {
 // If `-Pscratch` is specified, do not source the previously generated config at core/src/main/resources/META-INF/native-image
 // otherwise, the previously generated config will be merged into the newly generated config.
 val shouldGenerateFromScratch = project.findProperty("scratch").let {
-    if (it == null) {
-        false
-    } else if (it == "") {
-        true
-    } else {
-        throw IllegalArgumentException("-Pscratch option must be specified without any value.")
+    when (it) {
+        null -> {
+            false
+        }
+        "" -> {
+            true
+        }
+        else -> {
+            throw IllegalArgumentException("-Pscratch option must be specified without any value.")
+        }
     }
 }
 
@@ -50,6 +54,7 @@ val nativeImageConfigToolPath = "${graalHome.resolve("lib/svm/bin/native-image-c
 
 val thisProject = project
 val callerFilterFile = projectDir.resolve("src/trace-filters/caller-filter.json")
+val buildDir = layout.buildDirectory.asFile.get()
 val processNativeImageTracesOutputDir = buildDir.resolve("step-1-process-native-image-traces")
 val simplifyNativeImageConfigOutputDir = buildDir.resolve("step-2-simplify-native-image-config")
 val nativeImageConfigOutputDir = buildDir.resolve("step-3-final-native-image-config")

--- a/native-image-config/build.gradle.kts
+++ b/native-image-config/build.gradle.kts
@@ -12,9 +12,9 @@ buildscript {
     dependencies {
         // TODO(trustin): Use platform(libs.boms.jackson) once Gradle supports platform() for build dependencies.
         //                https://github.com/gradle/gradle/issues/21788
-        val jacksonDatabind: Dependency = libs.jackson.databind.get()
+        val jacksonDatabind: ModuleVersionSelector = libs.jackson.databind.get()
         classpath(
-            group = jacksonDatabind.group!!,
+            group = jacksonDatabind.group,
             name = jacksonDatabind.name,
             version = libs.boms.jackson.get().version
         )


### PR DESCRIPTION
Motivation:

`project.buildDir` has been deprecated in favor of `layout.buildDirectory` in Gradle.

Modifications:

- Replaced all `project.buildDir` usages
- Replaced `if-else` chain with `when`

Result:

Less deprecation warnings when importing Armeria into IntelliJ IDEA
