### PR TITLE
Automatically reconnect Kubernetes watcher when closed exceptionally

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientFactory.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientFactory.java
@@ -17,6 +17,8 @@
 package com.linecorp.armeria.client.kubernetes;
 
 import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 
 import io.fabric8.kubernetes.client.http.HttpClient;
 
@@ -34,6 +36,13 @@ public class ArmeriaHttpClientFactory implements HttpClient.Factory {
      * This method is only called for clients constructed using the Config.
      */
     protected void additionalConfig(WebClientBuilder builder) {
+        // no default implementation
+    }
+
+    /**
+     * Subclasses may use this to apply additional configuration for {@link WebSocketClient}.
+     */
+    protected void additionalWebSocketConfig(WebSocketClientBuilder builder) {
         // no default implementation
     }
 }

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
@@ -29,6 +29,7 @@ import com.google.common.base.Strings;
 
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.websocket.WebSocketClient;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 import com.linecorp.armeria.client.websocket.WebSocketClientHandshakeException;
 import com.linecorp.armeria.client.websocket.WebSocketSession;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -69,10 +70,12 @@ final class ArmeriaWebSocketClient implements SafeCloseable {
             if (webSocketClient0 != null) {
                 return webSocketClient0;
             }
-            webSocketClient0 = WebSocketClient.builder()
-                                              .factory(armeriaHttpClientBuilder.clientFactory(true))
-                                              .aggregateContinuation(true)
-                                              .build();
+            final WebSocketClientBuilder webSocketClientBuilder =
+                    WebSocketClient.builder()
+                                   .factory(armeriaHttpClientBuilder.clientFactory(true))
+                                   .aggregateContinuation(true);
+            armeriaHttpClientBuilder.getClientFactory().additionalWebSocketConfig(webSocketClientBuilder);
+            webSocketClient0 = webSocketClientBuilder.build();
             this.webSocketClient = webSocketClient0;
             return webSocketClient0;
         } finally {

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
@@ -272,8 +272,8 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
                 newServiceWatch.close();
             } else {
                 serviceWatch = newServiceWatch;
+                logger.info("[{}/{}] Service watcher is started.", namespace, serviceName);
             }
-            logger.info("[{}/{}] Service watcher is started.", namespace, serviceName);
             return null;
         }, worker);
     }
@@ -373,8 +373,8 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
                 newPodwatch.close();
             } else {
                 podWatch = newPodwatch;
+                logger.info("[{}/{}] Pod watcher is started.", namespace, serviceName);
             }
-            logger.info("[{}/{}] Pod watcher is started.", namespace, serviceName);
             return null;
         }, worker);
     }
@@ -458,8 +458,8 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
                 newNodeWatch.close();
             } else {
                 nodeWatch = newNodeWatch;
+                logger.info("[{}/{}] Node watcher is started.", namespace, serviceName);
             }
-            logger.info("[{}/{}] Node watcher is started.", namespace, serviceName);
             return null;
         }, worker);
     }

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
@@ -271,7 +271,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
             logger.warn("[{}/{}] Failed to start the service watcher.", namespace, serviceName, e);
             return;
         }
-        // Recheck the closed flag because the watchService() method may take a while.
+        // Recheck the closed flag because the doWatchService() method may take a while.
         if (closed) {
             newServiceWatch.close();
         } else {
@@ -372,7 +372,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
             logger.warn("[{}/{}] Failed to start the pod watcher.", namespace, serviceName, e);
             return;
         }
-        // Recheck the closed flag because the watchPod() method may take a while.
+        // Recheck the closed flag because the doWatchPod() method may take a while.
         if (closed) {
             newPodwatch.close();
         } else {
@@ -458,7 +458,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
             return;
         }
         final Watch newNodeWatch = doWatchNode();
