### PR TITLE
Modify behavior of `Endpoint#withAttrs` to merge attributes

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -711,6 +711,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
      * {@link Attributes}. For attributes with the same {@link AttributeKey}, the attribute
      * in {@param newAttributes} has higher precedence.
      */
+    @UnstableApi
     @SuppressWarnings("unchecked")
     public Endpoint withAttrs(Attributes newAttributes) {
         requireNonNull(newAttributes, "newAttributes");

--- a/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/EndpointTest.java
@@ -745,8 +745,8 @@ class EndpointTest {
         attrs2.set(key1, "value1-2");
         attrs2.set(key3, "value3");
 
-        final Endpoint endpointB = endpoint.withAttrs(attrs.build());
-        final Endpoint endpointC = endpointB.withAttrs(attrs2.build());
+        final Endpoint endpointB = endpoint.replaceAttrs(attrs.build());
+        final Endpoint endpointC = endpointB.replaceAttrs(attrs2.build());
 
         assertThat(endpointB.attr(key1))
                 .isEqualTo("value1");
@@ -767,10 +767,40 @@ class EndpointTest {
                                            Maps.immutableEntry(key3, "value3"));
 
         // Reset attrs with an empty attributes.
-        final Endpoint newEndpointB = endpointB.withAttrs(Attributes.of());
+        final Endpoint newEndpointB = endpointB.replaceAttrs(Attributes.of());
         assertThat(newEndpointB.attrs().isEmpty()).isTrue();
 
-        final Endpoint sameEndpoint = endpoint.withAttrs(Attributes.of());
+        final Endpoint sameEndpoint = endpoint.replaceAttrs(Attributes.of());
         assertThat(sameEndpoint).isSameAs(endpoint);
+    }
+
+    @Test
+    void withAttrs() {
+        final AttributeKey<String> key1 = AttributeKey.valueOf("key1");
+        final AttributeKey<String> key2 = AttributeKey.valueOf("key2");
+
+        final Endpoint endpoint = Endpoint.parse("a").withAttrs(Attributes.of(key1, "val1"));
+        assertThat(endpoint.attrs().attrs())
+                .toIterable()
+                .containsExactlyInAnyOrder(Maps.immutableEntry(key1, "val1"));
+
+        assertThat(endpoint.withAttrs(Attributes.of(key2, "val2")).attrs().attrs())
+                .toIterable()
+                .containsExactlyInAnyOrder(Maps.immutableEntry(key1, "val1"),
+                                           Maps.immutableEntry(key2, "val2"));
+
+        assertThat(endpoint.withAttrs(Attributes.of(key1, "val1")).attrs().attrs())
+                .toIterable()
+                .containsExactlyInAnyOrder(Maps.immutableEntry(key1, "val1"));
+
+        assertThat(endpoint.withAttrs(Attributes.of(key1, "val2")).attrs().attrs())
+                .toIterable()
+                .containsExactlyInAnyOrder(Maps.immutableEntry(key1, "val2"));
+
+        assertThat(endpoint.withAttrs(Attributes.of()).attrs().attrs())
+                .toIterable()
+                .containsExactlyInAnyOrder(Maps.immutableEntry(key1, "val1"));
+
+        assertThat(endpoint.withAttrs(Attributes.of())).isSameAs(endpoint);
     }
 }


### PR DESCRIPTION
Motivation:

It seems inconsistent that `Endpoint#withAttr` merges the attribute to the existing attributes, whereas `Endpoint#withAttrs` simply replaces the previous attributes.
I propose that we modify the behavior of `Endpoint#withAttrs` to be aligned with `Endpoint#withAttr`. Additionally, in order to support the previous behavior, I propose a new API `Endpoint#replaceAttrs` be added.

I've confirmed that there are no uses of this API at least internally.

ref: https://github.com/line/armeria/pull/5785#discussion_r1654225883

Modifications:

- Modified the behavior of `Endpoint#withAttrs` to merge attributes
- Added a new API `Endpoint#replaceAttrs` to support the previous behavior

Result:

- More consistent APIs
- Preparation for https://github.com/line/armeria/pull/5785

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
