### PR TITLE
Synchronize HttpHeaderNames with Guava

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -141,6 +141,8 @@ jobs:
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }},${{ steps.setup-jdk.outputs.path }}
+          # Unshaded tests are skipped for PRs to avoid running the same tests twice.
+          -PskipUnshadedTests=${{ github.ref_name != 'main' }} \
         shell: bash
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -142,7 +142,7 @@ jobs:
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }},${{ steps.setup-jdk.outputs.path }}
           # Unshaded tests are skipped for PRs to avoid running the same tests twice.
-          -PskipUnshadedTests=${{ github.ref_name != 'main' }} \
+          -PpreferShadedTests=${{ github.ref_name != 'main' }} \
         shell: bash
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -141,8 +141,8 @@ jobs:
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
           -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }},${{ steps.setup-jdk.outputs.path }} \
-          # Unshaded tests are skipped for PRs to avoid running the same tests twice.
           -PpreferShadedTests=${{ github.ref_name != 'main' }}
+          # Unshaded tests are skipped for PRs to avoid running the same tests twice.
         shell: bash
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -140,9 +140,9 @@ jobs:
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
           -PtestJavaVersion=${{ matrix.java }} \
           ${{ matrix.min-java && format('-PminimumJavaVersion={0}', matrix.min-java) || '' }} \
-          -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }},${{ steps.setup-jdk.outputs.path }}
+          -Porg.gradle.java.installations.paths=${{ steps.setup-build-jdk.outputs.path }},${{ steps.setup-jdk.outputs.path }} \
           # Unshaded tests are skipped for PRs to avoid running the same tests twice.
