### PR TITLE
feat: Fix `maybeWebSocketUpgrade` to return true when Connection/Upgrade header has multiple…

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtil.java
@@ -885,11 +885,11 @@ public final class ArmeriaHttpUtil {
 
     private static boolean maybeWebSocketUpgrade(AsciiString header, CharSequence value) {
         if (HttpHeaderNames.CONNECTION.contentEqualsIgnoreCase(header) &&
-            HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(value)) {
+            AsciiString.containsIgnoreCase(value, HttpHeaderValues.UPGRADE)) {
             return true;
         }
         return HttpHeaderNames.UPGRADE.contentEqualsIgnoreCase(header) &&
-               HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(value);
+               AsciiString.containsIgnoreCase(value, HttpHeaderValues.WEBSOCKET);
     }
 
     private static CaseInsensitiveMap toLowercaseMap(Iterator<? extends CharSequence> valuesIter,

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -503,23 +503,17 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
-    void toArmeriaRequestHeadersForWebSocketUpgrade() {
-        final Http2Headers in = new ArmeriaHttp2Headers().set("a", "b");
+    void toArmeriaForWebSocketUpgrade() {
+        final io.netty.handler.codec.http.HttpHeaders in = new DefaultHttpHeaders()
+            .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE + ", " + HttpHeaderValues.UPGRADE)
+            .add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET + ", additional_value");
+        final HttpHeadersBuilder out = HttpHeaders.builder();
+        out.sizeHint(in.size());
+        toArmeria(in, out);
+        final HttpHeaders outHeaders = out.build();
 
-        final ChannelHandlerContext ctx = mockChannelHandlerContext();
-
-        in.set(HttpHeaderNames.METHOD, "GET")
-                .set(HttpHeaderNames.PATH, "/")
-                // It works even if the header contains multiple values
-                .set(HttpHeaderNames.CONNECTION, "keep-alive, upgrade")
-                .set(HttpHeaderNames.UPGRADE, "websocket, additional_value");
-        // Request headers without pseudo headers.
-        final RequestTarget reqTarget = RequestTarget.forServer(in.path().toString());
-        final RequestHeaders headers =
-                ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false, "https",
-                        serverConfig(), reqTarget);
-        assertThat(headers.get(HttpHeaderNames.CONNECTION)).isEqualTo("keep-alive, upgrade");
-        assertThat(headers.get(HttpHeaderNames.UPGRADE)).isEqualTo("websocket, additional_value");
+        assertThat(outHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo("keep-alive, upgrade");
+        assertThat(outHeaders.get(HttpHeaderNames.UPGRADE)).isEqualTo("websocket, additional_value");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -503,6 +503,26 @@ class ArmeriaHttpUtilTest {
     }
 
     @Test
+    void toArmeriaRequestHeadersForWebSocketUpgrade() {
+        final Http2Headers in = new ArmeriaHttp2Headers().set("a", "b");
+
+        final ChannelHandlerContext ctx = mockChannelHandlerContext();
+
+        in.set(HttpHeaderNames.METHOD, "GET")
+                .set(HttpHeaderNames.PATH, "/")
+                // It works even if the header contains multiple values
+                .set(HttpHeaderNames.CONNECTION, "keep-alive, upgrade")
+                .set(HttpHeaderNames.UPGRADE, "websocket");
+        // Request headers without pseudo headers.
+        final RequestTarget reqTarget = RequestTarget.forServer(in.path().toString());
+        final RequestHeaders headers =
+                ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false, "https",
+                        serverConfig(), reqTarget);
+        assertThat(headers.get(HttpHeaderNames.CONNECTION)).isEqualTo("keep-alive, upgrade");
+        assertThat(headers.get(HttpHeaderNames.UPGRADE)).isEqualTo("websocket");
+    }
+
+    @Test
     void isAbsoluteUri() {
         final String good = "none+http://a.com";
         assertThat(ArmeriaHttpUtil.isAbsoluteUri(good)).isTrue();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/ArmeriaHttpUtilTest.java
@@ -512,14 +512,14 @@ class ArmeriaHttpUtilTest {
                 .set(HttpHeaderNames.PATH, "/")
                 // It works even if the header contains multiple values
                 .set(HttpHeaderNames.CONNECTION, "keep-alive, upgrade")
-                .set(HttpHeaderNames.UPGRADE, "websocket");
+                .set(HttpHeaderNames.UPGRADE, "websocket, additional_value");
         // Request headers without pseudo headers.
         final RequestTarget reqTarget = RequestTarget.forServer(in.path().toString());
         final RequestHeaders headers =
                 ArmeriaHttpUtil.toArmeriaRequestHeaders(ctx, in, false, "https",
                         serverConfig(), reqTarget);
         assertThat(headers.get(HttpHeaderNames.CONNECTION)).isEqualTo("keep-alive, upgrade");
-        assertThat(headers.get(HttpHeaderNames.UPGRADE)).isEqualTo("websocket");
+        assertThat(headers.get(HttpHeaderNames.UPGRADE)).isEqualTo("websocket, additional_value");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
@@ -194,7 +194,7 @@ class WebSocketServiceHandshakeTest {
 
         final RequestHeadersBuilder headersBuilder =
                 RequestHeaders.builder(HttpMethod.CONNECT, "/chat")
-                              .add(HttpHeaderNames.PROTOCOL, HttpHeaderValues.WEBSOCKET.toString())
+                              .add(HttpHeaderNames.PROTOCOL, HttpHeaderValues.WEBSOCKET.toString());
         SplitHttpResponse split = client.execute(headersBuilder.build()).split();
         ResponseHeaders responseHeaders = split.headers().join();
         split.body().abort();

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
@@ -102,7 +102,9 @@ class WebSocketServiceHandshakeTest {
                                           .build();
         final RequestHeadersBuilder headersBuilder =
                 RequestHeaders.builder(HttpMethod.GET, "/chat")
-                              .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE.toString());
+                              // It works even if the header contains multiple values
+                              .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE +
+                                      ", " + HttpHeaderValues.KEEP_ALIVE);
         final Channel channel;
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             final AggregatedHttpResponse res = client.execute(headersBuilder.build()).aggregate().join();
@@ -114,7 +116,7 @@ class WebSocketServiceHandshakeTest {
                                                    "Connection: Upgrade");
         }
 
-        headersBuilder.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toString());
+        headersBuilder.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET + ", additional_value");
         try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
             final AggregatedHttpResponse res = client.execute(headersBuilder.build()).aggregate().join();
 
