### PR TITLE
Bump Node.js version

### DIFF
--- a/docs-client/build.gradle
+++ b/docs-client/build.gradle
@@ -11,8 +11,8 @@ if (rootProject.hasProperty('noWeb')) {
 }
 
 node {
-    version = '22.3.0'
-    npmVersion = '10.8.1'
+    version = '22.10.0'
+    npmVersion = '10.9.0'
     download = true
     npmInstallCommand = "ci"
 }

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -23,8 +23,8 @@ plugins {
 }
 
 node {
-    version = '22.3.0'
-    npmVersion = '10.8.1'
+    version = '22.10.0'
+    npmVersion = '10.9.0'
     download = true
     npmInstallCommand = "ci"
 }


### PR DESCRIPTION
Motivation:

I observed that `:docs-client:npmInstall` failed frequently. https://github.com/line/armeria/actions/runs/12268833874/job/34231348528?pr=5941#step:9:1028

I don't know the root cause, but it would be worth upgrading to the latest version.
https://nodejs.org/en/about/previous-releases#looking-for-latest-release-of-a-version-branch

Modifications:

- Node.js 22.3.0 -> 22.10.0
- NPM 10.8.1 -> 10.9.0

Result:

Fix the failure of `npm install`
