### PR TITLE
Use `macos-latest` for CI builds

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        on: [ ubicloud-standard-8, macos-12, windows-latest ]
+        on: [ ubicloud-standard-8, macos-latest, windows-latest ]
         java: [ 21 ]
         include:
           - java: 8


### PR DESCRIPTION
Motivation:

macos-12 is no longer supported in GitHub Actions. 

- https://github.com/line/armeria/actions/runs/12177357989?pr=5941
- https://github.com/actions/runner-images/issues/10721

Modifications:

- Use macos-latest instead.

Result:

Revive macOS CI
