### PR TITLE
Loosen the validation rule for URI authority

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.internal.common;
 
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.findAuthority;
+import static com.linecorp.armeria.internal.common.util.BitSetUtil.toBitSet;
 import static io.netty.util.internal.StringUtil.decodeHexNibble;
 import static java.util.Objects.requireNonNull;
 
@@ -73,14 +74,6 @@ public final class DefaultRequestTarget implements RequestTarget {
      * in a fragment. We currently use the same table with {@link #PATH_MUST_PRESERVE_ENCODING}.
      */
     private static final BitSet FRAGMENT_MUST_PRESERVE_ENCODING = PATH_MUST_PRESERVE_ENCODING;
-
-    private static BitSet toBitSet(String chars) {
-        final BitSet bitSet = new BitSet();
-        for (int i = 0; i < chars.length(); i++) {
-            bitSet.set(chars.charAt(i));
-        }
-        return bitSet;
-    }
 
     private enum ComponentType {
         CLIENT_PATH(PATH_ALLOWED, PATH_MUST_PRESERVE_ENCODING),

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -101,7 +101,7 @@ public final class SchemeAndAuthority {
 
         final int endBracket = ipV6Authority.indexOf(']');
         // An incomplete IPv6 address is rejected by URI constructor.
-        assert endBracket > 0 : "endBracket: " + endBracket + " (expected: >= 0)";
+        assert endBracket > 0 : "endBracket: " + endBracket + " (expected: > 0)";
         return ipV6Authority.substring(0, percentPos) + ipV6Authority.substring(endBracket);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SchemeAndAuthority.java
@@ -62,7 +62,7 @@ public final class SchemeAndAuthority {
         for (int i = 0; i < authorityWithoutUserInfo.length(); i++) {
             final char c = authorityWithoutUserInfo.charAt(i);
             if (c < 0x80 && RESERVED_CHARS.get(c)) {
-                throw new IllegalArgumentException("authority contains reserved character: " +
+                throw new IllegalArgumentException("The authority contains reserved character: " +
                                                    authority + " (" + c + ')');
             }
         }
@@ -101,7 +101,7 @@ public final class SchemeAndAuthority {
 
         final int endBracket = ipV6Authority.indexOf(']');
         // An incomplete IPv6 address is rejected by URI constructor.
-        assert endBracket >= 0 : "endBracket: " + endBracket + " (expected: >= 0)";
+        assert endBracket > 0 : "endBracket: " + endBracket + " (expected: >= 0)";
         return ipV6Authority.substring(0, percentPos) + ipV6Authority.substring(endBracket);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/BitSetUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/BitSetUtil.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.util;
+
+import java.util.BitSet;
+
+public final class BitSetUtil {
+
+    public static BitSet toBitSet(String chars) {
+        final BitSet bitSet = new BitSet();
+        for (int i = 0; i < chars.length(); i++) {
+            bitSet.set(chars.charAt(i));
+        }
+        return bitSet;
+    }
+
+    private BitSetUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/client/UnderscoredAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/UnderscoredAuthorityTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class UnderscoredAuthorityTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of("Hello, world!"));
+        }
+    };
+
+    @Test
+    void shouldAllowUnderscoreInAuthority() {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .addressResolverGroupFactory(unused -> {
+                                                      return MockAddressResolverGroup.localhost();
+                                                  })
+                                                  .build()) {
+            final BlockingWebClient client =
+                    WebClient.builder("http://my_key.z1.armeria.dev:" + server.httpPort())
+                             .factory(factory)
+                             .build()
+                             .blocking();
+
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response = client.get("/");
+                final ClientRequestContext ctx = captor.get();
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                assertThat(response.contentUtf8()).isEqualTo("Hello, world!");
+                final RequestLog log = ctx.log().whenComplete().join();
+
+                assertThat(log.requestHeaders().authority())
+                        .isEqualTo("my_key.z1.armeria.dev:" + server.httpPort());
+            }
+        }
+    }
+
+    @Test
+    void shouldAllowUnderscoreInEndpoint() {
+        final Endpoint endpoint = Endpoint.parse("my_key.z1.armeria.dev:" + server.httpPort());
+        assertThat(endpoint.authority()).isEqualTo("my_key.z1.armeria.dev:" + server.httpPort());
+        assertThat(endpoint.host()).isEqualTo("my_key.z1.armeria.dev");
+        assertThat(endpoint.port()).isEqualTo(server.httpPort());
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -48,6 +48,10 @@ class SchemeAndAuthorityTest {
     @ParameterizedTest
     @CsvSource({
             "foo:bar",        // Invalid port
+            "http://foo:80",  // Scheme included
+            "foo/bar",        // Authority with path
+            "foo?bar=1",      // Authority with query
+            "foo#bar",        // Authority with fragment
             "[192.168.0.1]",  // Bracketed IPv4
             "[::1", "::1]",   // Incomplete IPv6
             "[::1]%eth0",     // IPv6 with scope

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -25,13 +25,15 @@ import org.junit.jupiter.params.provider.CsvSource;
 class SchemeAndAuthorityTest {
     @ParameterizedTest
     @CsvSource({
-            "0.0.0.0:80,        0.0.0.0:80,         0.0.0.0,            80",    // IPv4
-            "[::1]:8080,        [::1]:8080,         [::1],              8080",  // IPv6
-            "unix%3Afoo.sock,   unix%3Afoo.sock,    unix%3Afoo.sock,    -1",    // Domain socket
-            "foo.bar,           foo.bar,            foo.bar,            -1",    // Only host
-            "foo:,              foo:,               foo,                -1",    // Empty port
-            "bar:80,            bar:80,             bar,                80",    // Host and port
-            "foo@bar:80,        bar:80,             bar,                80",    // Userinfo and host and port
+            "0.0.0.0:80,        0.0.0.0:80,          0.0.0.0,            80",    // IPv4
+            "[::1]:8080,        [::1]:8080,          [::1],              8080",  // IPv6
+            "unix%3Afoo.sock,   unix%3Afoo.sock,     unix%3Afoo.sock,    -1",    // Domain socket
+            "foo.bar,           foo.bar,             foo.bar,            -1",    // Only host
+            "foo:,              foo:,                foo,                -1",    // Empty port
+            "bar:80,            bar:80,              bar,                80",    // Host and port
+            "foo@bar:80,        bar:80,              bar,                80",    // Userinfo and host and port
+            "foo_bar:80,        foo_bar:80,          foo_bar,            80",    // Underscore in host
+            "한글.com:80,        xn--bj0bj06e.com:80, xn--bj0bj06e.com,   80",    // IDN
     })
     void fromAuthority(String authority, String expectedAuthority, String expectedHost,
                        int expectedPort) {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -25,8 +25,13 @@ import org.junit.jupiter.params.provider.CsvSource;
 class SchemeAndAuthorityTest {
     @ParameterizedTest
     @CsvSource({
-            "0.0.0.0:80,        0.0.0.0:80,          0.0.0.0,            80",    // IPv4
-            "[::1]:8080,        [::1]:8080,          [::1],              8080",  // IPv6
+            "0.0.0.0,           0.0.0.0,             0.0.0.0,            -1",    // IPv4
+            "0.0.0.0:,          0.0.0.0:,            0.0.0.0,            -1",    // IPv4 with empty port
+            "0.0.0.0:80,        0.0.0.0:80,          0.0.0.0,            80",    // IPv4 with port
+            "[::1],             [::1],               [::1],              -1",    // IPv6
+            "[::1]:,            [::1]:,              [::1],              -1",    // IPv6 with empty port
+            "[::1]:8080,        [::1]:8080,          [::1],              8080",  // IPv6 with port
+            "[::1%eth0]:8080,   [::1]:8080,          [::1],              8080",  // IPv6 with port
             "unix%3Afoo.sock,   unix%3Afoo.sock,     unix%3Afoo.sock,    -1",    // Domain socket
             "foo.bar,           foo.bar,             foo.bar,            -1",    // Only host
             "foo:,              foo:,                foo,                -1",    // Empty port
@@ -47,15 +52,16 @@ class SchemeAndAuthorityTest {
 
     @ParameterizedTest
     @CsvSource({
-            "foo:bar",        // Invalid port
-            "http://foo:80",  // Scheme included
-            "foo/bar",        // Authority with path
-            "foo?bar=1",      // Authority with query
-            "foo#bar",        // Authority with fragment
-            "[192.168.0.1]",  // Bracketed IPv4
-            "[::1", "::1]",   // Incomplete IPv6
-            "[::1]%eth0",     // IPv6 with scope
-            "unix:foo.sock"   // Invalid domain socket
+            "foo:bar",                 // Invalid port
+            "http://foo:80",           // Scheme included
+            "foo/bar",                 // Authority with path
+            "foo?bar=1",               // Authority with query
+            "foo#bar",                 // Authority with fragment
+            "[192.168.0.1]",           // Bracketed IPv4
+            "[::1", "::1]",            // Incomplete IPv6 with scope
+            "[::1%eth0", "::1%eth0]",  // Incomplete IPv6 with scope
+            "[::1]%eth0",              // Invalid IPv6 scope
+            "unix:foo.sock"            // Invalid domain socket
     })
     void fromBadAuthority(String badAuthority) {
         assertThatThrownBy(() -> SchemeAndAuthority.of(null, badAuthority))

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -47,8 +47,7 @@ class SchemeAndAuthorityTest {
 
     @ParameterizedTest
     @CsvSource({
-            "foo:bar", "http://foo:80", "foo/bar", "foo?bar=1", "foo#bar",
-            "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
+            "foo:bar", "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
     })
     void fromBadAuthority(String badAuthority) {
         assertThatThrownBy(() -> SchemeAndAuthority.of(null, badAuthority))

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -31,7 +31,7 @@ class SchemeAndAuthorityTest {
             "[::1],             [::1],               [::1],              -1",    // IPv6
             "[::1]:,            [::1]:,              [::1],              -1",    // IPv6 with empty port
             "[::1]:8080,        [::1]:8080,          [::1],              8080",  // IPv6 with port
-            "[::1%eth0]:8080,   [::1]:8080,          [::1],              8080",  // IPv6 with port
+            "[::1%eth0]:8080,   [::1]:8080,          [::1],              8080",  // IPv6 with port and scope
             "unix%3Afoo.sock,   unix%3Afoo.sock,     unix%3Afoo.sock,    -1",    // Domain socket
             "foo.bar,           foo.bar,             foo.bar,            -1",    // Only host
             "foo:,              foo:,                foo,                -1",    // Empty port

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -47,7 +47,11 @@ class SchemeAndAuthorityTest {
 
     @ParameterizedTest
     @CsvSource({
-            "foo:bar", "[192.168.0.1]", "[::1", "::1]", "[::1]%eth0", "unix:foo.sock"
+            "foo:bar",        // Invalid port
+            "[192.168.0.1]",  // Bracketed IPv4
+            "[::1", "::1]",   // Incomplete IPv6
+            "[::1]%eth0",     // IPv6 with scope
+            "unix:foo.sock"   // Invalid domain socket
     })
     void fromBadAuthority(String badAuthority) {
         assertThatThrownBy(() -> SchemeAndAuthority.of(null, badAuthority))

--- a/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/SchemeAndAuthorityTest.java
@@ -58,7 +58,7 @@ class SchemeAndAuthorityTest {
             "foo?bar=1",               // Authority with query
             "foo#bar",                 // Authority with fragment
             "[192.168.0.1]",           // Bracketed IPv4
-            "[::1", "::1]",            // Incomplete IPv6 with scope
+            "[::1", "::1]",            // Incomplete IPv6
             "[::1%eth0", "::1%eth0]",  // Incomplete IPv6 with scope
             "[::1]%eth0",              // Invalid IPv6 scope
             "unix:foo.sock"            // Invalid domain socket

--- a/core/src/test/java/com/linecorp/armeria/server/ServiceFinderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServiceFinderTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria;
+package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,11 +28,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
-import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.Server;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.ServiceRequestContext;
-import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.cors.CorsService;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.server.logging.LoggingService;


### PR DESCRIPTION
Motivation:

The authority part in a URI was validated by
`URI.parseServerAuthority()` which only allows alphanumeric characters, `.` and `-`.
https://github.com/openjdk/jdk/blob/dc35f3e8a84c8f622a4cabb8aee0f96de2e2ea30/src/java.base/share/classes/java/net/URI.java#L3513-L3515

As a result, if underscore (`_`) is set in an authority, `URISyntaxException` is raised. We think the rule is too strict because a request can also be sent to an instance when CSLB is used. `_` is a valid character in a DNS record. Users may want to send a request to a host whose name is `beta_api.cloud.instance-123.somewhere.com`.

Related: #5814

Modifications:

- Remove the usage of `URI.parseServerAuthority()` in `SchemeAndAuthority`
- Parse a hostname and a port from a raw authority.

Result:

- Validation is relaxed to permit underscores (_) in URI's authority.
- Closes #5814
