### PR TITLE
Update documentation for default value in Backoff.exponential where multiplier is not specified

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -59,7 +59,7 @@ public interface Backoff extends Unwrappable {
     }
 
     /**
-     * Returns a {@link Backoff} that waits an exponentially-increasing amount of time between attempts.
+     * Returns a {@link Backoff} that waits an exponentially-increasing with multiplier 2.0 amount of time between attempts.
      */
     static Backoff exponential(long initialDelayMillis, long maxDelayMillis) {
         return exponential(initialDelayMillis, maxDelayMillis, 2.0);

--- a/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/Backoff.java
@@ -59,7 +59,8 @@ public interface Backoff extends Unwrappable {
     }
 
     /**
-     * Returns a {@link Backoff} that waits an exponentially-increasing with multiplier 2.0 amount of time between attempts.
+     * Returns a {@link Backoff} that waits an exponentially-increasing with multiplier
+     * 2.0 amount of time between attempts.
      */
     static Backoff exponential(long initialDelayMillis, long maxDelayMillis) {
         return exponential(initialDelayMillis, maxDelayMillis, 2.0);


### PR DESCRIPTION
Motivation:

Docs were confusing when using the framework. Needed to dig into the code to find the default multipler. So let's add it in the documentation
