### PR TITLE
Handle a null ExecutionResult in `GraphqlService`

### DIFF
--- a/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandler.java
+++ b/graphql/src/main/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandler.java
@@ -46,7 +46,8 @@ public interface GraphqlErrorHandler {
      */
     @Nullable
     HttpResponse handle(
-            ServiceRequestContext ctx, ExecutionInput input, ExecutionResult result, @Nullable Throwable cause);
+            ServiceRequestContext ctx, ExecutionInput input, @Nullable ExecutionResult result,
+            @Nullable Throwable cause);
 
     /**
      * Returns a composed {@link GraphqlErrorHandler} that applies this first and the specified

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandlerTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandlerTest.java
@@ -116,7 +116,6 @@ class GraphqlErrorHandlerTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
 
-            sb.requestTimeoutMillis(0);
             final GraphqlService service =
                     GraphqlService.builder()
                                   .graphql(newGraphQL())
@@ -131,7 +130,6 @@ class GraphqlErrorHandlerTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
 
-            sb.requestTimeoutMillis(0);
             final GraphqlService service =
                     GraphqlService.builder()
                                   .graphql(newGraphQL())
@@ -154,8 +152,7 @@ class GraphqlErrorHandlerTest {
                                                .content(MediaType.GRAPHQL, "{foo}")
                                                .build();
         final ServerExtension server = blocking ? blockingServer : GraphqlErrorHandlerTest.server;
-        final AggregatedHttpResponse response = server.blockingWebClient(cb -> cb.responseTimeoutMillis(0))
-                                                      .execute(request);
+        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 

--- a/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandlerTest.java
+++ b/graphql/src/test/java/com/linecorp/armeria/server/graphql/GraphqlErrorHandlerTest.java
@@ -20,83 +20,166 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+import graphql.GraphQL;
 import graphql.GraphQLError;
 import graphql.GraphqlErrorException;
+import graphql.execution.instrumentation.Instrumentation;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.parameters.InstrumentationCreateStateParameters;
 import graphql.schema.DataFetcher;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
 
 class GraphqlErrorHandlerTest {
 
-    @RegisterExtension
-    static ServerExtension server = new ServerExtension() {
-        @Override
-        protected void configure(ServerBuilder sb) throws Exception {
-            final File graphqlSchemaFile =
-                    new File(getClass().getResource("/testing/graphql/test.graphqls").toURI());
+    private static final AtomicBoolean shouldFailRequests = new AtomicBoolean();
 
-            final GraphqlErrorHandler errorHandler
-                    = (ctx, input, result, cause) -> {
-                final List<GraphQLError> errors = result.getErrors();
-                if (errors.stream().map(GraphQLError::getMessage).anyMatch(m -> m.endsWith("foo"))) {
-                    return HttpResponse.of(HttpStatus.BAD_REQUEST);
+    private static GraphQL newGraphQL() throws Exception {
+        final File graphqlSchemaFile =
+                new File(GraphqlErrorHandlerTest.class.getResource("/testing/graphql/test.graphqls").toURI());
+        final SchemaParser schemaParser = new SchemaParser();
+        final SchemaGenerator schemaGenerator = new SchemaGenerator();
+        final TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry();
+        typeRegistry.merge(schemaParser.parse(graphqlSchemaFile));
+        final RuntimeWiring.Builder runtimeWiringBuilder = RuntimeWiring.newRuntimeWiring();
+        final DataFetcher<String> foo = dataFetcher("foo");
+        runtimeWiringBuilder.type("Query",
+                                  typeWiring -> typeWiring.dataFetcher("foo", foo));
+        final DataFetcher<String> error = dataFetcher("error");
+        runtimeWiringBuilder.type("Query",
+                                  typeWiring -> typeWiring.dataFetcher("error", error));
+
+        final GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry,
+                                                                                 runtimeWiringBuilder.build());
+        final Instrumentation instrumentation = new Instrumentation() {
+            @Override
+            public InstrumentationState createState(
+                    InstrumentationCreateStateParameters parameters) {
+                if (shouldFailRequests.get()) {
+                    throw new AnticipatedException("external exception");
+                } else {
+                    return Instrumentation.super.createState(parameters);
                 }
-                return null;
-            };
+            }
+        };
 
-            final GraphqlService service =
-                    GraphqlService.builder()
-                                  .schemaFile(graphqlSchemaFile)
-                                  .runtimeWiring(c -> {
-                                      final DataFetcher<String> foo = dataFetcher("foo");
-                                      c.type("Query",
-                                             typeWiring -> typeWiring.dataFetcher("foo", foo));
-                                      final DataFetcher<String> error = dataFetcher("error");
-                                      c.type("Query",
-                                             typeWiring -> typeWiring.dataFetcher("error", error));
-                                  })
-                                  .errorHandler(errorHandler)
-                                  .build();
-            sb.service("/graphql", service);
+        return new GraphQL.Builder(graphQLSchema)
+                .instrumentation(instrumentation)
+                .build();
+    }
+
+    private static final GraphqlErrorHandler errorHandler
+            = (ctx, input, result, cause) -> {
+        if (result == null) {
+            assertThat(cause).isNotNull();
+            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT,
+                                   cause.getMessage());
         }
+        final List<GraphQLError> errors = result.getErrors();
+        if (errors.stream().map(GraphQLError::getMessage).anyMatch(m -> m.endsWith("foo"))) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST);
+        }
+        return null;
     };
 
     private static DataFetcher<String> dataFetcher(String value) {
         return environment -> {
             final ServiceRequestContext ctx = GraphqlServiceContexts.get(environment);
-            assertThat(ctx.eventLoop().inEventLoop()).isTrue();
             // Make sure that a ServiceRequestContext is available
             assertThat(ServiceRequestContext.current()).isSameAs(ctx);
             throw GraphqlErrorException.newErrorException().message(value).build();
         };
     }
 
-    @Test
-    void handledError() {
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+
+            sb.requestTimeoutMillis(0);
+            final GraphqlService service =
+                    GraphqlService.builder()
+                                  .graphql(newGraphQL())
+                                  .errorHandler(errorHandler)
+                                  .build();
+            sb.service("/graphql", service);
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension blockingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+
+            sb.requestTimeoutMillis(0);
+            final GraphqlService service =
+                    GraphqlService.builder()
+                                  .graphql(newGraphQL())
+                                  .useBlockingTaskExecutor(true)
+                                  .errorHandler(errorHandler)
+                                  .build();
+            sb.service("/graphql", service);
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        shouldFailRequests.set(false);
+    }
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void handledError(boolean blocking) {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL, "{foo}")
                                                .build();
-        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
+        final ServerExtension server = blocking ? blockingServer : GraphqlErrorHandlerTest.server;
+        final AggregatedHttpResponse response = server.blockingWebClient(cb -> cb.responseTimeoutMillis(0))
+                                                      .execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
-    @Test
-    void unhandledError() {
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void unhandledGraphqlError(boolean blocking) {
         final HttpRequest request = HttpRequest.builder().post("/graphql")
                                                .content(MediaType.GRAPHQL, "{error}")
                                                .build();
+        final ServerExtension server = blocking ? blockingServer : GraphqlErrorHandlerTest.server;
         final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void unhandledException(boolean blocking) {
+        shouldFailRequests.set(true);
+        final HttpRequest request = HttpRequest.builder().post("/graphql")
+                                               .content(MediaType.GRAPHQL, "{error}")
+                                               .build();
+        final ServerExtension server = blocking ? blockingServer : GraphqlErrorHandlerTest.server;
+        final AggregatedHttpResponse response = server.blockingWebClient().execute(request);
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.contentUtf8()).isEqualTo("external exception");
     }
 }

--- a/graphql/src/test/resources/testing/graphql/test.graphqls
+++ b/graphql/src/test/resources/testing/graphql/test.graphqls
@@ -1,7 +1,6 @@
 type Query {
     foo: String
     error: String
-    exception: String
     optionalInput(value: ComplexTypeInput): String
 }
 

--- a/graphql/src/test/resources/testing/graphql/test.graphqls
+++ b/graphql/src/test/resources/testing/graphql/test.graphqls
@@ -1,6 +1,7 @@
 type Query {
     foo: String
     error: String
+    exception: String
     optionalInput(value: ComplexTypeInput): String
 }
 


### PR DESCRIPTION
Motivation:

If `GraphQL.execute(input)` returns a `CompletableFuture` completing exceptionally, `NullPointException` is raised while handling `ExecutionResult`.
```java
java.lang.NullPointerException: Cannot invoke "graphql.ExecutionResult.getData()" because "executionResult" is null
	at com.linecorp.armeria.server.graphql.DefaultGraphqlService.lambda$execute$1(DefaultGraphqlService.java:117)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
```

Modifications:

- Check if `cause != null` before accessing `executionResult` in the callback of `executeGraphql(ctx, input)`.

Result:

- `NullPointerException` is no longer raised when `GraphqlService` handles errors.
- Closes #5815
