### PR TITLE
Add `Status` parameter to `GrpcExceptionHandlerFunction.apply()` method.

### DIFF
--- a/examples/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/GrpcExceptionHandler.java
+++ b/examples/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/GrpcExceptionHandler.java
@@ -11,7 +11,7 @@ class GrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
     @Nullable
     @Override
-    public Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+    public Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
         if (cause instanceof IllegalArgumentException) {
             return Status.INVALID_ARGUMENT.withCause(cause);
         }

--- a/examples/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/GrpcExceptionHandler.java
+++ b/examples/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/GrpcExceptionHandler.java
@@ -11,7 +11,7 @@ class GrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
     @Nullable
     @Override
-    public Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+    public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
         if (cause instanceof IllegalArgumentException) {
             return Status.INVALID_ARGUMENT.withCause(cause);
         }

--- a/grpc-kotlin/src/test/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptorTest.kt
+++ b/grpc-kotlin/src/test/kotlin/com/linecorp/armeria/server/grpc/kotlin/CoroutineServerInterceptorTest.kt
@@ -228,7 +228,12 @@ internal class CoroutineServerInterceptorTest {
             object : ServerExtension() {
                 override fun configure(sb: ServerBuilder) {
                     val exceptionHandler =
-                        GrpcExceptionHandlerFunction { _: RequestContext, throwable: Throwable, _: Metadata ->
+                        GrpcExceptionHandlerFunction {
+                                _: RequestContext,
+                                _: Status?,
+                                throwable: Throwable,
+                                _: Metadata,
+                            ->
                             if (throwable is AnticipatedException && throwable.message == "Invalid access") {
                                 return@GrpcExceptionHandlerFunction Status.UNAUTHENTICATED
                             }

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/DefaultGrpcExceptionHandlerFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/DefaultGrpcExceptionHandlerFunction.java
@@ -58,7 +58,7 @@ enum DefaultGrpcExceptionHandlerFunction implements GrpcExceptionHandlerFunction
         if (cause instanceof ClosedSessionException || cause instanceof ClosedChannelException) {
             if (ctx instanceof ServiceRequestContext) {
                 // Upstream uses CANCELLED
-                // https://github.com/grpc/grpc-java/blob/2c83ef06327adabd8e234/Users/minu/IdeaProjects/armeria/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunctionBuilder.java850a5dc9dbd9ac063b0/stub/src/main/java/io/grpc/stub/ServerCalls.java#L289-L291
+                // https://github.com/grpc/grpc-java/blob/2c83ef06327adabd8e234850a5dc9dbd9ac063b0/stub/src/main/java/io/grpc/stub/ServerCalls.java#L289-L291
                 return Status.CANCELLED.withCause(cause);
             }
             // ClosedChannelException is used any time the Netty channel is closed. Proper error

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GoogleGrpcExceptionHandlerFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GoogleGrpcExceptionHandlerFunction.java
@@ -40,7 +40,7 @@ public interface GoogleGrpcExceptionHandlerFunction extends GrpcExceptionHandler
 
     @Nullable
     @Override
-    default Status apply(RequestContext ctx, Throwable throwable, Metadata metadata) {
+    default Status apply(RequestContext ctx, Status status, Throwable throwable, Metadata metadata) {
         return handleException(ctx, throwable, metadata, this::applyStatusProto);
     }
 
@@ -48,7 +48,7 @@ public interface GoogleGrpcExceptionHandlerFunction extends GrpcExceptionHandler
      * Maps the specified {@link Throwable} to a {@link com.google.rpc.Status},
      * and mutates the specified {@link Metadata}.
      * The `grpc-status-details-bin` key is ignored since it will be overwritten
-     * by {@link GoogleGrpcExceptionHandlerFunction#apply(RequestContext, Throwable, Metadata)}.
+     * by {@link GrpcExceptionHandlerFunction#apply(RequestContext, Status, Throwable, Metadata)}.
      * If {@code null} is returned, the built-in mapping rule is used by default.
      */
     com.google.rpc.@Nullable Status applyStatusProto(RequestContext ctx, Throwable throwable,

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GoogleGrpcExceptionHandlerFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GoogleGrpcExceptionHandlerFunction.java
@@ -40,7 +40,7 @@ public interface GoogleGrpcExceptionHandlerFunction extends GrpcExceptionHandler
 
     @Nullable
     @Override
-    default Status apply(RequestContext ctx, Status status, Throwable throwable, Metadata metadata) {
+    default Status apply(RequestContext ctx, @Nullable Status status, Throwable throwable, Metadata metadata) {
         return handleException(ctx, throwable, metadata, this::applyStatusProto);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunction.java
@@ -48,12 +48,13 @@ public interface GrpcExceptionHandlerFunction {
     }
 
     /**
-     * Maps the specified {@link Throwable} to a gRPC {@link Status},
-     * and mutates the specified {@link Metadata}.
-     * If {@code null} is returned, the built-in mapping rule is used by default.
+     * Maps the specified {@link Throwable} to a gRPC {@link Status} and mutates the specified {@link Metadata}.
+     * The {@link Status} that was created via {@link Status#fromThrowable(Throwable)} might be specified
+     * as well. You can return this {@link Status} or any other {@link Status} as needed.
+     * If {@code null} is returned, {@link #of()} will be used as the default.
      */
     @Nullable
-    Status apply(RequestContext ctx, Throwable cause, Metadata metadata);
+    Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata);
 
     /**
      * Returns a {@link GrpcExceptionHandlerFunction} that returns the result of this function
@@ -63,12 +64,12 @@ public interface GrpcExceptionHandlerFunction {
      */
     default GrpcExceptionHandlerFunction orElse(GrpcExceptionHandlerFunction next) {
         requireNonNull(next, "next");
-        return (ctx, cause, metadata) -> {
-            final Status status = apply(ctx, cause, metadata);
-            if (status != null) {
-                return status;
+        return (ctx, status, cause, metadata) -> {
+            final Status newStatus = apply(ctx, status, cause, metadata);
+            if (newStatus != null) {
+                return newStatus;
             }
-            return next.apply(ctx, cause, metadata);
+            return next.apply(ctx, status, cause, metadata);
         };
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunction.java
@@ -49,9 +49,12 @@ public interface GrpcExceptionHandlerFunction {
 
     /**
      * Maps the specified {@link Throwable} to a gRPC {@link Status} and mutates the specified {@link Metadata}.
-     * The {@link Status} that was created via {@link Status#fromThrowable(Throwable)} might be specified
-     * as well. You can return this {@link Status} or any other {@link Status} as needed.
-     * If {@code null} is returned, {@link #of()} will be used as the default.
+     * If {@code null} is returned, {@link #of()} will be used to return {@link Status} as the default.
+     *
+     * <p>The {@link Status} may also be specified as a parameter if it is created by
+     * the upstream gRPC framework.
+     * You can return the {@link Status} or any other {@link Status} as needed. If the exception is raised
+     * internally in Armeria, no {@link Status} created, so {@code null} will be specified.
      */
     @Nullable
     Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -248,7 +248,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         prepareHeaders(compressor, metadata, remainingNanos);
 
         final BiFunction<ClientRequestContext, Throwable, HttpResponse> errorResponseFactory =
-                (unused, cause) -> HttpResponse.ofFailure(exceptionHandler.apply(ctx, cause, metadata)
+                (unused, cause) -> HttpResponse.ofFailure(exceptionHandler.apply(ctx, null, cause, metadata)
                                                                           .withDescription(cause.getMessage())
                                                                           .asRuntimeException());
         final HttpResponse res = initContextAndExecuteWithFallback(
@@ -454,7 +454,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
             });
         } catch (Throwable t) {
             final Metadata metadata = new Metadata();
-            close(exceptionHandler.apply(ctx, t, metadata), metadata);
+            close(exceptionHandler.apply(ctx, null, t, metadata), metadata);
         }
     }
 
@@ -511,7 +511,7 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
 
     private void closeWhenListenerThrows(Throwable t) {
         final Metadata metadata = new Metadata();
-        closeWhenEos(exceptionHandler.apply(ctx, t, metadata), metadata);
+        closeWhenEos(exceptionHandler.apply(ctx, null, t, metadata), metadata);
     }
 
     private void closeWhenEos(Status status, Metadata metadata) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
@@ -120,7 +120,7 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
                 decompressor(ForwardingDecompressor.forGrpc(decompressor));
             } catch (Throwable t) {
                 final Metadata metadata = new Metadata();
-                transportStatusListener.transportReportStatus(exceptionHandler.apply(ctx, t, metadata),
+                transportStatusListener.transportReportStatus(exceptionHandler.apply(ctx, null, t, metadata),
                                                               metadata);
                 return;
             }
@@ -148,7 +148,8 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
     @Override
     public void processOnError(Throwable cause) {
         final Metadata metadata = new Metadata();
-        transportStatusListener.transportReportStatus(exceptionHandler.apply(ctx, cause, metadata), metadata);
+        transportStatusListener.transportReportStatus(
+                exceptionHandler.apply(ctx, null, cause, metadata), metadata);
     }
 
     @Override

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/UnwrappingGrpcExceptionHandleFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/UnwrappingGrpcExceptionHandleFunction.java
@@ -34,8 +34,9 @@ public final class UnwrappingGrpcExceptionHandleFunction implements GrpcExceptio
         delegate = handlerFunction;
     }
 
+    @Nullable
     @Override
-    public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+    public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
         final Throwable t = peelAndUnwrap(cause);
         return delegate.apply(ctx, status, t, metadata);
     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/UnwrappingGrpcExceptionHandleFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/UnwrappingGrpcExceptionHandleFunction.java
@@ -35,9 +35,9 @@ public final class UnwrappingGrpcExceptionHandleFunction implements GrpcExceptio
     }
 
     @Override
-    public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+    public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
         final Throwable t = peelAndUnwrap(cause);
-        return delegate.apply(ctx, t, metadata);
+        return delegate.apply(ctx, status, t, metadata);
     }
 
     private static Throwable peelAndUnwrap(Throwable t) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -213,7 +213,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     public final void close(Throwable exception, boolean cancelled) {
         exception = Exceptions.peel(exception);
         final Metadata metadata = generateMetadataFromThrowable(exception);
-        final Status status = exceptionHandler.apply(ctx, exception, metadata);
+        final Status status = exceptionHandler.apply(ctx, null, exception, metadata);
         close(new ServerStatusAndMetadata(status, metadata, false, cancelled), exception);
     }
 
@@ -223,7 +223,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
             close(new ServerStatusAndMetadata(status, metadata, false));
             return;
         }
-        Status newStatus = exceptionHandler.apply(ctx, status.getCause(), metadata);
+        Status newStatus = exceptionHandler.apply(ctx, status, status.getCause(), metadata);
         assert newStatus != null;
         if (status.getDescription() != null) {
             newStatus = newStatus.withDescription(status.getDescription());

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -239,7 +239,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
                     return HttpResponse.of(
                             (ResponseHeaders) AbstractServerCall.statusToTrailers(
                                     ctx, defaultHeaders.get(serializationFormat).toBuilder(),
-                                    exceptionHandler.apply(ctx, e, metadata), metadata));
+                                    exceptionHandler.apply(ctx, null, e, metadata), metadata));
                 }
             } else {
                 if (Boolean.TRUE.equals(ctx.attr(AbstractUnframedGrpcService.IS_UNFRAMED_GRPC))) {
@@ -320,7 +320,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         call.setListener(listener);
         call.startDeframing();
         ctx.whenRequestCancelling().handle((cancellationCause, unused) -> {
-            final Status status = call.exceptionHandler().apply(ctx, cancellationCause, headers);
+            final Status status = call.exceptionHandler().apply(ctx, null, cancellationCause, headers);
             assert status != null;
             call.close(new ServerStatusAndMetadata(status, new Metadata(), true, true));
             return null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilder.java
@@ -878,7 +878,8 @@ public final class GrpcServiceBuilder {
     @Deprecated
     public GrpcServiceBuilder exceptionMapping(GrpcStatusFunction statusFunction) {
         requireNonNull(statusFunction, "statusFunction");
-        return exceptionHandler(statusFunction::apply);
+        return exceptionHandler(
+                (ctx, status, throwable, metadata) -> statusFunction.apply(ctx, throwable, metadata));
     }
 
     /**
@@ -943,7 +944,9 @@ public final class GrpcServiceBuilder {
         checkState(exceptionHandler == null,
                    "addExceptionMapping() and exceptionMapping() are mutually exclusive.");
 
-        exceptionMappingsBuilder().on(exceptionType, statusFunction::apply);
+        exceptionMappingsBuilder().on(exceptionType,
+                                      (ctx, status, throwable, metadata) ->
+                                              statusFunction.apply(ctx, throwable, metadata));
         return this;
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientBuilderTest.java
@@ -290,7 +290,7 @@ class GrpcClientBuilderTest {
 
     @Test
     void useDefaultGrpcExceptionHandlerFunctionAsFallback() {
-        final GrpcExceptionHandlerFunction noopExceptionHandler = (ctx, cause, metadata) -> null;
+        final GrpcExceptionHandlerFunction noopExceptionHandler = (ctx, status, cause, metadata) -> null;
         final GrpcExceptionHandlerFunction exceptionHandler =
                 GrpcExceptionHandlerFunction.builder()
                                             .on(ContentTooLargeException.class, noopExceptionHandler)

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientExceptionHandlerTest.java
@@ -85,15 +85,15 @@ class GrpcClientExceptionHandlerTest {
         final RuntimeException exception = new RuntimeException();
         final TestServiceBlockingStub stub =
                 GrpcClients.builder(server.httpUri())
-                           .exceptionHandler(((ctx, cause, metadata) -> {
+                           .exceptionHandler(((ctx, status, cause, metadata) -> {
                                stringDeque.add("1");
                                return null;
                            }))
-                           .exceptionHandler(((ctx, cause, metadata) -> {
+                           .exceptionHandler(((ctx, status, cause, metadata) -> {
                                stringDeque.add("2");
                                return null;
                            }))
-                           .exceptionHandler(((ctx, cause, metadata) -> {
+                           .exceptionHandler(((ctx, status, cause, metadata) -> {
                                if (cause == exception) {
                                    stringDeque.add("3");
                                    return Status.DATA_LOSS;

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -747,7 +747,7 @@ class GrpcClientTest {
         responseObserver.awaitCompletion();
         assertThat(responseObserver.getValues()).isEmpty();
         assertThat(GrpcExceptionHandlerFunction.of()
-                                               .apply(null, responseObserver.getError(), null)
+                                               .apply(null, null, responseObserver.getError(), null)
                                                .getCode()).isEqualTo(Code.CANCELLED);
 
         final RequestLog log = requestLogQueue.take();
@@ -783,7 +783,7 @@ class GrpcClientTest {
         responseObserver.awaitCompletion(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
         assertThat(responseObserver.getValues()).hasSize(1);
         assertThat(GrpcExceptionHandlerFunction.of()
-                                               .apply(null, responseObserver.getError(), null)
+                                               .apply(null, null, responseObserver.getError(), null)
                                                .getCode()).isEqualTo(Code.CANCELLED);
 
         checkRequestLog((rpcReq, rpcRes, grpcStatus) -> {
@@ -1418,7 +1418,7 @@ class GrpcClientTest {
 
         assertThat(recorder.getError()).isNotNull();
         assertThat(GrpcExceptionHandlerFunction.of()
-                                               .apply(null, recorder.getError(), null)
+                                               .apply(null, null, recorder.getError(), null)
                                                .getCode())
                 .isEqualTo(Status.DEADLINE_EXCEEDED.getCode());
 
@@ -1618,10 +1618,10 @@ class GrpcClientTest {
         verify(responseObserver,
                timeout(operationTimeoutMillis())).onError(captor.capture());
         assertThat(GrpcExceptionHandlerFunction.of()
-                                               .apply(null, captor.getValue(), null)
+                                               .apply(null, null, captor.getValue(), null)
                                                .getCode()).isEqualTo(Status.UNKNOWN.getCode());
         assertThat(GrpcExceptionHandlerFunction.of()
-                                               .apply(null, captor.getValue(), null)
+                                               .apply(null, null, captor.getValue(), null)
                                                .getDescription()).isEqualTo(errorMessage);
         verifyNoMoreInteractions(responseObserver);
 

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/DefaultGrpcExceptionHandlerFunctionTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/DefaultGrpcExceptionHandlerFunctionTest.java
@@ -33,7 +33,7 @@ class DefaultGrpcExceptionHandlerFunctionTest {
     void failFastExceptionToUnavailableCode() {
         assertThat(GrpcExceptionHandlerFunction
                            .of()
-                           .apply(null, new FailFastException(CircuitBreaker.ofDefaultName()), null)
+                           .apply(null, null, new FailFastException(CircuitBreaker.ofDefaultName()), null)
                            .getCode()).isEqualTo(Status.Code.UNAVAILABLE);
     }
 
@@ -41,7 +41,8 @@ class DefaultGrpcExceptionHandlerFunctionTest {
     void invalidProtocolBufferExceptionToInvalidArgumentCode() {
         assertThat(GrpcExceptionHandlerFunction
                            .of()
-                           .apply(null, new InvalidProtocolBufferException("Failed to parse message"), null)
+                           .apply(null, null,
+                                  new InvalidProtocolBufferException("Failed to parse message"), null)
                            .getCode()).isEqualTo(Status.Code.INVALID_ARGUMENT);
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunctionBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/common/grpc/GrpcExceptionHandlerFunctionBuilderTest.java
@@ -47,7 +47,7 @@ class GrpcExceptionHandlerFunctionBuilderTest {
         builder.on(A1Exception.class, Status.RESOURCE_EXHAUSTED);
 
         assertThatThrownBy(() -> {
-            builder.on(A1Exception.class, (ctx, throwable, metadata) -> Status.UNIMPLEMENTED);
+            builder.on(A1Exception.class, (ctx, status, throwable, metadata) -> Status.UNIMPLEMENTED);
         }).isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("is already added with");
 
@@ -60,26 +60,26 @@ class GrpcExceptionHandlerFunctionBuilderTest {
     @Test
     void sortExceptionHandler() {
         final GrpcExceptionHandlerFunctionBuilder builder = GrpcExceptionHandlerFunction.builder();
-        builder.on(A1Exception.class, (ctx, throwable, metadata) -> Status.RESOURCE_EXHAUSTED);
-        builder.on(A2Exception.class, (ctx, throwable, metadata) -> Status.UNIMPLEMENTED);
+        builder.on(A1Exception.class, (ctx, status, throwable, metadata) -> Status.RESOURCE_EXHAUSTED);
+        builder.on(A2Exception.class, (ctx, status, throwable, metadata) -> Status.UNIMPLEMENTED);
 
         assertThat(builder.exceptionMappings.stream().map(it -> (Class) it.getKey()))
                 .containsExactly(A2Exception.class, A1Exception.class);
 
-        builder.on(B1Exception.class, (ctx, throwable, metadata) -> Status.UNAUTHENTICATED);
+        builder.on(B1Exception.class, (ctx, status, throwable, metadata) -> Status.UNAUTHENTICATED);
         assertThat(builder.exceptionMappings.stream().map(it -> (Class) it.getKey()))
                 .containsExactly(A2Exception.class,
                                  A1Exception.class,
                                  B1Exception.class);
 
-        builder.on(A3Exception.class, (ctx, throwable, metadata) -> Status.UNAUTHENTICATED);
+        builder.on(A3Exception.class, (ctx, status, throwable, metadata) -> Status.UNAUTHENTICATED);
         assertThat(builder.exceptionMappings.stream().map(it -> (Class) it.getKey()))
                 .containsExactly(A3Exception.class,
                                  A2Exception.class,
                                  A1Exception.class,
                                  B1Exception.class);
 
-        builder.on(B2Exception.class, (ctx, throwable, metadata) -> Status.NOT_FOUND);
+        builder.on(B2Exception.class, (ctx, status, throwable, metadata) -> Status.NOT_FOUND);
         assertThat(builder.exceptionMappings.stream().map(it -> (Class) it.getKey()))
                 .containsExactly(A3Exception.class,
                                  A2Exception.class,
@@ -89,19 +89,19 @@ class GrpcExceptionHandlerFunctionBuilderTest {
 
         final GrpcExceptionHandlerFunction exceptionHandler = builder.build().orElse(
                 GrpcExceptionHandlerFunction.of());
-        Status status = exceptionHandler.apply(ctx, new A3Exception(), new Metadata());
+        Status status = exceptionHandler.apply(ctx, null, new A3Exception(), new Metadata());
         assertThat(status.getCode()).isEqualTo(Code.UNAUTHENTICATED);
 
-        status = exceptionHandler.apply(ctx, new A2Exception(), new Metadata());
+        status = exceptionHandler.apply(ctx, null, new A2Exception(), new Metadata());
         assertThat(status.getCode()).isEqualTo(Code.UNIMPLEMENTED);
 
-        status = exceptionHandler.apply(ctx, new A1Exception(), new Metadata());
+        status = exceptionHandler.apply(ctx, null, new A1Exception(), new Metadata());
         assertThat(status.getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
 
-        status = exceptionHandler.apply(ctx, new B2Exception(), new Metadata());
+        status = exceptionHandler.apply(ctx, null, new B2Exception(), new Metadata());
         assertThat(status.getCode()).isEqualTo(Code.NOT_FOUND);
 
-        status = exceptionHandler.apply(ctx, new B1Exception(), new Metadata());
+        status = exceptionHandler.apply(ctx, null, new B1Exception(), new Metadata());
         assertThat(status.getCode()).isEqualTo(Code.UNAUTHENTICATED);
     }
 
@@ -110,13 +110,13 @@ class GrpcExceptionHandlerFunctionBuilderTest {
         final GrpcExceptionHandlerFunction exceptionHandler =
                 GrpcExceptionHandlerFunction
                         .builder()
-                        .on(A2Exception.class, (ctx, throwable, metadata) -> Status.PERMISSION_DENIED)
-                        .on(A1Exception.class, (ctx1, cause, metadata) -> Status.DEADLINE_EXCEEDED)
+                        .on(A2Exception.class, (ctx, status, throwable, metadata) -> Status.PERMISSION_DENIED)
+                        .on(A1Exception.class, (ctx1, status, cause, metadata) -> Status.DEADLINE_EXCEEDED)
                         .build();
 
         for (Throwable ex : ImmutableList.of(new A2Exception(), new A3Exception())) {
             final Metadata metadata = new Metadata();
-            final Status newStatus = exceptionHandler.apply(ctx, ex, metadata);
+            final Status newStatus = exceptionHandler.apply(ctx, null, ex, metadata);
             assertThat(newStatus.getCode()).isEqualTo(Code.PERMISSION_DENIED);
             assertThat(newStatus.getCause()).isEqualTo(ex);
             assertThat(metadata.keys()).isEmpty();
@@ -124,7 +124,7 @@ class GrpcExceptionHandlerFunctionBuilderTest {
 
         final A1Exception cause = new A1Exception();
         final Metadata metadata = new Metadata();
-        final Status newStatus = exceptionHandler.apply(ctx, cause, metadata);
+        final Status newStatus = exceptionHandler.apply(ctx, null, cause, metadata);
 
         assertThat(newStatus.getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
         assertThat(newStatus.getCause()).isEqualTo(cause);
@@ -136,7 +136,7 @@ class GrpcExceptionHandlerFunctionBuilderTest {
         final GrpcExceptionHandlerFunction exceptionHandler =
                 GrpcExceptionHandlerFunction
                         .builder()
-                        .on(B1Exception.class, (ctx, throwable, metadata) -> {
+                        .on(B1Exception.class, (ctx, status, throwable, metadata) -> {
                             metadata.put(TEST_KEY, throwable.getClass().getSimpleName());
                             return Status.ABORTED;
                         })
@@ -144,14 +144,14 @@ class GrpcExceptionHandlerFunctionBuilderTest {
 
         final B1Exception cause = new B1Exception();
         final Metadata metadata1 = new Metadata();
-        final Status newStatus1 = exceptionHandler.apply(ctx, cause, metadata1);
+        final Status newStatus1 = exceptionHandler.apply(ctx, null, cause, metadata1);
         assertThat(newStatus1.getCode()).isEqualTo(Code.ABORTED);
         assertThat(metadata1.get(TEST_KEY)).isEqualTo("B1Exception");
         assertThat(metadata1.keys()).containsOnly(TEST_KEY.name());
 
         final Metadata metadata2 = new Metadata();
         metadata2.put(TEST_KEY2, "test");
-        final Status newStatus2 = exceptionHandler.apply(ctx, cause, metadata2);
+        final Status newStatus2 = exceptionHandler.apply(ctx, null, cause, metadata2);
 
         assertThat(newStatus2.getCode()).isEqualTo(Code.ABORTED);
         assertThat(metadata2.get(TEST_KEY)).isEqualTo("B1Exception");

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/TestServiceImpl.java
@@ -367,7 +367,7 @@ public class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
             } catch (Throwable e) {
                 failure = e;
                 if (GrpcExceptionHandlerFunction.of()
-                                                .apply(ServiceRequestContext.current(), e, new Metadata())
+                                                .apply(ServiceRequestContext.current(), null, e, new Metadata())
                                                 .getCode() == Status.CANCELLED.getCode()) {
                     // Stream was cancelled by client, responseStream.onError() might be called already or
                     // will be called soon by inbounding StreamObserver.

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncServerInterceptorTest.java
@@ -55,7 +55,7 @@ class AsyncServerInterceptorTest {
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            final GrpcExceptionHandlerFunction exceptionHandler = (ctx, throwable, metadata) -> {
+            final GrpcExceptionHandlerFunction exceptionHandler = (ctx, status, throwable, metadata) -> {
                 exceptionCounter.getAndIncrement();
                 if (throwable instanceof AnticipatedException &&
                     "Invalid access".equals(throwable.getMessage())) {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerAnnotationOnlyTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerAnnotationOnlyTest.java
@@ -132,8 +132,9 @@ class GrpcExceptionHandlerAnnotationOnlyTest {
 
     private static class FirstGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("first");
             if (Objects.equals(cause.getMessage(), "first")) {
                 return Status.UNAUTHENTICATED;
@@ -144,8 +145,9 @@ class GrpcExceptionHandlerAnnotationOnlyTest {
 
     private static class SecondGrpcExceptionHandler  implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("second");
             if (Objects.equals(cause.getMessage(), "second")) {
                 return Status.INVALID_ARGUMENT;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerAnnotationOnlyTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerAnnotationOnlyTest.java
@@ -133,7 +133,7 @@ class GrpcExceptionHandlerAnnotationOnlyTest {
     private static class FirstGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("first");
             if (Objects.equals(cause.getMessage(), "first")) {
                 return Status.UNAUTHENTICATED;
@@ -145,7 +145,7 @@ class GrpcExceptionHandlerAnnotationOnlyTest {
     private static class SecondGrpcExceptionHandler  implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("second");
             if (Objects.equals(cause.getMessage(), "second")) {
                 return Status.INVALID_ARGUMENT;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerTest.java
@@ -74,7 +74,7 @@ class GrpcExceptionHandlerTest {
                                   .addService("/foo", new FooTestServiceImpl())
                                   .addService("/bar", new BarTestServiceImpl(),
                                               TestServiceGrpc.getUnaryCallMethod())
-                                  .exceptionHandler((ctx, throwable, metadata) -> {
+                                  .exceptionHandler((ctx, status, throwable, metadata) -> {
                                       exceptionHandler.add("global");
                                       return Status.INTERNAL;
                                   })
@@ -88,7 +88,7 @@ class GrpcExceptionHandlerTest {
         protected void configure(ServerBuilder sb) throws Exception {
             sb.requestTimeoutMillis(5000)
               .service(GrpcService.builder()
-                                  .addService(new TestServiceIOException())
+                                  .addService(new ErrorTestServiceImpl())
                                   .build());
         }
     };
@@ -459,12 +459,17 @@ class GrpcExceptionHandlerTest {
                 .isInstanceOfSatisfying(StatusRuntimeException.class, e -> {
                     assertThat(e.getStatus().getCode()).isEqualTo(Status.UNAVAILABLE.getCode());
                 });
+        assertThatThrownBy(() -> client.unaryCall2(globalRequest))
+                .isInstanceOfSatisfying(StatusRuntimeException.class, e -> {
+                    assertThat(e.getStatus().getCode()).isEqualTo(Status.INVALID_ARGUMENT.getCode());
+                    assertThat(e.getStatus().getCause().getMessage()).contains("IllegalArgumentException");
+                });
     }
 
     private static class FirstGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("first");
             if (Objects.equals(cause.getMessage(), "first")) {
                 return Status.UNAUTHENTICATED;
@@ -476,7 +481,7 @@ class GrpcExceptionHandlerTest {
     private static class SecondGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("second");
             if (Objects.equals(cause.getMessage(), "second")) {
                 return Status.INVALID_ARGUMENT;
@@ -488,7 +493,7 @@ class GrpcExceptionHandlerTest {
     private static class ThirdGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("third");
             if (Objects.equals(cause.getMessage(), "third")) {
                 return Status.NOT_FOUND;
@@ -500,7 +505,7 @@ class GrpcExceptionHandlerTest {
     private static class ForthGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
         @Override
-        public @Nullable Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("forth");
             if (Objects.equals(cause.getMessage(), "forth")) {
                 return Status.UNAVAILABLE;
@@ -594,11 +599,16 @@ class GrpcExceptionHandlerTest {
         }
     }
 
-    // TestServiceIOException has DefaultGRPCExceptionHandlerFunction as fallback exception handler
-    private static class TestServiceIOException extends TestServiceImpl {
+    private static class ErrorTestServiceImpl extends TestServiceImpl {
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
             responseObserver.onError(new IOException());
+        }
+
+        @Override
+        public void unaryCall2(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            responseObserver.onError(new StatusRuntimeException(Status.INVALID_ARGUMENT.withCause(
+                    new IllegalArgumentException())));
         }
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcExceptionHandlerTest.java
@@ -468,8 +468,9 @@ class GrpcExceptionHandlerTest {
 
     private static class FirstGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("first");
             if (Objects.equals(cause.getMessage(), "first")) {
                 return Status.UNAUTHENTICATED;
@@ -480,8 +481,9 @@ class GrpcExceptionHandlerTest {
 
     private static class SecondGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("second");
             if (Objects.equals(cause.getMessage(), "second")) {
                 return Status.INVALID_ARGUMENT;
@@ -492,8 +494,9 @@ class GrpcExceptionHandlerTest {
 
     private static class ThirdGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("third");
             if (Objects.equals(cause.getMessage(), "third")) {
                 return Status.NOT_FOUND;
@@ -504,8 +507,9 @@ class GrpcExceptionHandlerTest {
 
     private static class ForthGrpcExceptionHandler implements GrpcExceptionHandlerFunction {
 
+        @Nullable
         @Override
-        public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause, Metadata metadata) {
+        public Status apply(RequestContext ctx, @Nullable Status status, Throwable cause, Metadata metadata) {
             exceptionHandler.add("forth");
             if (Objects.equals(cause.getMessage(), "forth")) {
                 return Status.UNAVAILABLE;

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -132,13 +132,13 @@ class GrpcServiceBuilderTest {
         assertThatThrownBy(() -> GrpcService.builder()
                                             .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED)
                                             .exceptionHandler(
-                                                    (ctx, cause, metadata) -> Status.PERMISSION_DENIED))
+                                                    (ctx, status, cause, metadata) -> Status.PERMISSION_DENIED))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("addExceptionMapping() and exceptionHandler() are mutually exclusive.");
 
         assertThatThrownBy(() -> GrpcService.builder()
                                             .exceptionHandler(
-                                                    (ctx, cause, metadata) -> Status.PERMISSION_DENIED)
+                                                    (ctx, status, cause, metadata) -> Status.PERMISSION_DENIED)
                                             .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("addExceptionMapping() and exceptionHandler() are mutually exclusive.");

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
@@ -102,7 +102,7 @@ class GrpcStatusMappingTest {
             sb.service(
                     GrpcService.builder()
                                .addService(new TestServiceImpl())
-                               .exceptionHandler((ctx, cause, metadata) -> {
+                               .exceptionHandler((ctx, status, cause, metadata) -> {
                                    final String attr = ctx.attr(METHOD_ATTR);
                                    if (attr != null) {
                                        metadata.put(METHOD_KEY, attr);

--- a/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/TestServiceTest.kt
+++ b/it/grpc/kotlin/src/test/kotlin/com/linecorp/armeria/grpc/kotlin/TestServiceTest.kt
@@ -206,7 +206,7 @@ class TestServiceTest {
                 .service(
                     GrpcService.builder()
                         .addService(TestServiceImpl())
-                        .exceptionHandler { _, throwable, _ ->
+                        .exceptionHandler { _, _, throwable, _ ->
                             when (throwable) {
                                 is AuthError -> {
                                     Status.UNAUTHENTICATED

--- a/it/grpc/reactor/src/test/java/com/linecorp/armeria/grpc/reactor/TestServiceTest.java
+++ b/it/grpc/reactor/src/test/java/com/linecorp/armeria/grpc/reactor/TestServiceTest.java
@@ -60,7 +60,7 @@ class TestServiceTest {
         final HttpServiceWithRoutes grpcService =
                 GrpcService.builder()
                            .addService(new TestServiceImpl())
-                           .exceptionHandler((ctx, throwable, metadata) -> {
+                           .exceptionHandler((ctx, status, throwable, metadata) -> {
                                if (throwable instanceof TestServiceImpl.AuthException) {
                                    return Status.UNAUTHENTICATED.withDescription(throwable.getMessage())
                                                                 .withCause(throwable);

--- a/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/TestServiceTest.scala
+++ b/it/grpc/scala/src/test/scala/com/linecorp/armeria/grpc/scala/TestServiceTest.scala
@@ -88,7 +88,7 @@ object TestServiceTest {
           .builder()
           .addService(TestServiceGrpc.bindService(new TestServiceImpl, ExecutionContext.global))
           .exceptionHandler {
-            case (_, e: AuthError, _) =>
+            case (_, _, e: AuthError, _) =>
               Status.UNAUTHENTICATED.withDescription(e.getMessage).withCause(e)
             case _ => null
           }


### PR DESCRIPTION
Motivation:
When an exception is raised, `GrpcService` creates a new `Status` from `Status.getCause()` via `GrpcExceptionHandlerFunction`. This can result in sending an incorrect status in certain situations:
- If the original exception is a `StatusRuntimeException` containing the `Status` that the user wants to send.
- The original exception has already been converted into a `Status` via `Status.fromThrowable()`: https://github.com/grpc/grpc-java/blob/5770114d08dcd352f2288ef52d17e1833530323c/stub/src/main/java/io/grpc/stub/ServerCalls.java#L389
- This converted `Status` is ignored and a new, potentially incorrect `Status` is created by `GrpcExceptionHandlerFunction` and sent.

Modifications:
- Added a `Status` parameter to the `GrpcExceptionHandlerFunction.apply()` method.
- Updated the default implementation of `GrpcExceptionHandlerFunction.of()` to return the provided `Status` if it is not an unknown status.

Result:
- The `GrpcExceptionHandlerFunction` now properly handles and returns the correct `Status`.
- (Breaking) The `apply` method of `GrpcExceptionHandlerFunction` now takes a `Status`.