### PR TITLE
Use `DEBUG` to log `invalid authorization header` in `OAuth2TokenExtractor`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/OAuth2TokenExtractor.java
@@ -61,7 +61,7 @@ final class OAuth2TokenExtractor implements Function<RequestHeaders, OAuth2Token
 
         final Matcher matcher = AUTHORIZATION_HEADER_PATTERN.matcher(authorization);
         if (!matcher.matches()) {
-            logger.warn("Invalid authorization header: " + authorization);
+            logger.debug("Invalid authorization header: {}", authorization);
             return null;
         }
 


### PR DESCRIPTION
Motivation:

Invalid authorization is a client error so there isn't much a server maintainer can do. It seems better to use `DEBUG` to detect problems during development. `WARN` could be noisy because it may be related to a monitoring system.

Modifications:

- Use `DEBUG` to log an invalid authorization header.

Result:

An invalid authorization header is now logged at `DEBUG` by the OAuth2 token extractor.
