### PR TITLE
Upgrade Node.js to 22.3.0

### DIFF
--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -11,15 +11,10 @@ if (rootProject.hasProperty('noWeb')) {
 }
 
 node {
-    version = '16.19.1'
+    version = '22.3.0'
+    npmVersion = '10.8.1'
     download = true
     npmInstallCommand = "ci"
-
-    // Change the cache location under Gradle user home directory so that it's cached by CI.
-    if (System.getenv('CI') != null) {
-        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
-        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
-    }
 }
 
 // Add the option that works around the dependency conflicts.

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -23,15 +23,10 @@ plugins {
 }
 
 node {
-    version = '16.19.1'
+    version = '22.3.0'
+    npmVersion = '10.8.1'
     download = true
     npmInstallCommand = "ci"
-
-    // Change the cache location under Gradle user home directory so that it's cached by CI.
-    if (System.getenv('CI') != null) {
-        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
-        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
-    }
 }
 
 // Add the option that works around the dependency conflicts.


### PR DESCRIPTION
Motivation:

Our CI has occasionally been failing to download Node.js 16.19.1 for the past few days. https://github.com/line/armeria/actions/runs/10200377198/job/28219691450?pr=5580#step:5:26
```
Could not determine the dependencies of task ':docs-client:nodeSetup'.
> Failed to query the value of task ':docs-client:nodeSetup' property 'nodeArchiveFile'.
  > Could not resolve all files for configuration ':docs-client:detachedConfiguration1'.
    > Could not download node-16.19.1-linux-x64.tar.gz (org.nodejs:node:16.19.1)
      > Could not get resource 'https://nodejs.org/dist/v16.19.1/node-v16.19.1-linux-x64.tar.gz'.
        > Read timed out
```

We encountered a similar problem in Central Dogma CI. Some details are somewhat different but the download failure also happened in Central Dogma. The problem was resolved by 1) upgrading Node.js version and 2) removing the custom cache location of Gradle. https://github.com/line/centraldogma/pull/994

Modifications:

- Bump Node.js to 22.3.0 from 16.19.1
- Remove the cache location for Node.js

Result:

Stable CI builds.
