### PR TITLE
Fix flaky `InitiateConnectionShutdownTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/InitiateConnectionShutdownTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/InitiateConnectionShutdownTest.java
@@ -142,6 +142,7 @@ class InitiateConnectionShutdownTest {
         });
         await().untilTrue(finished);
         await().untilTrue(connectionClosed);
+        clientChannel.closeFuture().syncUninterruptibly();
     }
 
     @BeforeEach


### PR DESCRIPTION
Motivation: 

- #5743
- #5333
- #3982

I'm not sure this change could resolve the flakiness but it would be worthwhile to explicitly wait for a connection to close before checking invocations.

Modifications:

- Wait for `clientChannel` to be closed.

Result:

- Closes #5743
- Closes #5333
- Closes #3982

I will reopen the issues if the flaky is reproduced. 
