### PR TITLE
`ResponseTimeout` can be scheduled at an earlier timing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -507,6 +507,17 @@ public class AbstractClientOptionsBuilder {
     }
 
     /**
+     * Sets the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeout(Duration)}}
+     * will start to be scheduled.
+     * @see ResponseTimeoutMode
+     */
+    @UnstableApi
+    public AbstractClientOptionsBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return option(ClientOptions.RESPONSE_TIMEOUT_MODE,
+                      requireNonNull(responseTimeoutMode, "responseTimeoutMode"));
+    }
+
+    /**
      * Builds {@link ClientOptions} with the given options and the
      * {@linkplain ClientOptions#of() default options}.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -509,6 +509,7 @@ public class AbstractClientOptionsBuilder {
     /**
      * Sets the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeout(Duration)}}
      * will start to be scheduled.
+     *
      * @see ResponseTimeoutMode
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -198,6 +198,9 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
         final CancellationScheduler scheduler = cancellationScheduler();
         if (scheduler != null) {
             scheduler.updateTask(newCancellationTask());
+            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.REQUEST_WRITE) {
+                scheduler.start();
+            }
         }
         if (ctx.isCancelled()) {
             // The previous cancellation task wraps the cause with an UnprocessedRequestException

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -198,7 +198,7 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
         final CancellationScheduler scheduler = cancellationScheduler();
         if (scheduler != null) {
             scheduler.updateTask(newCancellationTask());
-            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.REQUEST_WRITE) {
+            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.CONNECTION_ACQUIRED) {
                 scheduler.start();
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
@@ -224,6 +224,12 @@ public final class BlockingWebClientRequestPreparation
     }
 
     @Override
+    public BlockingWebClientRequestPreparation responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        delegate.responseTimeoutMode(responseTimeoutMode);
+        return this;
+    }
+
+    @Override
     public BlockingWebClientRequestPreparation requestOptions(RequestOptions requestOptions) {
         delegate.requestOptions(requestOptions);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -295,4 +295,9 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     public ClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
         return (ClientBuilder) super.contextHook(contextHook);
     }
+
+    @Override
+    public ClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (ClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -156,6 +156,10 @@ public final class ClientOptions
     public static final ClientOption<Supplier<? extends AutoCloseable>> CONTEXT_HOOK =
             ClientOption.define("CONTEXT_HOOK", NOOP_CONTEXT_HOOK);
 
+    @UnstableApi
+    public static final ClientOption<ResponseTimeoutMode> RESPONSE_TIMEOUT_MODE =
+            ClientOption.define("RESPONSE_TIMEOUT_MODE", Flags.responseTimeoutMode());
+
     private static final List<AsciiString> PROHIBITED_HEADER_NAMES = ImmutableList.of(
             HttpHeaderNames.HTTP2_SETTINGS,
             HttpHeaderNames.METHOD,
@@ -393,6 +397,16 @@ public final class ClientOptions
     @SuppressWarnings("unchecked")
     public Supplier<AutoCloseable> contextHook() {
         return (Supplier<AutoCloseable>) get(CONTEXT_HOOK);
+    }
+
+    /**
+     * Returns the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeoutMillis()}
+     * will start to be scheduled.
+     * @see ResponseTimeoutMode
+     */
+    @UnstableApi
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return get(RESPONSE_TIMEOUT_MODE);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -402,6 +402,7 @@ public final class ClientOptions
     /**
      * Returns the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeoutMillis()}
      * will start to be scheduled.
+     *
      * @see ResponseTimeoutMode
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -222,4 +222,9 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder {
     public ClientOptionsBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
         return (ClientOptionsBuilder) super.contextHook(contextHook);
     }
+
+    @Override
+    public ClientOptionsBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (ClientOptionsBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -612,6 +612,14 @@ public interface ClientRequestContext extends RequestContext {
     @UnstableApi
     ExchangeType exchangeType();
 
+    /**
+     * Returns the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeoutMillis()}
+     * will start to be scheduled.
+     * @see ResponseTimeoutMode
+     */
+    @UnstableApi
+    ResponseTimeoutMode responseTimeoutMode();
+
     @Override
     default ClientRequestContext unwrap() {
         return (ClientRequestContext) RequestContext.super.unwrap();

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -615,6 +615,7 @@ public interface ClientRequestContext extends RequestContext {
     /**
      * Returns the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeoutMillis()}
      * will start to be scheduled.
+     *
      * @see ResponseTimeoutMode
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -168,6 +168,11 @@ public class ClientRequestContextWrapper
     }
 
     @Override
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return unwrap().responseTimeoutMode();
+    }
+
+    @Override
     public void hook(Supplier<? extends AutoCloseable> contextHook) {
         unwrap().hook(contextHook);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
@@ -30,7 +30,7 @@ import io.netty.util.AttributeKey;
 final class DefaultRequestOptions implements RequestOptions {
 
     static final DefaultRequestOptions EMPTY = new DefaultRequestOptions(-1, -1, -1, null,
-                                                                         ImmutableMap.of(), null);
+                                                                         ImmutableMap.of(), null, null);
 
     private final long responseTimeoutMillis;
     private final long writeTimeoutMillis;
@@ -40,17 +40,21 @@ final class DefaultRequestOptions implements RequestOptions {
     private final Map<AttributeKey<?>, Object> attributeMap;
     @Nullable
     private final ExchangeType exchangeType;
+    @Nullable
+    private final ResponseTimeoutMode responseTimeoutMode;
 
     DefaultRequestOptions(long responseTimeoutMillis, long writeTimeoutMillis,
                           long maxResponseLength, @Nullable Long requestAutoAbortDelayMillis,
                           Map<AttributeKey<?>, Object> attributeMap,
-                          @Nullable ExchangeType exchangeType) {
+                          @Nullable ExchangeType exchangeType,
+                          @Nullable ResponseTimeoutMode responseTimeoutMode) {
         this.responseTimeoutMillis = responseTimeoutMillis;
         this.writeTimeoutMillis = writeTimeoutMillis;
         this.maxResponseLength = maxResponseLength;
         this.requestAutoAbortDelayMillis = requestAutoAbortDelayMillis;
         this.attributeMap = attributeMap;
         this.exchangeType = exchangeType;
+        this.responseTimeoutMode = responseTimeoutMode;
     }
 
     @Override
@@ -85,6 +89,12 @@ final class DefaultRequestOptions implements RequestOptions {
         return exchangeType;
     }
 
+    @Nullable
+    @Override
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return responseTimeoutMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -101,13 +111,14 @@ final class DefaultRequestOptions implements RequestOptions {
                writeTimeoutMillis == that.writeTimeoutMillis &&
                maxResponseLength == that.maxResponseLength &&
                attributeMap.equals(that.attributeMap) &&
-               exchangeType == that.exchangeType;
+               exchangeType == that.exchangeType &&
+               responseTimeoutMode == that.responseTimeoutMode;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(responseTimeoutMillis, writeTimeoutMillis, maxResponseLength,
-                            attributeMap, exchangeType);
+                            attributeMap, exchangeType, responseTimeoutMode);
     }
 
     @Override
@@ -119,6 +130,7 @@ final class DefaultRequestOptions implements RequestOptions {
                           .add("requestAutoAbortDelayMillis", requestAutoAbortDelayMillis)
                           .add("attributeMap", attributeMap)
                           .add("exchangeType", exchangeType)
+                          .add("responseTimeoutMode", responseTimeoutMode)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -416,4 +416,11 @@ public final class FutureTransformingRequestPreparation<T>
         delegate.exchangeType(exchangeType);
         return this;
     }
+
+    @Override
+    public FutureTransformingRequestPreparation<T> responseTimeoutMode(
+            ResponseTimeoutMode responseTimeoutMode) {
+        delegate.responseTimeoutMode(responseTimeoutMode);
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -294,7 +294,7 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
             final CancellationScheduler responseCancellationScheduler =
                     ctxExtension.responseCancellationScheduler();
             responseCancellationScheduler.updateTask(newCancellationTask());
-            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.RESPONSE_READ) {
+            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.REQUEST_SENT) {
                 responseCancellationScheduler.start();
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -294,7 +294,9 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
             final CancellationScheduler responseCancellationScheduler =
                     ctxExtension.responseCancellationScheduler();
             responseCancellationScheduler.updateTask(newCancellationTask());
-            responseCancellationScheduler.start();
+            if (ctx.responseTimeoutMode() == ResponseTimeoutMode.RESPONSE_READ) {
+                responseCancellationScheduler.start();
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptions.java
@@ -112,4 +112,14 @@ public interface RequestOptions {
      */
     @Nullable
     ExchangeType exchangeType();
+
+    /**
+     * Returns the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeoutMillis()}
+     * will start to be scheduled.
+     *
+     * @see ResponseTimeoutMode
+     */
+    @Nullable
+    @UnstableApi
+    ResponseTimeoutMode responseTimeoutMode();
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptionsBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.netty.util.AttributeKey;
 
@@ -41,6 +42,8 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
     private long maxResponseLength = -1;
     @Nullable
     private Long requestAutoAbortDelayMillis;
+    @Nullable
+    private ResponseTimeoutMode responseTimeoutMode;
 
     @Nullable
     private Map<AttributeKey<?>, Object> attributes;
@@ -58,6 +61,7 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
                 attributes = new HashMap<>(attrs);
             }
             exchangeType = options.exchangeType();
+            responseTimeoutMode = options.responseTimeoutMode();
         }
     }
 
