### PR TITLE
`WeightRampingUpStrategy` uses locks to avoid occasional selection failure for `XdsEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -147,24 +147,20 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
 
     private void refreshEndpoints(List<Endpoint> endpoints) {
         // Allow subclasses to update the endpoints first.
-        updateNewEndpoints(endpoints).handle((ignored, e) -> {
-            lock.lock();
-            try {
-                pendingFutures.removeIf(ListeningFuture::tryComplete);
-            } finally {
-                lock.unlock();
-            }
-            return null;
-        });
+        updateNewEndpoints(endpoints);
+        lock.lock();
+        try {
+            pendingFutures.removeIf(ListeningFuture::tryComplete);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * Invoked when the {@link EndpointGroup} has been updated.
      */
     @UnstableApi
-    protected CompletableFuture<Void> updateNewEndpoints(List<Endpoint> endpoints) {
-        return UnmodifiableFuture.completedFuture(null);
-    }
+    protected void updateNewEndpoints(List<Endpoint> endpoints) {}
 
     private void addPendingFuture(ListeningFuture future) {
         lock.lock();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy.EndpointsRam
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 import com.linecorp.armeria.common.util.Ticker;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 
 import io.netty.util.concurrent.EventExecutor;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
@@ -134,6 +135,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         @VisibleForTesting
         final Map<Long, EndpointsRampingUpEntry> rampingUpWindowsMap = new HashMap<>();
         private Object2LongOpenHashMap<Endpoint> endpointCreatedTimestamps = new Object2LongOpenHashMap<>();
+        private final ReentrantShortLock lock = new ReentrantShortLock(true);
 
         RampingUpEndpointWeightSelector(EndpointGroup endpointGroup, EventExecutor executor) {
             super(endpointGroup);
@@ -145,9 +147,14 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         }
 
         @Override
-        protected CompletableFuture<Void> updateNewEndpoints(List<Endpoint> endpoints) {
-            // Use the executor so the order of endpoints change is guaranteed.
-            return CompletableFuture.runAsync(() -> updateEndpoints(endpoints), executor);
+        protected void updateNewEndpoints(List<Endpoint> endpoints) {
+            // Use a lock so the order of endpoints change is guaranteed.
+            lock.lock();
+            try {
+                updateEndpoints(endpoints);
+            } finally {
+                lock.unlock();
+            }
         }
 
         private long computeCreateTimestamp(Endpoint endpoint) {
@@ -245,14 +252,19 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         }
 
         private void updateWeightAndStep(long window) {
-            final EndpointsRampingUpEntry entry = rampingUpWindowsMap.get(window);
-            assert entry != null;
-            final Set<EndpointAndStep> endpointAndSteps = entry.endpointAndSteps();
-            updateWeightAndStep(endpointAndSteps);
-            if (endpointAndSteps.isEmpty()) {
-                rampingUpWindowsMap.remove(window).scheduledFuture.cancel(true);
+            lock.lock();
+            try {
+                final EndpointsRampingUpEntry entry = rampingUpWindowsMap.get(window);
+                assert entry != null;
+                final Set<EndpointAndStep> endpointAndSteps = entry.endpointAndSteps();
+                updateWeightAndStep(endpointAndSteps);
+                if (endpointAndSteps.isEmpty()) {
+                    rampingUpWindowsMap.remove(window).scheduledFuture.cancel(true);
+                }
+                buildEndpointSelector();
+            } finally {
+                lock.unlock();
             }
-            buildEndpointSelector();
         }
 
         private void updateWeightAndStep(Set<EndpointAndStep> endpointAndSteps) {
@@ -268,7 +280,12 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
         }
 
         private void close() {
-            rampingUpWindowsMap.values().forEach(e -> e.scheduledFuture.cancel(true));
+            lock.lock();
+            try {
+                rampingUpWindowsMap.values().forEach(e -> e.scheduledFuture.cancel(true));
+            } finally {
+                lock.unlock();
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
@@ -29,7 +28,6 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -64,12 +64,11 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
         }
 
         @Override
-        protected CompletableFuture<Void> updateNewEndpoints(List<Endpoint> endpoints) {
+        protected void updateNewEndpoints(List<Endpoint> endpoints) {
             final EndpointsAndWeights endpointsAndWeights = this.endpointsAndWeights;
             if (endpointsAndWeights == null || endpointsAndWeights.endpoints != endpoints) {
                 this.endpointsAndWeights = new EndpointsAndWeights(endpoints);
             }
-            return UnmodifiableFuture.completedFuture(null);
         }
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ReentrantShortLock.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ReentrantShortLock.java
@@ -28,6 +28,12 @@ import com.linecorp.armeria.common.CoreBlockHoundIntegration;
 public class ReentrantShortLock extends ReentrantLock {
     private static final long serialVersionUID = 8999619612996643502L;
 
+    public ReentrantShortLock() {}
+
+    public ReentrantShortLock(boolean fair) {
+        super(fair);
+    }
+
     @Override
     public void lock() {
         super.lock();


### PR DESCRIPTION
Motivation:

https://github.com/line/armeria/issues/5749

While re-investigating this issue, I found that the probably cause is the changes introduced by https://github.com/line/armeria/pull/5693

Previously, when `updateEndpoints` is called the `endpointSelector` was initialized from the same thread 

https://github.com/line/armeria/blob/da7f76a7eebf9b03a51ff68a9245269eee4a5a6d/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L147-L150

However after the PR above,  `updateEndpoints` doesn't update the `endpointSelector` immediately and instead schedules an update task

https://github.com/line/armeria/blob/191fb7db981d1d47de8ce50be0b0f6d5d9dfa8ee/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L150

For this reason, even if `updateEndpoints` is called the `endpointSelector` will remain as the `EMPTY_SELECTOR`.

https://github.com/line/armeria/blob/191fb7db981d1d47de8ce50be0b0f6d5d9dfa8ee/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java#L128

Normally, this isn't an issue since `refreshEndpoints` will be called after the call to `updateEndpoints` which will in turn complete the `select` call. However, `XdsEndpointGroup` is composed of multiple internal `EndpointGroup`s and only `selectNow` is called. Because the initialization event is never propagated to the `XdsEndpointSelector` occasional failures can occur.

https://github.com/line/armeria/blob/191fb7db981d1d47de8ce50be0b0f6d5d9dfa8ee/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultLoadBalancer.java#L61-L84

Modifications:

- Use locks instead of event loops for `updateEndpoints`

Result:

- Endpoint selection calls to `WeightRampingUpStrategy` succeeds before the first call to `updateEndpoints` for  `XdsEndpointGroup`.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
