### PR TITLE
Fixed `AsyncServerInterceptor` to be compatible with OpenTelmetry

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/ServerCallUtil.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/ServerCallUtil.java
@@ -18,7 +18,7 @@ package com.linecorp.armeria.server.grpc;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.grpc.AbstractServerCall;
@@ -34,8 +34,9 @@ final class ServerCallUtil {
 
     static {
         try {
-            delegateMH = MethodHandles.lookup().findVirtual(ForwardingServerCall.class, "delegate",
-                                                            MethodType.methodType(ServerCall.class));
+            final Method delegate = ForwardingServerCall.class.getDeclaredMethod("delegate");
+            delegate.setAccessible(true);
+            delegateMH = MethodHandles.lookup().unreflect(delegate);
         } catch (NoSuchMethodException | IllegalAccessException e) {
             delegateMH = null;
         }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Executor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -44,6 +46,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
 import io.grpc.ServerCall;
 import io.netty.channel.EventLoop;
 import testing.grpc.Messages.SimpleRequest;
@@ -60,10 +63,14 @@ class DeferredListenerTest {
                             AsyncServerInterceptor.class.getName());
     }
 
-    @Test
-    void shouldLazilyExecuteCallbacks() {
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void shouldLazilyExecuteCallbacks(boolean wrap) {
         final EventLoop eventLoop = CommonPools.workerGroup().next();
-        final UnaryServerCall<SimpleRequest, SimpleResponse> serverCall = newServerCall(eventLoop, null);
+        ServerCall<SimpleRequest, SimpleResponse> serverCall = newServerCall(eventLoop, null);
+        if (wrap) {
+            serverCall = new SimpleForwardingServerCall<SimpleRequest, SimpleResponse>(serverCall) {};
+        }
         assertListenerEvents(serverCall, eventLoop);
 
         final Executor blockingExecutor =


### PR DESCRIPTION
Motivation:

There was a bug in `AsyncServerInterceptor` where a `ForwardingServerCall` was not unwrapped properly via reflection. Because of that, OpenTelemetry's `TracingServerCall` that wraps the existing `ServerCall` using `ForwardingServerCall` was rejected by the following condition.
https://github.com/line/armeria/blob/6dd5cd18dcdc32431316f272128287b2037249d3/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java#L51-L52

Modifications:

- Use the correct reflection API to unsafely access `ForwardingServerCall.delegate()`.

Result:

- Fix a bug where `AsyncServerInterceptor` is incompatible with the OpenTelemetry gRPC agent.
- Closes #5937

