### PR TITLE
Fix flaky test in DefaultDnsResolverTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolverTest.java
@@ -155,8 +155,6 @@ class DefaultDnsResolverTest {
                             NoopDnsCache.INSTANCE, eventLoop, ImmutableList.of(), 1,
                             queryTimeoutMillis, HostsFileEntriesResolver.DEFAULT);
 
-            final DnsQuestionContext ctx = new DnsQuestionContext(eventLoop, queryTimeoutMillis);
-
             final Stopwatch stopwatch = Stopwatch.createStarted();
             final List<DefaultDnsQuestion> questions;
             if (resolvedAddressType == ResolvedAddressTypes.IPV4_PREFERRED) {
@@ -169,9 +167,9 @@ class DefaultDnsResolverTest {
                         new DefaultDnsQuestion("foo.com.", DnsRecordType.A));
             }
 
-            // resolver.resolveAll() should be executed by the event loop set to DnsNameResolver.
+            // resolver.resolve() should be executed by the event loop set to DnsNameResolver.
             final CompletableFuture<List<DnsRecord>> result = eventLoop.submit(() -> {
-                return resolver.resolveAll(ctx, questions, "");
+                return resolver.resolve(questions, "");
             }).get();
 
             final List<DnsRecord> records = result.join();


### PR DESCRIPTION
Motivation:

Fix #5725

Modifications:

- resolve is using resolveAll when questions has more than 1 item. So change to  resolveAll and avoid creating ctx which schedules cancel before stopwatch.

Result:

- Closes #5725
