### PR TITLE
Make CI run all branches on push

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "**"
     tags-ignore:
       # The release versions will be verified by 'publish-release.yml'
       - armeria-*


### PR DESCRIPTION
We create branches for patch versions that need to be verified by CI.

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

> '**' : Matches all branch and tag names. This is the default behavior when you don't use a branches or tags filter.