-        // Recheck the closed flag because the watchNode() method may take a while.
+        // Recheck the closed flag because the doWatchNode() method may take a while.
         if (closed) {
             newNodeWatch.close();
         } else {

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
@@ -43,11 +43,10 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
                             kubernetesClientBuilderCustomizer = TestKubernetesClientBuilderCustomizer.class)
 class KubernetesEndpointGroupFaultToleranceTest {
 
-    private static KubernetesClient staticClient;
     private KubernetesClient client;
 
     @Test
-    void test() throws InterruptedException {
+    void shouldReconnectOnWatcherException() throws InterruptedException {
         // Prepare Kubernetes resources
         final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"), newNode("3.3.3.3"));
         final Deployment deployment = newDeployment();

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes.endpoints;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesEndpointGroupMockServerTest.newDeployment;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesEndpointGroupMockServerTest.newNode;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesEndpointGroupMockServerTest.newPod;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesEndpointGroupMockServerTest.newService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+@EnableKubernetesMockClient(crud = true,
+                            kubernetesClientBuilderCustomizer = TestKubernetesClientBuilderCustomizer.class)
+class KubernetesEndpointGroupFaultToleranceTest {
+
+    private static KubernetesClient staticClient;
+    private KubernetesClient client;
+
+    @Test
+    void test() throws InterruptedException {
+        // Prepare Kubernetes resources
+        final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"), newNode("3.3.3.3"));
+        final Deployment deployment = newDeployment();
+        final int nodePort = 30000;
+        final Service service = newService(nodePort);
+        final List<Pod> pods = nodes.stream()
+                                    .map(node -> node.getMetadata().getName())
+                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
+                                    .collect(toImmutableList());
+
+        // Create Kubernetes resources
+        for (Node node : nodes) {
+            client.nodes().resource(node).create();
+        }
+        client.pods().resource(pods.get(0)).create();
+        client.pods().resource(pods.get(1)).create();
+        client.apps().deployments().resource(deployment).create();
+        client.services().resource(service).create();
+
+        final KubernetesEndpointGroup endpointGroup = KubernetesEndpointGroup.of(client, "test",
+                                                                                 "nginx-service");
+        endpointGroup.whenReady().join();
+
+        // Initial state
+        await().untilAsserted(() -> {
+            final List<Endpoint> endpoints = endpointGroup.endpoints();
+            // Wait until all endpoints are ready
+            assertThat(endpoints).containsExactlyInAnyOrder(
+                    Endpoint.of("1.1.1.1", nodePort),
+                    Endpoint.of("2.2.2.2", nodePort)
+            );
+        });
+
+        TestKubernetesClientBuilderCustomizer.injectFault(true);
+        // Add a new pod
+        try {
+            client.pods().resource(pods.get(2)).create();
+        } catch (Exception e) {
+            // Expected
+        }
+
+        Thread.sleep(2000);
+
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(
+                Endpoint.of("1.1.1.1", nodePort),
+                Endpoint.of("2.2.2.2", nodePort)
+        );
+
+        TestKubernetesClientBuilderCustomizer.injectFault(false);
+        // Make sure the new pod is added when the fault is recovered.
+        await().untilAsserted(() -> {
+            final List<Endpoint> endpoints = endpointGroup.endpoints();
+            assertThat(endpoints).containsExactlyInAnyOrder(
+                    Endpoint.of("1.1.1.1", nodePort),
+                    Endpoint.of("2.2.2.2", nodePort),
+                    Endpoint.of("3.3.3.3", nodePort)
+            );
+        });
+    }
+}

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupFaultToleranceTest.java
@@ -39,8 +39,9 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 
-@EnableKubernetesMockClient(crud = true,
-                            kubernetesClientBuilderCustomizer = TestKubernetesClientBuilderCustomizer.class)
+@EnableKubernetesMockClient(
+        crud = true,
+        kubernetesClientBuilderCustomizer = TestKubernetesClientBuilderCustomizer.class)
 class KubernetesEndpointGroupFaultToleranceTest {
 
     private KubernetesClient client;
@@ -82,11 +83,7 @@ class KubernetesEndpointGroupFaultToleranceTest {
 
         TestKubernetesClientBuilderCustomizer.injectFault(true);
         // Add a new pod
-        try {
-            client.pods().resource(pods.get(2)).create();
-        } catch (Exception e) {
-            // Expected
-        }
+        client.pods().resource(pods.get(2)).create();
 
         Thread.sleep(2000);
 

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -22,7 +22,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -66,16 +65,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 @EnableKubernetesMockClient(crud = true)
 class KubernetesEndpointGroupMockServerTest {
 
-    private static KubernetesClient staticClient;
-
     private KubernetesClient client;
-
-    @AfterAll
-    static void afterAll() {
-        // A workaround for the issue that the static client is leaked.
-        // Remove once https://github.com/fabric8io/kubernetes-client/pull/5854 is released.
-        staticClient.close();
-    }
 
     @Test
     void createEndpointsWithNodeIpAndPort() throws InterruptedException {
@@ -344,7 +334,7 @@ class KubernetesEndpointGroupMockServerTest {
                 .build();
     }
 
-    private static Node newNode(String ip) {
+    static Node newNode(String ip) {
         return newNode(ip, "InternalIP");
     }
 
@@ -413,7 +403,7 @@ class KubernetesEndpointGroupMockServerTest {
                 .build();
     }
 
-    private static Pod newPod(PodTemplateSpec template, String newNodeName) {
+    static Pod newPod(PodTemplateSpec template, String newNodeName) {
         final PodSpec spec = template.getSpec()
                                      .toBuilder()
                                      .withNodeName(newNodeName)

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/TestKubernetesClientBuilderCustomizer.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/TestKubernetesClientBuilderCustomizer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes.endpoints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientFactory;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.websocket.WebSocketFrame;
+import com.linecorp.armeria.internal.common.websocket.WebSocketFrameEncoder;
+
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesClientBuilderCustomizer;
+
+public class TestKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestKubernetesClientBuilderCustomizer.class);
+
+    private static volatile boolean shouldInjectFault;
+
+    static void injectFault(boolean shouldInjectFault) {
+        TestKubernetesClientBuilderCustomizer.shouldInjectFault = shouldInjectFault;
+    }
+
+    @Override
+    public void accept(KubernetesClientBuilder kubernetesClientBuilder) {
+        kubernetesClientBuilder.withHttpClientFactory(new ArmeriaHttpClientFactory() {
+
+            @Override
+            protected void additionalWebSocketConfig(WebSocketClientBuilder builder) {
+                builder.decorator((delegate, ctx, req) -> {
+                    // Do something with the request.
+                    final HttpResponse response = delegate.execute(ctx, req);
+                    return response.mapData(object -> {
+                        final HttpData newData;
+                        if (shouldInjectFault) {
+                            object.close();
+                            final WebSocketFrameEncoder encoder = WebSocketFrameEncoder.of(false);
+                            final WebSocketFrame frame = WebSocketFrame.ofText("invalid data");
+                            newData = HttpData.wrap(encoder.encode(ctx, frame));
+                        } else {
+                            newData = object;
+                        }
+                        return newData;
+                    });
+                });
+            }
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

A watcher in `KubernetesEndpointGroup` automatically reconnects when it fails to connect to the remote peer. However, it does not reconnect when a `WatcherException` is raised.

```
io.fabric8.kubernetes.client.WatcherException: too old resource version: 573375490 (573377297)
	at io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.onStatus(AbstractWatchManager.java:401)
	at io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.onMessage(AbstractWatchManager.java:369)
	at io.fabric8.kubernetes.client.dsl.internal.WatcherWebSocketListener.onMessage(WatcherWebSocketListener.java:52)
	at com.linecorp.armeria.client.kubernetes.ArmeriaWebSocket.onNext(ArmeriaWebSocket.java:106)
	at com.linecorp.armeria.client.kubernetes.ArmeriaWebSocket.onNext(ArmeriaWebSocket.java:37)
	at com.linecorp.armeria.common.stream.DefaultStreamMessage.notifySubscriberWithElements(DefaultStreamMessage.java:412)
        ...
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: too old resource version: 573375490 (573377297)
	... 62 common frames omitted
```

I don't know why `too old resource version` was raised but an important thing is that watchers should not be stopped until `KubernetesEndpointGroup` is closed.

Modifications:

- Refactor `KuberntesEndpointGroup` to start watchers asynchronously.
- Automatically restart `Watcher`s when `onClose(WatcherException)` is invoked.
- Add more logs that I think might be useful.
  - Also make the log formats consistent
- Debounce the update of endpoints to prevent `EndpointGroup.whenReady()` from completing with a small number of endpoints.
  - The purpose is to prevent a few endpoints from receiving too much traffic when a watcher is newly created.

Result:

`KubernetesEndpointGroup` automatically reconnects a `Watcher` when `WatcherException` is raised.
