### PR TITLE
Make ClientRequestContext.authority() and host() return non-null

### DIFF
--- a/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
+++ b/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.brave;
 
-import static com.linecorp.armeria.client.ClientRequestContextUtil.*;
+import static com.linecorp.armeria.client.ClientRequestContextUtil.firstNonNullException;
 
 import java.net.InetSocketAddress;
 

--- a/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
+++ b/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.brave;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.client.ClientRequestContextUtil.*;
 
 import java.net.InetSocketAddress;
 
@@ -72,7 +72,7 @@ final class ArmeriaHttpClientParser implements HttpRequestParser, HttpResponsePa
             return;
         }
 
-        span.tag(SpanTags.TAG_HTTP_HOST, firstNonNull(ctx.authority(), "UNKNOWN"))
+        span.tag(SpanTags.TAG_HTTP_HOST, firstNonNullException(ctx::authority, "UNKNOWN"))
             .tag(SpanTags.TAG_HTTP_URL, ctx.uri().toString());
     }
 

--- a/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
+++ b/brave/brave6/src/main/java/com/linecorp/armeria/client/brave/ArmeriaHttpClientParser.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.brave;
 
-import static com.linecorp.armeria.client.ClientRequestContextUtil.firstNonNullException;
+import static com.linecorp.armeria.client.ObjectUtil.firstNonNullException;
 
 import java.net.InetSocketAddress;
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -290,11 +290,13 @@ public interface ClientRequestContext extends RequestContext {
      *     <li>{@link Endpoint#authority()}.</li>
      * </ol>
      */
+    @UnstableApi
     String authority();
 
     /**
      * Returns the host part of {@link #authority()}, without a port number.
      */
+    @UnstableApi
     String host();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -290,15 +290,11 @@ public interface ClientRequestContext extends RequestContext {
      *     <li>{@link Endpoint#authority()}.</li>
      * </ol>
      */
-    @Nullable
-    @UnstableApi
     String authority();
 
     /**
      * Returns the host part of {@link #authority()}, without a port number.
      */
-    @Nullable
-    @UnstableApi
     String host();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import java.util.function.Supplier;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * The utility class for ClientRequestContext.
+ */
+public final class ClientRequestContextUtil {
+
+    /**
+     * Returns a non-null value. If an unexpected exception occurs while retrieving the first value,
+     * or the first value is null, this function will return the second value.
+     * Otherwise, it returns the first value.
+     */
+    public static <T> T firstNonNullException(@CheckForNull Supplier<T> firstSupplier, @CheckForNull T second) {
+        try {
+            if (firstSupplier != null) {
+                final T first = firstSupplier.get();
+                if (first != null) {
+                    return first;
+                }
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+
+        if (second != null) {
+            return second;
+        }
+
+        throw new NullPointerException("Both parameters are null");
+    }
+
+    private ClientRequestContextUtil() {
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -70,13 +70,11 @@ public class ClientRequestContextWrapper
         return unwrap().fragment();
     }
 
-    @Nullable
     @Override
     public String authority() {
         return unwrap().authority();
     }
 
-    @Nullable
     @Override
     public String host() {
         return unwrap().host();

--- a/core/src/main/java/com/linecorp/armeria/client/ObjectUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ObjectUtil.java
@@ -17,19 +17,17 @@ package com.linecorp.armeria.client;
 
 import java.util.function.Supplier;
 
-import javax.annotation.CheckForNull;
-
 /**
- * The utility class for ClientRequestContext.
+ * The utility class for Object.
  */
-public final class ClientRequestContextUtil {
+public final class ObjectUtil {
 
     /**
      * Returns a non-null value. If an unexpected exception occurs while retrieving the first value,
      * or the first value is null, this function will return the second value.
      * Otherwise, it returns the first value.
      */
-    public static <T> T firstNonNullException(@CheckForNull Supplier<T> firstSupplier, @CheckForNull T second) {
+    public static <T> T firstNonNullException(Supplier<T> firstSupplier, T second) {
         try {
             if (firstSupplier != null) {
                 final T first = firstSupplier.get();
@@ -45,9 +43,9 @@ public final class ClientRequestContextUtil {
             return second;
         }
 
-        throw new NullPointerException("Both parameters are null");
+        throw new NullPointerException("Both parameters are null.");
     }
 
-    private ClientRequestContextUtil() {
+    private ObjectUtil() {
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/observation/DefaultHttpClientObservationConvention.java
+++ b/core/src/main/java/com/linecorp/armeria/client/observation/DefaultHttpClientObservationConvention.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.observation;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.armeria.client.ClientRequestContextUtil.firstNonNullException;
 
 import java.net.InetSocketAddress;
 
@@ -106,7 +106,7 @@ class DefaultHttpClientObservationConvention implements ObservationConvention<Cl
         }
         final ImmutableList.Builder<KeyValue> builder = ImmutableList.builderWithExpectedSize(expectedSize);
         builder.add(HighCardinalityKeys.HTTP_PATH.withValue(ctx.path()),
-                    HighCardinalityKeys.HTTP_HOST.withValue(firstNonNull(ctx.authority(), "UNKNOWN")),
+                    HighCardinalityKeys.HTTP_HOST.withValue(firstNonNullException(ctx::authority, "UNKNOWN")),
                     HighCardinalityKeys.HTTP_URL.withValue(ctx.uri().toString()));
         addIfNotNull(addressRemote, builder);
         addIfNotNull(addressLocal, builder);

--- a/core/src/main/java/com/linecorp/armeria/client/observation/DefaultHttpClientObservationConvention.java
+++ b/core/src/main/java/com/linecorp/armeria/client/observation/DefaultHttpClientObservationConvention.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.armeria.client.observation;
 
-import static com.linecorp.armeria.client.ClientRequestContextUtil.firstNonNullException;
+import static com.linecorp.armeria.client.ObjectUtil.firstNonNullException;
 
 import java.net.InetSocketAddress;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -806,26 +806,22 @@ public final class DefaultClientRequestContext
     @Override
     public String host() {
         final String authority = authority();
-        if (authority == null) {
-            throw new IllegalStateException("ClientRequestContext may be in the process of initialization." +
-                                            "In this case, host() or authority() could be null");
-        }
         return SchemeAndAuthority.of(null, authority).host();
     }
 
     @Override
     public URI uri() {
         final String scheme = getScheme(sessionProtocol());
-        final String authority = authority();
         final String path = path();
         final String query = query();
         final String fragment = fragment();
         try (TemporaryThreadLocals tmp = TemporaryThreadLocals.acquire()) {
             final StringBuilder buf = tmp.stringBuilder();
             buf.append(scheme);
-            if (authority != null) {
+            try {
+                final String authority = authority();
                 buf.append("://").append(authority);
-            } else {
+            } catch (IllegalStateException e) {
                 buf.append(':');
             }
             buf.append(path);

--- a/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
@@ -221,7 +221,8 @@ class DefaultClientRequestContextTest {
                 HttpMethod.POST, "/foo",
                 HttpHeaderNames.SCHEME, "http"));
         final DefaultClientRequestContext ctx = newContext(ClientOptions.of(), request1);
-        assertThat(ctx.authority()).isNull();
+
+        assertThatThrownBy(() -> ctx.authority()).isInstanceOf(IllegalStateException.class);
         assertThat(ctx.uri().toString()).isEqualTo("http:/foo");
         assertThat(ctx.uri()).hasScheme("http").hasAuthority(null).hasPath("/foo");
 


### PR DESCRIPTION
Motivation:
- If host(), authority() never return null, `host()`, `authority()` will become stableAPI.


Modifications:
- `host()`, `authority()` of `ClientRequestContext` will throw `IllegalStateException` if `host`, `authority` are null.
- Remove annotations `@UnstableAPI`, `@Nullable` from `host()`, `authority()`.
- Rearrange a little bit in `autoFillSchemeAuthorityAndOrigin()`. (It can be called during initialization of `ClientRequestContext`)
- Add a test case.

Result:
- Closes https://github.com/line/armeria/issues/5552