### PR TITLE
Fix a bug where CORS headers are not injected when a `ServerErrorHandler` is set

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/CorsHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/CorsHeaderUtil.java
@@ -25,6 +25,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
@@ -33,8 +34,10 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.cors.CorsConfig;
 import com.linecorp.armeria.server.cors.CorsPolicy;
+import com.linecorp.armeria.server.cors.CorsService;
 
 import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
 
 /**
  * A utility class related to CORS headers.
@@ -46,6 +49,8 @@ public final class CorsHeaderUtil {
     public static final String NULL_ORIGIN = "null";
     public static final String DELIMITER = ",";
     private static final Joiner HEADER_JOINER = Joiner.on(DELIMITER);
+
+    private static AttributeKey<Boolean> IS_CORS_SET = AttributeKey.valueOf(CorsService.class, "IS_CORS_SET");
 
     public static ResponseHeaders addCorsHeaders(ServiceRequestContext ctx, CorsConfig corsConfig,
                                                  ResponseHeaders responseHeaders) {
@@ -64,7 +69,7 @@ public final class CorsHeaderUtil {
      * @param headers the headers to modify
      */
     public static void setCorsResponseHeaders(ServiceRequestContext ctx, HttpRequest req,
-                                              ResponseHeadersBuilder headers, CorsConfig config) {
+                                              HttpHeadersBuilder headers, CorsConfig config) {
         final CorsPolicy policy = setCorsOrigin(ctx, req, headers, config);
         if (policy != null) {
             setCorsAllowCredentials(headers, policy);
@@ -73,7 +78,7 @@ public final class CorsHeaderUtil {
         }
     }
 
-    public static void setCorsAllowCredentials(ResponseHeadersBuilder headers, CorsPolicy policy) {
+    public static void setCorsAllowCredentials(HttpHeadersBuilder headers, CorsPolicy policy) {
         // The string "*" cannot be used for a resource that supports credentials.
         // https://www.w3.org/TR/cors/#resource-requests
         if (policy.isCredentialsAllowed() &&
@@ -82,7 +87,7 @@ public final class CorsHeaderUtil {
         }
     }
 
-    private static void setCorsExposeHeaders(ResponseHeadersBuilder headers, CorsPolicy corsPolicy) {
+    private static void setCorsExposeHeaders(HttpHeadersBuilder headers, CorsPolicy corsPolicy) {
         if (corsPolicy.exposedHeaders().isEmpty()) {
             return;
         }
@@ -90,7 +95,7 @@ public final class CorsHeaderUtil {
         headers.set(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS, joinExposedHeaders(corsPolicy));
     }
 
-    public static void setCorsAllowHeaders(RequestHeaders requestHeaders, ResponseHeadersBuilder headers,
+    public static void setCorsAllowHeaders(RequestHeaders requestHeaders, HttpHeadersBuilder headers,
                                            CorsPolicy corsPolicy) {
         if (corsPolicy.shouldAllowAllRequestHeaders()) {
             final String header = requestHeaders.get(HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS);
@@ -118,7 +123,7 @@ public final class CorsHeaderUtil {
      */
     @Nullable
     public static CorsPolicy setCorsOrigin(ServiceRequestContext ctx, HttpRequest request,
-                                           ResponseHeadersBuilder headers, CorsConfig config) {
+                                           HttpHeadersBuilder headers, CorsConfig config) {
 
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         if (origin != null) {
@@ -149,26 +154,26 @@ public final class CorsHeaderUtil {
         return null;
     }
 
-    private static void setCorsOrigin(ResponseHeadersBuilder headers, String origin) {
+    private static void setCorsOrigin(HttpHeadersBuilder headers, String origin) {
         headers.set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, origin);
     }
 
-    private static void echoCorsRequestOrigin(HttpRequest request, ResponseHeadersBuilder headers) {
+    private static void echoCorsRequestOrigin(HttpRequest request, HttpHeadersBuilder headers) {
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
         if (origin != null) {
             setCorsOrigin(headers, origin);
         }
     }
 
-    private static void addCorsVaryHeader(ResponseHeadersBuilder headers) {
+    private static void addCorsVaryHeader(HttpHeadersBuilder headers) {
         headers.add(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN.toString());
     }
 
-    private static void setCorsAnyOrigin(ResponseHeadersBuilder headers) {
+    private static void setCorsAnyOrigin(HttpHeadersBuilder headers) {
         setCorsOrigin(headers, ANY_ORIGIN);
     }
 
-    private static void setCorsNullOrigin(ResponseHeadersBuilder headers) {
+    private static void setCorsNullOrigin(HttpHeadersBuilder headers) {
         setCorsOrigin(headers, NULL_ORIGIN);
     }
 
@@ -202,6 +207,14 @@ public final class CorsHeaderUtil {
      */
     private static String joinAllowedRequestHeaders(CorsPolicy corsPolicy) {
         return joinHeaders(corsPolicy.allowedRequestHeaders());
+    }
+
+    public static boolean isCorsHeadersSet(ServiceRequestContext ctx) {
+        return ctx.hasAttr(IS_CORS_SET);
+    }
+
+    public static void corsHeadersSet(ServiceRequestContext ctx) {
+        ctx.setAttr(IS_CORS_SET, true);
     }
 
     private CorsHeaderUtil() {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/CorsHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/CorsHeaderUtil.java
@@ -28,8 +28,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeadersBuilder;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.cors.CorsConfig;
@@ -50,17 +48,8 @@ public final class CorsHeaderUtil {
     public static final String DELIMITER = ",";
     private static final Joiner HEADER_JOINER = Joiner.on(DELIMITER);
 
-    private static AttributeKey<Boolean> IS_CORS_SET = AttributeKey.valueOf(CorsService.class, "IS_CORS_SET");
-
-    public static ResponseHeaders addCorsHeaders(ServiceRequestContext ctx, CorsConfig corsConfig,
-                                                 ResponseHeaders responseHeaders) {
-        final HttpRequest httpRequest = ctx.request();
-        final ResponseHeadersBuilder responseHeadersBuilder = responseHeaders.toBuilder();
-
-        setCorsResponseHeaders(ctx, httpRequest, responseHeadersBuilder, corsConfig);
-
-        return responseHeadersBuilder.build();
-    }
+    private static final AttributeKey<Boolean> IS_CORS_SET =
+            AttributeKey.valueOf(CorsService.class, "IS_CORS_SET");
 
     /**
      * Emit CORS headers if origin was found.
@@ -207,6 +196,11 @@ public final class CorsHeaderUtil {
      */
     private static String joinAllowedRequestHeaders(CorsPolicy corsPolicy) {
         return joinHeaders(corsPolicy.allowedRequestHeaders());
+    }
+
+    public static boolean isForbiddenOrigin(CorsConfig config, ServiceRequestContext ctx, RequestHeaders req) {
+        return config.isShortCircuit() &&
+               config.getPolicy(req.get(HttpHeaderNames.ORIGIN), ctx.routingContext()) == null;
     }
 
     public static boolean isCorsHeadersSet(ServiceRequestContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
@@ -69,8 +69,8 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
     /**
      * Sets CORS headers for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests">
      * simple CORS requests</a>.
-     * This method does not support preflight requests or forbidden origins because they require a complete
-     * response that is delegated to {@code serverErrorHandler}.
+     * This method does not support preflight requests because they require a complete response that is
+     * delegated to {@code serverErrorHandler}.
      */
     private static boolean shouldSetCorsHeaders(@Nullable CorsService corsService, ServiceRequestContext ctx) {
         if (corsService == null) {
@@ -83,13 +83,16 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
         }
 
         final RequestHeaders headers = ctx.request().headers();
-        //noinspection RedundantIfStatement
-        if (isCorsPreflightRequest(headers) || isForbiddenOrigin(corsService.config(), ctx, headers)) {
+
+        if (isCorsPreflightRequest(headers)) {
             return false;
-        } else {
-            // A simple CORS request.
-            return true;
         }
+        //noinspection RedundantIfStatement
+        if (isForbiddenOrigin(corsService.config(), ctx, headers)) {
+            return false;
+        }
+        // A simple CORS request.
+        return true;
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
@@ -16,15 +16,12 @@
 
 package com.linecorp.armeria.server;
 
-import static com.linecorp.armeria.internal.server.CorsHeaderUtil.addCorsHeaders;
-
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.server.cors.CorsConfig;
+import com.linecorp.armeria.internal.server.CorsHeaderUtil;
 import com.linecorp.armeria.server.cors.CorsService;
 
 /**
@@ -50,49 +47,19 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
                                                @Nullable RequestHeaders headers,
                                                HttpStatus status, @Nullable String description,
                                                @Nullable Throwable cause) {
-
-        if (ctx == null) {
-            return serverErrorHandler.renderStatus(null, serviceConfig, headers, status, description, cause);
-        }
-
-        final CorsService corsService = ctx.findService(CorsService.class);
-        if (corsService == null) {
-            return serverErrorHandler.renderStatus(ctx, serviceConfig, headers, status, description, cause);
-        }
-
-        final AggregatedHttpResponse res = serverErrorHandler.renderStatus(ctx, serviceConfig, headers, status,
-                                                                           description, cause);
-
-        if (res == null) {
-            return serverErrorHandler.renderStatus(ctx, serviceConfig, headers, status, description, cause);
-        }
-
-        final CorsConfig corsConfig = corsService.config();
-        final ResponseHeaders updatedResponseHeaders = addCorsHeaders(ctx, corsConfig,
-                                                                      res.headers());
-
-        return AggregatedHttpResponse.of(updatedResponseHeaders, res.content());
+        return serverErrorHandler.renderStatus(ctx, serviceConfig, headers, status, description, cause);
     }
 
     @Nullable
     @Override
     public HttpResponse onServiceException(ServiceRequestContext ctx, Throwable cause) {
-        if (cause instanceof HttpResponseException) {
-            final HttpResponse oldRes = serverErrorHandler.onServiceException(ctx, cause);
-            if (oldRes == null) {
-                return null;
-            }
-            final CorsService corsService = ctx.findService(CorsService.class);
-            if (corsService == null) {
-                return oldRes;
-            }
-            return oldRes.recover(HttpResponseException.class, ex -> {
-                return ex.httpResponse()
-                         .mapHeaders(oldHeaders -> addCorsHeaders(ctx, corsService.config(), oldHeaders));
+        final CorsService corsService = ctx.findService(CorsService.class);
+        if (corsService != null && !CorsHeaderUtil.isCorsHeadersSet(ctx)) {
+            ctx.mutateAdditionalResponseHeaders(builder -> {
+                CorsHeaderUtil.setCorsResponseHeaders(ctx, ctx.request(), builder, corsService.config());
             });
-        } else {
-            return serverErrorHandler.onServiceException(ctx, cause);
         }
+        return serverErrorHandler.onServiceException(ctx, cause);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
@@ -68,9 +68,8 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
 
     /**
      * Sets CORS headers for <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests">
-     * simple CORS requests</a>.
-     * This method does not support preflight requests because they require a complete response that is
-     * delegated to {@code serverErrorHandler}.
+     * simple CORS requests</a> or main requests.
+     * Preflight requests is unsupported because we don't know if it is safe to perform the main request.
      */
     private static boolean shouldSetCorsHeaders(@Nullable CorsService corsService, ServiceRequestContext ctx) {
         if (corsService == null) {
@@ -81,9 +80,7 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
             // CORS headers were set by CorsService.
             return false;
         }
-
         final RequestHeaders headers = ctx.request().headers();
-
         if (isCorsPreflightRequest(headers)) {
             return false;
         }
@@ -91,7 +88,7 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
         if (isForbiddenOrigin(corsService.config(), ctx, headers)) {
             return false;
         }
-        // A simple CORS request.
+
         return true;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/CorsServerErrorHandler.java
@@ -58,6 +58,7 @@ final class CorsServerErrorHandler implements ServerErrorHandler {
     public HttpResponse onServiceException(ServiceRequestContext ctx, Throwable cause) {
         final CorsService corsService = ctx.findService(CorsService.class);
         if (shouldSetCorsHeaders(corsService, ctx)) {
+            assert corsService != null;
             ctx.mutateAdditionalResponseHeaders(builder -> {
                 CorsHeaderUtil.setCorsResponseHeaders(ctx, ctx.request(), builder, corsService.config());
             });

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.server.cors;
 
 import static com.linecorp.armeria.internal.common.ArmeriaHttpUtil.isCorsPreflightRequest;
+import static com.linecorp.armeria.internal.server.CorsHeaderUtil.isForbiddenOrigin;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -29,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -133,8 +133,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
         if (isCorsPreflightRequest(req.headers())) {
             return handleCorsPreflight(ctx, req);
         }
-        if (config.isShortCircuit() &&
-            config.getPolicy(req.headers().get(HttpHeaderNames.ORIGIN), ctx.routingContext()) == null) {
+        if (isForbiddenOrigin(config, ctx, req.headers())) {
             return forbidden();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/cors/CorsService.java
@@ -127,6 +127,7 @@ public final class CorsService extends SimpleDecoratingHttpService {
 
     @Override
     public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        CorsHeaderUtil.corsHeadersSet(ctx);
         // check if CORS preflight must be returned, or if
         // we need to forbid access because origin could not be validated
         if (isCorsPreflightRequest(req.headers())) {
@@ -137,11 +138,10 @@ public final class CorsService extends SimpleDecoratingHttpService {
             return forbidden();
         }
 
-        return unwrap().serve(ctx, req).mapHeaders(headers -> {
-            final ResponseHeadersBuilder builder = headers.toBuilder();
+        ctx.mutateAdditionalResponseHeaders(builder -> {
             CorsHeaderUtil.setCorsResponseHeaders(ctx, req, builder, config);
-            return builder.build();
         });
+        return unwrap().serve(ctx, req);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
@@ -20,10 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -31,6 +34,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.HttpStatusException;
@@ -51,23 +55,50 @@ class CorsServerErrorHandlerTest {
                                         HttpResponseException.of(
                                                 HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)), false);
 
-            addCorsServiceWithException(sb, myService, "/cors_status_exception-route",
+            addCorsServiceWithException(sb, myService, "/cors_status_exception_route",
                                         HttpStatusException.of(HttpStatus.INTERNAL_SERVER_ERROR), true);
-            addCorsServiceWithException(sb, myService, "/cors_response_exception-route",
+            addCorsServiceWithException(sb, myService, "/cors_response_exception_route",
                                         HttpResponseException.of(
                                                 HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)), true);
+
+            sb.service("/cors_service_exception_throw", ((HttpService) (ctx, req) -> {
+                throw new RuntimeException("Service exception");
+            }).decorate(corsDecorator()));
+
+            sb.service("/cors_service_exception_return", ((HttpService) (ctx, req) -> {
+                return HttpResponse.ofFailure(new RuntimeException("Service exception"));
+            }).decorate(corsDecorator()));
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension serverWithErrorHandler = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.decorator(corsDecorator());
+            sb.service("/cors_service_exception_throw", (ctx, req) -> {
+                throw new AnticipatedException("Service exception");
+            });
+
+            sb.service("/cors_service_exception_return", (ctx, req) -> {
+                return HttpResponse.ofFailure(new AnticipatedException("Service exception"));
+            });
+            sb.decorator("/cors_decorator_exception_throw", (delegate, ctx, req) -> {
+                throw new AnticipatedException("Service exception");
+            });
+
+            sb.errorHandler((ctx, cause) -> {
+                if (cause instanceof AnticipatedException) {
+                    return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                }
+                return null;
+            });
         }
     };
 
     private static void addCorsServiceWithException(ServerBuilder sb, HttpService myService, String pathPattern,
                                                     Exception exception, boolean useRouteDecorator) {
-        final Function<? super HttpService, CorsService> corsService =
-                CorsService.builder("http://example.com")
-                           .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
-                           .allowRequestHeaders("allow_request_header")
-                           .exposeHeaders("expose_header_1", "expose_header_2")
-                           .preflightResponseHeader("x-preflight-cors", "Hello CORS")
-                           .newDecorator();
+        final Function<? super HttpService, CorsService> corsService = corsDecorator();
         if (useRouteDecorator) {
             sb.decorator(pathPattern, corsService);
             sb.decorator(pathPattern, (delegate, ctx, req) -> {
@@ -80,6 +111,18 @@ class CorsServerErrorHandlerTest {
                                  });
         }
         sb.service(pathPattern, myService);
+    }
+
+    @Nonnull
+    private static Function<? super HttpService, CorsService> corsDecorator() {
+        final Function<? super HttpService, CorsService> corsService =
+                CorsService.builder("http://example.com")
+                           .allowRequestMethods(HttpMethod.POST, HttpMethod.GET)
+                           .allowRequestHeaders("allow_request_header")
+                           .exposeHeaders("expose_header_1", "expose_header_2")
+                           .preflightResponseHeader("x-preflight-cors", "Hello CORS")
+                           .newDecorator();
+        return corsService;
     }
 
     private static AggregatedHttpResponse request(WebClient client, HttpMethod method, String path,
@@ -97,15 +140,56 @@ class CorsServerErrorHandlerTest {
     @ParameterizedTest
     @CsvSource({
             "/cors_status_exception",
-            "/cors_status_exception-route",
+            "/cors_status_exception_route",
             "/cors_response_exception",
-            "/cors_response_exception-route"
+            "/cors_response_exception_route",
     })
     void testCorsHeaderWithException(String path) {
         final WebClient client = server.webClient();
         final AggregatedHttpResponse response = preflightRequest(client, path,
                                                                  "http://example.com", "GET");
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo(
+                "allow_request_header");
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo(
+                "http://example.com");
+    }
+
+    /**
+     * Test a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests">simple request</a>
+     * that does not trigger a CORS preflight.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "/cors_service_exception_throw",
+            "/cors_service_exception_return",
+    })
+    void testSimpleRequest(String path) {
+        final BlockingWebClient client = server.blockingWebClient(cb -> {
+            cb.addHeader(HttpHeaderNames.ORIGIN, "http://example.com");
+        });
+        final AggregatedHttpResponse response = client.get(path);
+
+        assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo(
+                "allow_request_header");
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo(
+                "http://example.com");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/cors_service_exception_throw",
+            "/cors_service_exception_return",
+            "/cors_decorator_exception_throw"
+    })
+    void testCorsHeaderWithExceptionErrorHandler(String path) {
+        final BlockingWebClient client = serverWithErrorHandler.blockingWebClient(cb -> {
+            cb.addHeader(HttpHeaderNames.ORIGIN, "http://example.com");
+        });
+        final AggregatedHttpResponse response = client.get(path);
+
+        assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo(
                 "allow_request_header");
         assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo(

--- a/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/cors/CorsServerErrorHandlerTest.java
@@ -144,15 +144,13 @@ class CorsServerErrorHandlerTest {
             "/cors_response_exception",
             "/cors_response_exception_route",
     })
-    void testCorsHeaderWithException(String path) {
+    void shouldNotHandlePreflightRequest(String path) {
         final WebClient client = server.webClient();
         final AggregatedHttpResponse response = preflightRequest(client, path,
                                                                  "http://example.com", "GET");
         assertThat(response.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isEqualTo(
-                "allow_request_header");
-        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo(
-                "http://example.com");
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS)).isNull();
+        assertThat(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN)).isNull();
     }
 
     /**

--- a/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsConfigurationTest.java
+++ b/spring/boot3-autoconfigure/src/test/java/com/linecorp/armeria/spring/ArmeriaSettingsConfigurationTest.java
@@ -28,11 +28,14 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerConfig;
 import com.linecorp.armeria.server.ServerErrorHandler;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.VirtualHost;
 import com.linecorp.armeria.spring.ArmeriaSettingsConfigurationTest.TestConfiguration;
 
@@ -119,6 +122,9 @@ class ArmeriaSettingsConfigurationTest {
         assertThat(config.gracefulShutdownQuietPeriod().toMillis()).isEqualTo(1000);
 
         assertThat(config.dependencyInjector().getInstance(Object.class)).isSameAs(dummyObject);
-        assertThat(config.errorHandler().onServiceException(null, null)).isSameAs(dummyResponse);
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(config.errorHandler().onServiceException(ctx, new RuntimeException()))
+                .isSameAs(dummyResponse);
     }
 }


### PR DESCRIPTION
Motivation:

`ServerErrorHandler.renderStatus()` is used in `DefaultServerErrorHandler` and may not be called in a custom `ServerErrorHandler`. Attempting to inject CORS headers via `CorsServerErrorHandler.renderStatus()` may not work.

Modifications:

- Use `ctx.mutateAdditionalResponseHeaders()` to set CORS headers instead of mutating the response headers.
- Store whether a CORS is set by `CorsService` to ctx.attr().
  - The value is used in `CorsServerErrorHandler` to set if missing

Result:

- CORS headers for failed requests are now correctly set even when a custom `ServerErrorHandler` is configured.
- Fixes #5493