### PR TITLE
Fix failing nacos tests

### DIFF
--- a/nacos/src/test/java/com/linecorp/armeria/internal/nacos/NacosClientBuilderTest.java
+++ b/nacos/src/test/java/com/linecorp/armeria/internal/nacos/NacosClientBuilderTest.java
@@ -32,7 +32,7 @@ class NacosClientBuilderTest extends NacosTestBase {
     void gets403WhenNoToken() throws Exception {
         final HttpStatus status = WebClient.of(nacosUri())
                                            .blocking()
-                                           .get("/nacos/v1/ns/service/list?pageNo=0&pageSize=10")
+                                           .get("/v1/ns/service/list?pageNo=0&pageSize=10")
                                            .status();
         assertThat(status).isEqualTo(HttpStatus.FORBIDDEN);
     }

--- a/nacos/src/test/java/com/linecorp/armeria/internal/nacos/NacosTestBase.java
+++ b/nacos/src/test/java/com/linecorp/armeria/internal/nacos/NacosTestBase.java
@@ -80,7 +80,7 @@ public abstract class NacosTestBase {
     static void start() {
         // Initialize Nacos Client
         nacosUri = URI.create(
-                "http://" + nacosContainer.getHost() + ':' + nacosContainer.getMappedPort(8848));
+                "http://" + nacosContainer.getHost() + ':' + nacosContainer.getMappedPort(8848) + "/nacos");
     }
 
     protected static NacosClient client(@Nullable String serviceName, @Nullable String groupName) {


### PR DESCRIPTION
Motivation:

For some reason, it seems like the main CI doesn't run docker tests.
In any case, I found that Nacos tests are failing due to incorrect server uri settings.

Modifications:

- Fixed the test URI to prepend a `/nacos` uri

Result:

- Nacos tests pass now

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
