### PR TITLE
Fix flaky `ServerMetrics` tests

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServerMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMetricsTest.java
@@ -206,7 +206,7 @@ class ServerMetricsTest {
 
             assertThat(result.status()).isSameAs(HttpStatus.OK);
             assertThat(serverMetrics.pendingRequests()).isZero();
-            assertThat(serverMetrics.activeRequests()).isZero();
+            await().untilAsserted(() -> assertThat(serverMetrics.activeRequests()).isZero());
             await().until(() -> serverMetrics.activeConnections() == 0);
         }
     }
@@ -273,7 +273,7 @@ class ServerMetricsTest {
 
             assertThat(result.status()).isSameAs(HttpStatus.SERVICE_UNAVAILABLE);
             assertThat(serverMetrics.pendingRequests()).isZero();
-            assertThat(serverMetrics.activeRequests()).isZero();
+            await().untilAsserted(() -> assertThat(serverMetrics.activeRequests()).isZero());
             await().until(() -> serverMetrics.activeConnections() == 0);
         }
     }


### PR DESCRIPTION
Motivation:

- https://ge.armeria.dev/s/4nbxggtjahu5w/tests/task/:core:shadedTest/details/com.linecorp.armeria.server.ServerMetricsTest/checkWhenOk(SessionProtocol%2C%20long%2C%20long)%5B1%5D?top-execution=1
- https://ge.armeria.dev/s/ymlrbcecdkwz4/tests/task/:core:shadedTest/details/com.linecorp.armeria.server.ServerMetricsTest/checkWhenRequestTimeout(SessionProtocol%2C%20long%2C%20long)%5B1%5D?top-execution=1

The above flaky tests are failing relatively often: https://ge.armeria.dev/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.server.ServerMetricsTest#

Cancelling the request doesn't guarantee that the server-side request is closed immediately.

Modifications:

- Added an `await` condition which waits until the active request in server-side has indeed been closed

Result:

- Less flaky tests regarding `ServerMetrics`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
