### PR TITLE
Do not log gRPC CANCELLED exception in a client

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -260,7 +260,7 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
             ctxExtension.responseCancellationScheduler().cancelScheduled();
         }
 
-        if (cancel) {
+        if (cancel || (cause != null && Exceptions.isStreamCancelling(cause))) {
             cancelAction(cause);
             return;
         }


### PR DESCRIPTION
Motivation:
I found this log that is unnecessary when an `XdsEndpointGroup` is closed:
```
Unexpected exception while closing a request:
io.grpc.StatusRuntimeException: CANCELLED: Cancelled by client with StreamObserver.onError()
	at io.grpc.Status.asRuntimeException(Status.java:533)
	at com.linecorp.armeria.internal.common.grpc.StatusAndMetadata.asRuntimeException(StatusAndMetadata.java:53)
	at com.linecorp.armeria.internal.common.grpc.GrpcLogUtil.rpcResponse(GrpcLogUtil.java:62)
	at com.linecorp.armeria.internal.client.grpc.ArmeriaClientCall.close(ArmeriaClientCall.java:574)
	at com.linecorp.armeria.internal.client.grpc.ArmeriaClientCall.doCancel(ArmeriaClientCall.java:333)
	at com.linecorp.armeria.internal.client.grpc.ArmeriaClientCall.lambda$cancel$7(ArmeriaClientCall.java:312)
	at com.linecorp.armeria.common.DefaultContextAwareRunnable.run(DefaultContextAwareRunnable.java:45)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.kqueue.KQueueEventLoop.run(KQueueEventLoop.java:300)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:994)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.grpc.StatusException: CANCELLED: shutdown
	at io.grpc.Status.asException(Status.java:541)
	at com.linecorp.armeria.xds.SotwXdsStream.stop(SotwXdsStream.java:121)
  ...
```