### PR TITLE
Fix to call the duplicator's child stream subscriber methods by the correct executor

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessageDuplicator.java
@@ -285,12 +285,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
 
         private void doSubscribe(DownstreamSubscription<T> subscription) {
             if (state == State.ABORTED) {
-                final EventExecutor executor = subscription.executor;
-                if (executor.inEventLoop()) {
-                    failLateProcessorSubscriber(subscription);
-                } else {
-                    executor.execute(() -> failLateProcessorSubscriber(subscription));
-                }
+                subscription.failLateProcessorSubscriber();
                 return;
             }
 
@@ -298,66 +293,6 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             unsubscribedUpdater.decrementAndGet(duplicator);
             if (upstreamSubscription != null) {
                 subscription.invokeOnSubscribe();
-            }
-        }
-
-        private static void failLateProcessorSubscriber(DownstreamSubscription<?> subscription) {
-            final Subscriber<?> lateSubscriber = subscription.subscriber();
-            try {
-                lateSubscriber.onSubscribe(NoopSubscription.get());
-                lateSubscriber.onError(
-                        new IllegalStateException("duplicator is closed or no more downstream can be added."));
-            } catch (Throwable t) {
-                throwIfFatal(t);
-                logger.warn("Subscriber should not throw an exception. subscriber: {}", lateSubscriber, t);
-            }
-        }
-
-        void unsubscribe(DownstreamSubscription<T> subscription, @Nullable Throwable cause) {
-            if (subscription.executor.inEventLoop()) {
-                doUnsubscribe(subscription, cause);
-            } else {
-                subscription.executor.execute(() -> doUnsubscribe(subscription, cause));
-            }
-        }
-
-        private void doUnsubscribe(DownstreamSubscription<T> subscription, @Nullable Throwable cause) {
-            if (!downstreamSubscriptions.remove(subscription)) {
-                return;
-            }
-
-            final Subscriber<? super T> subscriber = subscription.subscriber();
-            subscription.clearSubscriber();
-
-            final CompletableFuture<Void> completionFuture = subscription.whenComplete();
-            if (cause == null) {
-                try {
-                    subscriber.onComplete();
-                    completionFuture.complete(null);
-                } catch (Throwable t) {
-                    completionFuture.completeExceptionally(t);
-                    throwIfFatal(t);
-                    logger.warn("Subscriber.onComplete() should not raise an exception. subscriber: {}",
-                                subscriber, t);
-                } finally {
-                    cleanupIfLastSubscription();
-                }
-                return;
-            }
-
-            try {
-                if (subscription.notifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
-                    subscriber.onError(cause);
-                }
-                completionFuture.completeExceptionally(cause);
-            } catch (Throwable t) {
-                final Exception composite = new CompositeException(t, cause);
-                completionFuture.completeExceptionally(composite);
-                throwIfFatal(t);
-                logger.warn("Subscriber.onError() should not raise an exception. subscriber: {}",
-                            subscriber, composite);
-            } finally {
-                cleanupIfLastSubscription();
             }
         }
 
@@ -621,7 +556,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
         private final StreamMessage<T> streamMessage;
         private Subscriber<? super T> subscriber;
         private final StreamMessageProcessor<T> processor;
-        private final EventExecutor executor;
+        private final EventExecutor downstreamExecutor;
         private final boolean withPooledObjects;
         private final boolean notifyCancellation;
 
@@ -648,7 +583,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             this.streamMessage = streamMessage;
             this.subscriber = subscriber;
             this.processor = processor;
-            this.executor = executor;
+            downstreamExecutor = executor;
             this.withPooledObjects = withPooledObjects;
             this.notifyCancellation = notifyCancellation;
         }
@@ -669,6 +604,25 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             }
         }
 
