### PR TITLE
Test failure: com.linecorp.armeria.server.ServerBuilderTest.contextHook()

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -141,6 +142,13 @@ class ServerBuilderTest {
                      .idleTimeoutMillis(idleTimeoutMillis)
                      .pingIntervalMillis(pingIntervalMillis)
                      .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        poppedRouterCnt.set(0);
+        poppedRouterCnt2.set(0);
+        poppedCnt.set(0);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

#5769 

Modifications:

- Added tearDown method with `@AfterEach` in order to reset each count variables used in tests

When executing this test in my local env, this test succeeded and I wasn't sure why this test failure was caused.
But, after adding this tearDown method, we will be able to avoid inappropriate variables staying  in cnt variables.

Result:

- Closes #5769 
- `Test failure: com.linecorp.armeria.server.ServerBuilderTest.contextHook()` will be resolved.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
