### PR TITLE
Change conflicting meter names  in `ServerMetrics`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
@@ -157,18 +157,22 @@ public final class ServerMetrics implements MeterBinder {
     public void bindTo(MeterRegistry meterRegistry) {
         meterRegistry.gauge("armeria.server.connections", activeConnections);
         // pending requests
-        meterRegistry.gauge("armeria.server.pending.requests",
-                            ImmutableList.of(Tag.of("protocol", "http1")), pendingHttp1Requests);
-        meterRegistry.gauge("armeria.server.pending.requests",
-                            ImmutableList.of(Tag.of("protocol", "http2")), pendingHttp2Requests);
+        final String allRequestsMeterName = "armeria.server.all.requests";
+        meterRegistry.gauge(allRequestsMeterName,
+                            ImmutableList.of(Tag.of("protocol", "http1"), Tag.of("state", "pending")),
+                            pendingHttp1Requests);
+        meterRegistry.gauge(allRequestsMeterName,
+                            ImmutableList.of(Tag.of("protocol", "http2"), Tag.of("state", "pending")),
+                            pendingHttp2Requests);
         // Active requests
-        final String activeRequestMeterName = "armeria.server.active.requests.all";
-        meterRegistry.gauge(activeRequestMeterName, ImmutableList.of(Tag.of("protocol", "http1")),
+        meterRegistry.gauge(allRequestsMeterName,
+                            ImmutableList.of(Tag.of("protocol", "http1"), Tag.of("state", "active")),
                             activeHttp1Requests);
-        meterRegistry.gauge(activeRequestMeterName, ImmutableList.of(Tag.of("protocol", "http2")),
+        meterRegistry.gauge(allRequestsMeterName,
+                            ImmutableList.of(Tag.of("protocol", "http2"), Tag.of("state", "active")),
                             activeHttp2Requests);
-        meterRegistry.gauge(activeRequestMeterName,
-                            ImmutableList.of(Tag.of("protocol", "http1.websocket")),
+        meterRegistry.gauge(allRequestsMeterName,
+                            ImmutableList.of(Tag.of("protocol", "http1.websocket"), Tag.of("state", "active")),
                             activeHttp1WebSocketRequests);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
@@ -162,11 +162,12 @@ public final class ServerMetrics implements MeterBinder {
         meterRegistry.gauge("armeria.server.pending.requests",
                             ImmutableList.of(Tag.of("protocol", "http2")), pendingHttp2Requests);
         // Active requests
-        meterRegistry.gauge("armeria.server.active.requests", ImmutableList.of(Tag.of("protocol", "http1")),
+        final String activeRequestMeterName = "armeria.server.active.requests.all";
+        meterRegistry.gauge(activeRequestMeterName, ImmutableList.of(Tag.of("protocol", "http1")),
                             activeHttp1Requests);
-        meterRegistry.gauge("armeria.server.active.requests", ImmutableList.of(Tag.of("protocol", "http2")),
+        meterRegistry.gauge(activeRequestMeterName, ImmutableList.of(Tag.of("protocol", "http2")),
                             activeHttp2Requests);
-        meterRegistry.gauge("armeria.server.active.requests",
+        meterRegistry.gauge(activeRequestMeterName,
                             ImmutableList.of(Tag.of("protocol", "http1.websocket")),
                             activeHttp1WebSocketRequests);
     }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMetricsTest.java
@@ -296,8 +296,10 @@ class ServerMetricsTest {
 
             final String protocolName = protocol == SessionProtocol.H1C ? "http1" : "http2";
             // armeria.server.active.requests.all#value is measured by ServerMetrics
-            assertThat(meters).containsKey("armeria.server.active.requests.all#value{protocol=" + protocolName +
-                                           '}');
+            assertThat(meters).containsKey("armeria.server.all.requests#value{protocol=" + protocolName +
+                                           ",state=active}");
+            assertThat(meters).containsKey("armeria.server.all.requests#value{protocol=" + protocolName +
+                                           ",state=pending}");
         });
     }
 }


### PR DESCRIPTION
Motivation:

`MetricCollectingService` uses `.active.requests` to track the number of the current requests. If `armeria.server` is used as the prefix of the meter name, the name conflicts with "armeria.server.active.requests" in `ServerMetrics`.

`ServerMetrics.activeRequests()` counts all requests including `TransientService` which is excluded by `MetricCollectingService` with no `TransientServiceOption`. So, semantically, it would be better to use `.all` to the meter name to indicate that it counts all requests.

Modifications:

- Rename "armeria.server.active.requests" in `ServerMetrics` to "armeria.server.all.requests{state=active}".
- Rename "armeria.server.pending.requests" in `ServerMetrics` to "armeria.server.all.requests{state=pending}".

Result:

The meter names in `ServerMetrics` no longer conflict with `MetricCollectingService`.

