### PR TITLE
fix: logger.warn instead of ISE on transcoding options for non-unary gRPC

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingService.java
@@ -159,10 +159,12 @@ final class HttpJsonTranscodingService extends AbstractUnframedGrpcService
 
                 final HttpRule httpRule = methodOptions.getExtension(AnnotationsProto.http);
 
-                checkArgument(methodDefinition.getMethodDescriptor().getType() == MethodType.UNARY,
-                              "Only unary methods can be configured with an HTTP/JSON endpoint: " +
-                              "method=%s, httpRule=%s",
-                              methodDefinition.getMethodDescriptor().getFullMethodName(), httpRule);
+                if (methodDefinition.getMethodDescriptor().getType() != MethodType.UNARY) {
+                    logger.warn("Only unary methods can be configured with an HTTP/JSON endpoint: " +
+                                "method={}, httpRule={}",
+                                methodDefinition.getMethodDescriptor().getFullMethodName(), httpRule);
+                    continue;
+                }
 
                 @Nullable
                 final Entry<Route, List<PathVariable>> routeAndVariables = toRouteAndPathVariables(httpRule);

--- a/grpc/src/test/proto/testing/grpc/transcoding.proto
+++ b/grpc/src/test/proto/testing/grpc/transcoding.proto
@@ -237,6 +237,12 @@ service HttpJsonTranscodingTestService {
       post: "/v1/arbitrary_wrapped"
     };
   }
+
+  rpc EchoBidirectionalStream(stream Message) returns (stream Message) {
+    option (google.api.http) = {
+      post: "/v1/echo/bidirectional_stream"
+    };
+  }
 }
 
 message GetMessageRequestV1 {


### PR DESCRIPTION
Motivation:

- #5828 
- When an rpc method has transcoding options, the server won't start up.

Modifications:

- Warn and skip the method instead of preventing server startup.

Result:

- Closes #5828
- Server can start if a gRPC non-unary rpc is configured to have transcoding options. 
