### PR TITLE
Introduce rawPath in RequestTarget and ServiceRequestContext

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractRequestContextBuilder.java
@@ -155,7 +155,8 @@ public abstract class AbstractRequestContextBuilder {
         } else {
             reqTarget = DefaultRequestTarget.createWithoutValidation(
                     RequestTargetForm.ORIGIN, null, null, null, -1,
-                    uri.getRawPath(), uri.getRawPath(), uri.getRawQuery(), uri.getRawFragment());
+                    uri.getRawPath(), uri.getRawPath(), null,
+                    uri.getRawQuery(), uri.getRawFragment());
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
@@ -132,9 +132,9 @@ public interface RequestTarget {
     String maybePathWithMatrixVariables();
 
     /**
-     * Returns the raw server path of this {@link RequestTarget}, which always starts with {@code '/'}.
-     * Unlike {@link #path()}, the returned string is the original request path without any normalization.
-     * For client target it always returns null.
+     * Returns the server-side raw path of this {@link RequestTarget} from the ":path" header.
+     * Unlike {@link #path()}, the returned string is the original path without any normalization.
+     * For client-side target it always returns {@code null}.
      */
     @Nullable
     String rawPath();

--- a/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RequestTarget.java
@@ -132,6 +132,14 @@ public interface RequestTarget {
     String maybePathWithMatrixVariables();
 
     /**
+     * Returns the raw server path of this {@link RequestTarget}, which always starts with {@code '/'}.
+     * Unlike {@link #path()}, the returned string is the original request path without any normalization.
+     * For client target it always returns null.
+     */
+    @Nullable
+    String rawPath();
+
+    /**
      * Returns the query of this {@link RequestTarget}.
      */
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -250,7 +250,7 @@ public final class DefaultRequestTarget implements RequestTarget {
 
     private DefaultRequestTarget(RequestTargetForm form, @Nullable String scheme,
                                  @Nullable String authority, @Nullable String host, int port,
-                                 String path,String maybePathWithMatrixVariables, @Nullable String rawPath,
+                                 String path, String maybePathWithMatrixVariables, @Nullable String rawPath,
                                  @Nullable String query, @Nullable String fragment) {
 
         assert (scheme != null && authority != null && host != null) ||

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultRequestTarget.java
@@ -224,8 +224,8 @@ public final class DefaultRequestTarget implements RequestTarget {
      */
     public static RequestTarget createWithoutValidation(
             RequestTargetForm form, @Nullable String scheme, @Nullable String authority,
-            @Nullable String host, int port, String path, String pathWithMatrixVariables, @Nullable String rawPath,
-            @Nullable String query, @Nullable String fragment) {
+            @Nullable String host, int port, String path, String pathWithMatrixVariables,
+            @Nullable String rawPath, @Nullable String query, @Nullable String fragment) {
         return new DefaultRequestTarget(
                 form, scheme, authority, host, port, path, pathWithMatrixVariables, rawPath, query, fragment);
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -306,6 +306,14 @@ public final class DefaultServiceRequestContext
     }
 
     @Override
+    public String rawPath() {
+        final String rawPath = requestTarget().rawPath();
+        // rawPath should not be null for server-side targets.
+        assert rawPath != null;
+        return rawPath;
+    }
+
+    @Override
     public URI uri() {
         final HttpRequest request = request();
         assert request != null;

--- a/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/RoutingContext.java
@@ -169,6 +169,7 @@ public interface RoutingContext {
                         oldReqTarget.port(),
                         pathWithoutMatrixVariables,
                         path,
+                        path,
                         oldReqTarget.query(),
                         oldReqTarget.fragment());
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -336,6 +336,11 @@ public interface ServiceRequestContext extends RequestContext {
     String decodedMappedPath();
 
     /**
+     * Returns the original path without normalization from the ":path" header.
+     */
+    String rawPath();
+
+    /**
      * Returns the {@link URI} associated with the current {@link Request}.
      * Note that this method is a shortcut of calling {@link HttpRequest#uri()} on {@link #request()}.
      */

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -121,6 +121,11 @@ public class ServiceRequestContextWrapper
         return unwrap().decodedMappedPath();
     }
 
+    @Override
+    public String rawPath() {
+        return unwrap().rawPath();
+    }
+
     @Nullable
     @Override
     public MediaType negotiatedResponseMediaType() {

--- a/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
@@ -18,17 +18,17 @@ package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import com.google.common.io.ByteStreams;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 class RawPathTest {
@@ -40,58 +40,68 @@ class RawPathTest {
             sb.serviceUnder("/", (ctx, req) -> {
                 final String rawPath = ctx.routingContext().requestTarget().rawPath();
                 assertThat(rawPath).isNotNull();
-                return HttpResponse.of("rawPath:" + rawPath);
+                assertThat(ctx.rawPath()).isEqualTo(rawPath);
+
+                final String expectedRawPath = ctx.request().headers().get("X-Raw-Path");
+                assertThat(rawPath).isEqualTo(expectedRawPath);
+                return HttpResponse.of(HttpStatus.OK);
             });
         }
     };
 
-    private static final Set<String> TEST_URLS = new HashSet<>();
-
-    static {
-        TEST_URLS.add("/");
-        TEST_URLS.add("//");
-        TEST_URLS.add("/service//foo");
-        TEST_URLS.add("/service/foo..bar");
-        TEST_URLS.add("/service..hello/foobar");
-        TEST_URLS.add("/service//test//////a/?flag=hello");
-        TEST_URLS.add("/service/foo:bar");
-        TEST_URLS.add("/service/foo::::::bar");
-        TEST_URLS.add("/cache/v1.0/rnd_team/get/krisjey:56578015655:1223");
-        TEST_URLS.add("/signout/56578015655?crumb=s-1475829101-cec4230588-%E2%98%83");
-        TEST_URLS.add(
-                "/search/num=20&newwindow=1&espv=2&q=url+path+colon&oq=url+path+colon&gs_l=serp.3" +
-                        "..0i30k1.80626.89265.0.89464.18.16.1.1.1.0.154.1387.0j12.12.0....0...1c.1j4.64.s" +
-                        "erp..4.14.1387...0j35i39k1j0i131k1j0i19k1j0i30i19k1j0i8i30i19k1j0i5i30i19k1j0i8i10" +
-                        "i30i19k1.Z6SsEq-rZDw");
-        TEST_URLS.add("/service/foo*bar4");
-        TEST_URLS.add("/gwturl#user:45/comments");
-        TEST_URLS.add("/service:name/hello");
-        TEST_URLS.add("/service/foo|bar5");
-        TEST_URLS.add("/service/foo\\bar6");
-        TEST_URLS.add("/[]");
-        TEST_URLS.add("/a+b");
-        TEST_URLS.add("/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29*%2B%2C%3B%3D");
-    }
-
-    @Test
-    void rawPathOfUrl() throws Exception {
-        for (String url : TEST_URLS) {
-            rawPathAssertion(url);
-        }
-    }
-
-    private static void rawPathAssertion(String path) throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "//",
+            "/service//foo",
+            "/service/foo..bar",
+            "/service..hello/foobar",
+            "/service//test//////a/",
+            "/service//test//////a/?flag=hello",
+            "/service/foo:bar",
+            "/service/foo::::::bar",
+            "/another/foo/",
+            "/cache/v1.0/rnd_team/get/krisjey:56578015655:1223",
+            "/signout/56578015655?crumb=s-1475829101-cec4230588-%E2%98%83",
+            "/search/num=20&newwindow=1&espv=2&q=url+path+colon&oq=url+path+colon&gs_l=serp.3" +
+            "..0i30k1.80626.89265.0.89464.18.16.1.1.1.0.154.1387.0j12.12.0....0...1c.1j4.64.serp" +
+            "..4.14.1387...0j35i39k1j0i131k1j0i19k1j0i30i19k1j0i8i30i19k1j0i5i30i19k1j0i8i10i30i19k1" +
+            ".Z6SsEq-rZDw",
+            "/service/foo*bar4",
+            "/gwturl#user:45/comments",
+            "/service:name/hello",
+            "/service::::name/hello",
+            "/..service/foobar1",
+            "/service../foobar2",
+            "/service/foobar3..",
+            "/service/foo|bar5",
+            "/service/foo\\bar6",
+            "/\\\\",
+            "/\"?\"",
+            "/service/foo>bar",
+            "/service/foo<bar",
+            "/[]",
+            "/a+b",
+            "/a%20b",
+            "/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29*%2B%2C%3B%3D"
+    })
+    void rawPathOfUrl(String url) throws Exception {
         try (Socket s = new Socket()) {
             s.connect(server.httpSocketAddress());
             s.setSoTimeout(10000);
             s.getOutputStream().write(
-                    ("GET " + path + " HTTP/1.0\r\n" +
+                    ("GET " + url + " HTTP/1.0\r\n" +
                             "Host:" + server.httpUri().getAuthority() + "\r\n" +
                             "Connection: close\r\n" +
+                            "X-Raw-Path: " + url + "\r\n" +
                             "\r\n").getBytes(StandardCharsets.US_ASCII));
-            final String ret = new String(ByteStreams.toByteArray(s.getInputStream()),
-                    StandardCharsets.US_ASCII);
-            assertThat(ret).contains("rawPath:" + path);
+            final BufferedReader in = new BufferedReader(
+                    new InputStreamReader(s.getInputStream(), StandardCharsets.US_ASCII));
+            // only reads a first line because it only needs to check the expected status
+            // and does not wait for the server to close the connection.
+            assertThat(in.readLine())
+                    .as(url)
+                    .startsWith("HTTP/1.1 200");
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
@@ -23,10 +23,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.google.common.io.ByteStreams;
-import io.netty.util.NetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.io.ByteStreams;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -81,7 +81,8 @@ class RawPathTest {
     }
 
     private static void rawPathAssertion(String path) throws Exception {
-        try (Socket s = new Socket(NetUtil.LOCALHOST, server.httpPort())) {
+        try (Socket s = new Socket()) {
+            s.connect(server.httpSocketAddress());
             s.setSoTimeout(10000);
             s.getOutputStream().write(
                     ("GET " + path + " HTTP/1.0\r\n" +

--- a/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/RawPathTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.io.ByteStreams;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RawPathTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.serviceUnder("/", (ctx, req) -> {
+                final String rawPath = ctx.routingContext().requestTarget().rawPath();
+                assertThat(rawPath).isNotNull();
+                return HttpResponse.of("rawPath:" + rawPath);
+            });
+        }
+    };
+
+    private static final Set<String> TEST_URLS = new HashSet<>();
+
+    static {
+        TEST_URLS.add("/");
+        TEST_URLS.add("//");
+        TEST_URLS.add("/service//foo");
+        TEST_URLS.add("/service/foo..bar");
+        TEST_URLS.add("/service..hello/foobar");
+        TEST_URLS.add("/service//test//////a/?flag=hello");
+        TEST_URLS.add("/service/foo:bar");
+        TEST_URLS.add("/service/foo::::::bar");
+        TEST_URLS.add("/cache/v1.0/rnd_team/get/krisjey:56578015655:1223");
+        TEST_URLS.add("/signout/56578015655?crumb=s-1475829101-cec4230588-%E2%98%83");
+        TEST_URLS.add(
+                "/search/num=20&newwindow=1&espv=2&q=url+path+colon&oq=url+path+colon&gs_l=serp.3" +
+                        "..0i30k1.80626.89265.0.89464.18.16.1.1.1.0.154.1387.0j12.12.0....0...1c.1j4.64.s" +
+                        "erp..4.14.1387...0j35i39k1j0i131k1j0i19k1j0i30i19k1j0i8i30i19k1j0i5i30i19k1j0i8i10" +
+                        "i30i19k1.Z6SsEq-rZDw");
+        TEST_URLS.add("/service/foo*bar4");
+        TEST_URLS.add("/gwturl#user:45/comments");
+        TEST_URLS.add("/service:name/hello");
+        TEST_URLS.add("/service/foo|bar5");
+        TEST_URLS.add("/service/foo\\bar6");
+        TEST_URLS.add("/[]");
+        TEST_URLS.add("/a+b");
+        TEST_URLS.add("/%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29*%2B%2C%3B%3D");
+    }
+
+    @Test
+    void rawPathOfUrl() throws Exception {
+        for (String url : TEST_URLS) {
+            rawPathAssertion(url);
+        }
+    }
+
+    private static void rawPathAssertion(String path) throws Exception {
+        try (Socket s = new Socket(NetUtil.LOCALHOST, server.httpPort())) {
+            s.setSoTimeout(10000);
+            s.getOutputStream().write(
+                    ("GET " + path + " HTTP/1.0\r\n" +
+                            "Host:" + server.httpUri().getAuthority() + "\r\n" +
+                            "Connection: close\r\n" +
+                            "\r\n").getBytes(StandardCharsets.US_ASCII));
+            final String ret = new String(ByteStreams.toByteArray(s.getInputStream()),
+                    StandardCharsets.US_ASCII);
+            assertThat(ret).contains("rawPath:" + path);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
It may be useful if we have access to the original request path unmodified. For example we have use cases where the decoding rules are different from the ones at `decodedPath`.

Modifications:
- Added `rawPath` method in `RequestTarget` to store the rawPath.
- The rawPath is from the unmodified ':path' header at the server side; the client side target, it's always null.
- Added `rawPath` method in `ServiceRequestContext`, it's always non null for server-side targets.

Result:

- Closes #5931.
- Users will get access to the raw request path for a request.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
