### PR TITLE
Fix flaky tests

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/DefaultDnsCacheTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DefaultDnsCacheTest.java
@@ -290,6 +290,10 @@ class DefaultDnsCacheTest {
         dnsCache.cache(query0, ImmutableList.of(record0));
         // Exceeds the maximum size. The old cache, query0, should be removed.
         dnsCache.cache(query1, ImmutableList.of(record1));
+
+        // Perform a get operation to trigger the eviction.
+        dnsCache.get(query0);
+        dnsCache.get(query1);
         await().untilTrue(evicted);
         assertThat(removed).isFalse();
     }

--- a/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/StreamMessageCollectingTest.java
@@ -207,10 +207,11 @@ class StreamMessageCollectingTest {
           .hasCauseInstanceOf(CancelledSubscriptionException.class);
 
         final List<ByteBuf> bufs = ImmutableList.copyOf(data.values());
-
-        for (ByteBuf buf : bufs) {
-            assertThat(buf.refCnt()).isZero();
-        }
+        await().untilAsserted(() -> {
+            for (ByteBuf buf : bufs) {
+                assertThat(buf.refCnt()).isZero();
+            }
+        });
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/Http1ServerDelayedCloseConnectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1ServerDelayedCloseConnectionTest.java
@@ -109,7 +109,9 @@ class Http1ServerDelayedCloseConnectionTest {
             assertThat(in.readLine()).isEmpty();
             assertThat(in.readLine()).isEqualToIgnoringCase("OK");
 
-            assertThat(server.server().numConnections()).isEqualTo(1);
+            await().untilAsserted(() -> {
+                assertThat(server.server().numConnections()).isEqualTo(1);
+            });
 
             socket.close();
             assertThatThrownBy(


### PR DESCRIPTION
Motivation:

Three tests often fail in CI builds.
- #5942
- #5724
- #4960 

The cause of the failures seems to be a timing issue.

Modifications:

- Wrap assertion with `await().untilAsserted()`
- Perform get operations to evict the old caches.

Result:

- Fixes #5942
- Fixes #5724
- Fixes #4960 