@@ -192,7 +194,10 @@ class WebSocketServiceHandshakeTest {
 
         final RequestHeadersBuilder headersBuilder =
                 RequestHeaders.builder(HttpMethod.CONNECT, "/chat")
-                              .add(HttpHeaderNames.PROTOCOL, HttpHeaderValues.WEBSOCKET.toString());
+                              .add(HttpHeaderNames.PROTOCOL, HttpHeaderValues.WEBSOCKET.toString())
+                              // It works even if the header contains multiple values
+                              .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE.toString())
+                              .add(HttpHeaderNames.UPGRADE, "additional_value");
         SplitHttpResponse split = client.execute(headersBuilder.build()).split();
         ResponseHeaders responseHeaders = split.headers().join();
         split.body().abort();

--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHandshakeTest.java
@@ -195,9 +195,6 @@ class WebSocketServiceHandshakeTest {
         final RequestHeadersBuilder headersBuilder =
                 RequestHeaders.builder(HttpMethod.CONNECT, "/chat")
                               .add(HttpHeaderNames.PROTOCOL, HttpHeaderValues.WEBSOCKET.toString())
-                              // It works even if the header contains multiple values
-                              .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE.toString())
-                              .add(HttpHeaderNames.UPGRADE, "additional_value");
         SplitHttpResponse split = client.execute(headersBuilder.build()).split();
         ResponseHeaders responseHeaders = split.headers().join();
         split.body().abort();


### PR DESCRIPTION
### Motivation:

1. I requested websocket request for my armeria server with those headers:
* Connection: keep-alive, websocket
* Upgrade: websocket

2. It returns:
```
The upgrade header must contain:
  Upgrade: websocket
  Connection: Upgrade
```

3. I trouble-shooted and found:
https://github.com/line/armeria/pull/5230

4. So I upgraded my armeria server's dependency from 1.23.1 to 1.26.0

5. But it still occurs even though I upgraded deps properly.

6. So I debugged, and found that there are one more conditional statement in `toArmeria` in `ArmeriaHttpUtil.java`
```kt
private static boolean maybeWebSocketUpgrade(AsciiString header, CharSequence value) {
    if (HttpHeaderNames.CONNECTION.contentEqualsIgnoreCase(header) &&
        HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(value)) {
        return true;
    }
    return HttpHeaderNames.UPGRADE.contentEqualsIgnoreCase(header) &&
           HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(value);
}
```

=> I wrote this PR because It is confusing that the multivalue header accepted by `WebSocketUtil` is not accepted by the websocket conditional statement of `ArmeriaHttpUtil`. If the two utils perform different roles in different scopes, and the strictness of websocket checks should be different, this PR can be closed. (But the question still remains as to whether multi-value headers should be supported.)

### Modifications:

- Like above [PR](https://github.com/line/armeria/pull/5230)'s `WebSocketUtil.java`, change the conditional statement from `equals` to `contains`

Result:

- Closes #5957. 
- Can upgrade websocket request with multiple connection value