### PR TITLE
Propagate exception from `StreamMessage` to `InputStream`.

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessageInputStream.java
@@ -154,7 +154,7 @@ final class StreamMessageInputStream<T> extends InputStream {
 
         @Override
         public void onError(Throwable cause) {
-            byteBufsInputStream.setEos();
+            byteBufsInputStream.interrupt(cause);
         }
 
         @Override

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageInputStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageInputStreamTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -227,15 +228,20 @@ class StreamMessageInputStreamTest {
 
         final ByteBuf result = Unpooled.buffer();
         int read;
-        while ((read = inputStream.read()) != -1) {
-            result.writeByte(read);
+        try {
+            while ((read = inputStream.read()) != -1) {
+                result.writeByte(read);
+            }
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(InterruptedIOException.class)
+                         .hasCauseInstanceOf(AbortedStreamException.class);
         }
 
+        // Read before the exception is raised.
         final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
-        assertThat(inputStream.read()).isEqualTo(-1);
     }
 
     @Test
@@ -256,15 +262,20 @@ class StreamMessageInputStreamTest {
 
         final ByteBuf result = Unpooled.buffer();
         int read;
-        while ((read = inputStream.read()) != -1) {
-            result.writeByte(read);
+        try {
+            while ((read = inputStream.read()) != -1) {
+                result.writeByte(read);
+            }
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(InterruptedIOException.class)
+                         .hasCauseInstanceOf(RuntimeException.class);
         }
 
+        // Read before the exception is raised.
         final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);
         assertThat(inputStream.available()).isZero();
-        assertThat(inputStream.read()).isEqualTo(-1);
     }
 
     @Test
@@ -335,10 +346,16 @@ class StreamMessageInputStreamTest {
 
         final ByteBuf result = Unpooled.buffer();
         int read;
-        while ((read = inputStream.read()) != -1) {
-            result.writeByte(read);
+        try {
+            while ((read = inputStream.read()) != -1) {
+                result.writeByte(read);
+            }
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(InterruptedIOException.class)
+                         .hasCauseInstanceOf(RuntimeException.class);
         }
 
+        // Read before the exception is raised.
         final byte[] actual = ByteBufUtil.getBytes(result);
         result.release();
         assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
Motivation:
The `InputStream` returned from `StreamMessage.toInputStream()` should raise an exception if the original `StreamMessage` is closed with an exception. Currently, the `InputStream` only returns `-1` in such cases, which does not inform the caller of the underlying issue.

Modification:
- Updated the implementation to propagate the exception to the `InputStream` if the original `StreamMessage` is closed with an exception.

Result:
- The `InputStream` now correctly raises an exception if the original `StreamMessage` is closed with an exception.
