### PR TITLE
Fix flaky `StreamMessageCollectingTest.filteredStreamMessage_exception()`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
@@ -165,7 +165,11 @@ class StreamMessageCollectingTest {
         }).isInstanceOf(CompletionException.class)
           .hasCause(cause);
 
-        assertRefCount(data, 0);
+        await().untilAsserted(() -> {
+            // subscription.cancel() is called after onError() which completes the collecting future
+            // exceptionally.
+            assertRefCount(data, 0);
+        });
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`upstream.cancel()` is called after `onError(ex)`
https://github.com/line/armeria/blob/6a01398173b3abaea8fd7f613193ea7ba6376e88/core/src/main/java/com/linecorp/armeria/common/stream/FilteredStreamMessage.java#L225-L228 So the test `data` may not be released when `filtered.collect().join()` completes exceptionally.

Modifications:

- Wrap the assertion with `await()`

Result:

Fix the flaky test
