### PR TITLE
Add missing static constructors to `ResponseEntity`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/ResponseEntity.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseEntity.java
@@ -30,7 +30,7 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
     /**
      * Returns a newly created {@link ResponseEntity} with the specified {@link ResponseHeaders}.
      */
-    static ResponseEntity<Void> of(ResponseHeaders headers) {
+    static <T> ResponseEntity<T> of(ResponseHeaders headers) {
         return of(headers, null, HttpHeaders.of());
     }
 
@@ -44,15 +44,6 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
     }
 
     /**
-     * Returns a newly created {@link ResponseEntity} with the specified {@code content} and
-     * {@link HttpStatus#OK} status.
-     */
-    static <T> ResponseEntity<T> of(T content) {
-        requireNonNull(content, "content");
-        return of(ResponseHeaders.of(HttpStatus.OK), content, HttpHeaders.of());
-    }
-
-    /**
      * Returns a newly created {@link ResponseEntity} with the specified {@link ResponseHeaders},
      * {@code content} and {@linkplain HttpHeaders trailers}.
      */
@@ -60,6 +51,38 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
         requireNonNull(headers, "headers");
         requireNonNull(trailers, "trailers");
         return new DefaultResponseEntity<>(headers, content, trailers);
+    }
+
+    /**
+     * Returns a newly created {@link ResponseEntity} with the specified {@link HttpStatus}.
+     */
+    static <T> ResponseEntity<T> of(HttpStatus status) {
+        return of(ResponseHeaders.of(status));
+    }
+
+    /**
+     * Returns a newly created {@link ResponseEntity} with the specified {@link HttpStatus} and
+     * {@code content}.
+     */
+    static <T> ResponseEntity<T> of(HttpStatus status, T content) {
+        return of(ResponseHeaders.of(status), content);
+    }
+
+    /**
+     * Returns a newly created {@link ResponseEntity} with the specified {@link HttpStatus},
+     * {@code content} and {@linkplain HttpHeaders trailers}.
+     */
+    static <T> ResponseEntity<T> of(HttpStatus status, @Nullable T content, HttpHeaders trailers) {
+        return of(ResponseHeaders.of(status), content, trailers);
+    }
+
+    /**
+     * Returns a newly created {@link ResponseEntity} with the specified {@code content} and
+     * {@link HttpStatus#OK} status.
+     */
+    static <T> ResponseEntity<T> of(T content) {
+        requireNonNull(content, "content");
+        return of(HttpStatus.OK, content);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/ResponseEntity.java
+++ b/core/src/main/java/com/linecorp/armeria/common/ResponseEntity.java
@@ -18,7 +18,6 @@ package com.linecorp.armeria.common;
 
 import static java.util.Objects.requireNonNull;
 
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
@@ -31,7 +30,8 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
      * Returns a newly created {@link ResponseEntity} with the specified {@link ResponseHeaders}.
      */
     static <T> ResponseEntity<T> of(ResponseHeaders headers) {
-        return of(headers, null, HttpHeaders.of());
+        requireNonNull(headers, "headers");
+        return new DefaultResponseEntity<>(headers, null, HttpHeaders.of());
     }
 
     /**
@@ -39,7 +39,6 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
      * {@code content}.
      */
     static <T> ResponseEntity<T> of(ResponseHeaders headers, T content) {
-        requireNonNull(content, "content");
         return of(headers, content, HttpHeaders.of());
     }
 
@@ -47,8 +46,9 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
      * Returns a newly created {@link ResponseEntity} with the specified {@link ResponseHeaders},
      * {@code content} and {@linkplain HttpHeaders trailers}.
      */
-    static <T> ResponseEntity<T> of(ResponseHeaders headers, @Nullable T content, HttpHeaders trailers) {
+    static <T> ResponseEntity<T> of(ResponseHeaders headers, T content, HttpHeaders trailers) {
         requireNonNull(headers, "headers");
+        requireNonNull(content, "content");
         requireNonNull(trailers, "trailers");
         return new DefaultResponseEntity<>(headers, content, trailers);
     }
@@ -72,7 +72,7 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
      * Returns a newly created {@link ResponseEntity} with the specified {@link HttpStatus},
      * {@code content} and {@linkplain HttpHeaders trailers}.
      */
-    static <T> ResponseEntity<T> of(HttpStatus status, @Nullable T content, HttpHeaders trailers) {
+    static <T> ResponseEntity<T> of(HttpStatus status, T content, HttpHeaders trailers) {
         return of(ResponseHeaders.of(status), content, trailers);
     }
 
@@ -81,7 +81,6 @@ public interface ResponseEntity<T> extends HttpEntity<T> {
      * {@link HttpStatus#OK} status.
      */
     static <T> ResponseEntity<T> of(T content) {
-        requireNonNull(content, "content");
         return of(HttpStatus.OK, content);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceResponseConverterTest.java
@@ -416,15 +416,13 @@ class AnnotatedServiceResponseConverterTest {
                 public ResponseEntity<Void> expectNotModified() {
                     // Will send '304 Not Modified' because ResponseEntity overrides the @StatusCode
                     // annotation.
-                    return ResponseEntity.of(ResponseHeaders.of(HttpStatus.NOT_MODIFIED));
+                    return ResponseEntity.of(HttpStatus.NOT_MODIFIED);
                 }
 
                 @Get("/expect-unauthorized")
                 public ResponseEntity<HttpResponse> expectUnauthorized() {
                     // Will send '401 Unauthorized' because the content of ResponseEntity is HttpResponse.
-                    return ResponseEntity.of(
-                            ResponseHeaders.of(HttpStatus.OK),
-                            HttpResponse.of(HttpStatus.UNAUTHORIZED));
+                    return ResponseEntity.of(HttpStatus.OK, HttpResponse.of(HttpStatus.UNAUTHORIZED));
                 }
 
                 @Get("/expect-no-content-from-converter")

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -900,7 +900,7 @@ class AnnotatedServiceTest {
         @Path("/response-entity-void")
         public ResponseEntity<Void> responseEntityVoid(RequestContext ctx) {
             validateContext(ctx);
-            return ResponseEntity.of(ResponseHeaders.of(HttpStatus.OK));
+            return ResponseEntity.of(HttpStatus.OK);
         }
 
         @Get
@@ -914,15 +914,14 @@ class AnnotatedServiceTest {
         @Path("/response-entity-status")
         public ResponseEntity<Void> responseEntityResponseData(RequestContext ctx) {
             validateContext(ctx);
-            return ResponseEntity.of(ResponseHeaders.of(HttpStatus.MOVED_PERMANENTLY));
+            return ResponseEntity.of(HttpStatus.MOVED_PERMANENTLY);
         }
 
         @Get
         @Path("/response-entity-http-response")
         public ResponseEntity<HttpResponse> responseEntityHttpResponse(RequestContext ctx) {
             validateContext(ctx);
-            return ResponseEntity.of(ResponseHeaders.of(HttpStatus.OK),
-                                     HttpResponse.of(HttpStatus.UNAUTHORIZED));
+            return ResponseEntity.of(HttpStatus.OK, HttpResponse.of(HttpStatus.UNAUTHORIZED));
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ResponseEntityUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/ResponseEntityUtilTest.java
@@ -72,7 +72,7 @@ class ResponseEntityUtilTest {
                                                                .routingResult(routingResult)
                                                                .build();
 
-        final ResponseEntity<Void> result = ResponseEntity.of(ResponseHeaders.of(HttpStatus.OK));
+        final ResponseEntity<Void> result = ResponseEntity.of(HttpStatus.OK);
         final ResponseHeaders actual = ResponseEntityUtil.buildResponseHeaders(ctx, result);
         assertThat(actual.contentType()).isEqualTo(MediaType.JSON_UTF_8);
     }

--- a/rxjava3/src/test/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunctionTest.java
+++ b/rxjava3/src/test/java/com/linecorp/armeria/server/rxjava3/ObservableResponseConverterFunctionTest.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.internal.testing.AnticipatedException;
 import com.linecorp.armeria.internal.testing.GenerateNativeImageTrace;
@@ -90,6 +91,11 @@ class ObservableResponseConverterFunctionTest {
                 public Maybe<HttpResult<String>> httpResult() {
                     return Maybe.just(HttpResult.of("a"));
                 }
+
+                @Get("/response-entity")
+                public Maybe<ResponseEntity<String>> responseEntity() {
+                    return Maybe.just(ResponseEntity.of("a"));
+                }
             });
 
             sb.annotatedService("/single", new Object() {
@@ -117,6 +123,11 @@ class ObservableResponseConverterFunctionTest {
                 @Get("/http-result")
                 public Single<HttpResult<String>> httpResult() {
                     return Single.just(HttpResult.of("a"));
+                }
+
+                @Get("/response-entity")
+                public Single<ResponseEntity<String>> responseEntity() {
+                    return Single.just(ResponseEntity.of("a"));
                 }
             });
 


### PR DESCRIPTION
Motivation:

This PR adds more static constructors to `ResponseEntity` to match those available in the deprecated `HttpResult`.

Modifications:

- Add static constructors for `HttpStatus`
- Replace `Void` return type with `<T>` (breaking change)
- Add missing tests to `rxjava3` module

Result:

- `ResponseEntity` can now be used the same way that `HttpResult` was used.