### PR TITLE
Replace synchronized blocks in retrofit2 with ReentrantLock(Improve)

### DIFF
--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/PipeBuffer.java
@@ -36,6 +36,11 @@ final class PipeBuffer {
         if (byteCount == 0) {
             return;
         }
+        /*
+         * Once use okhttp4, the synchronized block could be replaced by Reentrant and Condition for Virtual Thread support.
+         * Especially, Timeout.awaitSignal(Condition) can be used upper than the okio 3.3.0.
+         * Please refer here. https://github.com/square/okio/pull/1176/files
+         */
         synchronized (buffer) {
             if (sourceClosed) {
                 return;


### PR DESCRIPTION
Motivation:

- Replace synchronized blocks in retrofit2 for Virtual Thread
- This is improvement of #4610

Modifications:

- remove `synchronized` in ArmeriaCallFactory's createRequest() by using CAS
- Add comments related to buffer's synchronized blocks.

Result:

- Remove synchronized block in retrofit2, but still have one issue with PipeBuffer(needed okhttp4)