### PR TITLE
Support nested context paths.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/AbstractContextPathServicesBuilder.java
@@ -20,12 +20,14 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.server.ServerBuilder.decorate;
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.RouteDecoratingService;
 import com.linecorp.armeria.internal.server.RouteUtil;
 import com.linecorp.armeria.internal.server.annotation.AnnotatedServiceExtensions;
@@ -40,16 +42,33 @@ abstract class AbstractContextPathServicesBuilder<SELF extends AbstractContextPa
     private final T parent;
     private final VirtualHostBuilder virtualHostBuilder;
 
+    @Nullable
+    private SELF previousNode;
+
+
     AbstractContextPathServicesBuilder(T parent, VirtualHostBuilder virtualHostBuilder,
                                        Set<String> contextPaths) {
+        this(parent, virtualHostBuilder, contextPaths, ImmutableSet.of(), null);
+    }
+
+    AbstractContextPathServicesBuilder(T parent,
+                                       VirtualHostBuilder virtualHostBuilder,
+                                       Set<String> contextPaths,
+                                       Set<String> previousContextPaths,
+                                       @Nullable SELF previousNode) {
         checkArgument(!contextPaths.isEmpty(), "At least one context path is required");
         for (String contextPath: contextPaths) {
             RouteUtil.ensureAbsolutePath(contextPath, "contextPath");
         }
 
+        final Set<String> mergedContextPaths = previousContextPaths.isEmpty() ?
+                                               contextPaths :
+                                               mergeContextPaths(previousContextPaths, contextPaths);
+
         this.parent = parent;
-        this.contextPaths = ImmutableSet.copyOf(contextPaths);
+        this.contextPaths = ImmutableSet.copyOf(mergedContextPaths);
         this.virtualHostBuilder = virtualHostBuilder;
+        this.previousNode = previousNode;
     }
 
     @SuppressWarnings("unchecked")
@@ -406,7 +425,33 @@ abstract class AbstractContextPathServicesBuilder<SELF extends AbstractContextPa
         return parent;
     }
 
+    public abstract SELF contextPath(String... contextPaths);
+
     final Set<String> contextPaths() {
         return contextPaths;
     }
+
+    T parent() {
+        return parent;
+    }
+
+    VirtualHostBuilder virtualHostBuilder() {
+        return virtualHostBuilder;
+    }
+
+    @Nullable
+    public SELF before() {
+        return previousNode;
+    }
+
+    private Set<String> mergeContextPaths(Set<String> previousContextPaths, Set<String> contextPaths) {
+        final Set<String> compositedPaths = new HashSet<>();
+        for (String previousPath : previousContextPaths) {
+            for (String contextPath : contextPaths) {
+                compositedPaths.add(previousPath + contextPath);
+            }
+        }
+        return compositedPaths;
+    }
+
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ContextPathServicesBuilder.java
@@ -16,11 +16,16 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import javax.naming.Context;
+
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -44,6 +49,24 @@ public final class ContextPathServicesBuilder
     ContextPathServicesBuilder(ServerBuilder parent, VirtualHostBuilder virtualHostBuilder,
                                Set<String> contextPaths) {
         super(parent, virtualHostBuilder, contextPaths);
+    }
+
+    ContextPathServicesBuilder(ServerBuilder parent,
+                               VirtualHostBuilder virtualHostBuilder,
+                               Set<String> contextPaths,
+                               Set<String> previousContextPaths,
+                               ContextPathServicesBuilder contextPathServicesBuilder) {
+        super(parent, virtualHostBuilder, contextPaths, previousContextPaths, contextPathServicesBuilder);
+    }
+
+    @Override
+    public ContextPathServicesBuilder contextPath(String... contextPaths) {
+        final ImmutableSet<String> currentContextPaths = ImmutableSet.copyOf(requireNonNull(contextPaths, "contextPaths"));
+        return new ContextPathServicesBuilder(parent(),
+                                              virtualHostBuilder(),
+                                              currentContextPaths,
+                                              contextPaths(),
+                                              this);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostContextPathServicesBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostContextPathServicesBuilder.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.google.common.collect.ImmutableSet;
+
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
@@ -45,6 +47,23 @@ public final class VirtualHostContextPathServicesBuilder
     VirtualHostContextPathServicesBuilder(VirtualHostBuilder parent, VirtualHostBuilder virtualHostBuilder,
                                           Set<String> contextPaths) {
         super(parent, virtualHostBuilder, contextPaths);
+    }
+
+    VirtualHostContextPathServicesBuilder(VirtualHostBuilder parent, VirtualHostBuilder virtualHostBuilder,
+                                          Set<String> contextPaths,
+                                          Set<String> previousContextPaths,
+                                          VirtualHostContextPathServicesBuilder virtualHostContextPathServicesBuilder) {
+        super(parent, virtualHostBuilder, contextPaths, previousContextPaths, virtualHostContextPathServicesBuilder);
+    }
+
+    @Override
+    public VirtualHostContextPathServicesBuilder contextPath(String... contextPaths) {
+        final ImmutableSet<String> currentContextPaths = ImmutableSet.copyOf(requireNonNull(contextPaths, "contextPaths"));
+        return new VirtualHostContextPathServicesBuilder(parent(),
+                                                         virtualHostBuilder(),
+                                                         currentContextPaths,
+                                                         contextPaths(),
+                                                         this);
     }
 
     /**


### PR DESCRIPTION
### Motivation:
- Currently, `armeria` supports only `1-depth` context paths. Sometimes, user want deeper context paths than 1-depth when they use `contextPaths()`.

### Modifications:
- Make `ContextPathServiceBuilder` tree to support nested context paths. 
- Add public functions. 
  - `before()` is for going back previous node.
  - `contextPath()` is for adding context paths and making child `ContextPathServiceBuilder`
- Add package-private and private functions.
  - `parent()`: To give Child `contextPathServiceBuilder` parent object. because of this, child can return parent object when `and()` is called.
  - `virtualHostbuilder()`: to relay their context via `ContextPathServiceBuilder` tree.
  - `mergeContextPaths()`: to merge previous context paths and current context paths. 

### Example
- I make a example armeria codes and test codes
- repository : https://github.com/chickenchickenlove/nestedcontext
- armeria example : https://github.com/chickenchickenlove/nestedcontext/blob/master/src/main/java/org/example/Main.java
- test example: https://github.com/chickenchickenlove/nestedcontext/blob/master/pytest/my_test.py


### Result:
- Closes https://github.com/line/armeria/issues/5758
- User can use nested context paths. for example, 
```java
sb.contextPath("/rest")
      .contextPath("/catalog")
          .service("/product", new GetProductService())
          .service("/products", new ProductsHandler())
          .before()
      .contextPath("/cart")
          .contextPath("/foo")
               .contextPath("/bar")
                    .service("/checkout", new CheckoutService());
                    .and()
  .contextPath("/gql")
      .service("/catalog", new GraphQLService());
```

`/rest/catalog/product` => `getProductService`
`/rest/catalog/products` => `productsHandler`
`/rest/cart/foo/bar/checkout` => `checkoutService`
`/gql/catalog` => `GraphQLService`
