### PR TITLE
Fix `ClientFactory` leaks in `ResteasyClient`

### DIFF
--- a/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
+++ b/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaJaxrsClientEngine.java
@@ -110,6 +110,7 @@ public class ArmeriaJaxrsClientEngine implements AsyncClientHttpEngine, Closeabl
 
     @Override
     public void close() {
+        client.options().factory().closeAsync();
     }
 
     /**

--- a/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
+++ b/resteasy/src/test/java/com/linecorp/armeria/server/resteasy/CalculatorServiceClientServerTest.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.jboss.resteasy.core.ResteasyDeploymentImpl;
 import org.jboss.resteasy.spi.ResteasyDeployment;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -40,6 +41,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.client.resteasy.ArmeriaResteasyClientBuilder;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.LogLevel;
 import com.linecorp.armeria.common.logging.LogWriter;
 import com.linecorp.armeria.internal.testing.GenerateNativeImageTrace;
@@ -69,6 +71,16 @@ class CalculatorServiceClientServerTest {
                     .build().register(serverBuilder);
         }
     };
+
+    @Nullable
+    private static Client restClient;
+
+    @AfterEach
+    void tearDown() {
+        if (restClient != null) {
+            restClient.close();
+        }
+    }
 
     @Test
     void testCalcContext() throws Exception {
@@ -121,7 +133,7 @@ class CalculatorServiceClientServerTest {
                                                            .decorator(LoggingClient.builder()
                                                                                    .logWriter(logWriter)
                                                                                    .newDecorator());
-        final Client restClient = ArmeriaResteasyClientBuilder.newBuilder(webClientBuilder).build();
+        restClient = ArmeriaResteasyClientBuilder.newBuilder(webClientBuilder).build();
         return restClient.target(restServer.httpUri());
     }
 }


### PR DESCRIPTION
Motivation:

A `ClientFactory` leak was detected in `CalculatorServiceClientServerTest`
```java
10:19:16.263 [Test worker] ERROR io.netty.util.ResourceLeakDetector - LEAK: ClientFactory.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records:
Created at:
	com.linecorp.armeria.client.DefaultClientFactory.<init>(DefaultClientFactory.java:101)
	com.linecorp.armeria.client.ClientFactoryBuilder.build(ClientFactoryBuilder.java:998)
	com.linecorp.armeria.client.resteasy.ArmeriaResteasyClientBuilder.buildWebClient(ArmeriaResteasyClientBuilder.java:193)
	com.linecorp.armeria.client.resteasy.ArmeriaResteasyClientBuilder.build(ArmeriaResteasyClientBuilder.java:210)
	com.linecorp.armeria.server.resteasy.CalculatorServiceClientServerTest.newWebTarget(CalculatorServiceClientServerTest.java:124)
	com.linecorp.armeria.server.resteasy.CalculatorServiceClientServerTest.testCalc(CalculatorServiceClientServerTest.java:92)
```

A new `ClientFactory` is created when a `ResteasyClient` is made but the factory isn't closed.
https://github.com/line/armeria/blob/cbe744e453eb66e7a1588d2d4cab8582d446b9ce/resteasy/src/main/java/com/linecorp/armeria/client/resteasy/ArmeriaResteasyClientBuilder.java#L91

Modifications:

- Close the `WebClient`'s `ClientFactory` when `ArmeriaJaxrsClientEngine` is closed.

Result:

`ResteasyClient` now correctly releases `ClientFactory` when it is closed.