-          -PpreferShadedTests=${{ github.ref_name != 'main' }} \
+          -PpreferShadedTests=${{ github.ref_name != 'main' }}
         shell: bash
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -227,6 +227,9 @@ if (tasks.findByName('trimShadedJar')) {
         keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.ec.** { *; }"
         keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.rsa.** { *; }"
         keep "class com.linecorp.armeria.internal.shaded.bouncycastle.jcajce.provider.asymmetric.x509.** { *; }"
+        // Keep the Guava classes accessed during testing.
+        keep "class com.linecorp.armeria.internal.shaded.guava.net.HttpHeaders { *; }"
+        keep "class com.linecorp.armeria.internal.shaded.guava.net.MediaType { *; }"
         dontnote
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -747,6 +747,12 @@ public final class HttpHeaderNames {
     public static final AsciiString PERMISSIONS_POLICY = create("Permissions-Policy");
     /**
      * The HTTP <a
+     * href="https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-report-only-http-header-field">{@code
+     * Permissions-Policy-Report-Only}</a> header field name.
+     */
+    public static final AsciiString PERMISSIONS_POLICY_REPORT_ONLY = create("Permissions-Policy-Report-Only");
+    /**
+     * The HTTP <a
      * href="https://datatracker.ietf.org/doc/html/rfc8942">{@code
      * Accept-CH}</a> header field name.
      */
@@ -905,23 +911,32 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString OBSERVE_BROWSING_TOPICS = create("Observe-Browsing-Topics");
     /**
-     * The HTTP <a href="https://datatracker.ietf.org/doc/html/rfc8586">{@code CDN-Loop}</a> header field name.
-     */
-    public static final AsciiString CDN_LOOP = create("CDN-Loop");
-
-    /**
      * The HTTP <a
      * href="https://wicg.github.io/turtledove/#handling-direct-from-seller-signals">{@code
      * Sec-Ad-Auction-Fetch}</a> header field name.
      */
     public static final AsciiString SEC_AD_AUCTION_FETCH = create("Sec-Ad-Auction-Fetch");
-
+    /**
+     * The HTTP <a
+     * href="https://privacycg.github.io/gpc-spec/#the-sec-gpc-header-field-for-http-requests">{@code
+     * Sec-GPC}</a> header field name.
+     */
+    public static final AsciiString SEC_GPC = create("Sec-GPC");
     /**
      * The HTTP <a
      * href="https://wicg.github.io/turtledove/#handling-direct-from-seller-signals">{@code
      * Ad-Auction-Signals}</a> header field name.
      */
     public static final AsciiString AD_AUCTION_SIGNALS = create("Ad-Auction-Signals");
+    /**
+     * The HTTP <a href="https://wicg.github.io/turtledove/#http-headerdef-ad-auction-allowed">{@code
+     * Ad-Auction-Allowed}</a> header field name.
+     */
+    public static final AsciiString AD_AUCTION_ALLOWED = create("Ad-Auction-Allowed");
+    /**
+     * The HTTP <a href="https://datatracker.ietf.org/doc/html/rfc8586">{@code CDN-Loop}</a> header field name.
+     */
+    public static final AsciiString CDN_LOOP = create("CDN-Loop");
 
     private static final Map<CharSequence, AsciiString> map;
     private static final Map<AsciiString, String> inverseMap;

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -573,6 +573,9 @@ relocations [ { from: "com.google.common", to: "com.doe.john.myproject.shaded.gu
               { from: "com.google.thirdparty.publicsuffix", to: "com.doe.john.myproject.shaded.publicsuffix" } ]
 ```
 
+Unshaded tests are disabled by default when a shading task is configured. If you want to run unshaded tests,
+you can specify `-PskipUnshadedTests=false` option.
+
 ### Trimming a shaded JAR with `trim` flag
 
 If you shade many dependencies, your JAR will grow huge, even if you only use

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -574,7 +574,7 @@ relocations [ { from: "com.google.common", to: "com.doe.john.myproject.shaded.gu
 ```
 
 Unshaded tests are disabled by default when a shading task is configured. If you want to run unshaded tests,
-you can specify `-PskipUnshadedTests=false` option.
+you can specify `-PpreferShadedTests=false` option.
 
 ### Trimming a shaded JAR with `trim` flag
 

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -254,7 +254,7 @@ configure(relocatedProjects) {
 
     gradle.taskGraph.whenReady {
         // Skip unshaded tests if shaded tests will run.
-        // Disabled by default. To enable, set the property 'skipUnshadedTests' to 'false'.
+        // To enable, set the property 'skipUnshadedTests' to 'false'.
         boolean skipUnshadedTests = true
         if (rootProject.hasProperty('skipUnshadedTests') && "false" == rootProject.property('skipUnshadedTests')) {
             skipUnshadedTests = false

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -254,13 +254,13 @@ configure(relocatedProjects) {
 
     gradle.taskGraph.whenReady {
         // Skip unshaded tests if shaded tests will run.
-        // To enable, set the property 'skipUnshadedTests' to 'false'.
-        boolean skipUnshadedTests = true
-        if (rootProject.hasProperty('skipUnshadedTests') && "false" == rootProject.property('skipUnshadedTests')) {
-            skipUnshadedTests = false
+        // To enable, set the property 'preferShadedTests' to 'false'.
+        boolean runUnshadedTests = false
+        if (rootProject.hasProperty('preferShadedTests') && "false" == rootProject.property('preferShadedTests')) {
+            runUnshadedTests = true
         }
         if (gradle.taskGraph.hasTask(tasks.shadedTest)) {
-            tasks.test.onlyIf { !skipUnshadedTests }
+            tasks.test.onlyIf { runUnshadedTests }
         }
     }
 }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -254,8 +254,13 @@ configure(relocatedProjects) {
 
     gradle.taskGraph.whenReady {
         // Skip unshaded tests if shaded tests will run.
+        // Disabled by default. To enable, set the property 'skipUnshadedTests' to 'false'.
+        boolean skipUnshadedTests = true
+        if (rootProject.hasProperty('skipUnshadedTests') && "false" == rootProject.property('skipUnshadedTests')) {
+            skipUnshadedTests = false
+        }
         if (gradle.taskGraph.hasTask(tasks.shadedTest)) {
-            tasks.test.onlyIf { false }
+            tasks.test.onlyIf { !skipUnshadedTests }
         }
     }
 }


### PR DESCRIPTION
Motivation:

`HttpHeaderNamesTest` failed locally because we omitted three headers when upgrading the Guava version to 33.2.0.

We can't detect the problem from our CI builds since all fields of Guava `HttpHeaders` are removed by the `trimShadedJar` task on which the `build` task depends. The fields are actually used for testing.

Modifications:

- Keep `HttpHeaders` and `MediaType` of Guava from trimming to avoid unexpected test results.
- Add `-PpreferShadedTests=<boolean>` option to run unshaded tests along with shaded tests
  - This option is disabled by default to avoid running the same tests twice.
- Add missing headers to `HttpHeaderNames`

Result:

New headers from Guava have been added to `HttpHeaderNames`.
