### PR TITLE
Enable NullAway for `:core`

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/armeria/server/RoutersBenchmark.java
@@ -78,7 +78,7 @@ public class RoutersBenchmark {
         final Path multipartUploadsLocation = Flags.defaultMultipartUploadsLocation();
         final ServiceErrorHandler serviceErrorHandler = ServerErrorHandler.ofDefault().asServiceErrorHandler();
         return new ServiceConfig(route, route,
-                                 SERVICE, defaultLogName, defaultServiceName, defaultServiceNaming, 0, 0,
+                                 SERVICE, defaultServiceName, defaultServiceNaming, defaultLogName, 0, 0,
                                  false, AccessLogWriter.disabled(), CommonPools.blockingTaskExecutor(),
                                  SuccessFunction.always(), 0, multipartUploadsLocation,
                                  MultipartRemovalStrategy.ON_RESPONSE_COMPLETION,

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ plugins {
     alias libs.plugins.kotlin apply false
     alias libs.plugins.ktlint apply false
     alias libs.plugins.errorprone apply false
+    alias libs.plugins.nullaway apply false
 }
 
 allprojects {
@@ -171,13 +172,34 @@ configure(projectsWithFlags('java')) {
     // Error Prone compiler
     if (!rootProject.hasProperty('noLint')) {
         apply plugin: 'net.ltgt.errorprone'
+        apply plugin: 'net.ltgt.nullaway'
 
         dependencies {
             errorprone libs.errorprone.core
+            errorprone libs.nullaway
+        }
+
+        nullaway {
+            annotatedPackages.add("com.linecorp.armeria")
         }
 
         tasks.withType(JavaCompile) {
             options.errorprone.excludedPaths = '.*/gen-src/.*'
+            options.errorprone.nullaway {
+                if (name.toLowerCase().contains("test")) {
+                    // Disable NullAway for tests for now.
+                    disable()
+                } else if (name.matches(/compileJava[0-9]+.*/)) {
+                    // Disable MR-JAR classes which seem to confuse NullAway and break the build.
+                    disable()
+                } else if (project != project(':core')) {
+                    // TODO(trustin): Enable NullAway for all projects once we fix all violations.
+                    warn()
+                } else {
+                    error()
+                    assertsEnabled = true
+                }
+            }
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -216,6 +216,7 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
      * {@link Channel#flush()} when each write unit is done.
      */
     final void writeHeaders(RequestHeaders headers, boolean needs100Continue) {
+        assert session != null;
         final SessionProtocol protocol = session.protocol();
         assert protocol != null;
         if (needs100Continue) {

--- a/core/src/main/java/com/linecorp/armeria/client/Client.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Client.java
@@ -24,6 +24,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
@@ -71,6 +72,7 @@ public interface Client<I extends Request, O extends Response> extends Unwrappab
      * @see ClientFactory#unwrap(Object, Class)
      * @see Unwrappable
      */
+    @Nullable
     @Override
     default <T> T as(Class<T> type) {
         requireNonNull(type, "type");

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -52,26 +52,31 @@ public class ClientRequestContextWrapper
         return unwrap().newDerivedContext(id, req, rpcReq, endpoint);
     }
 
+    @Nullable
     @Override
     public EndpointGroup endpointGroup() {
         return unwrap().endpointGroup();
     }
 
+    @Nullable
     @Override
     public Endpoint endpoint() {
         return unwrap().endpoint();
     }
 
+    @Nullable
     @Override
     public String fragment() {
         return unwrap().fragment();
     }
 
+    @Nullable
     @Override
     public String authority() {
         return unwrap().authority();
     }
 
+    @Nullable
     @Override
     public String host() {
         return unwrap().host();

--- a/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DecoratingClientFactory.java
@@ -108,11 +108,13 @@ public class DecoratingClientFactory extends AbstractUnwrappable<ClientFactory> 
         return unwrap().newClient(params);
     }
 
+    @Nullable
     @Override
     public <T> ClientBuilderParams clientBuilderParams(T client) {
         return unwrap().clientBuilderParams(client);
     }
 
+    @Nullable
     @Override
     public <T> T unwrap(Object client, Class<T> type) {
         return unwrap().unwrap(client, type);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -184,6 +184,7 @@ final class DefaultClientFactory implements ClientFactory {
                 "No ClientFactory for scheme: " + scheme + " matched clientType: " + clientType);
     }
 
+    @Nullable
     @Override
     public <T> T unwrap(Object client, Class<T> type) {
         final T params = ClientFactory.super.unwrap(client, type);

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
@@ -147,6 +147,7 @@ final class DefaultDnsCache implements DnsCache {
         }
     }
 
+    @Nullable
     @Override
     public List<DnsRecord> get(DnsQuestion question) throws UnknownHostException {
         requireNonNull(question, "question");

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultRequestOptions.java
@@ -68,6 +68,7 @@ final class DefaultRequestOptions implements RequestOptions {
         return maxResponseLength;
     }
 
+    @Nullable
     @Override
     public Long requestAutoAbortDelayMillis() {
         return requestAutoAbortDelayMillis;
@@ -78,6 +79,7 @@ final class DefaultRequestOptions implements RequestOptions {
         return attributeMap;
     }
 
+    @Nullable
     @Override
     public ExchangeType exchangeType() {
         return exchangeType;

--- a/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Endpoint.java
@@ -37,6 +37,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
@@ -323,6 +325,7 @@ public final class Endpoint implements Comparable<Endpoint>, EndpointGroup {
         return EndpointSelectionStrategy.weightedRoundRobin();
     }
 
+    @Nonnull
     @Override
     public Endpoint selectNow(ClientRequestContext ctx) {
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -88,6 +88,7 @@ public final class FutureTransformingRequestPreparation<T>
 
         return response.exceptionally(cause -> {
             cause = Exceptions.peel(cause);
+            assert errorHandler != null;
             final Object maybeRecovered = errorHandler.apply(cause);
             if (maybeRecovered instanceof Throwable) {
                 // The cause was translated.

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -110,9 +110,12 @@ final class HttpChannelPool implements AsyncCloseable {
                                           SessionProtocol.H2, SessionProtocol.H2C));
         pendingAcquisitions = newEnumMap(httpAndHttpsValues());
         allChannels = new IdentityHashMap<>();
-        connectTimeoutMillis = (Integer) clientFactory.options()
-                .channelOptions()
-                .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+        final Integer connectTimeoutMillisBoxed =
+                (Integer) clientFactory.options()
+                                       .channelOptions()
+                                       .get(ChannelOption.CONNECT_TIMEOUT_MILLIS);
+        assert connectTimeoutMillisBoxed != null;
+        connectTimeoutMillis = connectTimeoutMillisBoxed;
         bootstraps = new Bootstraps(clientFactory, eventLoop, sslCtxHttp1Or2, sslCtxHttp1Only);
     }
 
@@ -828,6 +831,7 @@ final class HttpChannelPool implements AsyncCloseable {
 
             switch (result) {
                 case SUCCESS:
+                    assert pch != null;
                     timingsBuilder.pendingAcquisitionEnd();
                     childPromise.complete(pch);
                     break;

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -132,6 +132,14 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                           .responseTimeoutMillis(0)
                           .maxResponseLength(UPGRADE_RESPONSE_MAX_LENGTH).build();
 
+    private static final RequestTarget REQ_TARGET_ASTERISK;
+
+    static {
+        final RequestTarget asterisk = RequestTarget.forClient("*");
+        assert asterisk != null;
+        REQ_TARGET_ASTERISK = asterisk;
+    }
+
     private enum HttpPreference {
         HTTP1_REQUIRED,
         HTTP2_PREFERRED,
@@ -215,7 +223,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
      * See <a href="https://http2.github.io/http2-spec/#discover-https">HTTP/2 specification</a>.
      */
     private void configureAsHttps(Channel ch, SocketAddress remoteAddr) {
-        assert isHttps();
+        assert sslCtx != null;
 
         final ChannelPipeline p = ch.pipeline();
         final SSLEngine sslEngine;
@@ -564,7 +572,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             final DefaultClientRequestContext reqCtx = new DefaultClientRequestContext(
                     ctx.channel().eventLoop(), Flags.meterRegistry(), H1C, RequestId.random(),
                     com.linecorp.armeria.common.HttpMethod.OPTIONS,
-                    RequestTarget.forClient("*"), ClientOptions.of(),
+                    REQ_TARGET_ASTERISK, ClientOptions.of(),
                     HttpRequest.of(com.linecorp.armeria.common.HttpMethod.OPTIONS, "*"),
                     null, REQUEST_OPTIONS_FOR_UPGRADE_REQUEST, CancellationScheduler.noop(),
                     System.nanoTime(), SystemInfo.currentTimeMicros());

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -284,7 +284,9 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
         }
 
         final StringBuilder logMsg = new StringBuilder("Unexpected exception while closing a request");
-        final String authority = ctx.request().authority();
+        final HttpRequest request = ctx.request();
+        assert request != null;
+        final String authority = request.authority();
         if (authority != null) {
             logMsg.append(" to ").append(authority);
         }
@@ -311,7 +313,9 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
             @Override
             public void run(Throwable cause) {
                 delegate.close(cause);
-                ctx.request().abort(cause);
+                final HttpRequest request = ctx.request();
+                assert request != null;
+                request.abort(cause);
                 ctx.logBuilder().endResponse(cause);
             }
         };

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -166,6 +166,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         return serializationFormat;
     }
 
+    @Nullable
     @Override
     public SessionProtocol protocol() {
         return protocol;
@@ -223,8 +224,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         final long writeTimeoutMillis = ctx.writeTimeoutMillis();
 
         assert protocol != null;
-        assert responseDecoder != null;
         assert requestEncoder != null;
+        assert responseDecoder != null;
         if (!protocol.isMultiplex() && !serializationFormat.requiresNewConnection(protocol)) {
             // When HTTP/1.1 is used and the serialization format does not require
             // a new connection (w.g. WebSocket):
@@ -236,6 +237,7 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
                     useHttp1Pipelining ? req.whenComplete()
                                        : CompletableFuture.allOf(req.whenComplete(), res.whenComplete());
             completionFuture.handle((ret, cause) -> {
+                assert responseDecoder != null;
                 if (isAcquirable(responseDecoder.keepAliveHandler())) {
                     pooledChannel.release();
                 }

--- a/core/src/main/java/com/linecorp/armeria/client/NoopHostFileEntriesResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/NoopHostFileEntriesResolver.java
@@ -18,12 +18,15 @@ package com.linecorp.armeria.client;
 
 import java.net.InetAddress;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.ResolvedAddressTypes;
 
 enum NoopHostFileEntriesResolver implements HostsFileEntriesResolver {
     INSTANCE;
 
+    @Nullable
     @Override
     public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
         return null;

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -561,15 +561,21 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
                 redirectSignatures = new LinkedHashSet<>();
 
                 final String originalProtocol = ctx.sessionProtocol().isTls() ? "https" : "http";
+                final String originalAuthority = ctx.authority();
+                assert originalAuthority != null;
                 final RedirectSignature originalSignature = new RedirectSignature(originalProtocol,
-                                                                                  ctx.authority(),
+                                                                                  originalAuthority,
                                                                                   request.headers().path(),
                                                                                   request.method());
                 redirectSignatures.add(originalSignature);
             }
 
-            final RedirectSignature signature = new RedirectSignature(nextReqTarget.scheme(),
-                                                                      nextReqTarget.authority(),
+            final String nextScheme = nextReqTarget.scheme();
+            final String nextAuthority = nextReqTarget.authority();
+            assert nextScheme != null;
+            assert nextAuthority != null;
+            final RedirectSignature signature = new RedirectSignature(nextScheme,
+                                                                      nextAuthority,
                                                                       nextReqTarget.pathAndQuery(),
                                                                       nextMethod);
             if (!redirectSignatures.add(signature)) {

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -350,6 +350,7 @@ final class RefreshingAddressResolver
             }
             refreshing = true;
 
+            assert address != null;
             final String hostname = address.getHostName();
             // 'sendQueries()' always successfully completes.
             sendQueries(questions, hostname, originalCreationTimeNanos).thenAccept(entry -> {
@@ -370,6 +371,7 @@ final class RefreshingAddressResolver
 
             final Throwable cause = entry.cause();
             if (cause != null) {
+                assert autoRefreshBackoff != null;
                 final long nextDelayMillis = autoRefreshBackoff.nextDelayMillis(numAttemptsSoFar++);
 
                 if (nextDelayMillis < 0) {
@@ -400,6 +402,8 @@ final class RefreshingAddressResolver
             if (address == null) {
                 return false;
             }
+
+            assert autoRefreshTimeoutFunction != null;
 
             if (autoRefreshTimeoutFunction == DEFAULT_AUTO_REFRESH_TIMEOUT_FUNCTION) {
                 return true;

--- a/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UnprocessedRequestException.java
@@ -55,7 +55,9 @@ public final class UnprocessedRequestException extends RuntimeException {
     @Nonnull
     @Override
     public Throwable getCause() {
-        return super.getCause();
+        final Throwable cause = super.getCause();
+        assert cause != null;
+        return cause;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/WebSocketHttp1ClientChannelHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebSocketHttp1ClientChannelHandler.java
@@ -189,6 +189,7 @@ final class WebSocketHttp1ClientChannelHandler extends ChannelDuplexHandler impl
                         return;
                     }
 
+                    assert res != null;
                     res.startResponse();
                     final ResponseHeaders responseHeaders = ArmeriaHttpUtil.toArmeria(nettyRes);
                     if (responseHeaders.status() == HttpStatus.SWITCHING_PROTOCOLS) {
@@ -215,6 +216,7 @@ final class WebSocketHttp1ClientChannelHandler extends ChannelDuplexHandler impl
                     final ByteBuf data = (ByteBuf) msg;
                     final int dataLength = data.readableBytes();
                     if (dataLength > 0) {
+                        assert res != null;
                         final long maxContentLength = res.maxContentLength();
                         final long writtenBytes = res.writtenBytes();
                         if (maxContentLength > 0 && writtenBytes > maxContentLength - dataLength) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerMetrics.java
@@ -51,10 +51,16 @@ final class CircuitBreakerMetrics {
         parent.gauge(idPrefix.name("state"), idPrefix.tags(), state, AtomicDouble::get);
 
         final String requests = idPrefix.name("requests");
-        parent.gauge(requests, idPrefix.tags("result", "success"),
-                     latestEventCount, lec -> lec.get().success());
-        parent.gauge(requests, idPrefix.tags("result", "failure"),
-                     latestEventCount, lec -> lec.get().failure());
+        parent.gauge(requests, idPrefix.tags("result", "success"), latestEventCount, lec -> {
+            final EventCount eventCount = lec.get();
+            assert eventCount != null;
+            return eventCount.success();
+        });
+        parent.gauge(requests, idPrefix.tags("result", "failure"), latestEventCount, lec -> {
+            final EventCount eventCount = lec.get();
+            assert eventCount != null;
+            return eventCount.failure();
+        });
 
         final String transitions = idPrefix.name("transitions");
         transitionsToClosed = parent.counter(transitions, idPrefix.tags("state", CLOSED.name()));

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerRuleWithContentBuilder.java
@@ -83,6 +83,7 @@ public final class CircuitBreakerRuleWithContentBuilder<T extends Response>
             if (content == null) {
                 return NEXT_DECISION;
             }
+            assert responseFilter != null;
             return responseFilter.apply(ctx, content)
                                  .handle((matched, cause0) -> {
                                      if (cause0 != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/DefaultCircuitBreakerClientHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/DefaultCircuitBreakerClientHandler.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.circuitbreaker.CircuitBreakerCallback;
 
 final class DefaultCircuitBreakerClientHandler implements CircuitBreakerClientHandler {
@@ -35,6 +36,7 @@ final class DefaultCircuitBreakerClientHandler implements CircuitBreakerClientHa
         this.mapping = mapping;
     }
 
+    @Nullable
     @Override
     public CircuitBreakerCallback tryRequest(ClientRequestContext ctx, Request req) {
         final CircuitBreaker circuitBreaker;

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/KeyedCircuitBreakerMapping.java
@@ -39,8 +39,11 @@ import com.linecorp.armeria.common.Request;
  */
 final class KeyedCircuitBreakerMapping implements CircuitBreakerMapping {
 
-    static final CircuitBreakerMapping hostMapping = new KeyedCircuitBreakerMapping(
-            true, false, false, (host, method, path) -> CircuitBreaker.of(host));
+    static final CircuitBreakerMapping hostMapping =
+            new KeyedCircuitBreakerMapping(true, false, false, (host, method, path) -> {
+                assert host != null;
+                return CircuitBreaker.of(host);
+            });
 
     private final ConcurrentMap<String, CircuitBreaker> mapping = new ConcurrentHashMap<>();
 

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -71,7 +71,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
 
     @Override
     public void onSuccess() {
-        final State currentState = state.get();
+        final State currentState = state();
         if (currentState.isClosed()) {
             // fires success event
             final EventCount updatedCount = currentState.counter().onSuccess();
@@ -95,7 +95,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
 
     @Override
     public void onFailure() {
-        final State currentState = state.get();
+        final State currentState = state();
         if (currentState.isClosed()) {
             // fires failure event
             final EventCount updatedCount = currentState.counter().onFailure();
@@ -138,7 +138,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
 
     @Override
     public boolean tryRequest() {
-        final State currentState = state.get();
+        final State currentState = state();
         if (currentState.isClosed()) {
             // all requests are allowed during CLOSED
             return true;
@@ -166,7 +166,7 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
 
     @Override
     public CircuitState circuitState() {
-        return state.get().circuitState;
+        return state().circuitState;
     }
 
     @Override
@@ -264,7 +264,9 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
 
     @VisibleForTesting
     State state() {
-        return state.get();
+        final State state = this.state.get();
+        assert state != null;
+        return state;
     }
 
     @VisibleForTesting
@@ -354,11 +356,13 @@ final class NonBlockingCircuitBreaker implements CircuitBreaker, CircuitBreakerC
             return EventCount.ZERO;
         }
 
+        @Nullable
         @Override
         public EventCount onSuccess() {
             return null;
         }
 
+        @Nullable
         @Override
         public EventCount onFailure() {
             return null;

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/SlidingWindowCounter.java
@@ -63,14 +63,18 @@ final class SlidingWindowCounter implements EventCounter {
 
     @Override
     public EventCount count() {
-        return snapshot.get();
+        final EventCount snapshot = this.snapshot.get();
+        assert snapshot != null;
+        return snapshot;
     }
 
+    @Nullable
     @Override
     public EventCount onSuccess() {
         return onEvent(Event.SUCCESS);
     }
 
+    @Nullable
     @Override
     public EventCount onFailure() {
         return onEvent(Event.FAILURE);
@@ -81,6 +85,7 @@ final class SlidingWindowCounter implements EventCounter {
         final long tickerNanos = ticker.read();
 
         final Bucket currentBucket = current.get();
+        assert currentBucket != null;
 
         if (tickerNanos < currentBucket.timestamp()) {
             // if current timestamp is older than bucket's timestamp (maybe race or GC pause?),

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointGroup.java
@@ -19,10 +19,12 @@ package com.linecorp.armeria.client.endpoint;
 import java.util.List;
 
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AbstractListenable;
 
 abstract class AbstractEndpointGroup extends AbstractListenable<List<Endpoint>> implements EndpointGroup {
 
+    @Nullable
     @Override
     protected List<Endpoint> latestValue() {
         if (whenReady().isDone()) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -227,7 +227,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         }
 
         @Override
-        public boolean complete(Endpoint value) {
+        public boolean complete(@Nullable Endpoint value) {
             cleanup(true);
             return super.complete(value);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
@@ -104,6 +105,7 @@ final class CompositeEndpointGroup extends AbstractEndpointGroup implements List
         return selectionStrategy;
     }
 
+    @Nullable
     @Override
     public Endpoint selectNow(ClientRequestContext ctx) {
         return selector.selectNow(ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
@@ -159,6 +160,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
         return selectionStrategy;
     }
 
+    @Nullable
     @Override
     public final Endpoint selectNow(ClientRequestContext ctx) {
         return maybeCreateSelector().selectNow(ctx);
@@ -198,7 +200,9 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
             return newSelector;
         }
 
-        return this.selector.get();
+        final EndpointSelector oldSelector = this.selector.get();
+        assert oldSelector != null;
+        return oldSelector;
     }
 
     /**
@@ -290,6 +294,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
         return false;
     }
 
+    @Nullable
     @Override
     protected List<Endpoint> latestValue() {
         final List<Endpoint> endpoints = this.endpoints;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/EndpointGroup.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.Listenable;
@@ -143,6 +144,7 @@ public interface EndpointGroup extends Listenable<List<Endpoint>>, EndpointSelec
      *         which was specified when constructing this {@link EndpointGroup},
      *         or {@code null} if this {@link EndpointGroup} is empty.
      */
+    @Nullable
     @Override
     Endpoint selectNow(ClientRequestContext ctx);
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OrElseEndpointGroup.java
@@ -26,6 +26,7 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 
@@ -68,6 +69,7 @@ final class OrElseEndpointGroup extends AbstractEndpointGroup implements Listena
         return first.selectionStrategy();
     }
 
+    @Nullable
     @Override
     public Endpoint selectNow(ClientRequestContext ctx) {
         return selector.selectNow(ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/RoundRobinStrategy.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
 
 final class RoundRobinStrategy implements EndpointSelectionStrategy {
 
@@ -46,6 +47,7 @@ final class RoundRobinStrategy implements EndpointSelectionStrategy {
             initialize();
         }
 
+        @Nullable
         @Override
         public Endpoint selectNow(ClientRequestContext ctx) {
             final List<Endpoint> endpoints = group().endpoints();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/StickyEndpointSelectionStrategy.java
@@ -25,6 +25,7 @@ import com.google.common.hash.Hashing;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
  * An {@link EndpointSelector} strategy which implements sticky load-balancing using
@@ -80,6 +81,7 @@ final class StickyEndpointSelectionStrategy implements EndpointSelectionStrategy
             initialize();
         }
 
+        @Nullable
         @Override
         public Endpoint selectNow(ClientRequestContext ctx) {
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightRampingUpStrategy.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.WeightRampingUpStrategy.EndpointsRampingUpEntry.EndpointAndStep;
 import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
 import com.linecorp.armeria.common.util.Ticker;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
@@ -166,6 +167,7 @@ final class WeightRampingUpStrategy implements EndpointSelectionStrategy {
             return ticker.read();
         }
 
+        @Nullable
         @Override
         public Endpoint selectNow(ClientRequestContext ctx) {
             return endpointSelector.selectEndpoint();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java
@@ -69,6 +69,7 @@ final class WeightedRoundRobinStrategy implements EndpointSelectionStrategy {
             }
         }
 
+        @Nullable
         @Override
         public Endpoint selectNow(ClientRequestContext ctx) {
             final EndpointsAndWeights endpointsAndWeights = this.endpointsAndWeights;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HttpHealthChecker.java
@@ -166,7 +166,7 @@ final class HttpHealthChecker implements AsyncCloseable {
 
         private final ClientRequestContext reqCtx;
         private final HttpResponse res;
-        @SuppressWarnings("NotNullFieldNotInitialized")
+        @Nullable
         private Subscription subscription;
         @Nullable
         private ResponseHeaders responseHeaders;
@@ -192,6 +192,8 @@ final class HttpHealthChecker implements AsyncCloseable {
 
         @Override
         public void onNext(HttpObject obj) {
+            assert subscription != null;
+
             if (closeable.isClosing()) {
                 subscription.cancel();
                 return;

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/DirectProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/DirectProxyConfig.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.client.proxy;
 
 import java.net.InetSocketAddress;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 /**
  * Represents a direct connection without a proxy.
  */
@@ -32,6 +34,7 @@ public final class DirectProxyConfig extends ProxyConfig {
         return ProxyType.DIRECT;
     }
 
+    @Nullable
     @Override
     public InetSocketAddress proxyAddress() {
         return null;

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Unwrappable;
 
 /**
@@ -152,6 +153,7 @@ public interface Backoff extends Unwrappable {
      *
      * @see Unwrappable
      */
+    @Nullable
     @Override
     default <T> T as(Class<T> type) {
         return Unwrappable.super.as(type);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryConfig.java
@@ -137,9 +137,14 @@ public final class RetryConfig<T extends Response> {
      * Converts this {@link RetryConfig} to a mutable {@link RetryConfigBuilder}.
      */
     public RetryConfigBuilder<T> toBuilder() {
-        final RetryConfigBuilder<T> builder =
-                retryRuleWithContent != null ?
-                builder0(retryRuleWithContent).maxContentLength(maxContentLength) : builder0(retryRule);
+        final RetryConfigBuilder<T> builder;
+        if (retryRuleWithContent != null) {
+            builder = builder0(retryRuleWithContent).maxContentLength(
+                    maxContentLength);
+        } else {
+            assert retryRule != null;
+            builder = builder0(retryRule);
+        }
         return builder
                 .maxTotalAttempts(maxTotalAttempts)
                 .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt);
@@ -197,8 +202,15 @@ public final class RetryConfig<T extends Response> {
      * response trailers.
      */
     public boolean requiresResponseTrailers() {
-        return needsContentInRule() ?
-               retryRuleWithContent().requiresResponseTrailers() : retryRule().requiresResponseTrailers();
+        if (needsContentInRule()) {
+            final RetryRuleWithContent<T> rule = retryRuleWithContent();
+            assert rule != null;
+            return rule.requiresResponseTrailers();
+        } else {
+            final RetryRule rule = retryRule();
+            assert rule != null;
+            return rule.requiresResponseTrailers();
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryRuleWithContentBuilder.java
@@ -89,6 +89,7 @@ public final class RetryRuleWithContentBuilder<T extends Response>
             if (content == null) {
                 return NEXT_DECISION;
             }
+            assert responseFilter != null;
             return responseFilter.apply(ctx, content)
                                  .handle((matched, cause0) -> {
                                      if (cause0 != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -426,8 +426,13 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                 }
                 return;
             }
-            final HttpResponse response0 = aggregatedRes != null ? aggregatedRes.toHttpResponse()
-                                                                 : response;
+            final HttpResponse response0;
+            if (aggregatedRes != null) {
+                response0 = aggregatedRes.toHttpResponse();
+            } else {
+                response0 = response;
+                assert response0 != null;
+            }
             handleResponseWithoutContent(retryConfig, ctx, rootReqDuplicator, originalReq, returnedRes,
                                          future, derivedCtx, response0, responseCause);
         });
@@ -517,7 +522,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     private static RetryRule retryRule(RetryConfig<HttpResponse> retryConfig) {
         if (retryConfig.needsContentInRule()) {
             return retryConfig.fromRetryRuleWithContent();
+        } else {
+            final RetryRule rule = retryConfig.retryRule();
+            assert rule != null;
+            return rule;
         }
-        return retryConfig.retryRule();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -192,6 +192,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                 retryConfig.retryRuleWithContent() : retryConfig.fromRetryRule();
         res.handle((unused1, cause) -> {
             try {
+                assert retryRule != null;
                 retryRule.shouldRetry(derivedCtx, res, cause).handle((decision, unused3) -> {
                     final Backoff backoff = decision != null ? decision.backoff() : null;
                     if (backoff != null) {

--- a/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ClientCacheControl.java
@@ -254,6 +254,7 @@ public final class ClientCacheControl extends CacheControl {
             return false;
         }
 
+        assert o != null;
         final ClientCacheControl that = (ClientCacheControl) o;
         return onlyIfCached == that.onlyIfCached &&
                maxStaleSeconds == that.maxStaleSeconds &&

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultAggregatedHttpRequest.java
@@ -47,11 +47,13 @@ final class DefaultAggregatedHttpRequest extends AbstractAggregatedHttpMessage
         return headers.path();
     }
 
+    @Nullable
     @Override
     public String scheme() {
         return headers.scheme();
     }
 
+    @Nullable
     @Override
     public String authority() {
         return headers.authority();

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultAggregationOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultAggregationOptions.java
@@ -42,6 +42,7 @@ final class DefaultAggregationOptions implements AggregationOptions {
         this.cacheResult = cacheResult;
     }
 
+    @Nullable
     @Override
     public EventExecutor executor() {
         return executor;
@@ -57,6 +58,7 @@ final class DefaultAggregationOptions implements AggregationOptions {
         return preferCached;
     }
 
+    @Nullable
     @Override
     public ByteBufAllocator alloc() {
         return alloc;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultCookie.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultCookie.java
@@ -89,11 +89,13 @@ final class DefaultCookie implements Cookie {
         return valueQuoted;
     }
 
+    @Nullable
     @Override
     public String domain() {
         return domain;
     }
 
+    @Nullable
     @Override
     public String path() {
         return path;
@@ -114,6 +116,7 @@ final class DefaultCookie implements Cookie {
         return httpOnly;
     }
 
+    @Nullable
     @Override
     public String sameSite() {
         return sameSite;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultDependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultDependencyInjector.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 
 final class DefaultDependencyInjector implements DependencyInjector {
@@ -45,6 +46,7 @@ final class DefaultDependencyInjector implements DependencyInjector {
         }
     }
 
+    @Nullable
     @Override
     public <T> T getInstance(Class<T> type) {
         lock.lock();

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultRequestHeaders.java
@@ -52,6 +52,7 @@ final class DefaultRequestHeaders extends DefaultHttpHeaders implements RequestH
         return super.selectLocale(supportedLocales);
     }
 
+    @Nullable
     @Override
     public List<LanguageRange> acceptLanguages() {
         return super.acceptLanguages();

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -588,6 +588,7 @@ public final class Flags {
             return tlsEngineType;
         }
         detectTlsEngineAndDumpOpenSslInfo();
+        assert tlsEngineType != null;
         return tlsEngineType;
     }
 
@@ -661,6 +662,7 @@ public final class Flags {
             return dumpOpenSslInfo;
         }
         detectTlsEngineAndDumpOpenSslInfo();
+        assert dumpOpenSslInfo != null;
         return dumpOpenSslInfo;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpHeaderNames.java
@@ -958,6 +958,7 @@ public final class HttpHeaderNames {
             }
         }
         map = builder.build();
+        assert inverseMapBuilder != null;
         inverseMap = inverseMapBuilder.build();
         // inverseMapBuilder is used only when building inverseMap.
         inverseMapBuilder = null;
@@ -965,6 +966,7 @@ public final class HttpHeaderNames {
 
     private static AsciiString create(String name) {
         final AsciiString cached = AsciiString.cached(Ascii.toLowerCase(name));
+        assert inverseMapBuilder != null;
         inverseMapBuilder.put(cached, name);
         return cached;
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponse.java
@@ -62,6 +62,7 @@ import com.linecorp.armeria.internal.common.stream.RecoverableStreamMessage;
 import com.linecorp.armeria.unsafe.PooledObjects;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
@@ -193,9 +194,10 @@ public interface HttpResponse extends Response, HttpMessage {
     static HttpResponse delayed(Supplier<? extends HttpResponse> responseSupplier, Duration delay) {
         requireNonNull(responseSupplier, "responseSupplier");
         requireNonNull(delay, "delay");
-        return delayed(responseSupplier, delay,
-                       RequestContext.mapCurrent(RequestContext::eventLoop,
-                                                 CommonPools.workerGroup()::next));
+        final EventLoop executor = RequestContext.mapCurrent(RequestContext::eventLoop,
+                                                             CommonPools.workerGroup()::next);
+        assert executor != null;
+        return delayed(responseSupplier, delay, executor);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/OrElseDependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/common/OrElseDependencyInjector.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.common;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 final class OrElseDependencyInjector implements DependencyInjector {
 
     private static final Logger logger = LoggerFactory.getLogger(OrElseDependencyInjector.class);
@@ -30,6 +32,7 @@ final class OrElseDependencyInjector implements DependencyInjector {
         this.second = second;
     }
 
+    @Nullable
     @Override
     public <T> T getInstance(Class<T> type) {
         final T instance = first.getInstance(type);

--- a/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareBlockingTaskExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareBlockingTaskExecutor.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.BlockingTaskExecutor;
 
 final class PropagatingContextAwareBlockingTaskExecutor
@@ -39,6 +40,7 @@ final class PropagatingContextAwareBlockingTaskExecutor
         super(executor);
     }
 
+    @Nullable
     @Override
     RequestContext contextOrNull() {
         return RequestContext.mapCurrent(Function.identity(), LogRequestContextWarningOnce.INSTANCE);

--- a/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutor.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutor.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 final class PropagatingContextAwareExecutor extends AbstractContextAwareExecutor<Executor> {
 
     static PropagatingContextAwareExecutor of(Executor executor) {
@@ -37,6 +39,7 @@ final class PropagatingContextAwareExecutor extends AbstractContextAwareExecutor
         super(executor);
     }
 
+    @Nullable
     @Override
     RequestContext contextOrNull() {
         return RequestContext.mapCurrent(Function.identity(), LogRequestContextWarningOnce.INSTANCE);

--- a/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareExecutorService.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 final class PropagatingContextAwareExecutorService
         extends AbstractContextAwareExecutorService<ExecutorService> {
 
@@ -38,6 +40,7 @@ final class PropagatingContextAwareExecutorService
         super(executor);
     }
 
+    @Nullable
     @Override
     RequestContext contextOrNull() {
         return RequestContext.mapCurrent(Function.identity(), LogRequestContextWarningOnce.INSTANCE);

--- a/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareScheduledExecutorService.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PropagatingContextAwareScheduledExecutorService.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 final class PropagatingContextAwareScheduledExecutorService
         extends AbstractContextAwareScheduledExecutorService<ScheduledExecutorService> {
 
@@ -38,6 +40,7 @@ final class PropagatingContextAwareScheduledExecutorService
         super(executor);
     }
 
+    @Nullable
     @Override
     RequestContext contextOrNull() {
         return RequestContext.mapCurrent(Function.identity(), LogRequestContextWarningOnce.INSTANCE);

--- a/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestContextWrapper.java
@@ -98,11 +98,13 @@ public abstract class RequestContextWrapper<T extends RequestContext>
         return unwrap().ownAttrs();
     }
 
+    @Nullable
     @Override
     public <V> V setAttr(AttributeKey<V> key, @Nullable V value) {
         return unwrap().setAttr(key, value);
     }
 
+    @Nullable
     @Override
     public HttpRequest request() {
         return unwrap().request();
@@ -167,6 +169,7 @@ public abstract class RequestContextWrapper<T extends RequestContext>
         return unwrap().decodedPath();
     }
 
+    @Nullable
     @Override
     public String query() {
         return unwrap().query();

--- a/core/src/main/java/com/linecorp/armeria/common/Scheme.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Scheme.java
@@ -114,8 +114,11 @@ public final class Scheme implements Comparable<Scheme> {
      * {@link SerializationFormat} and {@link SessionProtocol}.
      */
     public static Scheme of(SerializationFormat serializationFormat, SessionProtocol sessionProtocol) {
-        return SCHEMES.get(requireNonNull(serializationFormat, "serializationFormat").uriText() + '+' +
-                           requireNonNull(sessionProtocol, "sessionProtocol").uriText());
+        final Scheme scheme = SCHEMES.get(
+                requireNonNull(serializationFormat, "serializationFormat").uriText() + '+' +
+                requireNonNull(sessionProtocol, "sessionProtocol").uriText());
+        assert scheme != null;
+        return scheme;
     }
 
     private final SerializationFormat serializationFormat;

--- a/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ServerCacheControl.java
@@ -245,6 +245,7 @@ public final class ServerCacheControl extends CacheControl {
             return false;
         }
 
+        assert o != null;
         final ServerCacheControl that = (ServerCacheControl) o;
         return cachePublic == that.cachePublic &&
                cachePrivate == that.cachePrivate &&

--- a/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
@@ -29,7 +29,7 @@
  */
 package com.linecorp.armeria.common;
 
-import static com.linecorp.armeria.internal.common.util.StringUtil.toBoolean;
+import static com.linecorp.armeria.internal.common.util.StringUtil.toBooleanOrNull;
 import static io.netty.util.internal.MathUtil.findNextPositivePowerOfTwo;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -264,7 +264,7 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
         if (v == null) {
             return null;
         }
-        return toBoolean(v, false);
+        return toBooleanOrNull(v);
     }
 
     @Override
@@ -280,7 +280,7 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
         if (v == null) {
             return null;
         }
-        return toBoolean(v, false);
+        return toBooleanOrNull(v);
     }
 
     @Override
@@ -471,7 +471,7 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
     @Override
     public final boolean containsBoolean(IN_NAME name, boolean value) {
         return contains(name, actual -> {
-            final Boolean maybeBoolean = toBoolean(actual, false);
+            final Boolean maybeBoolean = toBooleanOrNull(actual);
             return maybeBoolean != null && maybeBoolean == value;
         });
     }

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -67,6 +67,7 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return "sysprops";
     }
 
+    @Nullable
     @Override
     public Sampler<Class<? extends Throwable>> verboseExceptionSampler() {
         final String spec = getNormalized("verboseExceptions");
@@ -82,16 +83,19 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return new ExceptionSampler(spec);
     }
 
+    @Nullable
     @Override
     public Boolean verboseSocketExceptions() {
         return getBoolean("verboseSocketExceptions");
     }
 
+    @Nullable
     @Override
     public Boolean verboseResponses() {
         return getBoolean("verboseResponses");
     }
 
+    @Nullable
     @Override
     public RequestContextStorageProvider requestContextStorageProvider() {
         final String providerFqcn = System.getProperty(PREFIX + "requestContextStorageProvider");
@@ -122,11 +126,13 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return matchedCandidates.get(0);
     }
 
+    @Nullable
     @Override
     public Boolean warnNettyVersions() {
         return getBoolean("warnNettyVersions");
     }
 
+    @Nullable
     @Override
     public TransportType transportType() {
         final String strTransportType = getNormalized("transportType");
@@ -145,11 +151,13 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         }
     }
 
+    @Nullable
     @Override
     public Boolean useOpenSsl() {
         return getBoolean("useOpenSsl");
     }
 
+    @Nullable
     @Override
     public TlsEngineType tlsEngineType() {
         final String strTlsEngineType = getNormalized("tlsEngineType");
@@ -167,201 +175,241 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         }
     }
 
+    @Nullable
     @Override
     public Boolean dumpOpenSslInfo() {
         return getBoolean("dumpOpenSslInfo");
     }
 
+    @Nullable
     @Override
     public Integer maxNumConnections() {
         return getInt("maxNumConnections");
     }
 
+    @Nullable
     @Override
     public Integer numCommonWorkers(TransportType transportType) {
         return getInt("numCommonWorkers");
     }
 
+    @Nullable
     @Override
     public Integer numCommonBlockingTaskThreads() {
         return getInt("numCommonBlockingTaskThreads");
     }
 
+    @Nullable
     @Override
     public Long defaultMaxRequestLength() {
         return getLong("defaultMaxRequestLength");
     }
 
+    @Nullable
     @Override
     public Long defaultMaxResponseLength() {
         return getLong("defaultMaxResponseLength");
     }
 
+    @Nullable
     @Override
     public Long defaultRequestTimeoutMillis() {
         return getLong("defaultRequestTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultResponseTimeoutMillis() {
         return getLong("defaultResponseTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultConnectTimeoutMillis() {
         return getLong("defaultConnectTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultWriteTimeoutMillis() {
         return getLong("defaultWriteTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultServerIdleTimeoutMillis() {
         return getLong("defaultServerIdleTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultClientIdleTimeoutMillis() {
         return getLong("defaultClientIdleTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp1MaxInitialLineLength() {
         return getInt("defaultHttp1MaxInitialLineLength");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp1MaxHeaderSize() {
         return getInt("defaultHttp1MaxHeaderSize");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp1MaxChunkSize() {
         return getInt("defaultHttp1MaxChunkSize");
     }
 
+    @Nullable
     @Override
     public Boolean defaultUseHttp2Preface() {
         return getBoolean("defaultUseHttp2Preface");
     }
 
+    @Nullable
     @Override
     public Boolean defaultPreferHttp1() {
         return getBoolean("preferHttp1");
     }
 
+    @Nullable
     @Override
     public Boolean defaultUseHttp2WithoutAlpn() {
         return getBoolean("defaultUseHttp2WithoutAlpn");
     }
 
+    @Nullable
     @Override
     public Boolean defaultUseHttp1Pipelining() {
         return getBoolean("defaultUseHttp1Pipelining");
     }
 
+    @Nullable
     @Override
     public Long defaultPingIntervalMillis() {
         return getLong("defaultPingIntervalMillis");
     }
 
+    @Nullable
     @Override
     public Integer defaultMaxServerNumRequestsPerConnection() {
         return getInt("defaultMaxServerNumRequestsPerConnection");
     }
 
+    @Nullable
     @Override
     public Integer defaultMaxClientNumRequestsPerConnection() {
         return getInt("defaultMaxClientNumRequestsPerConnection");
     }
 
+    @Nullable
     @Override
     public Long defaultMaxServerConnectionAgeMillis() {
         return getLong("defaultMaxServerConnectionAgeMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultMaxClientConnectionAgeMillis() {
         return getLong("defaultMaxClientConnectionAgeMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultServerConnectionDrainDurationMicros() {
         return getLong("defaultServerConnectionDrainDurationMicros");
     }
 
+    @Nullable
     @Override
     public Long defaultClientHttp2GracefulShutdownTimeoutMillis() {
         return getLong("defaultClientHttp2GracefulShutdownTimeoutMillis");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp2InitialConnectionWindowSize() {
         return getInt("defaultHttp2InitialConnectionWindowSize");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp2InitialStreamWindowSize() {
         return getInt("defaultHttp2InitialStreamWindowSize");
     }
 
+    @Nullable
     @Override
     public Integer defaultHttp2MaxFrameSize() {
         return getInt("defaultHttp2MaxFrameSize");
     }
 
+    @Nullable
     @Override
     public Long defaultHttp2MaxStreamsPerConnection() {
         return getLong("defaultHttp2MaxStreamsPerConnection");
     }
 
+    @Nullable
     @Override
     public Long defaultHttp2MaxHeaderListSize() {
         return getLong("defaultHttp2MaxHeaderListSize");
     }
 
+    @Nullable
     @Override
     public Integer defaultServerHttp2MaxResetFramesPerMinute() {
         return getInt("defaultServerHttp2MaxResetFramesPerMinute");
     }
 
+    @Nullable
     @Override
     public String defaultBackoffSpec() {
         return getNormalized("defaultBackoffSpec");
     }
 
+    @Nullable
     @Override
     public Integer defaultMaxTotalAttempts() {
         return getInt("defaultMaxTotalAttempts");
     }
 
+    @Nullable
     @Override
-    public @Nullable Long defaultRequestAutoAbortDelayMillis() {
+    public Long defaultRequestAutoAbortDelayMillis() {
         return getLong("defaultRequestAutoAbortDelayMillis");
     }
 
+    @Nullable
     @Override
     public String routeCacheSpec() {
         return getNormalized("routeCacheSpec");
     }
 
+    @Nullable
     @Override
     public String routeDecoratorCacheSpec() {
         return getNormalized("routeDecoratorCacheSpec");
     }
 
+    @Nullable
     @Override
     public String parsedPathCacheSpec() {
         return getNormalized("parsedPathCacheSpec");
     }
 
+    @Nullable
     @Override
     public String headerValueCacheSpec() {
         return getNormalized("headerValueCacheSpec");
     }
 
+    @Nullable
     @Override
     public List<String> cachedHeaders() {
         final String val = getNormalized("cachedHeaders");
@@ -371,16 +419,19 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return CSV_SPLITTER.splitToList(val);
     }
 
+    @Nullable
     @Override
     public String fileServiceCacheSpec() {
         return getNormalized("fileServiceCacheSpec");
     }
 
+    @Nullable
     @Override
     public String dnsCacheSpec() {
         return getNormalized("dnsCacheSpec");
     }
 
+    @Nullable
     @Override
     public Predicate<InetAddress> preferredIpV4Addresses() {
         final String val = getNormalized("preferredIpV4Addresses");
@@ -417,36 +468,43 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         }
     }
 
+    @Nullable
     @Override
     public Boolean useJdkDnsResolver() {
         return getBoolean("useJdkDnsResolver");
     }
 
+    @Nullable
     @Override
     public Boolean reportBlockedEventLoop() {
         return getBoolean("reportBlockedEventLoop");
     }
 
+    @Nullable
     @Override
     public Boolean reportMaskedRoutes() {
         return getBoolean("reportMaskedRoutes");
     }
 
+    @Nullable
     @Override
     public Boolean validateHeaders() {
         return getBoolean("validateHeaders");
     }
 
+    @Nullable
     @Override
     public Boolean tlsAllowUnsafeCiphers() {
         return getBoolean("tlsAllowUnsafeCiphers");
     }
 
+    @Nullable
     @Override
     public Integer defaultMaxClientHelloLength() {
         return getInt("defaultMaxClientHelloLength");
     }
 
+    @Nullable
     @Override
     public Set<TransientServiceOption> transientServiceOptions() {
         final String val = getNormalized("transientServiceOptions");
@@ -459,26 +517,31 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
                        .collect(toImmutableSet()));
     }
 
+    @Nullable
     @Override
     public Boolean useDefaultSocketOptions() {
         return getBoolean("useDefaultSocketOptions");
     }
 
+    @Nullable
     @Override
     public Boolean useLegacyRouteDecoratorOrdering() {
         return getBoolean("useLegacyRouteDecoratorOrdering");
     }
 
+    @Nullable
     @Override
     public Boolean allowDoubleDotsInQueryString() {
         return getBoolean("allowDoubleDotsInQueryString");
     }
 
+    @Nullable
     @Override
     public Boolean allowSemicolonInPathComponent() {
         return getBoolean("allowSemicolonInPathComponent");
     }
 
+    @Nullable
     @Override
     public Path defaultMultipartUploadsLocation() {
         return getAndParse("defaultMultipartUploadsLocation", Paths::get);
@@ -502,6 +565,7 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         }
     }
 
+    @Nullable
     @Override
     public Sampler<? super RequestContext> requestContextLeakDetectionSampler() {
         final String spec = getNormalized("requestContextLeakDetectionSampler");
@@ -516,18 +580,21 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         }
     }
 
+    @Nullable
     @Override
     public Long defaultUnhandledExceptionsReportIntervalMillis() {
         return getLong("defaultUnhandledExceptionsReportIntervalMillis");
     }
 
+    @Nullable
     @Override
     public Long defaultHttp1ConnectionCloseDelayMillis() {
         return getLong("defaultHttp1ConnectionCloseDelayMillis");
     }
 
+    @Nullable
     @Override
-    public @Nullable Long defaultUnloggedExceptionsReportIntervalMillis() {
+    public Long defaultUnloggedExceptionsReportIntervalMillis() {
         return getLong("defaultUnloggedExceptionsReportIntervalMillis");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/annotation/Nullable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/annotation/Nullable.java
@@ -32,7 +32,6 @@ import javax.annotation.meta.When;
  * @see NonNullByDefault
  */
 @Documented
-@Inherited
 @TypeQualifierNickname
 @Nonnull(when = When.MAYBE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/main/java/com/linecorp/armeria/common/annotation/Nullable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/annotation/Nullable.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/core/src/main/java/com/linecorp/armeria/common/auth/AuthUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/common/auth/AuthUtil.java
@@ -24,8 +24,15 @@ final class AuthUtil {
      * Compares two specified strings in the secure way.
      */
     static boolean secureEquals(@Nullable String a, @Nullable String b) {
-        final int aLength = a != null ? a.length() : 0;
-        final int bLength = b != null ? b.length() : 0;
+        if (a == null) {
+            return b == null;
+        }
+        if (b == null) {
+            return false;
+        }
+
+        final int aLength = a.length();
+        final int bLength = b.length();
         final int length = Math.min(aLength, bLength);
         int result = 0;
         for (int i = 0; i < length; i++) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -697,6 +697,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return requestStartTimeNanos;
     }
 
+    @Nullable
     @Override
     public Long requestFirstBytesTransferredTimeNanos() {
         ensureAvailable(RequestLogProperty.REQUEST_FIRST_BYTES_TRANSFERRED_TIME);
@@ -715,6 +716,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return requestEndTimeNanos - requestStartTimeNanos;
     }
 
+    @Nullable
     @Override
     public Throwable requestCause() {
         ensureAvailable(RequestLogProperty.REQUEST_CAUSE);
@@ -766,12 +768,14 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.SCHEME);
     }
 
+    @Nullable
     @Override
     public Channel channel() {
         ensureAvailable(RequestLogProperty.SESSION);
         return channel;
     }
 
+    @Nullable
     @Override
     public SSLSession sslSession() {
         ensureAvailable(RequestLogProperty.SESSION);
@@ -876,6 +880,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
     }
 
+    @Nullable
     @Override
     public String authenticatedUser() {
         ensureAvailable(RequestLogProperty.AUTHENTICATED_USER);
@@ -968,6 +973,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.REQUEST_HEADERS);
     }
 
+    @Nullable
     @Override
     public Object requestContent() {
         ensureAvailable(RequestLogProperty.REQUEST_CONTENT);
@@ -993,12 +999,14 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
     }
 
+    @Nullable
     @Override
     public Object rawRequestContent() {
         ensureAvailable(RequestLogProperty.REQUEST_CONTENT);
         return rawRequestContent;
     }
 
+    @Nullable
     @Override
     public String requestContentPreview() {
         ensureAvailable(RequestLogProperty.REQUEST_CONTENT_PREVIEW);
@@ -1136,6 +1144,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             // Set serviceName from ServiceType or innermost class name
             if (newServiceName == null) {
                 if (config != null) {
+                    assert sctx != null;
                     newServiceName = ServiceNaming.fullTypeName().serviceName(sctx);
                 } else if (rpcReq != null) {
                     newServiceName = rpcReq.serviceName();
@@ -1198,6 +1207,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return responseStartTimeNanos;
     }
 
+    @Nullable
     @Override
     public Long responseFirstBytesTransferredTimeNanos() {
         ensureAvailable(RequestLogProperty.RESPONSE_FIRST_BYTES_TRANSFERRED_TIME);
@@ -1222,6 +1232,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         return responseEndTimeNanos - requestStartTimeNanos;
     }
 
+    @Nullable
     @Override
     public Throwable responseCause() {
         ensureAvailable(RequestLogProperty.RESPONSE_CAUSE);
@@ -1315,6 +1326,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.RESPONSE_HEADERS);
     }
 
+    @Nullable
     @Override
     public Object responseContent() {
         ensureAvailable(RequestLogProperty.RESPONSE_CONTENT);
@@ -1343,6 +1355,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.RESPONSE_CONTENT);
     }
 
+    @Nullable
     @Override
     public String responseContentPreview() {
         ensureAvailable(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
@@ -1359,6 +1372,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         updateFlags(RequestLogProperty.RESPONSE_CONTENT_PREVIEW);
     }
 
+    @Nullable
     @Override
     public Object rawResponseContent() {
         ensureAvailable(RequestLogProperty.RESPONSE_CONTENT);
@@ -1570,7 +1584,6 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return true;
         }
 
-        @Nullable
         @Override
         public RequestLog getIfAvailable(RequestLogProperty... properties) {
             requireNonNull(properties, "properties");
@@ -1578,7 +1591,6 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return this;
         }
 
-        @Nullable
         @Override
         public RequestLog getIfAvailable(Iterable<RequestLogProperty> properties) {
             requireNonNull(properties, "properties");
@@ -1684,6 +1696,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return requestStartTimeNanos;
         }
 
+        @Nullable
         @Override
         public Long requestFirstBytesTransferredTimeNanos() {
             return requestFirstBytesTransferredTimeNanosSet ? requestFirstBytesTransferredTimeNanos : null;
@@ -1748,6 +1761,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
 
         @Override
         public String name() {
+            assert name != null;
             return name;
         }
 
@@ -1756,6 +1770,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return DefaultRequestLog.this.fullName();
         }
 
+        @Nullable
         @Override
         public String authenticatedUser() {
             return authenticatedUser;
@@ -1810,6 +1825,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             return responseStartTimeNanos;
         }
 
+        @Nullable
         @Override
         public Long responseFirstBytesTransferredTimeNanos() {
             return responseFirstBytesTransferredTimeNanosSet ? responseFirstBytesTransferredTimeNanos : null;

--- a/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilder.java
@@ -73,8 +73,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder logger(Logger logger) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.logger(logger);
+        maybeCreateLogWriterBuilder().logger(logger);
         return this;
     }
 
@@ -87,8 +86,7 @@ public abstract class LoggingDecoratorBuilder {
     @Deprecated
     public LoggingDecoratorBuilder logger(String loggerName) {
         requireNonNull(loggerName, "loggerName");
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.logger(LoggerFactory.getLogger(loggerName));
+        maybeCreateLogWriterBuilder().logger(LoggerFactory.getLogger(loggerName));
         return this;
     }
 
@@ -111,8 +109,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(LogLevel requestLogLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.requestLogLevel(requestLogLevel);
+        maybeCreateLogWriterBuilder().requestLogLevel(requestLogLevel);
         return this;
     }
 
@@ -123,8 +120,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevel(Class<? extends Throwable> clazz, LogLevel requestLogLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.requestLogLevel(clazz, requestLogLevel);
+        maybeCreateLogWriterBuilder().requestLogLevel(clazz, requestLogLevel);
         return this;
     }
 
@@ -137,8 +133,7 @@ public abstract class LoggingDecoratorBuilder {
     public LoggingDecoratorBuilder requestLogLevelMapper(
             Function<? super RequestOnlyLog, LogLevel> requestLogLevelMapper) {
         requireNonNull(requestLogLevelMapper, "requestLogLevelMapper");
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.requestLogLevelMapper(requestLogLevelMapper::apply);
+        maybeCreateLogWriterBuilder().requestLogLevelMapper(requestLogLevelMapper::apply);
         return this;
     }
 
@@ -149,8 +144,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder requestLogLevelMapper(RequestLogLevelMapper requestLogLevelMapper) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.requestLogLevelMapper(requestLogLevelMapper);
+        maybeCreateLogWriterBuilder().requestLogLevelMapper(requestLogLevelMapper);
         return this;
     }
 
@@ -176,8 +170,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatus status, LogLevel logLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseLogLevel(status, logLevel);
+        maybeCreateLogWriterBuilder().responseLogLevel(status, logLevel);
         return this;
     }
 
@@ -189,8 +182,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(HttpStatusClass statusClass, LogLevel logLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseLogLevel(statusClass, logLevel);
+        maybeCreateLogWriterBuilder().responseLogLevel(statusClass, logLevel);
         return this;
     }
 
@@ -201,8 +193,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevel(Class<? extends Throwable> clazz, LogLevel logLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseLogLevel(clazz, logLevel);
+        maybeCreateLogWriterBuilder().responseLogLevel(clazz, logLevel);
         return this;
     }
 
@@ -214,8 +205,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder successfulResponseLogLevel(LogLevel successfulResponseLogLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.successfulResponseLogLevel(successfulResponseLogLevel);
+        maybeCreateLogWriterBuilder().successfulResponseLogLevel(successfulResponseLogLevel);
         return this;
     }
 
@@ -227,8 +217,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder failureResponseLogLevel(LogLevel failedResponseLogLevel) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.failureResponseLogLevel(failedResponseLogLevel);
+        maybeCreateLogWriterBuilder().failureResponseLogLevel(failedResponseLogLevel);
         return this;
     }
 
@@ -241,7 +230,6 @@ public abstract class LoggingDecoratorBuilder {
     public LoggingDecoratorBuilder responseLogLevelMapper(
             Function<? super RequestLog, LogLevel> responseLogLevelMapper) {
         requireNonNull(responseLogLevelMapper, "responseLogLevelMapper");
-        maybeCreateLogWriterBuilder();
         return responseLogLevelMapper(responseLogLevelMapper::apply);
     }
 
@@ -252,8 +240,7 @@ public abstract class LoggingDecoratorBuilder {
      */
     @Deprecated
     public LoggingDecoratorBuilder responseLogLevelMapper(ResponseLogLevelMapper responseLogLevelMapper) {
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseLogLevelMapper(responseLogLevelMapper);
+        maybeCreateLogWriterBuilder().responseLogLevelMapper(responseLogLevelMapper);
         return this;
     }
 
@@ -284,8 +271,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> requestHeadersSanitizer) {
         requireNonNull(requestHeadersSanitizer, "requestHeadersSanitizer");
-        maybeCreateLogWriterBuilder();
-        logFormatterBuilder.requestHeadersSanitizer(convertToStringSanitizer(requestHeadersSanitizer));
+        maybeCreateLogFormatterBuilder().requestHeadersSanitizer(
+                convertToStringSanitizer(requestHeadersSanitizer));
         return this;
     }
 
@@ -316,9 +303,9 @@ public abstract class LoggingDecoratorBuilder {
     public LoggingDecoratorBuilder responseHeadersSanitizer(
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> responseHeadersSanitizer) {
-        maybeCreateLogWriterBuilder();
         requireNonNull(responseHeadersSanitizer, "responseHeadersSanitizer");
-        logFormatterBuilder.responseHeadersSanitizer(convertToStringSanitizer(responseHeadersSanitizer));
+        maybeCreateLogFormatterBuilder().responseHeadersSanitizer(
+                convertToStringSanitizer(responseHeadersSanitizer));
         return this;
     }
 
@@ -349,8 +336,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> requestTrailersSanitizer) {
         requireNonNull(requestTrailersSanitizer, "requestTrailersSanitizer");
-        maybeCreateLogWriterBuilder();
-        logFormatterBuilder.requestTrailersSanitizer(convertToStringSanitizer(requestTrailersSanitizer));
+        maybeCreateLogFormatterBuilder().requestTrailersSanitizer(
+                convertToStringSanitizer(requestTrailersSanitizer));
         return this;
     }
 
@@ -381,8 +368,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, ? super HttpHeaders,
                     ? extends @Nullable Object> responseTrailersSanitizer) {
         requireNonNull(responseTrailersSanitizer, "responseTrailersSanitizer");
-        maybeCreateLogWriterBuilder();
-        logFormatterBuilder.responseTrailersSanitizer(convertToStringSanitizer(responseTrailersSanitizer));
+        maybeCreateLogFormatterBuilder().responseTrailersSanitizer(
+                convertToStringSanitizer(responseTrailersSanitizer));
         return this;
     }
 
@@ -444,8 +431,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, Object,
                     ? extends @Nullable Object> requestContentSanitizer) {
         requireNonNull(requestContentSanitizer, "requestContentSanitizer");
-        maybeCreateLogWriterBuilder();
-        logFormatterBuilder.requestContentSanitizer(convertToStringSanitizer(requestContentSanitizer));
+        maybeCreateLogFormatterBuilder().requestContentSanitizer(
+                convertToStringSanitizer(requestContentSanitizer));
         return this;
     }
 
@@ -477,8 +464,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, Object,
                     ? extends @Nullable Object> responseContentSanitizer) {
         requireNonNull(responseContentSanitizer, "responseContentSanitizer");
-        maybeCreateLogWriterBuilder();
-        logFormatterBuilder.responseContentSanitizer(convertToStringSanitizer(responseContentSanitizer));
+        maybeCreateLogFormatterBuilder().responseContentSanitizer(
+                convertToStringSanitizer(responseContentSanitizer));
         return this;
     }
 
@@ -538,8 +525,8 @@ public abstract class LoggingDecoratorBuilder {
             BiFunction<? super RequestContext, ? super Throwable,
                     ? extends @Nullable Object> responseCauseSanitizer) {
         requireNonNull(responseCauseSanitizer, "responseCauseSanitizer");
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseCauseFilter((ctx, cause) -> responseCauseSanitizer.apply(ctx, cause) != null);
+        maybeCreateLogWriterBuilder().responseCauseFilter(
+                (ctx, cause) -> responseCauseSanitizer.apply(ctx, cause) != null);
         return this;
     }
 
@@ -565,8 +552,7 @@ public abstract class LoggingDecoratorBuilder {
     @Deprecated
     public LoggingDecoratorBuilder responseCauseFilter(Predicate<Throwable> responseCauseFilter) {
         requireNonNull(responseCauseFilter, "responseCauseFilter");
-        maybeCreateLogWriterBuilder();
-        logWriterBuilder.responseCauseFilter((ctx, cause) -> responseCauseFilter.test(cause));
+        maybeCreateLogWriterBuilder().responseCauseFilter((ctx, cause) -> responseCauseFilter.test(cause));
         return this;
     }
 
@@ -612,14 +598,20 @@ public abstract class LoggingDecoratorBuilder {
         return logWriterBuilder.build();
     }
 
-    private void maybeCreateLogWriterBuilder() {
+    private LogWriterBuilder maybeCreateLogWriterBuilder() {
         if (logWriter != null) {
             throw new IllegalStateException("The logWriter and the log properties cannot be set together.");
         }
-        if (logWriterBuilder != null) {
-            return;
+        if (logWriterBuilder == null) {
+            logWriterBuilder = LogWriter.builder();
+            logFormatterBuilder = LogFormatter.builderForText();
         }
-        logWriterBuilder = LogWriter.builder();
-        logFormatterBuilder = LogFormatter.builderForText();
+        return logWriterBuilder;
+    }
+
+    private TextLogFormatterBuilder maybeCreateLogFormatterBuilder() {
+        maybeCreateLogWriterBuilder();
+        assert logFormatterBuilder != null;
+        return logFormatterBuilder;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestScopedMdc.java
@@ -138,7 +138,7 @@ public final class RequestScopedMdc {
             try {
                 oldAdapterGetPropertyMap =
                         MethodHandles.publicLookup()
-                                     .findVirtual(oldAdapter.getClass(), "getPropertyMap",
+                                     .findVirtual(delegate.getClass(), "getPropertyMap",
                                                   MethodType.methodType(Map.class))
                                      .bindTo(delegate);
                 @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MimeParser.java
@@ -213,6 +213,9 @@ final class MimeParser {
 
                     case HEADERS:
                         logger.trace("state={}", State.HEADERS);
+                        assert bodyPartHeadersBuilder != null;
+                        assert bodyPartBuilder != null;
+
                         final String headerLine = readHeaderLine();
                         if (headerLine == null) {
                             // Need more data; DecodedHttpStreamMessage will handle.
@@ -241,6 +244,8 @@ final class MimeParser {
 
                     case BODY:
                         logger.trace("state={}", State.BODY);
+                        assert bodyPartPublisher != null;
+
                         final ByteBuf bodyContent = readBody();
                         if (bodyContent == NEED_MORE) {
                             final BodyPartPublisher currentPublisher = bodyPartPublisher;
@@ -267,6 +272,7 @@ final class MimeParser {
                         } else {
                             state = State.START_PART;
                         }
+                        assert bodyPartPublisher != null;
                         bodyPartPublisher.close();
                         bodyPartPublisher = null;
                         bodyPartHeadersBuilder = null;

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartDecoder.java
@@ -144,6 +144,8 @@ final class MultipartDecoder implements StreamMessage<BodyPart>, StreamDecoder<H
         if (!delegatedSubscriberUpdater.compareAndSet(this, null, multipartSubscriber)) {
             // Avoid calling method on late multipartSubscriber.
             // Because it's not static, so it will affect MultipartDecoder.
+            final MultipartSubscriber delegatedSubscriber = this.delegatedSubscriber;
+            assert delegatedSubscriber != null;
             SubscriberUtil.failLateSubscriber(executor, subscriber, delegatedSubscriber.subscriber);
             return;
         }
@@ -279,13 +281,13 @@ final class MultipartDecoder implements StreamMessage<BodyPart>, StreamDecoder<H
             }
         }
 
-        @SuppressWarnings("UnstableApiUsage")
         private void request0(long n) {
             final long oldDemand = demandOfMultipart;
             demandOfMultipart = LongMath.saturatedAdd(oldDemand, n);
             if (oldDemand == 0) {
                 // We want first body publisher
                 if (currentExposedBodyPartPublisher == null) {
+                    assert subscription != null;
                     //This will trigger DecodedHttpStreamMessage's upstream.
                     subscription.request(1);
                 } else {

--- a/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/multipart/MultipartEncoder.java
@@ -90,7 +90,9 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
         if (completionFutureUpdater.compareAndSet(this, null, completionFuture)) {
             return completionFuture;
         } else {
-            return this.completionFuture;
+            final CompletableFuture<Void> oldFuture = this.completionFuture;
+            assert oldFuture != null;
+            return oldFuture;
         }
     }
 
@@ -243,7 +245,9 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
             } else {
                 if (!completionFutureUpdater
                         .compareAndSet(MultipartEncoder.this, null, newEmitter.whenComplete())) {
-                    completeAsync(newEmitter.whenComplete(), MultipartEncoder.this.completionFuture);
+                    final CompletableFuture<Void> oldFuture = MultipartEncoder.this.completionFuture;
+                    assert oldFuture != null;
+                    completeAsync(newEmitter.whenComplete(), oldFuture);
                 }
             }
 
@@ -268,6 +272,8 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
         @Override
         public void onNext(BodyPart bodyPart) {
             requireNonNull(bodyPart, "bodyPart");
+            final StreamWriter<StreamMessage<HttpData>> emitter = MultipartEncoder.this.emitter;
+            assert emitter != null;
             emitter.write(createBodyPartPublisher(bodyPart));
         }
 
@@ -280,6 +286,8 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
             }
 
             closed = true;
+            final StreamWriter<StreamMessage<HttpData>> emitter = MultipartEncoder.this.emitter;
+            assert emitter != null;
             emitter.abort(cause);
         }
 
@@ -290,6 +298,8 @@ final class MultipartEncoder implements StreamMessage<HttpData> {
             }
 
             closed = true;
+            final StreamWriter<StreamMessage<HttpData>> emitter = MultipartEncoder.this.emitter;
+            assert emitter != null;
             emitter.close();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/AsyncMapStreamMessage.java
@@ -156,7 +156,11 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                 });
             } catch (Throwable ex) {
                 StreamMessageUtil.closeOrAbort(item, ex);
+
+                final Subscription upstream = this.upstream;
+                assert upstream != null;
                 upstream.cancel();
+
                 onError(ex);
             }
         }
@@ -169,6 +173,9 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
 
                 return;
             }
+
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
 
             try {
                 if (cause != null) {
@@ -195,7 +202,9 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                     }
                 }
             } catch (Throwable ex) {
-                StreamMessageUtil.closeOrAbort(item, ex);
+                if (item != null) {
+                    StreamMessageUtil.closeOrAbort(item, ex);
+                }
                 upstream.cancel();
                 onError(ex);
             }
@@ -230,6 +239,8 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
             if (n <= 0) {
                 onError(new IllegalArgumentException(
                         "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
+                final Subscription upstream = this.upstream;
+                assert upstream != null;
                 upstream.cancel();
                 return;
             }
@@ -256,6 +267,8 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
                 }
 
                 requestedFromUpstream = IntMath.saturatedAdd(requestedFromUpstream, (int) toRequest);
+                final Subscription upstream = this.upstream;
+                assert upstream != null;
                 upstream.request(toRequest);
             }
         }
@@ -267,6 +280,8 @@ final class AsyncMapStreamMessage<T, U> implements StreamMessage<U> {
             }
 
             canceled = true;
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
             upstream.cancel();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ConcatArrayStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ConcatArrayStreamMessage.java
@@ -115,7 +115,10 @@ final class ConcatArrayStreamMessage<T> implements StreamMessage<T> {
             if (executor.inEventLoop()) {
                 parent.nextSource();
             } else {
-                executor.execute(() -> parent.nextSource());
+                executor.execute(() -> {
+                    assert parent != null;
+                    parent.nextSource();
+                });
             }
         } else {
             subscriber.onSubscribe(NoopSubscription.get());

--- a/core/src/main/java/com/linecorp/armeria/common/stream/ConcatPublisherStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/ConcatPublisherStreamMessage.java
@@ -186,6 +186,8 @@ final class ConcatPublisherStreamMessage<T> implements StreamMessage<T> {
         }
 
         void nextSource() {
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
             upstream.request(1);
         }
     }
@@ -235,6 +237,7 @@ final class ConcatPublisherStreamMessage<T> implements StreamMessage<T> {
             // Reset 'completed' to subscribe to new Publisher
             currentPublisherCompleted = false;
             setUpstreamSubscription(subscription);
+            assert outerSubscriber != null;
             outerSubscriber.inInnerOnSubscribe = false;
         }
 
@@ -270,6 +273,7 @@ final class ConcatPublisherStreamMessage<T> implements StreamMessage<T> {
                 return;
             }
             currentPublisherCompleted = true;
+            assert outerSubscriber != null;
             if (outerSubscriber.completed) {
                 downstream.onComplete();
             } else {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultByteStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultByteStreamMessage.java
@@ -159,6 +159,7 @@ final class DefaultByteStreamMessage implements ByteStreamMessage {
             if (position >= end) {
                 // Drop tail bytes. Fully received the desired data already.
                 data.close();
+                assert upstream != null;
                 upstream.cancel();
                 return;
             }
@@ -196,6 +197,7 @@ final class DefaultByteStreamMessage implements ByteStreamMessage {
             }
 
             assert position <= end;
+            assert upstream != null;
             if (position == end) {
                 onComplete();
                 upstream.cancel();
@@ -207,6 +209,7 @@ final class DefaultByteStreamMessage implements ByteStreamMessage {
         }
 
         private void requestOneOrCancel() {
+            assert upstream != null;
             if (position < end) {
                 upstream.request(1);
             } else {
@@ -249,6 +252,7 @@ final class DefaultByteStreamMessage implements ByteStreamMessage {
         }
 
         private void request0(long n) {
+            assert upstream != null;
             if (n <= 0) {
                 onError(new IllegalArgumentException(
                         "n: " + n + " (expected: > 0, see Reactive Streams specification rule 3.9)"));
@@ -281,6 +285,7 @@ final class DefaultByteStreamMessage implements ByteStreamMessage {
                 return;
             }
             completed = true;
+            assert upstream != null;
             upstream.cancel();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -365,6 +365,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
             return;
         }
 
+        assert subscription != null;
         for (;;) {
             if (state == State.CLEANUP) {
                 cleanupObjects(null);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DeferredStreamMessage.java
@@ -177,6 +177,8 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
         }
 
         if (!collectingFutureUpdater.compareAndSet(this, null, NO_COLLECTING_FUTURE)) {
+            assert collectingExecutor != null;
+            assert collectionOptions != null;
             upstream.collect(collectingExecutor, collectionOptions).handle((result, cause) -> {
                 final CompletableFuture<List<T>> collectingFuture = this.collectingFuture;
                 assert collectingFuture != null;
@@ -296,6 +298,8 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
                 // Clear the subscriber when we become sure that the upstream will not produce events anymore.
                 final StreamMessage<T> upstream = this.upstream;
                 assert upstream != null;
+                final SubscriptionImpl downstreamSubscription = this.downstreamSubscription;
+                assert downstreamSubscription != null;
                 if (upstream.isComplete()) {
                     downstreamSubscription.clearSubscriber();
                 } else {
@@ -452,6 +456,8 @@ public class DeferredStreamMessage<T> extends CancellableStreamMessage<T> {
         requireNonNull(options, "options");
 
         if (!downstreamSubscriptionUpdater.compareAndSet(this, null, NOOP_SUBSCRIPTION)) {
+            final SubscriptionImpl downstreamSubscription = this.downstreamSubscription;
+            assert downstreamSubscription != null;
             final Subscriber<Object> subscriber = downstreamSubscription.subscriber();
             final Throwable cause = abortedOrLate(subscriber);
             final CompletableFuture<List<T>> collectingFuture = new CompletableFuture<>();

--- a/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/FuseableStreamMessage.java
@@ -272,6 +272,9 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
                 return;
             }
 
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
+
             U result = null;
             try {
                 if (function != null) {
@@ -332,6 +335,8 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
             if (canceled) {
                 return;
             }
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
             upstream.request(n);
         }
 
@@ -342,6 +347,8 @@ final class FuseableStreamMessage<T, U> implements StreamMessage<U> {
             }
 
             canceled = true;
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
             upstream.cancel();
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/PublisherBasedStreamMessage.java
@@ -170,7 +170,9 @@ public class PublisherBasedStreamMessage<T> extends AggregationSupport implement
                                                                       ImmediateEventExecutor.INSTANCE,
                                                                       false, false);
         if (!subscriberUpdater.compareAndSet(this, null, abortable)) {
-            this.subscriber.abort(cause);
+            final AbortableSubscriber oldSubscriber = this.subscriber;
+            assert oldSubscriber != null;
+            oldSubscriber.abort(cause);
             return;
         }
 
@@ -289,6 +291,8 @@ public class PublisherBasedStreamMessage<T> extends AggregationSupport implement
                 logger.warn("Subscriber.onError() should not raise an exception. subscriber: {}",
                             subscriber, composite);
             } finally {
+                final Subscription subscription = this.subscription;
+                assert subscription != null;
                 subscription.cancel();
             }
         }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageCollector.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageCollector.java
@@ -56,6 +56,7 @@ final class StreamMessageCollector<T> implements Subscriber<T> {
     public void onNext(T o) {
         requireNonNull(o, "o");
 
+        assert elementsBuilder != null;
         elementsBuilder.add(touchOrCopyAndClose(o, withPooledObjects));
     }
 
@@ -64,6 +65,7 @@ final class StreamMessageCollector<T> implements Subscriber<T> {
         if (future.isDone()) {
             return;
         }
+        assert elementsBuilder != null;
         future.complete(elementsBuilder.build());
         elementsBuilder = null;
     }
@@ -73,6 +75,7 @@ final class StreamMessageCollector<T> implements Subscriber<T> {
         if (future.isDone()) {
             return;
         }
+        assert elementsBuilder != null;
         final ImmutableList<T> elements = elementsBuilder.build();
         for (T element : elements) {
             StreamMessageUtil.closeOrAbort(element, t);

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
@@ -145,6 +145,8 @@ final class StreamMessageInputStream<T> extends InputStream {
                 byteBufsInputStream.add(result.byteBuf());
             } catch (Throwable ex) {
                 StreamMessageUtil.closeOrAbort(item, ex);
+                final Subscription upstream = this.upstream;
+                assert upstream != null;
                 upstream.cancel();
                 onError(ex);
             }
@@ -164,6 +166,8 @@ final class StreamMessageInputStream<T> extends InputStream {
             if (byteBufsInputStream.isEos()) {
                 return;
             }
+            final Subscription upstream = this.upstream;
+            assert upstream != null;
             upstream.request(1);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractUnwrappable.java
@@ -17,6 +17,8 @@ package com.linecorp.armeria.common.util;
 
 import static java.util.Objects.requireNonNull;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 /**
  * Skeletal {@link Unwrappable} implementation.
  *
@@ -33,6 +35,7 @@ public abstract class AbstractUnwrappable<T extends Unwrappable> implements Unwr
         this.delegate = requireNonNull(delegate, "delegate");
     }
 
+    @Nullable
     @Override
     public final <U> U as(Class<U> type) {
         final U result = Unwrappable.super.as(type);

--- a/core/src/main/java/com/linecorp/armeria/common/util/AppRootFinder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AppRootFinder.java
@@ -60,6 +60,7 @@ public final class AppRootFinder {
         // - This class
         // - The anonymous SecurityManager
         final Class<?>[] classes = classContextRef.get();
+        assert classes != null;
         final int toSkip = 2;
 
         if (callDepth < 0 || callDepth + toSkip >= classes.length) {

--- a/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/Exceptions.java
@@ -173,6 +173,7 @@ public final class Exceptions {
         requireNonNull(cause, "cause");
         if (cause instanceof UnprocessedRequestException) {
             cause = cause.getCause();
+            assert cause != null;
         }
 
         for (ExceptionClassifier classifier : exceptionClassifiers) {
@@ -218,7 +219,7 @@ public final class Exceptions {
      *         e.g. {@code return Exceptions.throwUnsafely(...);} vs.
      *              {@code Exceptions.throwUnsafely(...); return null;}
      */
-    @SuppressWarnings("ReturnOfNull")
+    @SuppressWarnings({ "ReturnOfNull", "NullAway" })
     public static <T> T throwUnsafely(Throwable cause) {
         doThrowUnsafely(requireNonNull(cause, "cause"));
         return null; // Never reaches here.

--- a/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
+++ b/core/src/main/java/com/linecorp/armeria/common/websocket/CloseByteBufWebSocketFrame.java
@@ -86,6 +86,7 @@ final class CloseByteBufWebSocketFrame extends ByteBufWebSocketFrame implements 
         }
     }
 
+    @Nullable
     @Override
     public String reasonPhrase() {
         return reasonPhrase;
@@ -135,7 +136,7 @@ final class CloseByteBufWebSocketFrame extends ByteBufWebSocketFrame implements 
 
         final CloseByteBufWebSocketFrame that = (CloseByteBufWebSocketFrame) obj;
         return status.equals(that.status()) &&
-               reasonPhrase.equals(that.reasonPhrase()) &&
+               Objects.equals(reasonPhrase, that.reasonPhrase()) &&
                super.equals(obj);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -416,7 +416,9 @@ public final class DefaultClientRequestContext
             if (whenInitializedUpdater.compareAndSet(this, null, whenInitialized)) {
                 return whenInitialized;
             } else {
-                return this.whenInitialized;
+                final CompletableFuture<Boolean> oldWhenInitialized = this.whenInitialized;
+                assert oldWhenInitialized != null;
+                return oldWhenInitialized;
             }
         }
     }
@@ -429,7 +431,9 @@ public final class DefaultClientRequestContext
         } else {
             if (!whenInitializedUpdater.compareAndSet(this, null,
                                                       UnmodifiableFuture.completedFuture(success))) {
-                this.whenInitialized.complete(success);
+                final CompletableFuture<Boolean> oldWhenInitialized = this.whenInitialized;
+                assert oldWhenInitialized != null;
+                oldWhenInitialized.complete(success);
             }
         }
     }
@@ -621,6 +625,7 @@ public final class DefaultClientRequestContext
                                                sessionProtocol(), method(), requestTarget());
     }
 
+    @Nullable
     @Override
     protected RequestTarget validateHeaders(RequestHeaders headers) {
         // no need to validate since internal headers will contain
@@ -645,6 +650,7 @@ public final class DefaultClientRequestContext
         return newChannel;
     }
 
+    @Nullable
     @Override
     public InetSocketAddress remoteAddress() {
         final InetSocketAddress remoteAddress = this.remoteAddress;
@@ -657,6 +663,7 @@ public final class DefaultClientRequestContext
         return newRemoteAddress;
     }
 
+    @Nullable
     @Override
     public InetSocketAddress localAddress() {
         final InetSocketAddress localAddress = this.localAddress;
@@ -696,11 +703,13 @@ public final class DefaultClientRequestContext
         return options;
     }
 
+    @Nullable
     @Override
     public EndpointGroup endpointGroup() {
         return endpointGroup;
     }
 
+    @Nullable
     @Override
     public Endpoint endpoint() {
         return endpoint;
@@ -712,6 +721,7 @@ public final class DefaultClientRequestContext
         return requestTarget().fragment();
     }
 
+    @Nullable
     @Override
     public String authority() {
         final HttpHeaders additionalRequestHeaders = this.additionalRequestHeaders;
@@ -755,6 +765,7 @@ public final class DefaultClientRequestContext
         return origin;
     }
 
+    @Nullable
     @Override
     public String host() {
         final String authority = authority();

--- a/core/src/main/java/com/linecorp/armeria/internal/client/PublicSuffix.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/PublicSuffix.java
@@ -100,7 +100,7 @@ public final class PublicSuffix {
                     for (int i = labels.length - 1; i >= 0; i--) {
                         // assume wildcard is at the first position, we don't need to create a new node for it
                         // but set the current node's isWildcard = true instead
-                        if (labels[i].equals("*")) {
+                        if ("*".equals(labels[i])) {
                             node.isWildcard = true;
                             break;
                         }
@@ -109,6 +109,7 @@ public final class PublicSuffix {
                         }
                         if (node.children.containsKey(labels[i])) {
                             node = node.children.get(labels[i]);
+                            assert node != null;
                         } else {
                             final TrieNode newNode = new TrieNode();
                             if (labels[i].charAt(0) == '!') {
@@ -157,12 +158,20 @@ public final class PublicSuffix {
         for (int i = end; i >= start; i--) {
             if (node.children != null && node.children.containsKey(labels[i])) {
                 node = node.children.get(labels[i]);
+                assert node != null;
             } else {
                 return false;
             }
             if (i == 1 && node.isWildcard) {
-                return node.children == null || !node.children.containsKey(labels[0]) ||
-                       !node.children.get(labels[0]).isException;
+                if (node.children == null) {
+                    return true;
+                }
+                if (!node.children.containsKey(labels[0])) {
+                    return true;
+                }
+                final TrieNode child = node.children.get(labels[0]);
+                assert child != null;
+                return !child.isException;
             }
         }
         return node.isEnd;

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/DnsUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/DnsUtil.java
@@ -131,7 +131,10 @@ public final class DnsUtil {
         return DEFAULT_DNS_QUERY_TIMEOUT_MILLIS;
     }
 
-    public static boolean isDnsQueryTimedOut(Throwable cause) {
+    public static boolean isDnsQueryTimedOut(@Nullable Throwable cause) {
+        if (cause == null) {
+            return false;
+        }
         final Throwable rootCause = Throwables.getRootCause(cause);
         if (rootCause instanceof DnsErrorCauseException) {
             return false;

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/StaticEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/StaticEndpointGroup.java
@@ -71,6 +71,7 @@ public final class StaticEndpointGroup implements EndpointGroup {
         return selectionStrategy;
     }
 
+    @Nullable
     @Override
     public Endpoint selectNow(ClientRequestContext ctx) {
         return selector.selectNow(ctx);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/BuiltInDependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/BuiltInDependencyInjector.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.annotation.ServerSentEventResponseConverterFunction;
 import com.linecorp.armeria.server.annotation.decorator.LoggingDecoratorFactoryFunction;
 import com.linecorp.armeria.server.annotation.decorator.RateLimitingDecoratorFactoryFunction;
@@ -42,6 +43,7 @@ public enum BuiltInDependencyInjector implements DependencyInjector {
 
     private static final Map<Class<?>, Object> instances = new ConcurrentHashMap<>();
 
+    @Nullable
     @Override
     public <T> T getInstance(Class<T> type) {
         if (!builtInClasses.contains(type)) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
@@ -171,6 +171,7 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
             return;
         }
         if (isInitialized()) {
+            assert eventLoop != null;
             if (eventLoop.inEventLoop()) {
                 clearTimeout0(resetTimeout);
             } else {
@@ -223,6 +224,7 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
             return;
         }
         if (isInitialized()) {
+            assert eventLoop != null;
             if (eventLoop.inEventLoop()) {
                 setTimeoutNanosFromStart0(timeoutNanos);
             } else {
@@ -254,6 +256,7 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
             return;
         }
         if (isInitialized()) {
+            assert eventLoop != null;
             if (eventLoop.inEventLoop()) {
                 extendTimeoutNanos0(adjustmentNanos);
             } else {
@@ -285,6 +288,7 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
     private void setTimeoutNanosFromNow(long timeoutNanos) {
         checkArgument(timeoutNanos > 0, "timeoutNanos: %s (expected: > 0)", timeoutNanos);
         if (isInitialized()) {
+            assert eventLoop != null;
             if (eventLoop.inEventLoop()) {
                 setTimeoutNanosFromNow0(timeoutNanos);
             } else {
@@ -393,7 +397,9 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
         if (whenCancellingUpdater.compareAndSet(this, null, cancellationFuture)) {
             return cancellationFuture;
         } else {
-            return this.whenCancelling;
+            final CancellationFuture oldWhenCancelling = this.whenCancelling;
+            assert oldWhenCancelling != null;
+            return oldWhenCancelling;
         }
     }
 
@@ -407,7 +413,9 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
         if (whenCancelledUpdater.compareAndSet(this, null, cancellationFuture)) {
             return cancellationFuture;
         } else {
-            return this.whenCancelled;
+            final CancellationFuture oldWhenCancelled = this.whenCancelled;
+            assert oldWhenCancelled != null;
+            return oldWhenCancelled;
         }
     }
 
@@ -427,7 +435,9 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
             });
             return timeoutFuture;
         } else {
-            return this.whenTimingOut;
+            final TimeoutFuture oldWhenTimingOut = this.whenTimingOut;
+            assert oldWhenTimingOut != null;
+            return oldWhenTimingOut;
         }
     }
 
@@ -447,7 +457,9 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
             });
             return timeoutFuture;
         } else {
-            return this.whenTimedOut;
+            final TimeoutFuture oldWhenTimedOut = this.whenTimedOut;
+            assert oldWhenTimedOut != null;
+            return oldWhenTimedOut;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -235,11 +235,13 @@ public final class DefaultRequestTarget implements RequestTarget {
         return form;
     }
 
+    @Nullable
     @Override
     public String scheme() {
         return scheme;
     }
 
+    @Nullable
     @Override
     public String authority() {
         return authority;
@@ -266,11 +268,13 @@ public final class DefaultRequestTarget implements RequestTarget {
         return maybePathWithMatrixVariables;
     }
 
+    @Nullable
     @Override
     public String query() {
         return query;
     }
 
+    @Nullable
     @Override
     public String fragment() {
         return fragment;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectAggregator.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/HttpObjectAggregator.java
@@ -121,6 +121,7 @@ public abstract class HttpObjectAggregator<T extends AggregatedHttpObject> imple
             if (dataLength > 0) {
                 final int allowedMaxDataLength = Integer.MAX_VALUE - contentLength;
                 if (dataLength > allowedMaxDataLength) {
+                    assert subscription != null;
                     subscription.cancel();
                     fail(new IllegalStateException("content length greater than Integer.MAX_VALUE"));
                     return;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
@@ -109,11 +109,13 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
         this.contextHook = (Supplier<AutoCloseable>) contextHook;
     }
 
+    @Nullable
     @Override
     public final HttpRequest request() {
         return req;
     }
 
+    @Nullable
     @Override
     public final RpcRequest rpcRequest() {
         return rpcReq;
@@ -192,6 +194,7 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
         return this.decodedPath = ArmeriaHttpUtil.decodePath(path());
     }
 
+    @Nullable
     @Override
     public final String query() {
         return reqTarget.query();
@@ -231,6 +234,7 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
         return attrs.ownAttr(key);
     }
 
+    @Nullable
     @Override
     public final <V> V setAttr(AttributeKey<V> key, @Nullable V value) {
         requireNonNull(key, "key");

--- a/core/src/main/java/com/linecorp/armeria/internal/common/ReflectiveDependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ReflectiveDependencyInjector.java
@@ -64,6 +64,7 @@ public final class ReflectiveDependencyInjector implements DependencyInjector {
 
     private boolean isShutdown;
 
+    @Nullable
     @Override
     public <T> T getInstance(Class<T> type) {
         lock.lock();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SplitHttpMessageSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SplitHttpMessageSubscriber.java
@@ -105,7 +105,9 @@ class SplitHttpMessageSubscriber implements Subscriber<HttpObject>, Subscription
         if (trailersFutureUpdater.compareAndSet(this, null, trailersFuture)) {
             return trailersFuture;
         } else {
-            return this.trailersFuture;
+            final HeadersFuture<HttpHeaders> oldTrailersFuture = this.trailersFuture;
+            assert oldTrailersFuture != null;
+            return oldTrailersFuture;
         }
     }
 
@@ -291,7 +293,9 @@ class SplitHttpMessageSubscriber implements Subscriber<HttpObject>, Subscription
         if (trailersFutureUpdater.compareAndSet(this, null, trailersFuture)) {
             trailersFuture.doComplete(trailers);
         } else {
-            this.trailersFuture.doComplete(trailers);
+            final HeadersFuture<HttpHeaders> oldTrailersFuture = this.trailersFuture;
+            assert oldTrailersFuture != null;
+            oldTrailersFuture.doComplete(trailers);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/encoding/DefaultHttpDecodedResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/encoding/DefaultHttpDecodedResponse.java
@@ -115,6 +115,7 @@ public final class DefaultHttpDecodedResponse extends AbstractHttpDecodedRespons
         return decoder != null ? decoder.decode((HttpData) obj) : obj;
     }
 
+    @Nullable
     @Override
     StreamDecoder decoder() {
         return decoder;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/DecodedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/DecodedStreamMessage.java
@@ -127,6 +127,7 @@ public final class DecodedStreamMessage<I, O>
 
         initialized = true;
         if (cancelled) {
+            assert upstream != null;
             upstream.cancel();
             return;
         }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/FixedStreamMessage.java
@@ -267,6 +267,7 @@ public abstract class FixedStreamMessage<T> extends AggregationSupport
 
     private void onError0(Throwable cause) {
         try {
+            assert subscriber != null;
             subscriber.onError(cause);
             if (!completionFuture.isDone()) {
                 completionFuture.completeExceptionally(cause);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/ThreeElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/ThreeElementFixedStreamMessage.java
@@ -76,6 +76,8 @@ public class ThreeElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
     @Override
     final List<T> drainAll(boolean withPooledObjects) {
         assert obj1 != null;
+        assert obj2 != null;
+        assert obj3 != null;
         final List<T> objs = ImmutableList.of(touchOrCopyAndClose(obj1, withPooledObjects),
                                               touchOrCopyAndClose(obj2, withPooledObjects),
                                               touchOrCopyAndClose(obj3, withPooledObjects));

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/TwoElementFixedStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/TwoElementFixedStreamMessage.java
@@ -72,6 +72,7 @@ public class TwoElementFixedStreamMessage<T> extends FixedStreamMessage<T> {
     @Override
     final List<T> drainAll(boolean withPooledObjects) {
         assert obj1 != null;
+        assert obj2 != null;
         final List<T> objs = ImmutableList.of(touchOrCopyAndClose(obj1, withPooledObjects),
                                               touchOrCopyAndClose(obj2, withPooledObjects));
         obj1 = obj2 = null;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -115,11 +115,11 @@ public final class ChannelUtil {
 
     static {
         final ImmutableSet.Builder<ChannelOption<?>> tcpOptionsBuilder = ImmutableSet.builder();
-        
+
         ChannelOption<Integer> epollTcpUserTimeout = null;
         ChannelOption<Integer> epollTcpKeepidle = null;
         ChannelOption<Integer> epollTcpKeepintvl = null;
-        
+
         try {
             final Class<?> clazz = Class.forName(
                     CHANNEL_PACKAGE_NAME + ".epoll.EpollChannelOption", false,
@@ -143,7 +143,7 @@ public final class ChannelUtil {
         } catch (Throwable ignored) {
             // Ignore
         }
-        
+
         ChannelUtil.epollTcpUserTimeout = epollTcpUserTimeout;
         ChannelUtil.epollTcpKeepidle = epollTcpKeepidle;
         ChannelUtil.epollTcpKeepintvl = epollTcpKeepintvl;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/MinifiedBouncyCastleProvider.java
@@ -41,6 +41,8 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 /**
  * A downsized version of {@link BouncyCastleProvider} which provides only RSA/DSA/EC {@link KeyFactorySpi}s
  * and X.509 {@link CertificateFactorySpi}.
@@ -159,6 +161,7 @@ public final class MinifiedBouncyCastleProvider extends Provider implements Conf
         keyInfoConverters.put(oid, keyInfoConverter);
     }
 
+    @Nullable
     @Override
     public AsymmetricKeyInfoConverter getKeyInfoConverter(ASN1ObjectIdentifier oid) {
         return keyInfoConverters.get(oid);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/StringUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/StringUtil.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 public final class StringUtil {
     private static final int MAX_NUM = 1000;
     private static final int MIN_NUM = -MAX_NUM;
@@ -56,15 +58,17 @@ public final class StringUtil {
         return Long.toString(num);
     }
 
-    public static Boolean toBoolean(String s, boolean errorOnFailure) {
+    public static Boolean toBoolean(String s) {
         final Boolean result = stringToBoolean.get(s);
         if (result != null) {
             return result;
         }
-        if (errorOnFailure) {
-            throw new IllegalArgumentException("must be one of " + stringToBoolean.keySet() + ": " + s);
-        }
-        return null;
+        throw new IllegalArgumentException("must be one of " + stringToBoolean.keySet() + ": " + s);
+    }
+
+    @Nullable
+    public static Boolean toBooleanOrNull(String s) {
+        return stringToBoolean.get(s);
     }
 
     private StringUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/TransportTypeProvider.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.common.util;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -171,10 +172,19 @@ public final class TransportTypeProvider {
             final Class<? extends SocketChannel> sc =
                     findClass(channelPackageName, socketChannelTypeName);
 
-            final Class<? extends ServerDomainSocketChannel> sdsc =
-                    findClass(channelPackageName, domainServerSocketChannelTypeName);
-            final Class<? extends DomainSocketChannel> dsc =
-                    findClass(channelPackageName, domainSocketChannelTypeName);
+            final Class<? extends ServerDomainSocketChannel> sdsc;
+            if (domainServerSocketChannelTypeName != null) {
+                sdsc = findClass(channelPackageName, domainServerSocketChannelTypeName);
+            } else {
+                sdsc = null;
+            }
+
+            final Class<? extends DomainSocketChannel> dsc;
+            if (domainSocketChannelTypeName != null) {
+                dsc = findClass(channelPackageName, domainSocketChannelTypeName);
+            } else {
+                dsc = null;
+            }
 
             final Class<? extends DatagramChannel> dc =
                     findClass(channelPackageName, datagramChannelTypeName);
@@ -193,20 +203,15 @@ public final class TransportTypeProvider {
         }
     }
 
-    @Nullable
     @SuppressWarnings("unchecked")
-    private static <T> Class<T> findClass(String channelPackageName,
-                                          @Nullable String className) throws Exception {
-        if (className == null) {
-            return null;
-        }
-
+    private static <T> Class<T> findClass(String channelPackageName, String className) throws Exception {
         return (Class<T>) Class.forName(channelPackageName + className, false,
                                         TransportTypeProvider.class.getClassLoader());
     }
 
     private static BiFunction<Integer, ThreadFactory, ? extends EventLoopGroup> findEventLoopGroupConstructor(
             Class<? extends EventLoopGroup> eventLoopGroupType) throws Exception {
+        requireNonNull(eventLoopGroupType, "eventLoopGroupType");
         final MethodHandle constructor =
                 MethodHandles.lookup().unreflectConstructor(
                         eventLoopGroupType.getConstructor(int.class, ThreadFactory.class));

--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -210,6 +210,7 @@ public final class DefaultServiceRequestContext
         this.additionalResponseTrailers = additionalResponseTrailers;
     }
 
+    @Nullable
     @Override
     protected RequestTarget validateHeaders(RequestHeaders headers) {
         checkArgument(headers.scheme() != null && headers.authority() != null,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AggregatedResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AggregatedResponseConverterFunction.java
@@ -47,6 +47,7 @@ final class AggregatedResponseConverterFunction implements ResponseConverterFunc
         this.responseConverter = responseConverter;
     }
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType contentType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -270,6 +270,7 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
                     return null;
                 }
 
+                assert beanFactoryId != null;
                 final Class<?> type = beanFactoryId.type();
                 typeSignature = new RequestObjectTypeSignature(TypeSignatureType.STRUCT, type.getName(), type,
                                                                new AnnotatedValueResolversWrapper(resolvers));

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTypeUtil.java
@@ -55,8 +55,8 @@ final class AnnotatedServiceTypeUtil {
                     .put(Byte.class, Byte::valueOf)
                     .put(Short.TYPE, Short::valueOf)
                     .put(Short.class, Short::valueOf)
-                    .put(Boolean.TYPE, s -> StringUtil.toBoolean(s, true))
-                    .put(Boolean.class, s -> StringUtil.toBoolean(s, true))
+                    .put(Boolean.TYPE, s -> StringUtil.toBoolean(s))
+                    .put(Boolean.class, s -> StringUtil.toBoolean(s))
                     .put(Integer.TYPE, Integer::valueOf)
                     .put(Integer.class, Integer::valueOf)
                     .put(Long.TYPE, Long::valueOf)
@@ -154,7 +154,9 @@ final class AnnotatedServiceTypeUtil {
             try {
                 return (T) methodHandle.invokeWithArguments(str);
             } catch (InvocationTargetException e) {
-                return Exceptions.throwUnsafely(e.getCause());
+                final Throwable cause = e.getCause();
+                assert cause != null;
+                return Exceptions.throwUnsafely(cause);
             } catch (Throwable t) {
                 return Exceptions.throwUnsafely(t);
             }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -727,7 +727,9 @@ final class AnnotatedValueResolver {
             return new Builder(annotatedElement, type, name)
                     .resolver((unused, ctx) -> {
                         final String filename = getName(annotatedElement);
-                        return Iterables.getFirst(ctx.aggregatedMultipart().files().get(filename), null);
+                        final FileAggregatedMultipart aggregatedMultipart = ctx.aggregatedMultipart();
+                        assert aggregatedMultipart != null;
+                        return Iterables.getFirst(aggregatedMultipart.files().get(filename), null);
                     })
                     .aggregation(AggregationStrategy.ALWAYS)
                     .build();
@@ -1597,6 +1599,7 @@ final class AnnotatedValueResolver {
         @Nullable
         private final AggregatedResult aggregatedResult;
 
+        @Nullable
         private volatile QueryParams queryParams;
 
         ResolverContext(ServiceRequestContext context, HttpRequest request,
@@ -1616,11 +1619,13 @@ final class AnnotatedValueResolver {
 
         @Nullable
         AggregatedHttpRequest aggregatedRequest() {
+            assert aggregatedResult != null;
             return aggregatedResult.aggregatedHttpRequest;
         }
 
         @Nullable
         FileAggregatedMultipart aggregatedMultipart() {
+            assert aggregatedResult != null;
             return aggregatedResult.aggregatedMultipart;
         }
 
@@ -1629,6 +1634,7 @@ final class AnnotatedValueResolver {
             if (result == null) {
                 result = queryParams;
                 if (result == null) {
+                    assert aggregatedResult != null;
                     queryParams = result = queryParamsOf(context.query(),
                                                          request.contentType(),
                                                          aggregatedResult);
@@ -1665,6 +1671,7 @@ final class AnnotatedValueResolver {
                 final QueryParams params1 = query != null ? QueryParams.fromQueryString(query) : null;
                 QueryParams params2 = null;
                 if (isFormData(contentType)) {
+                    assert contentType != null;
                     final AggregatedHttpRequest message = result.aggregatedHttpRequest;
                     if (message != null) {
                         // Respect 'charset' attribute of the 'content-type' header if it exists.

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultAnnotatedService.java
@@ -250,6 +250,7 @@ final class DefaultAnnotatedService implements AnnotatedService {
         return builder.build();
     }
 
+    @Nullable
     @Override
     public String name() {
         return name;
@@ -328,7 +329,9 @@ final class DefaultAnnotatedService implements AnnotatedService {
             // Fast-path: No aggregation required and blocking task executor is not used.
             switch (responseType) {
                 case HTTP_RESPONSE:
-                    return (HttpResponse) invoke(ctx, req, AggregatedResult.EMPTY);
+                    final HttpResponse res = (HttpResponse) invoke(ctx, req, AggregatedResult.EMPTY);
+                    assert res != null;
+                    return res;
                 case OTHER_OBJECTS:
                     return convertResponse(ctx, invoke(ctx, req, AggregatedResult.EMPTY));
             }

--- a/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java
@@ -216,6 +216,7 @@ abstract class AbstractHttpResponseSubscriber extends AbstractHttpResponseHandle
                 break;
             }
             case DONE:
+                assert subscription != null;
                 isSubscriptionCompleted = true;
                 subscription.cancel();
                 PooledObjects.close(o);

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultRoutingContext.java
@@ -165,6 +165,7 @@ final class DefaultRoutingContext implements RoutingContext {
         this.deferredCause = requireNonNull(deferredCause, "deferredCause");
     }
 
+    @Nullable
     @Override
     public HttpStatusException deferredStatusException() {
         return deferredCause;

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -89,6 +89,7 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
         return routingContext;
     }
 
+    @Nullable
     @Override
     public Routed<ServiceConfig> route() {
         if (routingContext.hasResult()) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerCodec.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerCodec.java
@@ -38,6 +38,8 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 
+import com.linecorp.armeria.common.annotation.Nullable;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CombinedChannelDuplexHandler;
@@ -64,7 +66,7 @@ final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequestDeco
     // Forked from https://github.com/netty/netty/blob/cf624c93c5f97097f1b13fe926ed50c32c8b1430/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
 
     /** A queue that is used for correlating a request and a response. */
-    private final Queue<HttpMethod> queue = new ArrayDeque<HttpMethod>();
+    private final Queue<HttpMethod> queue = new ArrayDeque<>();
 
     /**
      * Creates a new instance with the default decoder options
@@ -121,6 +123,7 @@ final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequestDeco
 
     private final class HttpServerResponseEncoder extends HttpResponseEncoder {
 
+        @Nullable
         private HttpMethod method;
 
         @Override

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -812,9 +812,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                     unfinishedRequests.remove(req);
                 }
 
-                final boolean needsDisconnection =
-                        ctx.channel().isActive() &&
-                        (handledLastRequest || responseEncoder.keepAliveHandler().needsDisconnection());
+                final boolean needsDisconnection = ctx.channel().isActive() &&
+                                                   (handledLastRequest || isNeedsDisconnection());
                 if (needsDisconnection) {
                     // Graceful shutdown mode: If a connection needs to be closed by `KeepAliveHandler`
                     // such as a max connection age or `ServiceRequestContext.initiateConnectionShutdown()`,
@@ -843,6 +842,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
             } catch (Throwable t) {
                 logger.warn("Unexpected exception:", t);
             }
+        }
+
+        private boolean isNeedsDisconnection() {
+            assert responseEncoder != null;
+            return responseEncoder.keepAliveHandler().needsDisconnection();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/LengthBasedServiceNaming.java
+++ b/core/src/main/java/com/linecorp/armeria/server/LengthBasedServiceNaming.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.util.TargetLengthBasedClassNameAbbreviator;
 
 final class LengthBasedServiceNaming implements ServiceNaming {
@@ -36,10 +37,11 @@ final class LengthBasedServiceNaming implements ServiceNaming {
         abbreviator = new TargetLengthBasedClassNameAbbreviator(shortenedServiceNameLength);
     }
 
+    @Nullable
     @Override
     public String serviceName(ServiceRequestContext ctx) {
         final String fullTypeName = ServiceNaming.fullTypeName().serviceName(ctx);
-        return abbreviate(fullTypeName);
+        return fullTypeName != null ? abbreviate(fullTypeName) : null;
     }
 
     private String abbreviate(String serviceName) {

--- a/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RouteCache.java
@@ -66,9 +66,15 @@ final class RouteCache {
      */
     static Router<ServiceConfig> wrapVirtualHostRouter(Router<ServiceConfig> delegate,
                                                        Set<Route> dynamicPredicateRoutes) {
-        return FIND_CACHE == null ? delegate
-                                  : new CachingRouter<>(delegate, ServiceConfig::route,
-                                                        FIND_CACHE, FIND_ALL_CACHE, dynamicPredicateRoutes);
+        if (FIND_CACHE == null) {
+            return delegate;
+        }
+
+        assert FIND_ALL_CACHE != null;
+        return new CachingRouter<>(delegate,
+                                   ServiceConfig::route,
+                                   FIND_CACHE, FIND_ALL_CACHE,
+                                   dynamicPredicateRoutes);
     }
 
     /**
@@ -77,11 +83,16 @@ final class RouteCache {
      */
     static Router<RouteDecoratingService> wrapRouteDecoratingServiceRouter(
             Router<RouteDecoratingService> delegate, Set<Route> dynamicPredicateRoutes) {
-        return DECORATOR_FIND_CACHE == null ? delegate
-                                            : new CachingRouter<>(delegate, RouteDecoratingService::route,
-                                                                  DECORATOR_FIND_CACHE,
-                                                                  DECORATOR_FIND_ALL_CACHE,
-                                                                  dynamicPredicateRoutes);
+        if (DECORATOR_FIND_CACHE == null) {
+            return delegate;
+        }
+
+        assert DECORATOR_FIND_ALL_CACHE != null;
+        return new CachingRouter<>(delegate,
+                                   RouteDecoratingService::route,
+                                   DECORATOR_FIND_CACHE,
+                                   DECORATOR_FIND_ALL_CACHE,
+                                   dynamicPredicateRoutes);
     }
 
     private static <T> Cache<RoutingContext, T> buildCache(String spec) {

--- a/core/src/main/java/com/linecorp/armeria/server/Routed.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Routed.java
@@ -83,6 +83,7 @@ public final class Routed<T> {
      */
     public Route route() {
         ensurePresence();
+        assert route != null;
         return route;
     }
 
@@ -110,6 +111,7 @@ public final class Routed<T> {
      */
     public T value() {
         ensurePresence();
+        assert value != null;
         return value;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContextWrapper.java
@@ -104,6 +104,7 @@ class RoutingContextWrapper implements RoutingContext {
         delegate.deferStatusException(cause);
     }
 
+    @Nullable
     @Override
     public HttpStatusException deferredStatusException() {
         return delegate.deferredStatusException();

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingResult.java
@@ -121,6 +121,7 @@ public final class RoutingResult {
      */
     public String path() {
         ensurePresence();
+        assert path != null;
         return path;
     }
 
@@ -142,6 +143,7 @@ public final class RoutingResult {
             return decodedPath;
         }
 
+        assert path != null;
         return this.decodedPath = ArmeriaHttpUtil.decodePath(path);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -550,6 +550,9 @@ public final class Server implements ListenableAsyncCloseable {
                 return thread;
             });
 
+            final GracefulShutdownSupport gracefulShutdownSupport = this.gracefulShutdownSupport;
+            assert gracefulShutdownSupport != null;
+
             b.group(bossGroup, config.workerGroup());
             b.handler(connectionLimitingHandler);
             b.childHandler(new HttpServerPipelineConfigurator(config, port, gracefulShutdownSupport,

--- a/core/src/main/java/com/linecorp/armeria/server/Service.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Service.java
@@ -69,6 +69,7 @@ public interface Service<I extends Request, O extends Response> extends Unwrappa
      *
      * @see Unwrappable
      */
+    @Nullable
     @Override
     default <T> T as(Class<T> type) {
         requireNonNull(type, "type");

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfig.java
@@ -93,8 +93,8 @@ public final class ServiceConfig {
     /**
      * Creates a new instance.
      */
-    ServiceConfig(Route route, Route mappedRoute, HttpService service, @Nullable String defaultLogName,
-                  @Nullable String defaultServiceName, ServiceNaming defaultServiceNaming,
+    ServiceConfig(Route route, Route mappedRoute, HttpService service, @Nullable String defaultServiceName,
+                  ServiceNaming defaultServiceNaming, @Nullable String defaultLogName,
                   long requestTimeoutMillis, long maxRequestLength,
                   boolean verboseResponses, AccessLogWriter accessLogWriter,
                   BlockingTaskExecutor blockingTaskExecutor,

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -337,6 +337,7 @@ final class ServiceConfigBuilder implements ServiceConfigSetters<ServiceConfigBu
     }
 
     ServiceConfig build(ServiceNaming defaultServiceNaming,
+                        @Nullable String defaultLogName,
                         long defaultRequestTimeoutMillis,
                         long defaultMaxRequestLength,
                         boolean defaultVerboseResponses,
@@ -374,8 +375,9 @@ final class ServiceConfigBuilder implements ServiceConfigSetters<ServiceConfigBu
         return new ServiceConfig(
                 routeWithBaseContextPath,
                 mappedRoute == null ? routeWithBaseContextPath : mappedRoute,
-                service, defaultLogName, defaultServiceName,
+                service, defaultServiceName,
                 this.defaultServiceNaming != null ? this.defaultServiceNaming : defaultServiceNaming,
+                this.defaultLogName != null ? this.defaultLogName : defaultLogName,
                 requestTimeoutMillis,
                 maxRequestLength,
                 verboseResponses != null ? verboseResponses : defaultVerboseResponses,
@@ -398,6 +400,7 @@ final class ServiceConfigBuilder implements ServiceConfigSetters<ServiceConfigBu
                           .add("route", route)
                           .add("service", service)
                           .add("defaultServiceNaming", defaultServiceNaming)
+                          .add("defaultLogName", defaultLogName)
                           .add("requestTimeoutMillis", requestTimeoutMillis)
                           .add("maxRequestLength", maxRequestLength)
                           .add("verboseResponses", verboseResponses)

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -92,6 +92,7 @@ public final class VirtualHost {
     private final Logger accessLogger;
 
     private final ServiceNaming defaultServiceNaming;
+    @Nullable
     private final String defaultLogName;
     private final long requestTimeoutMillis;
     private final long maxRequestLength;
@@ -114,7 +115,7 @@ public final class VirtualHost {
                 RejectedRouteHandler rejectionHandler,
                 Function<? super VirtualHost, ? extends Logger> accessLoggerMapper,
                 ServiceNaming defaultServiceNaming,
-                String defaultLogName,
+                @Nullable String defaultLogName,
                 long requestTimeoutMillis,
                 long maxRequestLength, boolean verboseResponses,
                 AccessLogWriter accessLogWriter,
@@ -362,6 +363,7 @@ public final class VirtualHost {
      * Returns the default value of the {@link RequestLog#name()} property which is used when no name was set
      * via {@link RequestLogBuilder#name(String, String)}.
      */
+    @Nullable
     public String defaultLogName() {
         return defaultLogName;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -1330,7 +1330,6 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                 this.defaultServiceNaming != null ?
                 this.defaultServiceNaming : template.defaultServiceNaming;
 
-        assert template.defaultLogName != null;
         final String defaultLogName =
                 this.defaultLogName != null ?
                 this.defaultLogName : template.defaultLogName;
@@ -1441,9 +1440,9 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                                         cfgSetters.getClass().getSimpleName());
                     }
                 }).map(cfgBuilder -> {
-                    return cfgBuilder.build(defaultServiceNaming, requestTimeoutMillis, maxRequestLength,
-                                            verboseResponses, accessLogWriter, blockingTaskExecutor,
-                                            successFunction, requestAutoAbortDelayMillis,
+                    return cfgBuilder.build(defaultServiceNaming, defaultLogName, requestTimeoutMillis,
+                                            maxRequestLength, verboseResponses, accessLogWriter,
+                                            blockingTaskExecutor, successFunction, requestAutoAbortDelayMillis,
                                             multipartUploadsLocation, multipartRemovalStrategy,
                                             serviceWorkerGroup, defaultHeaders,
                                             requestIdGenerator, defaultErrorHandler,
@@ -1452,8 +1451,8 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
 
         final ServiceConfig fallbackServiceConfig =
                 new ServiceConfigBuilder(RouteBuilder.FALLBACK_ROUTE, "/", FallbackService.INSTANCE)
-                        .build(defaultServiceNaming, requestTimeoutMillis, maxRequestLength, verboseResponses,
-                               accessLogWriter, blockingTaskExecutor, successFunction,
+                        .build(defaultServiceNaming, defaultLogName, requestTimeoutMillis, maxRequestLength,
+                               verboseResponses, accessLogWriter, blockingTaskExecutor, successFunction,
                                requestAutoAbortDelayMillis, multipartUploadsLocation, multipartRemovalStrategy,
                                serviceWorkerGroup, defaultHeaders, requestIdGenerator,
                                defaultErrorHandler, unloggedExceptionsReporter, "/", contextHook);

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -1325,24 +1325,37 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         ensureHostnamePatternMatchesDefaultHostname(hostnamePattern, defaultHostname);
 
         // Retrieve all settings as a local copy. Use default builder's properties if not set.
+        assert template.defaultServiceNaming != null;
         final ServiceNaming defaultServiceNaming =
                 this.defaultServiceNaming != null ?
                 this.defaultServiceNaming : template.defaultServiceNaming;
+
+        assert template.defaultLogName != null;
         final String defaultLogName =
                 this.defaultLogName != null ?
                 this.defaultLogName : template.defaultLogName;
+
+        assert template.requestTimeoutMillis != null;
         final long requestTimeoutMillis =
                 this.requestTimeoutMillis != null ?
                 this.requestTimeoutMillis : template.requestTimeoutMillis;
+
+        assert template.maxRequestLength != null;
         final long maxRequestLength =
                 this.maxRequestLength != null ?
                 this.maxRequestLength : template.maxRequestLength;
+
+        assert template.verboseResponses != null;
         final boolean verboseResponses =
                 this.verboseResponses != null ?
                 this.verboseResponses : template.verboseResponses;
+
+        assert template.requestAutoAbortDelayMillis != null;
         final long requestAutoAbortDelayMillis =
                 this.requestAutoAbortDelayMillis != null ?
                 this.requestAutoAbortDelayMillis : template.requestAutoAbortDelayMillis;
+
+        assert template.rejectedRouteHandler != null;
         final RejectedRouteHandler rejectedRouteHandler =
                 this.rejectedRouteHandler != null ?
                 this.rejectedRouteHandler : template.rejectedRouteHandler;
@@ -1493,6 +1506,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         SslContext sslContext = null;
         boolean releaseSslContextOnFailure = false;
         try {
+            assert template.tlsAllowUnsafeCiphers != null;
             final boolean tlsAllowUnsafeCiphers =
                     this.tlsAllowUnsafeCiphers != null ?
                     this.tlsAllowUnsafeCiphers : template.tlsAllowUnsafeCiphers;
@@ -1521,6 +1535,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
                     tlsCustomizers = this.tlsCustomizers;
                     sslContextFromThis = true;
                 } else {
+                    assert template.tlsSelfSigned != null;
                     tlsSelfSigned = template.tlsSelfSigned;
                     tlsCustomizers = template.tlsCustomizers;
                 }
@@ -1562,6 +1577,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
 
     private SelfSignedCertificate selfSignedCertificate() throws CertificateException {
         if (selfSignedCertificate == null) {
+            assert defaultHostname != null;
             return selfSignedCertificate = new SelfSignedCertificate(defaultHostname);
         }
         return selfSignedCertificate;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ByteArrayResponseConverterFunction.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 public final class ByteArrayResponseConverterFunction implements ResponseConverterFunction {
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultHttpResult.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/DefaultHttpResult.java
@@ -49,6 +49,7 @@ final class DefaultHttpResult<T> implements HttpResult<T> {
         return headers;
     }
 
+    @Nullable
     @Override
     public T content() {
         return content;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/HttpFileResponseConverterFunction.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.server.file.HttpFile;
  */
 public final class HttpFileResponseConverterFunction implements ResponseConverterFunction {
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonResponseConverterFunction.java
@@ -71,6 +71,7 @@ public final class JacksonResponseConverterFunction implements ResponseConverter
         this.mapper = requireNonNull(mapper, "mapper");
     }
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/NullToNoContentResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/NullToNoContentResponseConverterFunction.java
@@ -31,6 +31,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 public final class NullToNoContentResponseConverterFunction implements ResponseConverterFunction {
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType contentType) {
         return null;

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/ServerSentEventResponseConverterFunction.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 public final class ServerSentEventResponseConverterFunction implements ResponseConverterFunction {
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType contentType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/core/src/main/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/annotation/StringResponseConverterFunction.java
@@ -45,6 +45,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 public final class StringResponseConverterFunction implements ResponseConverterFunction {
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type resultType, @Nullable MediaType contentType) {
         if (contentType != null && contentType.is(MediaType.ANY_TEXT_TYPE)) {

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocService.java
@@ -57,6 +57,7 @@ import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ServerCacheControl;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.ThreadFactories;
@@ -75,6 +76,7 @@ import com.linecorp.armeria.server.file.AbstractHttpVfs;
 import com.linecorp.armeria.server.file.AggregatedHttpFile;
 import com.linecorp.armeria.server.file.FileService;
 import com.linecorp.armeria.server.file.HttpFile;
+import com.linecorp.armeria.server.file.HttpFileAttributes;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpVfs;
 import com.linecorp.armeria.server.file.MediaTypeResolver;
@@ -422,11 +424,18 @@ public final class DocService extends SimpleDecoratingHttpService {
             if (specificationLoader.contains(path)) {
                 return HttpFile.from(specificationLoader.get(path).thenApply(file -> {
                     assert file != AggregatedHttpFile.nonExistent();
-                    final HttpFileBuilder builder = HttpFile.builder(file.content(),
-                                                                     file.attributes().lastModifiedMillis());
+                    final HttpData fileContent = file.content();
+                    final ResponseHeaders fileHeaders = file.headers();
+                    final HttpFileAttributes fileAttrs = file.attributes();
+                    assert fileContent != null;
+                    assert fileHeaders != null;
+                    assert fileAttrs != null;
+
+                    final HttpFileBuilder builder = HttpFile.builder(fileContent,
+                                                                     fileAttrs.lastModifiedMillis());
                     builder.autoDetectedContentType(false);
                     builder.clock(clock);
-                    builder.setHeaders(file.headers());
+                    builder.setHeaders(fileHeaders);
                     builder.setHeaders(additionalHeaders);
                     if (contentEncoding != null) {
                         builder.setHeader(HttpHeaderNames.CONTENT_ENCODING, contentEncoding);

--- a/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
@@ -159,7 +159,9 @@ public final class MethodInfo {
         for (String query : exampleQueries) {
             final RequestTarget reqTarget = RequestTarget.forServer("/?" + query);
             checkArgument(reqTarget != null, "exampleQueries contains an invalid query string: %s", query);
-            exampleQueriesBuilder.add(reqTarget.query());
+            final String safeQuery = reqTarget.query();
+            assert safeQuery != null;
+            exampleQueriesBuilder.add(safeQuery);
         }
         this.exampleQueries = exampleQueriesBuilder.build();
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -209,6 +209,7 @@ public abstract class AbstractHttpFile implements HttpFile {
             return null;
         }
 
+        assert attrs != null;
         final long length = attrs.length();
         if (length == 0) {
             // No need to stream an empty file.

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -445,7 +445,9 @@ public final class FileService extends AbstractHttpService {
             if (decompress && encoding != null) {
                 assert aggregated instanceof HttpDataFile;
                 aggregated = decompress((HttpDataFile) aggregated, encoding, alloc);
-                if (aggregated.attributes().length() > config.maxCacheEntrySizeBytes()) {
+                final HttpFileAttributes attrs = aggregated.attributes();
+                assert attrs != null;
+                if (attrs.length() > config.maxCacheEntrySizeBytes()) {
                     // Invalidate the cache just in case the file was small previously.
                     cache.invalidate(pathAndEncoding);
                     return aggregated.toHttpFile();

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileSystemHttpFile.java
@@ -82,6 +82,7 @@ final class FileSystemHttpFile extends StreamingHttpFile<ByteChannel> {
         }, fileReadExecutor);
     }
 
+    @Nullable
     @Override
     protected ByteChannel newStream() throws IOException {
         try {

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpDataFile.java
@@ -90,7 +90,9 @@ final class HttpDataFile extends AbstractHttpFile implements AggregatedHttpFile 
     @Nonnull
     @Override
     public ResponseHeaders headers() {
-        return readHeaders(attrs);
+        final ResponseHeaders headers = readHeaders(attrs);
+        assert headers != null;
+        return headers;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/StreamingHttpFile.java
@@ -79,6 +79,7 @@ public abstract class StreamingHttpFile<T extends Closeable> extends AbstractHtt
         super(contentType, clock, dateEnabled, lastModifiedEnabled, entityTagFunction, headers);
     }
 
+    @Nullable
     @Override
     protected final HttpResponse doRead(ResponseHeaders headers, long length,
                                         Executor fileReadExecutor, ByteBufAllocator alloc) throws IOException {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogComponent.java
@@ -376,6 +376,7 @@ interface AccessLogComponent {
             return headerName;
         }
 
+        @Nullable
         @Override
         public Object getMessage0(RequestLog log) {
             return httpHeaders.apply(log).get(headerName);

--- a/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/AccessLogFormats.java
@@ -133,6 +133,7 @@ final class AccessLogFormats {
                         textBuilder.append(ch);
                     } else {
                         if (textBuilder.length() > 0) {
+                            assert condBuilder != null;
                             condBuilder.addHttpStatus(newStringAndReset(textBuilder));
                         }
                         // Loop again.

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedBeanFactoryRegistryTest.java
@@ -39,8 +39,9 @@ import com.linecorp.armeria.server.annotation.Param;
 public class AnnotatedBeanFactoryRegistryTest {
 
     public static final DependencyInjector noopDependencyInjector = new DependencyInjector() {
+        @Nullable
         @Override
-        public <T> @Nullable T getInstance(Class<T> type) {
+        public <T> T getInstance(Class<T> type) {
             return null;
         }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceNamingTest.java
@@ -186,7 +186,7 @@ class ServiceNamingTest {
 
     private static ServiceConfig newServiceConfig(HttpService httpService, ServiceNaming serviceNaming) {
         return new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(), httpService,
-                                 null, null, serviceNaming, 0, 0, false,
+                                 null, serviceNaming, null, 0, 0, false,
                                  AccessLogWriter.common(), CommonPools.blockingTaskExecutor(),
                                  SuccessFunction.always(),
                                  0, Files.newTemporaryFolder().toPath(),

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceTest.java
@@ -60,8 +60,9 @@ public class ServiceTest {
         // Test if FooService.serviceAdded() is invoked.
         final ServiceConfig cfg =
                 new ServiceConfig(Route.ofCatchAll(), Route.ofCatchAll(),
-                                  outer, /* defaultLogName */ null, /* defaultServiceName */ null,
-                                  ServiceNaming.of("FooService"), 1, 1, true,
+                                  outer, /* defaultServiceName */ null,
+                                  ServiceNaming.of("FooService"), /* defaultLogName */ null,
+                                  1, 1, true,
                                   AccessLogWriter.disabled(),
                                   CommonPools.blockingTaskExecutor(),
                                   SuccessFunction.always(),

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -98,6 +98,8 @@ netty = "4.1.110.Final"
 netty-incubator-transport-native-io_uring = "0.0.25.Final"
 nexus-publish = "2.0.0"
 node-gradle-plugin = "7.0.2"
+nullaway = "0.11.0"
+nullaway-gradle-plugin = "2.0.0"
 okhttp2 = "2.7.5" # For testing
 okhttp3 = { strictly = "3.14.9" } # Not just for testing. Used in the Retrofit mudule.
 okhttp4 = "4.12.0" # For testing
@@ -943,6 +945,10 @@ module = 'io.netty:netty-tcnative-boringssl-static'
 module = "io.netty.incubator:netty-incubator-transport-native-io_uring"
 version.ref = "netty-incubator-transport-native-io_uring"
 
+[libraries.nullaway]
+module = "com.uber.nullaway:nullaway"
+version.ref = "nullaway"
+
 [libraries.picocli]
 module = "info.picocli:picocli"
 version.ref = "picocli"
@@ -1396,15 +1402,16 @@ module = "io.github.resilience4j:resilience4j-micrometer"
 version.ref = "resilience4j"
 
 [plugins]
+errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-gradle-plugin" }
 jkube = { id = "org.eclipse.jkube.kubernetes", version.ref = "jkube" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh-gradle-plugin" }
-osdetector = { id = "com.google.osdetector", version.ref = "osdetector" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
-scalafmt = { id = "cz.alenkacz.gradle.scalafmt", version.ref = "scalafmt-gradle-plugin" }
-nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle-plugin" }
-errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone-gradle-plugin" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish" }
 node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle-plugin" }
+nullaway = { id = "net.ltgt.nullaway", version.ref = "nullaway-gradle-plugin" }
+osdetector = { id = "com.google.osdetector", version.ref = "osdetector" }
+scalafmt = { id = "cz.alenkacz.gradle.scalafmt", version.ref = "scalafmt-gradle-plugin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot2" }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -221,6 +221,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
         return params.options();
     }
 
+    @Nullable
     @Override
     public <T> T as(Class<T> type) {
         final T unwrapped = Unwrappable.super.as(type);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/GrpcClientFactory.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.util.Unwrappable;
@@ -225,6 +226,7 @@ final class GrpcClientFactory extends DecoratingClientFactory {
                 params.clientType(), optionsBuilder.build());
     }
 
+    @Nullable
     @Override
     public <T> T unwrap(Object client, Class<T> type) {
         final T unwrapped = super.unwrap(client, type);

--- a/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
+++ b/protobuf/src/main/java/com/linecorp/armeria/server/protobuf/ProtobufResponseConverterFunction.java
@@ -145,6 +145,7 @@ public final class ProtobufResponseConverterFunction implements ResponseConverte
         this.jsonPrinter = requireNonNull(jsonPrinter, "jsonPrinter");
     }
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/resilience4j2/src/main/java/com/linecorp/armeria/resilience4j/circuitbreaker/client/Resilience4JCircuitBreakerClientHandler.java
+++ b/resilience4j2/src/main/java/com/linecorp/armeria/resilience4j/circuitbreaker/client/Resilience4JCircuitBreakerClientHandler.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerClientHandler;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerMapping;
 import com.linecorp.armeria.client.circuitbreaker.ClientCircuitBreakerGenerator;
 import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.circuitbreaker.CircuitBreakerCallback;
 
@@ -102,6 +103,7 @@ public final class Resilience4JCircuitBreakerClientHandler implements CircuitBre
         this.mapping = mapping;
     }
 
+    @Nullable
     @Override
     public CircuitBreakerCallback tryRequest(ClientRequestContext ctx, Request req) {
         final CircuitBreaker circuitBreaker;

--- a/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
+++ b/rxjava2/src/main/java/com/linecorp/armeria/server/rxjava2/ObservableResponseConverterFunction.java
@@ -79,6 +79,7 @@ public final class ObservableResponseConverterFunction implements ResponseConver
         exceptionHandler = null;
     }
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
+++ b/rxjava3/src/main/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunction.java
@@ -79,6 +79,7 @@ public final class ObservableResponseConverterFunction implements ResponseConver
         exceptionHandler = null;
     }
 
+    @Nullable
     @Override
     public Boolean isResponseStreaming(Type returnType, @Nullable MediaType produceType) {
         final Class<?> clazz = typeToClass(unwrapUnaryAsyncType(returnType));

--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/SpringDependencyInjector.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/SpringDependencyInjector.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.BeanFactory;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.DependencyInjector;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**

--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/SpringDependencyInjector.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/SpringDependencyInjector.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.BeanFactory;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
@@ -138,6 +139,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>> i
         }
     }
 
+    @Nullable
     @Override
     protected List<Endpoint> latestValue() {
         final List<Endpoint> endpoints = state.endpoints();
@@ -158,6 +160,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>> i
         return selectionStrategy;
     }
 
+    @Nullable
     @Override
     public Endpoint selectNow(ClientRequestContext ctx) {
         return selector.selectNow(ctx);


### PR DESCRIPTION
Motivation:

It would be nice if we can fail our build if there is any potential
`null` dereference, so our users have much less chance of getting
`NullPointerException`.

Modifications:

- Updated the build so that NullAway plugin is enabled for `:core`
  - Note that the root `build.gradle` was modified so that we can
    enable NullAway for other projects in the future.
  - Other caveats:
    - NullAway is disabled for MR-JAR sources because it seems to make
      the build fail with unrelated errors (e.g. no symbol)
- Added `assert` sentences and `@Nullable` annotations wherever
  applicable
- Fixed a few minor potential `null` dereferences

Result:

- We're more confident about our `@Nullable` usages in our API.
- Theoretically, there should be no chance of `NullPointerException` at
  least in the `:core`.
  - However, note that some `NullPointerException`s might have become
    `AssertionError`s, since we added a bunch of assertions in this PR,
    so please review carefully :-)
- Partially resolves #1680 and #5184
