### PR TITLE
Fix Jacoco failure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/common/logback/LoggingEventWrapper,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**
+jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**
 shadowExclusions=META-INF/services/java.security.Provider
 org.gradle.caching = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**
+jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/common/logback/LoggingEventWrapper,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**
 shadowExclusions=META-INF/services/java.security.Provider
 org.gradle.caching = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -219,7 +219,7 @@ includeWithFlags ':it:jackson-provider',                       'java', 'relocate
 includeWithFlags ':it:kotlin',                                 'java', 'relocate', 'kotlin'
 includeWithFlags ':it:kubernetes-chaos-tests',                 'java', 'relocate'
 includeWithFlags ':it:logback1.4',                             'java11', 'relocate'
-includeWithFlags ':it:logback1.5',                             'java11', 'relocate'
+includeWithFlags ':it:logback1.5',                             'java11', 'relocate', 'no_aggregation'
 includeWithFlags ':it:multipart',                              'java17', 'relocate'
 includeWithFlags ':it:nio',                                    'java', 'relocate'
 includeWithFlags ':it:okhttp',                                 'java', 'relocate'


### PR DESCRIPTION
Motivation:

```
Caused by: java.lang.IllegalStateException: Can't add different class with same name: com/linecorp/armeria/common/logback/LoggingEventWrapper
	at org.jacoco.core.analysis.CoverageBuilder.visitCoverage(CoverageBuilder.java:106)
	at org.jacoco.core.analysis.Analyzer$1.visitEnd(Analyzer.java:100)
	at org.objectweb.asm.ClassVisitor.visitEnd(ClassVisitor.java:395)
	at org.jacoco.core.internal.flow.ClassProbesAdapter.visitEnd(ClassProbesAdapter.java:100)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:749)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:425)
	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:117)
	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:133)
	... 152 more
```

Modifications:

- Set `no_aggregation` flag to `:it:logback1.5`

Result:

Fixes #5989 