### PR TITLE
Fix JsonSchemaGenerator to handle StructInfo with same alias and name

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/JsonSchemaGenerator.java
@@ -77,7 +77,7 @@ final class JsonSchemaGenerator {
                 ImmutableMap.builderWithExpectedSize(serviceSpecification.structs().size());
         for (StructInfo struct : serviceSpecification.structs()) {
             typeSignatureToStructMappingBuilder.put(struct.name(), struct);
-            if (struct.alias() != null) {
+            if (struct.alias() != null && !struct.alias().equals(struct.name())) {
                 // TypeSignature.signature() could be StructInfo.alias() if the type is a protobuf Message.
                 typeSignatureToStructMappingBuilder.put(struct.alias(), struct);
             }


### PR DESCRIPTION
Motivation:

- The `StructInfo` `alias` has the same value as the `name` causing a duplicate key exception when building  `typeSignatureToStructMappingBuilder`. 
- Occurred when setting up a HTTP service which consumes protobuf messages

Modifications:

- Checks that the `struct` and `alias` don't have the same name to avoid duplicate key exception (alias is created here https://github.com/line/armeria/blob/main/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufDescriptiveTypeInfoProvider.java#L106)

Result:

- Improves the `JsonSchemaGenerator.java` for the documentation service by allowing resources to have the same alias and name as is the default behavior of https://github.com/line/armeria/blob/main/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufDescriptiveTypeInfoProvider.java#L106

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
