### PR TITLE
Fix race condition where `log.whenComplete` may not complete

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -992,11 +992,7 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             ctx.updateRpcRequest((RpcRequest) requestContent);
         }
         updateFlags(RequestLogProperty.REQUEST_CONTENT);
-
-        final int requestCompletionFlags = RequestLogProperty.FLAGS_REQUEST_COMPLETE & ~deferredFlags;
-        if (isAvailable(requestCompletionFlags)) {
-            setNamesIfAbsent();
-        }
+        setNamesIfAbsent();
     }
 
     @Nullable
@@ -1118,14 +1114,6 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             this.requestCause = requestCause;
         }
         updateFlags(flags);
-
-        // The check here covers two cases:
-        // 1) #endRequest has completed all flags except name.
-        // 2) #requestContent has been called from a different thread, but names hasn't been set
-        if (hasInterestedFlags(deferredFlags, RequestLogProperty.REQUEST_CONTENT) &&
-            isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
-            setNamesIfAbsent();
-        }
     }
 
     private void setNamesIfAbsent() {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1119,7 +1119,9 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
         }
         updateFlags(flags);
 
-        // Check if REQUEST_CONTENT has been set by calling #requestContent() from a different thread
+        // The check here covers two cases:
+        // 1) #endRequest has completed all flags except name.
+        // 2) #requestContent has been called from a different thread, but names hasn't been set
         if (hasInterestedFlags(deferredFlags, RequestLogProperty.REQUEST_CONTENT) &&
             isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
             setNamesIfAbsent();

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1104,12 +1104,11 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             }
         }
 
-        // Set names if request content is not deferred or it was deferred but has been set
-        // before the request completion.
-        if (!hasInterestedFlags(deferredFlags, RequestLogProperty.REQUEST_CONTENT) ||
-            isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
+        // Set names if request content is not deferred
+        if (!hasInterestedFlags(deferredFlags, RequestLogProperty.REQUEST_CONTENT)) {
             setNamesIfAbsent();
         }
+
         this.requestEndTimeNanos = requestEndTimeNanos;
 
         if (requestCause instanceof HttpStatusException || requestCause instanceof HttpResponseException) {
@@ -1119,6 +1118,12 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             this.requestCause = requestCause;
         }
         updateFlags(flags);
+
+        // Check if REQUEST_CONTENT has been set by calling #requestContent() from a different thread
+        if (hasInterestedFlags(deferredFlags, RequestLogProperty.REQUEST_CONTENT) &&
+            isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
+            setNamesIfAbsent();
+        }
     }
 
     private void setNamesIfAbsent() {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -109,12 +109,16 @@ public interface RequestLogBuilder extends RequestLogAccess {
      *    <li>A path pattern and HTTP method name for {@link HttpService}</li>
      * </ul>
      * This property is often used as a meter tag or distributed trace's span name.
+     * Note that calling {@link #responseContent(Object, Object)} will automatically fill
+     * {@link RequestLogProperty#NAME}, so {@link #name(String, String)} must be called beforehand.
      */
     void name(String serviceName, String name);
 
     /**
      * Sets the human-readable name of the {@link Request}, such as RPC method name, annotated service method
      * name or HTTP method name. This property is often used as a meter tag or distributed trace's span name.
+     * Note that calling {@link #responseContent(Object, Object)} will automatically fill
+     * {@link RequestLogProperty#NAME}, so {@link #name(String)} must be called beforehand.
      */
     void name(String name);
 


### PR DESCRIPTION
Motivation:

It has been reported that `log.whenComplete` is not completing in some cases in #5981.
The cause seems to be a race condition between `DefaultRequestLog#endRequest` and `DefaultRequestLog#requestContent`. Completion of `log.whenComplete` is important because
1) it is semantically bound to an HTTP request 2) users (including us) have clean up logic using `log.whenComplete`.

I propose that simply `endRequest` only sets `name` if content is not deferred, and `requestContent` sets `name` if content is deferred. The logic is easier to reason about, and there are minimal performance implications since a lock is held anyways.

Modifications:

- `#endRequest` sets `name` if `requestContent` isn't deferred
- `#requestContent` sets name if `requestContent` is deferred

Result:

- Closes #5981 

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