+        void failLateProcessorSubscriber() {
+            if (downstreamExecutor.inEventLoop()) {
+                failLateProcessorSubscriber0();
+            } else {
+                downstreamExecutor.execute(this::failLateProcessorSubscriber0);
+            }
+        }
+
+        private void failLateProcessorSubscriber0() {
+            try {
+                subscriber.onSubscribe(NoopSubscription.get());
+                subscriber.onError(
+                        new IllegalStateException("duplicator is closed or no more downstream can be added."));
+            } catch (Throwable t) {
+                throwIfFatal(t);
+                logger.warn("Subscriber should not throw an exception. subscriber: {}", subscriber, t);
+            }
+        }
+
         // Called from processor.processorExecutor
         void invokeOnSubscribe() {
             if (invokedOnSubscribe) {
@@ -676,10 +630,10 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             }
             invokedOnSubscribe = true;
 
-            if (executor.inEventLoop()) {
+            if (downstreamExecutor.inEventLoop()) {
                 invokeOnSubscribe0();
             } else {
-                executor.execute(this::invokeOnSubscribe0);
+                downstreamExecutor.execute(this::invokeOnSubscribe0);
             }
         }
 
@@ -688,7 +642,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             try {
                 subscriber.onSubscribe(this);
             } catch (Throwable t) {
-                processor.unsubscribe(this, t);
+                unsubscribe(t);
                 throwIfFatal(t);
                 logger.warn("Subscriber.onSubscribe() should not raise an exception. subscriber: {}",
                             subscriber, t);
@@ -700,7 +654,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             if (n <= 0) {
                 final Throwable cause = new IllegalArgumentException(
                         "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)");
-                processor.unsubscribe(this, cause);
+                unsubscribe(cause);
                 return;
             }
 
@@ -734,10 +688,10 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
         }
 
         void signal() {
-            if (executor.inEventLoop()) {
+            if (downstreamExecutor.inEventLoop()) {
                 doSignal();
             } else {
-                executor.execute(this::doSignal);
+                downstreamExecutor.execute(this::doSignal);
             }
         }
 
@@ -765,7 +719,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
 
             if (cancelledOrAborted != null) {
                 // Stream ended due to cancellation or abortion.
-                processor.unsubscribe(this, cancelledOrAborted);
+                unsubscribe(cancelledOrAborted);
                 return false;
             }
 
@@ -779,7 +733,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
             if (signal instanceof CloseEvent) {
                 // The stream has reached at its end.
                 offset++;
-                processor.unsubscribe(this, ((CloseEvent) signal).cause);
+                unsubscribe(((CloseEvent) signal).cause);
                 return false;
             }
 
@@ -820,7 +774,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                     // If an exception such as IllegalReferenceCountException is raised while operating
                     // on the ByteBuf, catch it and notify the subscriber with it. So the
                     // subscriber does not hang forever.
-                    processor.unsubscribe(this, thrown);
+                    unsubscribe(thrown);
                     return false;
                 }
 
@@ -840,7 +794,7 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                 try {
                     subscriber.onNext(obj);
                 } catch (Throwable t) {
-                    processor.unsubscribe(this, t);
+                    unsubscribe(t);
                     throwIfFatal(t);
                     logger.warn("Subscriber.onNext({}) should not raise an exception. subscriber: {}",
                                 obj, subscriber, t);
@@ -849,6 +803,54 @@ public class DefaultStreamMessageDuplicator<T> implements StreamMessageDuplicato
                     inOnNext = false;
                 }
                 return true;
+            }
+        }
+
+        void unsubscribe(@Nullable Throwable cause) {
+            if (downstreamExecutor.inEventLoop()) {
+                doUnsubscribe(cause);
+            } else {
+                downstreamExecutor.execute(() -> doUnsubscribe(cause));
+            }
+        }
+
+        private void doUnsubscribe(@Nullable Throwable cause) {
+            if (!processor.downstreamSubscriptions.remove(this)) {
+                return;
+            }
+
+            final Subscriber<? super T> subscriber = this.subscriber;
+            clearSubscriber();
+
+            final CompletableFuture<Void> completionFuture = whenComplete();
+            if (cause == null) {
+                try {
+                    subscriber.onComplete();
+                    completionFuture.complete(null);
+                } catch (Throwable t) {
+                    completionFuture.completeExceptionally(t);
+                    throwIfFatal(t);
+                    logger.warn("Subscriber.onComplete() should not raise an exception. subscriber: {}",
+                                subscriber, t);
+                } finally {
+                    processor.cleanupIfLastSubscription();
+                }
+                return;
+            }
+
+            try {
+                if (notifyCancellation || !(cause instanceof CancelledSubscriptionException)) {
+                    subscriber.onError(cause);
+                }
+                completionFuture.completeExceptionally(cause);
+            } catch (Throwable t) {
+                final Exception composite = new CompositeException(t, cause);
+                completionFuture.completeExceptionally(composite);
+                throwIfFatal(t);
+                logger.warn("Subscriber.onError() should not raise an exception. subscriber: {}",
+                            subscriber, composite);
+            } finally {
+                processor.cleanupIfLastSubscription();
             }
         }
 

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorChildSubscriberTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorChildSubscriberTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * This test checks that the duplicator does not release the elements that it holds until all subscribers are
+ * received all element via {@link Subscriber#onNext(Object)}.
+ * Previously, the duplicator has a bug that releases the elements when the duplicator is closed even though
+ * there's a subscriber that does not subscribe to the child stream message yet.
+ * See <a href="https://github.com/line/armeria/pull/3337">
+ * Fix not to release elements before subscribed in duplicator</a>
+ */
+class StreamMessageDuplicatorChildSubscriberTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop1 = new EventLoopExtension();
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop2 = new EventLoopExtension();
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop3 = new EventLoopExtension();
+
+    @Test
+    void childSubscriberMethodsMustBeCalledByExecutors() throws InterruptedException {
+        final StreamWriter<String> publisher = StreamMessage.streaming();
+        publisher.write("foo");
+        publisher.abort();
+
+        final StreamMessageDuplicator<String> duplicator =
+                publisher.toDuplicator(eventLoop1.get());
+
+        final StreamMessage<String> first = duplicator.duplicate();
+        final StreamMessage<String> second = duplicator.duplicate();
+
+        duplicator.close();
+
+        final CountDownLatch latch = new CountDownLatch(2);
+        final EventLoop executor2 = eventLoop2.get();
+        first.subscribe(new ChildSubscriber(executor2, latch), executor2);
+
+        final EventLoop executor3 = eventLoop3.get();
+        second.subscribe(new ChildSubscriber(executor3, latch), executor3);
+        latch.await();
+    }
+
+    private static final class ChildSubscriber implements Subscriber<String> {
+
+        private final EventLoop eventLoop;
+        private final CountDownLatch latch;
+
+        ChildSubscriber(EventLoop eventLoop, CountDownLatch latch) {
+            this.eventLoop = eventLoop;
+            this.latch = latch;
+        }
+
+        @Override
+        public void onSubscribe(Subscription s) {
+            assertThat(eventLoop.inEventLoop()).isTrue();
+            s.request(Long.MAX_VALUE);
+        }
+
+        @Override
+        public void onNext(String data) {
+            assertThat(eventLoop.inEventLoop()).isTrue();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            assertThat(eventLoop.inEventLoop()).isTrue();
+            latch.countDown();
+        }
+
+        @Override
+        public void onComplete() {
+            assertThat(eventLoop.inEventLoop()).isTrue();
+            latch.countDown();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageDuplicatorTest.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 
@@ -60,8 +58,6 @@ import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 class StreamMessageDuplicatorTest {
-
-    private static final Logger logger = LoggerFactory.getLogger(StreamMessageDuplicatorTest.class);
 
     private static final List<ByteBuf> byteBufs = new ArrayList<>();
 


### PR DESCRIPTION
Motivation:
Subscriber methods must be called by the executor that is specified when subscribing to a `StreamMessage`. However, the methods of the duplicator's child stream subscriber are currently being called from the duplicator's executor, which is incorrect.

Modifications:
- Updated the implementation to ensure that the duplicator's child stream subscriber methods are called by the correct executor as specified during subscription.

Result:
- The duplicator's child stream subscriber methods are now called by the correct executor.