### PR TITLE
Fix `*ServiceBindingBuilder` to return the correct self type

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathAnnotatedServiceConfigSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathAnnotatedServiceConfigSetters.java
@@ -23,8 +23,7 @@ import java.util.Set;
 abstract class AbstractContextPathAnnotatedServiceConfigSetters
         <SELF extends AbstractContextPathAnnotatedServiceConfigSetters<SELF, T>,
                 T extends AbstractContextPathServicesBuilder<?, ?>>
-        extends AbstractAnnotatedServiceConfigSetters<
-        AbstractContextPathAnnotatedServiceConfigSetters<SELF, T>> {
+        extends AbstractAnnotatedServiceConfigSetters<SELF> {
 
     private final T builder;
     private final Set<String> contextPaths;
@@ -42,7 +41,7 @@ abstract class AbstractContextPathAnnotatedServiceConfigSetters
      *                If path prefix is not set then this service is registered to handle requests matching
      *                {@code /}
      */
-    T build(Object service) {
+    public T build(Object service) {
         requireNonNull(service, "service");
         service(service);
         contextPaths(contextPaths);

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathServiceBindingBuilder.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 abstract class AbstractContextPathServiceBindingBuilder
         <SELF extends AbstractContextPathServiceBindingBuilder<SELF, T>,
                 T extends AbstractContextPathServicesBuilder<?, ?>>
-        extends AbstractServiceBindingBuilder<AbstractContextPathServiceBindingBuilder<SELF, T>> {
+        extends AbstractServiceBindingBuilder<SELF> {
 
     private final T contextPathServicesBuilder;
 

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractServiceBindingBuilder.java
@@ -44,8 +44,7 @@ import io.netty.channel.EventLoopGroup;
  * @see VirtualHostServiceBindingBuilder
  */
 abstract class AbstractServiceBindingBuilder<SELF extends AbstractServiceBindingBuilder<SELF>>
-        extends AbstractBindingBuilder<SELF>
-        implements ServiceConfigSetters<AbstractServiceBindingBuilder<SELF>> {
+        extends AbstractBindingBuilder<SELF> implements ServiceConfigSetters<SELF> {
 
     private final DefaultServiceConfigSetters defaultServiceConfigSetters = new DefaultServiceConfigSetters();
 
@@ -260,15 +259,5 @@ abstract class AbstractServiceBindingBuilder<SELF extends AbstractServiceBinding
                 serviceConfigBuilder(serviceConfigBuilder);
             }
         }
-    }
-
-    final void build0(HttpService service, Route mappedRoute) {
-        final List<Route> routes = buildRouteList(ImmutableSet.of());
-        assert routes.size() == 1; // Only one route is set via addRoute().
-        final HttpService decoratedService = defaultServiceConfigSetters.decorator().apply(service);
-        final ServiceConfigBuilder serviceConfigBuilder =
-                defaultServiceConfigSetters.toServiceConfigBuilder(routes.get(0), "/", decoratedService);
-        serviceConfigBuilder.addMappedRoute(mappedRoute);
-        serviceConfigBuilder(serviceConfigBuilder);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/contextpath/test/ServiceBuilderSelfTypeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/contextpath/test/ServiceBuilderSelfTypeTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.contextpath.test;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.server.ContextPathAnnotatedServiceConfigSetters;
+import com.linecorp.armeria.server.ContextPathServiceBindingBuilder;
+import com.linecorp.armeria.server.ContextPathServicesBuilder;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceBindingBuilder;
+import com.linecorp.armeria.server.VirtualHostBuilder;
+import com.linecorp.armeria.server.VirtualHostContextPathAnnotatedServiceConfigSetters;
+import com.linecorp.armeria.server.VirtualHostContextPathServiceBindingBuilder;
+import com.linecorp.armeria.server.VirtualHostContextPathServicesBuilder;
+
+class ServiceBuilderSelfTypeTest {
+
+    // A non-existent package is used to check if the API is exposed publicly.
+
+    @Test
+    void contextPathAnnotatedServiceConfigSetters() {
+        final ContextPathAnnotatedServiceConfigSetters setters =
+                Server.builder()
+                      .contextPath("/foo")
+                      .annotatedService()
+                      .addHeader("X-foo", "bar");
+        final ContextPathServicesBuilder contextPathServicesBuilder = setters.build(new Object());
+        final ServerBuilder serverBuilder = contextPathServicesBuilder.and();
+    }
+
+    @Test
+    void virtualHostContextPathAnnotatedServiceConfigSetters() {
+        final VirtualHostContextPathAnnotatedServiceConfigSetters setters =
+                Server.builder()
+                      .virtualHost("foo.com")
+                      .contextPath("/foo")
+                      .annotatedService()
+                      .addHeader("X-foo", "bar");
+        final VirtualHostContextPathServicesBuilder contextPathServicesBuilder = setters.build(new Object());
+        final VirtualHostBuilder serverBuilder = contextPathServicesBuilder.and();
+    }
+
+    @Test
+    void serviceBindingBuilder() {
+        final ServiceBindingBuilder serviceBindingBuilder =
+                Server.builder()
+                      .route()
+                      .path("/");
+        final ServiceBindingBuilder serviceBindingBuilder1 = serviceBindingBuilder.decorator(
+                (delegate, ctx, req) -> null);
+        serviceBindingBuilder1.build((ctx, req) -> null);
+    }
+
+    @Test
+    void contextPathServiceBindingBuilder() {
+        final ContextPathServiceBindingBuilder builder =
+                Server.builder()
+                      .contextPath("/foo")
+                      .route()
+                      .path("/")
+                      .addHeader("X-foo", "bar");
+        builder.build((ctx, req) -> null);
+    }
+
+    @Test
+    void virtualHostContextPathServiceBindingBuilder() {
+        final VirtualHostContextPathServiceBindingBuilder builder =
+                Server.builder()
+                      .virtualHost("foo.com")
+                      .contextPath("/foo")
+                      .route()
+                      .path("/")
+                      .addHeader("X-foo", "bar");
+        builder.build((ctx, req) -> null);
+    }
+}


### PR DESCRIPTION
Motivation:

While refactoring Central Dogma, I found that some methods of service binding builders return internal classes or super types.

Modifications:

- Pass `SELF` type to super classes to return the class itself

Result:

Service binding builder methods now correctly return the self-types.

