### PR TITLE
Add pendingResponse to ServerMetrics

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
@@ -118,8 +118,8 @@ abstract class GracefulShutdownSupport {
         private long lastResTimeNanos;
         private volatile long shutdownStartTimeNanos;
 
-        private DefaultGracefulShutdownSupport(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker,
-                                               ServerMetrics serverMetrics) {
+        private DefaultGracefulShutdownSupport(Duration quietPeriod, Executor blockingTaskExecutor,
+                                               Ticker ticker, ServerMetrics serverMetrics) {
             super(serverMetrics);
             quietPeriodNanos = quietPeriod.toNanos();
             this.blockingTaskExecutor = blockingTaskExecutor;

--- a/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.server;
 import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.LongAdder;
 
 import com.google.common.base.Ticker;
 
@@ -29,39 +28,48 @@ import com.google.common.base.Ticker;
  */
 abstract class GracefulShutdownSupport {
 
-    static GracefulShutdownSupport create(Duration quietPeriod, Executor blockingTaskExecutor) {
-        return create(quietPeriod, blockingTaskExecutor, Ticker.systemTicker());
+    private final ServerMetrics serverMetrics;
+
+    static GracefulShutdownSupport create(Duration quietPeriod, Executor blockingTaskExecutor,
+                                          ServerMetrics serverMetrics) {
+        return create(quietPeriod, blockingTaskExecutor, Ticker.systemTicker(), serverMetrics);
     }
 
-    static GracefulShutdownSupport create(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker) {
-        return new DefaultGracefulShutdownSupport(quietPeriod, blockingTaskExecutor, ticker);
+    static GracefulShutdownSupport create(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker,
+                                          ServerMetrics serverMetrics) {
+        return new DefaultGracefulShutdownSupport(quietPeriod, blockingTaskExecutor, ticker, serverMetrics);
     }
 
-    static GracefulShutdownSupport createDisabled() {
-        return new DisabledGracefulShutdownSupport();
+    static GracefulShutdownSupport createDisabled(ServerMetrics serverMetrics) {
+        return new DisabledGracefulShutdownSupport(serverMetrics);
     }
 
-    private final LongAdder pendingResponses = new LongAdder();
+    /**
+     * Creates a new instance.
+     */
+    private GracefulShutdownSupport(ServerMetrics serverMetrics) {
+        this.serverMetrics = serverMetrics;
+    }
 
     /**
      * Increases the number of pending responses.
      */
     final void inc() {
-        pendingResponses.increment();
+        serverMetrics.increasePendingResponse();
     }
 
     /**
      * Decreases the number of pending responses.
      */
     void dec() {
-        pendingResponses.decrement();
+        serverMetrics.decreasePendingResponse();
     }
 
     /**
      * Returns the number of pending responses.
      */
     final long pendingResponses() {
-        return pendingResponses.sum();
+        return serverMetrics.pendingResponses();
     }
 
     /**
@@ -77,6 +85,14 @@ abstract class GracefulShutdownSupport {
     private static final class DisabledGracefulShutdownSupport extends GracefulShutdownSupport {
 
         private volatile boolean shuttingDown;
+
+        /**
+         * Creates a new instance.
+         *
+         */
+        private DisabledGracefulShutdownSupport(ServerMetrics serverMetrics) {
+            super(serverMetrics);
+        }
 
         @Override
         boolean isShuttingDown() {
@@ -102,7 +118,9 @@ abstract class GracefulShutdownSupport {
         private long lastResTimeNanos;
         private volatile long shutdownStartTimeNanos;
 
-        DefaultGracefulShutdownSupport(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker) {
+        private DefaultGracefulShutdownSupport(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker,
+                                       ServerMetrics serverMetrics) {
+            super(serverMetrics);
             quietPeriodNanos = quietPeriod.toNanos();
             this.blockingTaskExecutor = blockingTaskExecutor;
             this.ticker = ticker;

--- a/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
+++ b/core/src/main/java/com/linecorp/armeria/server/GracefulShutdownSupport.java
@@ -55,14 +55,14 @@ abstract class GracefulShutdownSupport {
      * Increases the number of pending responses.
      */
     final void inc() {
-        serverMetrics.increasePendingResponse();
+        serverMetrics.increasePendingResponses();
     }
 
     /**
      * Decreases the number of pending responses.
      */
     void dec() {
-        serverMetrics.decreasePendingResponse();
+        serverMetrics.decreasePendingResponses();
     }
 
     /**
@@ -119,7 +119,7 @@ abstract class GracefulShutdownSupport {
         private volatile long shutdownStartTimeNanos;
 
         private DefaultGracefulShutdownSupport(Duration quietPeriod, Executor blockingTaskExecutor, Ticker ticker,
-                                       ServerMetrics serverMetrics) {
+                                               ServerMetrics serverMetrics) {
             super(serverMetrics);
             quietPeriodNanos = quietPeriod.toNanos();
             this.blockingTaskExecutor = blockingTaskExecutor;

--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -502,11 +502,11 @@ public final class Server implements ListenableAsyncCloseable {
         @Override
         protected CompletionStage<Void> doStart(@Nullable Void arg) {
             if (config().gracefulShutdownQuietPeriod().isZero()) {
-                gracefulShutdownSupport = GracefulShutdownSupport.createDisabled();
+                gracefulShutdownSupport = GracefulShutdownSupport.createDisabled(config.serverMetrics());
             } else {
                 gracefulShutdownSupport =
                         GracefulShutdownSupport.create(config().gracefulShutdownQuietPeriod(),
-                                                       config().blockingTaskExecutor());
+                                                       config().blockingTaskExecutor(), config.serverMetrics());
             }
 
             // Initialize the server sockets asynchronously.
@@ -585,8 +585,6 @@ public final class Server implements ListenableAsyncCloseable {
             final GracefulShutdownSupport gracefulShutdownSupport = this.gracefulShutdownSupport;
             assert gracefulShutdownSupport != null;
 
-            meterRegistry.gauge("armeria.server.pending.responses", gracefulShutdownSupport,
-                                GracefulShutdownSupport::pendingResponses);
             config.serverMetrics().bindTo(meterRegistry);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerMetrics.java
@@ -39,7 +39,7 @@ public final class ServerMetrics implements MeterBinder {
     private final LongAdder activeHttp1WebSocketRequests = new LongAdder();
     private final LongAdder activeHttp1Requests = new LongAdder();
     private final LongAdder activeHttp2Requests = new LongAdder();
-    private final LongAdder pendingResponse = new LongAdder();
+    private final LongAdder pendingResponses = new LongAdder();
 
     /**
      * AtomicInteger is used to read the number of active connections frequently.
@@ -103,7 +103,7 @@ public final class ServerMetrics implements MeterBinder {
      * Returns the number of pending responses.
      */
     public long pendingResponses() {
-        return pendingResponse.longValue();
+        return pendingResponses.longValue();
     }
 
     /**
@@ -161,12 +161,12 @@ public final class ServerMetrics implements MeterBinder {
         activeConnections.decrementAndGet();
     }
 
-    void increasePendingResponse() {
-        pendingResponse.increment();
+    void increasePendingResponses() {
+        pendingResponses.increment();
     }
 
-    void decreasePendingResponse() {
-        pendingResponse.decrement();
+    void decreasePendingResponses() {
+        pendingResponses.decrement();
     }
 
     @Override
@@ -191,9 +191,7 @@ public final class ServerMetrics implements MeterBinder {
                             ImmutableList.of(Tag.of("protocol", "http1.websocket"), Tag.of("state", "active")),
                             activeHttp1WebSocketRequests);
         // pending responses
-        meterRegistry.gauge(allRequestsMeterName,
-                            ImmutableList.of(Tag.of("protocol", "all"), Tag.of("state", "active")),
-                            pendingResponse);
+        meterRegistry.gauge("armeria.server.pending.responses", pendingResponses);
     }
 
     @Override
@@ -205,7 +203,7 @@ public final class ServerMetrics implements MeterBinder {
                           .add("pendingHttp2Requests", pendingHttp2Requests)
                           .add("activeHttp2Requests", activeHttp2Requests)
                           .add("activeConnections", activeConnections)
-                          .add("pendingResponse", pendingResponse)
+                          .add("pendingResponses", pendingResponses)
                           .toString();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/GracefulShutdownSupportTest.java
@@ -45,6 +45,8 @@ class GracefulShutdownSupportTest {
     @Mock
     private Ticker ticker;
 
+    private ServerMetrics serverMetrics;
+
     private GracefulShutdownSupport support;
     private ThreadPoolExecutor executor;
 
@@ -54,7 +56,9 @@ class GracefulShutdownSupportTest {
                 0, 1, 1, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
                 ThreadFactories.newThreadFactory("graceful-shutdown-test", true));
 
-        support = GracefulShutdownSupport.create(Duration.ofNanos(QUIET_PERIOD_NANOS), executor, ticker);
+        serverMetrics = new ServerMetrics();
+        support = GracefulShutdownSupport.create(Duration.ofNanos(QUIET_PERIOD_NANOS), executor, ticker,
+                                                 serverMetrics);
     }
 
     @AfterEach
@@ -64,7 +68,7 @@ class GracefulShutdownSupportTest {
 
     @Test
     void testDisabled() {
-        final GracefulShutdownSupport support = GracefulShutdownSupport.createDisabled();
+        final GracefulShutdownSupport support = GracefulShutdownSupport.createDisabled(serverMetrics);
         assertThat(support.isShuttingDown()).isFalse();
         assertThat(support.completedQuietPeriod()).isTrue();
         assertThat(support.isShuttingDown()).isTrue();


### PR DESCRIPTION
Motivation:

- Related Issue: #5666 
- Currently, GracefulShutdownSupport manages the pendingResponse metric. With the introduction of the ServerMetrics class, which handles server-related metrics, it’s necessary to consolidate the management of pendingResponse within ServerMetrics for better organization and consistency.

Modifications:

- Moved the pendingResponse metric from GracefulShutdownSupport to ServerMetrics.
- Renamed the pendingResponses method to activeNonTransientResponses to better reflect its purpose and functionality.


Result:

- Closes #5666 . (If this resolves the issue.)
- Server-related metrics are now managed within the ServerMetrics class, ensuring a centralized and consistent approach.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
