### PR TITLE
Expose the default `HealthCheckUpdateHandler`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceBuilder.java
@@ -234,10 +234,11 @@ public final class HealthCheckServiceBuilder implements TransientServiceBuilder 
      *
      * @return {@code this}
      * @see #updatable(HealthCheckUpdateHandler)
+     * @see HealthCheckUpdateHandler#of()
      */
     public HealthCheckServiceBuilder updatable(boolean updatable) {
         if (updatable) {
-            return updatable(DefaultHealthCheckUpdateHandler.INSTANCE);
+            return updatable(HealthCheckUpdateHandler.of());
         }
 
         updateHandler = null;

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -18,6 +18,7 @@ package com.linecorp.armeria.server.healthcheck;
 import java.util.concurrent.CompletionStage;
 
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.Server;
@@ -28,6 +29,31 @@ import com.linecorp.armeria.server.ServiceRequestContext;
  */
 @FunctionalInterface
 public interface HealthCheckUpdateHandler {
+
+    /**
+     * Returns the default {@link HealthCheckUpdateHandler} that accepts a JSON object which has a boolean
+     * property named {@code "healthy"} for a {@code PUT} or {@code POST} request. A JSON patch in a
+     * {@code PATCH} request is also accepted.
+     *
+     * <p>For example:
+     * <pre>{@code
+     * // Update healthiness of the server to unhealthy
+     * POST /internal/health HTTP/2.0
+     *
+     * { "healthy": false }
+     *
+     * // Patch healthiness of the server to unhealthy
+     * PATCH /internal/health HTTP/2.0
+     *
+     * [ { "op": "replace", "path": "/healthy", "value": false } ]
+     * }</pre>
+     *
+     */
+    @UnstableApi
+    static HealthCheckUpdateHandler of() {
+        return DefaultHealthCheckUpdateHandler.INSTANCE;
+    }
+
     /**
      * Determines if the healthiness of the {@link Server} needs to be changed or not from the given
      * {@link HttpRequest}.

--- a/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/healthcheck/HealthCheckUpdateHandler.java
@@ -47,7 +47,6 @@ public interface HealthCheckUpdateHandler {
      *
      * [ { "op": "replace", "path": "/healthy", "value": false } ]
      * }</pre>
-     *
      */
     @UnstableApi
     static HealthCheckUpdateHandler of() {


### PR DESCRIPTION
Motivation:

When implementing a custom `HealthCheckUpdateHandler`, I just wanted to add validation in front of the default implementation. However, it wasn't possible because the default implementation has package-private visibility.

Modifications:

- Expose the default `HealthCheckUpdateHandler` via `HealthCheckUpdateHandler.of()`

Result:

You can now use the default `HealthCheckUpdateHandler` via `HealthCheckUpdateHandler.of()`

