### PR TITLE
Introducing Armeria Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Visit [the official web site](https://armeria.dev/) for more information.
 [![Maven Central](https://img.shields.io/maven-central/v/com.linecorp.armeria/armeria.svg?label=version)](https://search.maven.org/search?q=g:com.linecorp.armeria%20AND%20a:armeria)
 [![GitHub release date](https://img.shields.io/github/release-date/line/armeria.svg?label=release)](https://github.com/line/armeria/commits)
 [![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.armeria.dev/scans)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Armeria%20Guru-006BFF)](https://gurubase.io/g/armeria)
 
 
 > Build a reactive microservice **at your pace**, not theirs.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Armeria Guru](https://gurubase.io/g/armeria) to Gurubase. Armeria Guru uses the data from this repo and data from the [docs](https://armeria.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Armeria Guru", which highlights that Armeria now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Armeria Guru in Gurubase, just let me know that's totally fine.