@@ -135,13 +139,20 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
         return this;
     }
 
+    @Override
+    @UnstableApi
+    public RequestOptionsBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        this.responseTimeoutMode = requireNonNull(responseTimeoutMode, "responseTimeoutMode");
+        return this;
+    }
+
     /**
      * Returns a newly created {@link RequestOptions} with the properties specified so far.
      */
     public RequestOptions build() {
         if (responseTimeoutMillis < 0 && writeTimeoutMillis < 0 &&
             maxResponseLength < 0 && requestAutoAbortDelayMillis == null && attributes == null &&
-            exchangeType == null) {
+            exchangeType == null && responseTimeoutMode == null) {
             return EMPTY;
         } else {
             final Map<AttributeKey<?>, Object> attributes;
@@ -152,7 +163,7 @@ public final class RequestOptionsBuilder implements RequestOptionsSetters {
             }
             return new DefaultRequestOptions(responseTimeoutMillis, writeTimeoutMillis,
                                              maxResponseLength, requestAutoAbortDelayMillis,
-                                             attributes, exchangeType);
+                                             attributes, exchangeType, responseTimeoutMode);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RequestOptionsSetters.java
@@ -157,4 +157,12 @@ public interface RequestOptionsSetters {
      */
     @UnstableApi
     RequestOptionsSetters exchangeType(ExchangeType exchangeType);
+
+    /**
+     * Sets the {@link ResponseTimeoutMode} which determines when a {@link #responseTimeout(Duration)}}
+     * will start to be scheduled.
+     *
+     * @see ResponseTimeoutMode
+     */
+    RequestOptionsSetters responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
@@ -30,7 +30,7 @@ import com.linecorp.armeria.common.util.TimeoutMode;
  * }</pre>
  * <ul>
  *     <li>
- *         If {@link ResponseTimeoutMode#REQUEST_START} is used, the timeout task will be scheduled
+ *         If {@link ResponseTimeoutMode#FROM_START} is used, the timeout task will be scheduled
  *         immediately on request start. If the responseTimeout is less than 3 seconds, the timeout task
  *         will trigger while the request goes through the decorator, and the request will fail before
  *         acquiring a new connection. If the responseTimeout is greater than (3s + 2s + 5s + 4s) 14 seconds
@@ -56,7 +56,7 @@ import com.linecorp.armeria.common.util.TimeoutMode;
  * <pre>{@code
  * |---request start---decorators(3s)---connection acquisition(2s)---request write(5s)---response read(4s)---|
  * }</pre>
- *  Assume {@link ResponseTimeoutMode#REQUEST_START} is set, and {@link TimeoutMode#SET_FROM_NOW}
+ *  Assume {@link ResponseTimeoutMode#FROM_START} is set, and {@link TimeoutMode#SET_FROM_NOW}
  *  with 1 second is called in the decorators. Then the timeout task will be triggered 1 second into connection
  *  acquisition.
  * <pre>{@code
@@ -75,7 +75,7 @@ public enum ResponseTimeoutMode {
      * the scheduling will take place as soon as an endpoint is acquired but before the decorator chain
      * is traversed.
      */
-    REQUEST_START,
+    FROM_START,
 
     /**
      * The response timeout is scheduled after the connection is acquired.

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
@@ -28,14 +28,14 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * }</pre>
  * <ul>
  *     <li>
- *         If {@link ResponseTimeoutMode#RESPONSE_READ} is used, the request will go through the decorators,
- *         acquire a connection, and write the request. Once the response header is read, the timeout task
- *         will trigger immediately since 5 seconds has passed which exceeds the responseTimeout of 2 seconds.
- *     </li>
- *     <li>
  *         If {@link ResponseTimeoutMode#REQUEST_START} is used, the timeout task will be scheduled
  *         immediately on request start. The timeout task will trigger while the request goes through
  *         the decorator, and the request will fail before acquiring a new connection.
+ *     </li>
+ *     <li>
+ *         If {@link ResponseTimeoutMode#REQUEST_SENT} is used, the request will go through the decorators,
+ *         acquire a connection, and write the request. Once the request is fully sent, the timeout task
+ *         will trigger immediately since 5 seconds has passed which exceeds the responseTimeout of 2 seconds.
  *     </li>
  * </ul>
  */
@@ -49,13 +49,13 @@ public enum ResponseTimeoutMode {
     REQUEST_START,
 
     /**
-     * The response timeout is scheduled when the request is first written on the wire.
+     * The response timeout is scheduled after the connection is acquired.
      */
-    REQUEST_WRITE,
+    CONNECTION_ACQUIRED,
 
     /**
-     * The response timeout is scheduled either when the response bytes are first read, or when the client
-     * finishes writing the request.
+     * The response timeout is scheduled either after the client fully writes the request
+     * or when the response bytes are first read.
      */
-    RESPONSE_READ,
+    REQUEST_SENT,
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
@@ -16,35 +16,64 @@
 
 package com.linecorp.armeria.client;
 
+import java.time.Duration;
+
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.TimeoutMode;
 
 /**
- * Specifies when to start scheduling a response timeout. Note that this value does not affect calculation
- * of the response timeout, but determines when the response timeout will affect the ongoing request.
+ * Specifies when to start scheduling a response timeout.
  *
- * <p>For example, assume the following scenario with a responseTimeout of 2 seconds:
+ * <p>For example:
  * <pre>{@code
- * |---request start---decorators(3s)---connection acquisition(2s)---request write/response read---|
+ * |---request start---decorators(3s)---connection acquisition(2s)---request write(5s)---response read(4s)---|
  * }</pre>
  * <ul>
  *     <li>
  *         If {@link ResponseTimeoutMode#REQUEST_START} is used, the timeout task will be scheduled
- *         immediately on request start. The timeout task will trigger while the request goes through
- *         the decorator, and the request will fail before acquiring a new connection.
+ *         immediately on request start. If the responseTimeout is less than 3 seconds, the timeout task
+ *         will trigger while the request goes through the decorator, and the request will fail before
+ *         acquiring a new connection. If the responseTimeout is greater than (3s + 2s + 5s + 4s) 14 seconds
+ *         the request will complete successfully.
  *     </li>
  *     <li>
- *         If {@link ResponseTimeoutMode#REQUEST_SENT} is used, the request will go through the decorators,
- *         acquire a connection, and write the request. Once the request is fully sent, the timeout task
- *         will trigger immediately since 5 seconds has passed which exceeds the responseTimeout of 2 seconds.
+ *         If {@link ResponseTimeoutMode#CONNECTION_ACQUIRED} is used, the timeout task will be scheduled
+ *         after connection acquisition. If the responseTimeout is greater than (5s + 4s) 9 seconds the
+ *         request will complete successfully.
+ *     </li>
+ *     <li>
+ *         If {@link ResponseTimeoutMode#REQUEST_SENT} is used, the the timeout task will be scheduled after
+ *         the request is fully written. If the responseTimeout is greater than 4 seconds the request will
+ *         complete successfully.
  *     </li>
  * </ul>
+ *
+ * <p>When {@link TimeoutMode#SET_FROM_NOW} is used, the timeout is assumed to be scheduled when
+ * {@link ClientRequestContext#setResponseTimeout(TimeoutMode, Duration)} was called. If the request
+ * has already reached {@link ResponseTimeoutMode}, then the timeout is scheduled normally.
+ * If the request didn't reach {@link ResponseTimeoutMode} yet, the elapsed time is computed once
+ * {@link ResponseTimeoutMode} is reached and the timeout is scheduled accordingly.
+ * <pre>{@code
+ * |---request start---decorators(3s)---connection acquisition(2s)---request write(5s)---response read(4s)---|
+ * }</pre>
+ *  Assume {@link ResponseTimeoutMode#REQUEST_START} is set, and {@link TimeoutMode#SET_FROM_NOW}
+ *  with 1 second is called in the decorators. Then the timeout task will be triggered 1 second into connection
+ *  acquisition.
+ * <pre>{@code
+ * |---request start---decorators(3s)---connection acquisition(2s)---request write(5s)---response read(4s)---|
+ * }</pre>
+ *  Assume {@link ResponseTimeoutMode#REQUEST_SENT} is set, and {@link TimeoutMode#SET_FROM_NOW}
+ *  with 1 second is called in the decorators. The request will continue until the request is fully sent.
+ *  Since (2s + 5s) 7 seconds have elapsed which is greater than the 1-second timeout, the timeout task will be
+ *  invoked immediately before the response read starts.
  */
 @UnstableApi
 public enum ResponseTimeoutMode {
 
     /**
      * The response timeout is scheduled when the request first starts to execute. More specifically,
-     * the scheduling will take place when the request starts to go through the decorator chain.
+     * the scheduling will take place as soon as an endpoint is acquired but before the decorator chain
+     * is traversed.
      */
     REQUEST_START,
 

--- a/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ResponseTimeoutMode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Specifies when to start scheduling a response timeout. Note that this value does not affect calculation
+ * of the response timeout, but determines when the response timeout will affect the ongoing request.
+ *
+ * <p>For example, assume the following scenario with a responseTimeout of 2 seconds:
+ * <pre>{@code
+ * |---request start---decorators(3s)---connection acquisition(2s)---request write/response read---|
+ * }</pre>
+ * <ul>
+ *     <li>
+ *         If {@link ResponseTimeoutMode#RESPONSE_READ} is used, the request will go through the decorators,
+ *         acquire a connection, and write the request. Once the response header is read, the timeout task
+ *         will trigger immediately since 5 seconds has passed which exceeds the responseTimeout of 2 seconds.
+ *     </li>
+ *     <li>
+ *         If {@link ResponseTimeoutMode#REQUEST_START} is used, the timeout task will be scheduled
+ *         immediately on request start. The timeout task will trigger while the request goes through
+ *         the decorator, and the request will fail before acquiring a new connection.
+ *     </li>
+ * </ul>
+ */
+@UnstableApi
+public enum ResponseTimeoutMode {
+
+    /**
+     * The response timeout is scheduled when the request first starts to execute. More specifically,
+     * the scheduling will take place when the request starts to go through the decorator chain.
+     */
+    REQUEST_START,
+
+    /**
+     * The response timeout is scheduled when the request is first written on the wire.
+     */
+    REQUEST_WRITE,
+
+    /**
+     * The response timeout is scheduled either when the response bytes are first read, or when the client
+     * finishes writing the request.
+     */
+    RESPONSE_READ,
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -254,4 +254,9 @@ public final class RestClientBuilder extends AbstractWebClientBuilder {
     public RestClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
         return (RestClientBuilder) super.contextHook(contextHook);
     }
+
+    @Override
+    public RestClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (RestClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -311,4 +311,10 @@ public final class RestClientPreparation implements RequestPreparationSetters {
         delegate.requestOptions(requestOptions);
         return this;
     }
+
+    @Override
+    public RestClientPreparation responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        delegate.responseTimeoutMode(responseTimeoutMode);
+        return this;
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
@@ -80,6 +80,12 @@ public class TransformingRequestPreparation<T, R> implements WebRequestPreparati
     }
 
     @Override
+    public TransformingRequestPreparation<T, R> responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        delegate.responseTimeoutMode(responseTimeoutMode);
+        return this;
+    }
+
+    @Override
     public TransformingRequestPreparation<T, R> requestOptions(RequestOptions requestOptions) {
         delegate.requestOptions(requestOptions);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -250,4 +250,9 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (WebClientBuilder) super.contextCustomizer(contextCustomizer);
     }
+
+    @Override
+    public WebClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (WebClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -329,6 +329,11 @@ public final class WebClientRequestPreparation
         if (exchangeType != null) {
             exchangeType(exchangeType);
         }
+
+        final ResponseTimeoutMode responseTimeoutMode = requestOptions.responseTimeoutMode();
+        if (responseTimeoutMode != null) {
+            responseTimeoutMode(responseTimeoutMode);
+        }
         return this;
     }
 
@@ -389,6 +394,12 @@ public final class WebClientRequestPreparation
     @Override
     public WebClientRequestPreparation exchangeType(ExchangeType exchangeType) {
         requestOptionsBuilder().exchangeType(exchangeType);
+        return this;
+    }
+
+    @Override
+    public WebClientRequestPreparation responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        requestOptionsBuilder().responseTimeoutMode(responseTimeoutMode);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -389,5 +390,10 @@ public final class WebSocketClientBuilder extends AbstractWebClientBuilder {
     @Override
     public WebSocketClientBuilder contextHook(Supplier<? extends AutoCloseable> contextHook) {
         return (WebSocketClientBuilder) super.contextHook(contextHook);
+    }
+
+    @Override
+    public WebSocketClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (WebSocketClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -101,7 +101,7 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final String DNS_CACHE_SPEC = "maximumSize=4096";
     static final long DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = 10000;
     static final long DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS = 3000;
-    static final ResponseTimeoutMode DEFAULT_RESPONSE_TIMEOUT_MODE = ResponseTimeoutMode.RESPONSE_READ;
+    static final ResponseTimeoutMode DEFAULT_RESPONSE_TIMEOUT_MODE = ResponseTimeoutMode.REQUEST_SENT;
 
     private DefaultFlagsProvider() {}
 

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.common.util.Sampler;
 import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.common.util.TransportType;
@@ -100,6 +101,7 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final String DNS_CACHE_SPEC = "maximumSize=4096";
     static final long DEFAULT_UNLOGGED_EXCEPTIONS_REPORT_INTERVAL_MILLIS = 10000;
     static final long DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS = 3000;
+    static final ResponseTimeoutMode DEFAULT_RESPONSE_TIMEOUT_MODE = ResponseTimeoutMode.RESPONSE_READ;
 
     private DefaultFlagsProvider() {}
 
@@ -510,5 +512,10 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Long defaultHttp1ConnectionCloseDelayMillis() {
         return DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS;
+    }
+
+    @Override
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return DEFAULT_RESPONSE_TIMEOUT_MODE;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.DnsResolverGroupBuilder;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
@@ -438,6 +439,9 @@ public final class Flags {
     private static final long DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS =
             getValue(FlagsProvider::defaultHttp1ConnectionCloseDelayMillis,
                     "defaultHttp1ConnectionCloseDelayMillis", value -> value >= 0);
+
+    private static final ResponseTimeoutMode RESPONSE_TIMEOUT_MODE =
+            getValue(FlagsProvider::responseTimeoutMode, "responseTimeoutMode");
 
     /**
      * Returns the specification of the {@link Sampler} that determines whether to retain the stack
@@ -1640,6 +1644,20 @@ public final class Flags {
     @UnstableApi
     public static long defaultHttp1ConnectionCloseDelayMillis() {
         return DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS;
+    }
+
+    /**
+     * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
+     * will start to be scheduled.
+     *
+     * <p>The default value of this flag is RESPONSE_READ. Specify the
+     * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
+     * override the default value.
+     * @see ResponseTimeoutMode
+     */
+    @UnstableApi
+    public static ResponseTimeoutMode responseTimeoutMode() {
+        return RESPONSE_TIMEOUT_MODE;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1650,9 +1650,10 @@ public final class Flags {
      * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
      * will start to be scheduled.
      *
-     * <p>The default value of this flag is REQUEST_SENT. Specify the
+     * <p>The default value of this flag is {@link ResponseTimeoutMode#REQUEST_SENT}. Specify the
      * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
      * override the default value.
+     *
      * @see ResponseTimeoutMode
      */
     @UnstableApi

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1650,7 +1650,7 @@ public final class Flags {
      * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
      * will start to be scheduled.
      *
-     * <p>The default value of this flag is RESPONSE_READ. Specify the
+     * <p>The default value of this flag is REQUEST_SENT. Specify the
      * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
      * override the default value.
      * @see ResponseTimeoutMode

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1238,9 +1238,10 @@ public interface FlagsProvider {
      * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
      * will start to be scheduled.
      *
-     * <p>The default value of this flag is REQUEST_SENT. Specify the
+     * <p>The default value of this flag is {@link ResponseTimeoutMode#REQUEST_SENT}. Specify the
      * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
      * override the default value.
+     *
      * @see ResponseTimeoutMode
      */
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1238,7 +1238,7 @@ public interface FlagsProvider {
      * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
      * will start to be scheduled.
      *
-     * <p>The default value of this flag is RESPONSE_READ. Specify the
+     * <p>The default value of this flag is REQUEST_SENT. Specify the
      * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
      * override the default value.
      * @see ResponseTimeoutMode

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -34,6 +34,7 @@ import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.client.DnsResolverGroupBuilder;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
@@ -1230,6 +1231,21 @@ public interface FlagsProvider {
     @Nullable
     @UnstableApi
     default Long defaultHttp1ConnectionCloseDelayMillis() {
+        return null;
+    }
+
+    /**
+     * Returns the {@link ResponseTimeoutMode} which determines when a response timeout
+     * will start to be scheduled.
+     *
+     * <p>The default value of this flag is RESPONSE_READ. Specify the
+     * {@code -Dcom.linecorp.armeria.responseTimeoutMode=ResponseTimeoutMode} JVM option to
+     * override the default value.
+     * @see ResponseTimeoutMode
+     */
+    @Nullable
+    @UnstableApi
+    default ResponseTimeoutMode responseTimeoutMode() {
         return null;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -36,6 +36,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.InetAddressPredicates;
 import com.linecorp.armeria.common.util.Sampler;
@@ -596,6 +597,12 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     @Override
     public Long defaultUnloggedExceptionsReportIntervalMillis() {
         return getLong("defaultUnloggedExceptionsReportIntervalMillis");
+    }
+
+    @Override
+    @Nullable
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return getAndParse("responseTimeoutMode", ResponseTimeoutMode::valueOf);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -428,7 +428,8 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private static void completeSatisfiedFutures(RequestLogFuture[] satisfiedFutures, RequestLog log,
                                                  RequestContext ctx) {
         if (!ctx.eventLoop().inEventLoop()) {
-            ctx.eventLoop().execute(() -> completeSatisfiedFutures(satisfiedFutures, log, ctx));
+            ctx.eventLoop().withoutContext().execute(
+                    () -> completeSatisfiedFutures(satisfiedFutures, log, ctx));
             return;
         }
         for (RequestLogFuture f : satisfiedFutures) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -428,8 +428,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     private static void completeSatisfiedFutures(RequestLogFuture[] satisfiedFutures, RequestLog log,
                                                  RequestContext ctx) {
         if (!ctx.eventLoop().inEventLoop()) {
-            ctx.eventLoop().withoutContext().execute(
-                    () -> completeSatisfiedFutures(satisfiedFutures, log, ctx));
+            ctx.eventLoop().execute(() -> completeSatisfiedFutures(satisfiedFutures, log, ctx));
             return;
         }
         for (RequestLogFuture f : satisfiedFutures) {

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -570,7 +570,7 @@ public final class DefaultClientRequestContext
                 log.endResponse(cause);
             }
         };
-        if (options.responseTimeoutMode() == ResponseTimeoutMode.REQUEST_START) {
+        if (options.responseTimeoutMode() == ResponseTimeoutMode.FROM_START) {
             responseCancellationScheduler.initAndStart(eventLoop().withoutContext(), cancellationTask);
         } else {
             responseCancellationScheduler.init(eventLoop().withoutContext());

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -285,15 +285,6 @@ public final class DefaultClientRequestContext
         responseTimeoutMode = responseTimeoutMode(options, requestOptions);
     }
 
-    private static ResponseTimeoutMode responseTimeoutMode(ClientOptions options,
-                                                           RequestOptions requestOptions) {
-        final ResponseTimeoutMode requestOptionTimeoutMode = requestOptions.responseTimeoutMode();
-        if (requestOptionTimeoutMode != null) {
-            return requestOptionTimeoutMode;
-        }
-        return options.responseTimeoutMode();
-    }
-
     private static ExchangeType guessExchangeType(RequestOptions requestOptions, @Nullable HttpRequest req) {
         final ExchangeType exchangeType = requestOptions.exchangeType();
         if (exchangeType != null) {
@@ -1075,5 +1066,14 @@ public final class DefaultClientRequestContext
     @Override
     public ResponseTimeoutMode responseTimeoutMode() {
         return responseTimeoutMode;
+    }
+
+    private static ResponseTimeoutMode responseTimeoutMode(ClientOptions options,
+                                                           RequestOptions requestOptions) {
+        final ResponseTimeoutMode requestOptionTimeoutMode = requestOptions.responseTimeoutMode();
+        if (requestOptionTimeoutMode != null) {
+            return requestOptionTimeoutMode;
+        }
+        return options.responseTimeoutMode();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -40,6 +40,7 @@ import com.linecorp.armeria.client.ClientOptions;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.AttributesGetters;
@@ -569,8 +570,12 @@ public final class DefaultClientRequestContext
                 log.endResponse(cause);
             }
         };
-        responseCancellationScheduler.init(eventLoop().withoutContext());
-        responseCancellationScheduler.updateTask(cancellationTask);
+        if (options.responseTimeoutMode() == ResponseTimeoutMode.REQUEST_START) {
+            responseCancellationScheduler.initAndStart(eventLoop().withoutContext(), cancellationTask);
+        } else {
+            responseCancellationScheduler.init(eventLoop().withoutContext());
+            responseCancellationScheduler.updateTask(cancellationTask);
+        }
     }
 
     @Nullable
@@ -1052,5 +1057,10 @@ public final class DefaultClientRequestContext
             }
         });
         return completableFuture;
+    }
+
+    @Override
+    public ResponseTimeoutMode responseTimeoutMode() {
+        return options.responseTimeoutMode();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ContextCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ContextCancellationTest.java
@@ -113,6 +113,8 @@ class ContextCancellationTest {
                     .hasRootCause(t);
             assertThat(connListener.opened()).isEqualTo(0);
             assertThat(requests).doesNotContain(testInfo.getDisplayName());
+            // don't validate the thread since we haven't started with event loop scheduling yet
+            validateCallbackChecks(null);
         }
     }
 
@@ -149,6 +151,8 @@ class ContextCancellationTest {
                     .hasCauseInstanceOf(UnprocessedRequestException.class)
                     .hasRootCause(t);
             assertThat(requests).doesNotContain(testInfo.getDisplayName());
+            // don't validate the thread since we haven't started with event loop scheduling yet
+            validateCallbackChecks(null);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/ContextCancellationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ContextCancellationTest.java
@@ -113,8 +113,6 @@ class ContextCancellationTest {
                     .hasRootCause(t);
             assertThat(connListener.opened()).isEqualTo(0);
             assertThat(requests).doesNotContain(testInfo.getDisplayName());
-            // don't validate the thread since we haven't started with event loop scheduling yet
-            validateCallbackChecks(null);
         }
     }
 
@@ -151,8 +149,6 @@ class ContextCancellationTest {
                     .hasCauseInstanceOf(UnprocessedRequestException.class)
                     .hasRootCause(t);
             assertThat(requests).doesNotContain(testInfo.getDisplayName());
-            // don't validate the thread since we haven't started with event loop scheduling yet
-            validateCallbackChecks(null);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
@@ -48,7 +48,7 @@ class TimeoutModeTest {
     void timeoutMode_requestStart() {
         final HttpResponse res = server
                 .webClient(cb -> {
-                    cb.responseTimeoutMode(ResponseTimeoutMode.REQUEST_START);
+                    cb.responseTimeoutMode(ResponseTimeoutMode.FROM_START);
                     cb.responseTimeoutMillis(50);
                     cb.decorator((delegate, ctx, req) -> {
                         final CompletableFuture<HttpResponse> f = new CompletableFuture<>();

--- a/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
@@ -69,7 +69,7 @@ class TimeoutModeTest {
         final HttpRequestWriter streaming = HttpRequest.streaming(HttpMethod.POST, "/");
         final HttpResponse res = server
                 .webClient(cb -> {
-                    cb.responseTimeoutMode(ResponseTimeoutMode.REQUEST_WRITE);
+                    cb.responseTimeoutMode(ResponseTimeoutMode.CONNECTION_ACQUIRED);
                     cb.responseTimeout(Duration.ofMillis(50));
                 })
                 .execute(streaming);
@@ -82,7 +82,7 @@ class TimeoutModeTest {
     void timeoutMode_responseWrite() {
         final HttpResponse res = server
                 .webClient(cb -> {
-                    cb.responseTimeoutMode(ResponseTimeoutMode.RESPONSE_READ);
+                    cb.responseTimeoutMode(ResponseTimeoutMode.REQUEST_SENT);
                     cb.responseTimeout(Duration.ofMillis(50));
                 })
                 .get("/");

--- a/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TimeoutModeTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpRequestWriter;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class TimeoutModeTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.streaming());
+        }
+    };
+
+    @Test
+    void timeoutMode_requestStart() {
+        final HttpResponse res = server
+                .webClient(cb -> {
+                    cb.responseTimeoutMode(ResponseTimeoutMode.REQUEST_START);
+                    cb.responseTimeoutMillis(50);
+                    cb.decorator((delegate, ctx, req) -> {
+                        final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
+                        CommonPools.workerGroup().schedule(() -> f.complete(delegate.execute(ctx, req)),
+                                                           100, TimeUnit.MILLISECONDS);
+                        return HttpResponse.of(f);
+                    });
+                })
+                .get("/");
+        assertThatThrownBy(() -> res.aggregate().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseInstanceOf(ResponseTimeoutException.class);
+    }
+
+    @Test
+    void timeoutMode_requestWrite() {
+        final HttpRequestWriter streaming = HttpRequest.streaming(HttpMethod.POST, "/");
+        final HttpResponse res = server
+                .webClient(cb -> {
+                    cb.responseTimeoutMode(ResponseTimeoutMode.REQUEST_WRITE);
+                    cb.responseTimeout(Duration.ofMillis(50));
+                })
+                .execute(streaming);
+        assertThatThrownBy(() -> res.aggregate().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(ResponseTimeoutException.class);
+    }
+
+    @Test
+    void timeoutMode_responseWrite() {
+        final HttpResponse res = server
+                .webClient(cb -> {
+                    cb.responseTimeoutMode(ResponseTimeoutMode.RESPONSE_READ);
+                    cb.responseTimeout(Duration.ofMillis(50));
+                })
+                .get("/");
+        assertThatThrownBy(() -> res.aggregate().join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(ResponseTimeoutException.class);
+    }
+}

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.AbstractDynamicEndpointGroupBuilder;
@@ -430,6 +431,11 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder
     public EurekaEndpointGroupBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (EurekaEndpointGroupBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public EurekaEndpointGroupBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (EurekaEndpointGroupBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 
     @Override

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -41,6 +41,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -550,5 +551,10 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     public EurekaUpdatingListenerBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (EurekaUpdatingListenerBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public EurekaUpdatingListenerBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (EurekaUpdatingListenerBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
@@ -593,6 +594,11 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     public GrpcClientBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (GrpcClientBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public GrpcClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (GrpcClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 
     /**

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -43,6 +43,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
@@ -449,5 +450,10 @@ public final class ArmeriaRetrofitBuilder extends AbstractClientOptionsBuilder {
     public ArmeriaRetrofitBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (ArmeriaRetrofitBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public ArmeriaRetrofitBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (ArmeriaRetrofitBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 }

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
@@ -21,6 +21,7 @@ import com.linecorp.armeria.client.{
   RequestOptions,
   RequestPreparationSetters,
   ResponseAs,
+  ResponseTimeoutMode,
   RestClientPreparation
 }
 import com.linecorp.armeria.common.annotation.UnstableApi
@@ -260,6 +261,11 @@ final class ScalaRestClientPreparation private[scala] (delegate: RestClientPrepa
    */
   def cookies(cookies: immutable.Seq[Cookie]): ScalaRestClientPreparation = {
     delegate.cookies(cookies.asJava)
+    this
+  }
+
+  override def responseTimeoutMode(responseTimeoutMode: ResponseTimeoutMode): ScalaRestClientPreparation = {
+    delegate.responseTimeoutMode(responseTimeoutMode)
     this
   }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
@@ -372,5 +373,10 @@ public final class ThriftClientBuilder extends AbstractClientOptionsBuilder {
     public ThriftClientBuilder contextCustomizer(
             Consumer<? super ClientRequestContext> contextCustomizer) {
         return (ThriftClientBuilder) super.contextCustomizer(contextCustomizer);
+    }
+
+    @Override
+    public ThriftClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
+        return (ThriftClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
 }


### PR DESCRIPTION
Motivation:

The original motivation of this PR stems from https://github.com/line/armeria/issues/4591.
There has been requests for a timeout which spans over an entire client's lifecycle. Following #5800, this can be achieved easily by adjusting where to call `CancellationScheduler#start`.

I propose that we add an enum `ResponseTimeoutMode` which decides when a `CancellationScheduler` will start to be scheduled. By doing so, we can allow users to choose when a response timeout will start to be scheduled per client.

Modifications:

- Introduced a new `ResponseTimeoutMode` enum and added options in `AbstractClientOptionsBuilder` and `Flags` respectively
- Depending on the set `ResponseTimeoutMode`, the timeout is started on 1) context init 2) request start 3) or response read

Result:

- Closes https://github.com/line/armeria/issues/4591

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
