### PR TITLE
Avoid redundant fromObject(value) calls in addObject methods

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
+++ b/core/src/main/java/com/linecorp/armeria/common/StringMultimap.java
@@ -722,7 +722,7 @@ abstract class StringMultimap<IN_NAME extends CharSequence, NAME extends IN_NAME
     final void addObject(IN_NAME name, Object value) {
         final NAME normalizedName = normalizeName(name);
         requireNonNull(value, "value");
-        addObjectAndNotify(normalizedName, fromObject(value), true);
+        addObjectAndNotify(normalizedName, value, true);
     }
 
     final void addObject(IN_NAME name, Iterable<?> values) {


### PR DESCRIPTION
Motivation:

In the addObject and addObjectAndNotify methods, the fromObject(value) function is being called redundantly. This results in unnecessary computations, which could affect performance and reduce code readability. By removing the redundant calls to fromObject(value), we can improve the efficiency and clarity of the code.

Modifications:

- Modified the addObject method to pass the original value directly to the addObjectAndNotify method without calling fromObject(value).
- Updated the addObjectAndNotify method to perform the fromObject(value) call once, ensuring it is not called multiple times for the same value.

Result:

- Improved code readability and maintainability.
- Eliminated the redundant fromObject(value) calls, enhancing performance.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
