### PR TITLE
Avoid setting default Content-Type in content methods without explicit MediaType

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BlockingWebClientRequestPreparation.java
@@ -337,6 +337,12 @@ public final class BlockingWebClientRequestPreparation
     }
 
     @Override
+    public BlockingWebClientRequestPreparation content(HttpData content) {
+        delegate.content(content);
+        return this;
+    }
+
+    @Override
     public BlockingWebClientRequestPreparation content(MediaType contentType, HttpData content) {
         delegate.content(contentType, content);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/FutureTransformingRequestPreparation.java
@@ -270,6 +270,12 @@ public final class FutureTransformingRequestPreparation<T>
     }
 
     @Override
+    public FutureTransformingRequestPreparation<T> content(HttpData content) {
+        delegate.content(content);
+        return this;
+    }
+
+    @Override
     public FutureTransformingRequestPreparation<T> content(MediaType contentType, HttpData content) {
         delegate.content(contentType, content);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientPreparation.java
@@ -193,6 +193,12 @@ public final class RestClientPreparation implements RequestPreparationSetters {
     }
 
     @Override
+    public RestClientPreparation content(HttpData content) {
+        delegate.content(content);
+        return this;
+    }
+
+    @Override
     public RestClientPreparation content(MediaType contentType, HttpData content) {
         delegate.content(contentType, content);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TransformingRequestPreparation.java
@@ -205,6 +205,12 @@ public class TransformingRequestPreparation<T, R> implements WebRequestPreparati
     }
 
     @Override
+    public TransformingRequestPreparation<T, R> content(HttpData content) {
+        delegate.content(content);
+        return this;
+    }
+
+    @Override
     public TransformingRequestPreparation<T, R> content(MediaType contentType,
                                                         HttpData content) {
         delegate.content(contentType, content);

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientRequestPreparation.java
@@ -498,6 +498,11 @@ public final class WebClientRequestPreparation
     }
 
     @Override
+    public WebClientRequestPreparation content(HttpData content) {
+        return (WebClientRequestPreparation) super.content(content);
+    }
+
+    @Override
     public WebClientRequestPreparation content(MediaType contentType, HttpData content) {
         return (WebClientRequestPreparation) super.content(contentType, content);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpMessageBuilder.java
@@ -90,15 +90,16 @@ public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
 
     @Override
     public AbstractHttpMessageBuilder content(String content) {
-        return content(MediaType.PLAIN_TEXT_UTF_8, content);
+        requireNonNull(content, "content");
+        return content(HttpData.of(MediaType.PLAIN_TEXT_UTF_8.charset(StandardCharsets.UTF_8),
+                content));
     }
 
     @Override
     public AbstractHttpMessageBuilder content(MediaType contentType, CharSequence content) {
         requireNonNull(contentType, "contentType");
         requireNonNull(content, "content");
-        return content(contentType,
-                       HttpData.of(contentType.charset(StandardCharsets.UTF_8),
+        return content(contentType, HttpData.of(contentType.charset(StandardCharsets.UTF_8),
                                    content));
     }
 
@@ -107,13 +108,16 @@ public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
         requireNonNull(contentType, "contentType");
         requireNonNull(content, "content");
         return content(contentType, HttpData.of(contentType.charset(StandardCharsets.UTF_8),
-                                                content));
+                                   content));
     }
 
     @Override
     @FormatMethod
     public AbstractHttpMessageBuilder content(@FormatString String format, Object... content) {
-        return content(MediaType.PLAIN_TEXT_UTF_8, format, content);
+        requireNonNull(format, "format");
+        requireNonNull(content, "content");
+        return content(HttpData.of(MediaType.PLAIN_TEXT_UTF_8.charset(StandardCharsets.UTF_8),
+                format, content));
     }
 
     @Override
@@ -131,6 +135,14 @@ public abstract class AbstractHttpMessageBuilder implements HttpMessageSetters {
     public AbstractHttpMessageBuilder content(MediaType contentType, byte[] content) {
         requireNonNull(content, "content");
         return content(contentType, HttpData.wrap(content));
+    }
+
+    @Override
+    public AbstractHttpMessageBuilder content(HttpData content) {
+        requireNonNull(content, "content");
+        checkState(publisher == null, "publisher has been set already");
+        this.content = content;
+        return this;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractHttpRequestBuilder.java
@@ -137,6 +137,11 @@ public abstract class AbstractHttpRequestBuilder
     }
 
     @Override
+    public AbstractHttpRequestBuilder content(HttpData content) {
+        return (AbstractHttpRequestBuilder) super.content(content);
+    }
+
+    @Override
     public AbstractHttpRequestBuilder content(MediaType contentType, HttpData content) {
         return (AbstractHttpRequestBuilder) super.content(contentType, content);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpMessageSetters.java
@@ -70,6 +70,16 @@ public interface HttpMessageSetters {
     HttpMessageSetters content(MediaType contentType, byte[] content);
 
     /**
+     * Sets the content for this message without setting a content-type header.
+     * The {@code content} will be wrapped using {@link HttpData#wrap(byte[])},
+     * meaning any modifications made to {@code content} will be directly reflected in the request.
+     *
+     * <p>Note: This method does not set a content-type header. The caller is responsible
+     * for setting an appropriate content-type header if required.
+     */
+    HttpMessageSetters content(HttpData content);
+
+    /**
      * Sets the content for this message.
      */
     HttpMessageSetters content(MediaType contentType, HttpData content);

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestBuilder.java
@@ -123,6 +123,11 @@ public final class HttpRequestBuilder extends AbstractHttpRequestBuilder {
     }
 
     @Override
+    public HttpRequestBuilder content(HttpData content) {
+        return (HttpRequestBuilder) super.content(content);
+    }
+
+    @Override
     public HttpRequestBuilder content(MediaType contentType, HttpData content) {
         return (HttpRequestBuilder) super.content(contentType, content);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpRequestSetters.java
@@ -80,6 +80,12 @@ public interface HttpRequestSetters extends RequestMethodSetters, PathAndQueryPa
      * Sets the content for this request.
      */
     @Override
+    HttpRequestSetters content(HttpData content);
+
+    /**
+     * Sets the content for this request.
+     */
+    @Override
     HttpRequestSetters content(MediaType contentType, HttpData content);
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/HttpResponseBuilder.java
@@ -173,6 +173,11 @@ public final class HttpResponseBuilder extends AbstractHttpMessageBuilder {
         return (HttpResponseBuilder) super.content(contentType, content);
     }
 
+    @Override
+    public HttpResponseBuilder content(HttpData content) {
+        return (HttpResponseBuilder) super.content(content);
+    }
+
     /**
      * Sets the content for this response.
      */

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientExpect100HeaderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientExpect100HeaderTest.java
@@ -109,7 +109,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo\n")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo\n")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -167,7 +167,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -217,7 +217,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo\n")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo\n")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -268,7 +268,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -314,7 +314,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo\n")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo\n")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -369,7 +369,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();
@@ -411,7 +411,7 @@ final class HttpClientExpect100HeaderTest {
             final CompletableFuture<AggregatedHttpResponse> future =
                     client.prepare()
                           .post("/")
-                          .content("foo\n")
+                          .content(MediaType.PLAIN_TEXT_UTF_8, "foo\n")
                           .header(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE)
                           .execute()
                           .aggregate();

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseBuilderTest.java
@@ -102,7 +102,7 @@ class HttpResponseBuilderTest {
         final AggregatedHttpResponse aggregatedRes = res.aggregate().join();
         assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.OK);
         assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
-        assertThat(aggregatedRes.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(aggregatedRes.contentType()).isNull();
     }
 
     @Test
@@ -116,7 +116,7 @@ class HttpResponseBuilderTest {
         final AggregatedHttpResponse aggregatedRes = res.aggregate().join();
         assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.OK);
         assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
-        assertThat(aggregatedRes.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(aggregatedRes.contentType()).isNull();
     }
 
     @Test
@@ -256,7 +256,7 @@ class HttpResponseBuilderTest {
         assertThat(aggregatedRes.headers().getAll(HttpHeaderNames.ACCEPT_ENCODING))
                 .containsExactly("gzip", "deflate", "gzip");
         assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
-        assertThat(aggregatedRes.contentType()).isEqualTo(MediaType.PLAIN_TEXT_UTF_8);
+        assertThat(aggregatedRes.contentType()).isNull();
         assertThat(aggregatedRes.trailers().contains("trailer-name")).isTrue();
         assertThat(aggregatedRes.trailers().get("trailer-name")).isEqualTo("trailer-value");
     }

--- a/core/src/test/java/com/linecorp/armeria/common/HttpResponseBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/HttpResponseBuilderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -106,6 +107,22 @@ class HttpResponseBuilderTest {
     }
 
     @Test
+    void buildWithPlainAndContentTypeHeader() {
+        final HttpResponse res = HttpResponse.builder()
+                                             .ok()
+                                             .content("Armeriaはいろんな使い方がアルメリア")
+                                             .header(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON)
+                                             .build();
+        final AggregatedHttpResponse aggregatedRes = res.aggregate().join();
+        assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
+
+        final List<String> contentTypeHeaders = aggregatedRes.headers().getAll(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(contentTypeHeaders).hasSize(1);
+        assertThat(contentTypeHeaders).containsExactly("application/json");
+    }
+
+    @Test
     void buildWithPlainFormat() {
         // Using non-ascii to test UTF-8 conversion
         final HttpResponse res = HttpResponse.builder()
@@ -117,6 +134,23 @@ class HttpResponseBuilderTest {
         assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.OK);
         assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
         assertThat(aggregatedRes.contentType()).isNull();
+    }
+
+    @Test
+    void buildWithPlainFormatAndContentTypeHeader() {
+        final HttpResponse res = HttpResponse.builder()
+                                             .ok()
+                                             .content("%sはいろんな使い方が%s",
+                                                      "Armeria", "アルメリア")
+                                             .header(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON)
+                                             .build();
+        final AggregatedHttpResponse aggregatedRes = res.aggregate().join();
+        assertThat(aggregatedRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggregatedRes.contentUtf8()).isEqualTo("Armeriaはいろんな使い方がアルメリア");
+
+        final List<String> contentTypeHeaders = aggregatedRes.headers().getAll(HttpHeaderNames.CONTENT_TYPE);
+        assertThat(contentTypeHeaders).hasSize(1);
+        assertThat(contentTypeHeaders).containsExactly("application/json");
     }
 
     @Test

--- a/core/src/test/java/com/linecorp/armeria/server/Http1ServerDelayedCloseConnectionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1ServerDelayedCloseConnectionTest.java
@@ -50,6 +50,7 @@ class Http1ServerDelayedCloseConnectionTest {
                 return HttpResponse.builder()
                                    .ok()
                                    .content("OK\n")
+                                    .header(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=utf-8")
                                    .header(HttpHeaderNames.CONNECTION, "close")
                                    .build();
             });

--- a/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
+++ b/scala/scala_2.13/src/main/scala/com/linecorp/armeria/client/scala/ScalaRestClientPreparation.scala
@@ -25,13 +25,23 @@ import com.linecorp.armeria.client.{
   RestClientPreparation
 }
 import com.linecorp.armeria.common.annotation.UnstableApi
-import com.linecorp.armeria.common.{Cookie, ExchangeType, HttpData, HttpResponse, MediaType, ResponseEntity}
+import com.linecorp.armeria.common.{
+  Cookie,
+  ExchangeType,
+  HttpData,
+  HttpMessageSetters,
+  HttpResponse,
+  MediaType,
+  ResponseEntity
+}
 import com.linecorp.armeria.scala.implicits._
 import io.netty.util.AttributeKey
+
 import java.lang.{Iterable => JIterable}
 import java.time.Duration
 import java.util.{Map => JMap}
 import org.reactivestreams.Publisher
+
 import scala.collection.immutable
 import scala.concurrent.Future
 
@@ -183,6 +193,11 @@ final class ScalaRestClientPreparation private[scala] (delegate: RestClientPrepa
 
   override def content(contentType: MediaType, content: Array[Byte]): ScalaRestClientPreparation = {
     delegate.content(contentType, content)
+    this
+  }
+
+  override def content(content: HttpData): ScalaRestClientPreparation = {
+    delegate.content(content)
     this
   }
 


### PR DESCRIPTION

Motivation:
- #5949 

HttpResponse could generate duplicate Content-Type headers if a user manually added a Content-Type header after setting the content with content(String). This can cause client errors or unexpected behavior when parsing the response.

Modifications:

- Updated the content methods without explicit MediaType in AbstractHttpMessageBuilder to avoid automatically setting the Content-Type header.
- Added a new content(HttpData) method to HttpMessageSetters that allows setting content without adding any headers by default.
- Adjusted test cases to ensure:
   - The Content-Type header is not automatically set when content(String) is used without MediaType.
   - No duplicate Content-Type headers are generated in response headers.

Result:

- The HttpResponse now avoids setting a default Content-Type header when content(String) is used, thereby reducing the risk of duplicate headers.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
