### PR TITLE
Refactor `HaProxy` exception handling

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -54,7 +54,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2Error;
-import io.netty.handler.proxy.ProxyConnectException;
 
 abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
 
@@ -377,8 +376,7 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
             session.markUnacquirable();
         }
 
-        if (cause instanceof ProxyConnectException || cause instanceof ResponseCompleteException) {
-            // - ProxyConnectException is handled by HttpSessionHandler.exceptionCaught().
+        if (cause instanceof ResponseCompleteException) {
             // - ResponseCompleteException means the response is successfully received.
             state = State.DONE;
             cancel();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -426,8 +426,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
             return;
         }
 
-        if (evt instanceof SessionProtocolNegotiationException ||
-            evt instanceof ProxyConnectException) {
+        if (evt instanceof SessionProtocolNegotiationException) {
             tryFailSessionPromise((Throwable) evt);
             ctx.close();
             return;


### PR DESCRIPTION
Motivation:

While working on https://github.com/line/armeria/pull/5793, I found that there were unnecessary `ProxyConnectException` related handling in the request handler. This is most likely due to the fact that `HaProxyHandler` works differently from the other proxy handlers in that the session is completed, and then a connection event is published.

This was probably when I was less familiar with netty. I propose that the `HaProxyHandler` complete the session similarly to the other handlers. A connection attempt is made first, and then the `sessionPromise` is succeeded or failed accordingly.

Modifications:

- `HaProxyHandler` doesn't succeed the `sessionPromise` immediately, but waits for the result of the `connect` future.
- Remove `ProxyConnectException` related logic in all places except for `HttpSessionHandler#exceptionCaught`

Result:

- The exception handling in `AbstractHttpRequestHandler` and `HttpSessionHandler` is a little simpler.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
