### PR TITLE
Fix flaky ReactiveWebServerLoadBalancerInteropTest

### DIFF
--- a/spring/boot3-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
+++ b/spring/boot3-webflux-autoconfigure/src/test/java/com/linecorp/armeria/spring/web/reactive/ReactiveWebServerLoadBalancerInteropTest.java
@@ -22,6 +22,8 @@ import static org.springframework.web.reactive.function.server.RequestPredicates
 import static org.springframework.web.reactive.function.server.RouterFunctions.route;
 import static org.springframework.web.reactive.function.server.ServerResponse.ok;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
@@ -50,7 +52,7 @@ import com.linecorp.armeria.common.SessionProtocol;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
+import ch.qos.logback.core.AppenderBase;
 import reactor.core.publisher.Mono;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -71,7 +73,7 @@ class ReactiveWebServerLoadBalancerInteropTest {
         RouterFunction<ServerResponse> routerFunction() {
             return route(GET("/router/api/ping"), request -> ok().body(fromValue("PONG")))
                     .and(route(HEAD("/router/api/ping"), request -> ok().body(fromValue("PONG")))
-                    .and(route(HEAD("/router/api/poke"), request -> ok().build())));
+                                 .and(route(HEAD("/router/api/poke"), request -> ok().build())));
         }
     }
 
@@ -79,7 +81,7 @@ class ReactiveWebServerLoadBalancerInteropTest {
     int port;
 
     final Logger httpWebHandlerAdapterLogger = (Logger) LoggerFactory.getLogger(HttpWebHandlerAdapter.class);
-    final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    final ConcurrentListAppender<ILoggingEvent> logAppender = new ConcurrentListAppender<>();
 
     @BeforeEach
     public void attachAppender() {
@@ -147,5 +149,15 @@ class ReactiveWebServerLoadBalancerInteropTest {
                            .filter(event -> event.getFormattedMessage().contains(errorLogSubString))
                            .collect(Collectors.toList()))
                 .isEmpty();
+    }
+
+    private static final class ConcurrentListAppender<E> extends AppenderBase<E> {
+
+        List<E> list = new CopyOnWriteArrayList<>();
+
+        @Override
+        protected void append(E eventObject) {
+            list.add(eventObject);
+        }
     }
 }


### PR DESCRIPTION
Motivation:

```
com.linecorp.armeria.spring.web.reactive.ReactiveWebServerLoadBalancerInteropTest.[1] sessionProtocol=H1C, path=/controller/api/ping
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1714)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.linecorp.armeria.spring.web.reactive.ReactiveWebServerLoadBalancerInteropTest.assertNoErrorLogByHttpWebHandlerAdapter(ReactiveWebServerLoadBalancerInteropTest.java:148)
```

It seems that `logAppender.list` was modified while retrieving elements

Modifications:

- Use `CopyOnWriteArrayList` to collect `ILoggingEvent`

Result:

Fixes #5462
