### PR TITLE
Fix Missing Use of `SuccessFunction` in Determining Response Success for Log Levels

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -28,8 +28,11 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.SuccessFunction;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.server.ServiceRequestContext;
 
 final class DefaultLogWriter implements LogWriter {
 
@@ -98,19 +101,23 @@ final class DefaultLogWriter implements LogWriter {
             final String responseStr = logFormatter.formatResponse(log);
             final RequestContext ctx = log.context();
             try (SafeCloseable ignored = ctx.push()) {
-                if (responseCause == null) {
+                if (isSuccess(log)) {
                     responseLogLevel.log(logger, responseStr);
                     return;
                 }
+                // If the request is not successful,
+                // we log the request first if it's unlogged to help debugging.
 
                 final LogLevel requestLogLevel = requestLogLevelMapper.apply(log);
                 assert requestLogLevel != null;
                 if (!requestLogLevel.isEnabled(logger)) {
-                    // Request wasn't logged, but this is an unsuccessful response,
-                    // so we log the request too to help debugging.
                     responseLogLevel.log(logger, logFormatter.formatRequest(log));
                 }
 
+                if (responseCause == null) {
+                    responseLogLevel.log(logger, responseStr);
+                    return;
+                }
                 if (responseCauseFilter.test(ctx, responseCause)) {
                     responseLogLevel.log(logger, responseStr);
                 } else {
@@ -118,6 +125,20 @@ final class DefaultLogWriter implements LogWriter {
                 }
             }
         }
+    }
+
+    static boolean isSuccess(RequestLog log) {
+        final RequestContext ctx = log.context();
+        final SuccessFunction successFunction;
+        if (ctx instanceof ClientRequestContext) {
+            successFunction = ((ClientRequestContext) ctx).options().successFunction();
+        } else if (ctx instanceof ServiceRequestContext) {
+            successFunction = ((ServiceRequestContext) ctx).config().successFunction();
+        } else {
+            throw new IllegalStateException(
+                    ctx + " is neither ClientRequestContext nor ServiceRequestContext");
+        }
+        return successFunction.isSuccess(ctx, log);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultLogWriter.java
@@ -114,11 +114,7 @@ final class DefaultLogWriter implements LogWriter {
                     responseLogLevel.log(logger, logFormatter.formatRequest(log));
                 }
 
-                if (responseCause == null) {
-                    responseLogLevel.log(logger, responseStr);
-                    return;
-                }
-                if (responseCauseFilter.test(ctx, responseCause)) {
+                if (responseCause == null || responseCauseFilter.test(ctx, responseCause)) {
                     responseLogLevel.log(logger, responseStr);
                 } else {
                     responseLogLevel.log(logger, responseStr, responseCause);
@@ -135,8 +131,9 @@ final class DefaultLogWriter implements LogWriter {
         } else if (ctx instanceof ServiceRequestContext) {
             successFunction = ((ServiceRequestContext) ctx).config().successFunction();
         } else {
-            throw new IllegalStateException(
-                    ctx + " is neither ClientRequestContext nor ServiceRequestContext");
+            throw new IllegalArgumentException(
+                    ctx + " is neither " + ClientRequestContext.class.getSimpleName() + " nor " +
+                    ServiceRequestContext.class.getSimpleName());
         }
         return successFunction.isSuccess(ctx, log);
     }

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapper.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common.logging;
 
+import static com.linecorp.armeria.common.logging.DefaultLogWriter.isSuccess;
 import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
@@ -43,7 +44,7 @@ public interface ResponseLogLevelMapper extends Function<RequestLog, LogLevel> {
      * {@code failureResponseLogLevel} if failure.
      */
     static ResponseLogLevelMapper of(LogLevel successfulResponseLogLevel, LogLevel failureResponseLogLevel) {
-        return log -> log.responseCause() == null ? successfulResponseLogLevel : failureResponseLogLevel;
+        return log -> isSuccess(log) ? successfulResponseLogLevel : failureResponseLogLevel;
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/logging/LoggingClientTest.java
@@ -90,7 +90,7 @@ class LoggingClientTest {
 
         customLoggerClient.execute(ctx, req);
 
-        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(3)).isInfoEnabled();
 
         // verify request log
         verify(logger).info(argThat((String actLog) -> actLog.contains("Request:") &&
@@ -152,7 +152,7 @@ class LoggingClientTest {
         client.execute(ctx, req);
 
         // After the sanitization.
-        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(3)).isInfoEnabled();
 
         // verify request log
         verify(logger).info(argThat((String text) -> text.contains("Request:") &&
@@ -196,7 +196,7 @@ class LoggingClientTest {
         client.execute(ctx, req);
 
         // After the sanitization.
-        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(3)).isInfoEnabled();
 
         // verify request log
         verify(logger).info(argThat((String text) -> text.contains("Request:") &&
@@ -239,10 +239,10 @@ class LoggingClientTest {
 
         client.execute(ctx, req);
 
-        // Ensure the request content (the phone number 333-490-4499) is sanitized.
-        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(3)).isInfoEnabled();
 
         // verify request log
+        // Ensure the request content (the phone number 333-490-4499) is sanitized.
         verify(logger).info(argThat((String text) -> text.contains("Request:") &&
                                                      !text.contains("333-490-4499")));
         // verify response log
@@ -283,10 +283,10 @@ class LoggingClientTest {
 
         client.execute(ctx, req);
 
-        // Ensure the request content (the phone number 333-490-4499) is sanitized.
-        verify(logger, times(2)).isInfoEnabled();
+        verify(logger, times(3)).isInfoEnabled();
 
         // verify request log
+        // Ensure the request content (the phone number 333-490-4499) is sanitized.
         verify(logger).info(argThat((String text) -> text.contains("Request:") &&
                                                      !text.contains("333-490-4499")));
         // verify response log
@@ -301,7 +301,7 @@ class LoggingClientTest {
         ctx.logBuilder().responseHeaders(ResponseHeaders.of(HttpStatus.INTERNAL_SERVER_ERROR));
 
         final Logger logger = LoggingTestUtil.newMockLogger(ctx, capturedCause);
-        when(logger.isDebugEnabled()).thenReturn(true);
+        when(logger.isWarnEnabled()).thenReturn(true);
 
         // use custom logger
         final LoggingClient customLoggerClient =
@@ -312,13 +312,14 @@ class LoggingClientTest {
         customLoggerClient.execute(ctx, req);
 
         verify(logger, times(2)).isDebugEnabled();
+        verify(logger, times(1)).isWarnEnabled();
 
         // verify request log
-        verify(logger).debug(argThat((String actLog) -> actLog.contains("Request:") &&
+        verify(logger).warn(argThat((String actLog) -> actLog.contains("Request:") &&
                                                         actLog.endsWith("headers=[:method=GET, :path=/]}")));
 
         // verify response log
-        verify(logger).debug(argThat((String actLog) -> actLog.contains("Response:") &&
+        verify(logger).warn(argThat((String actLog) -> actLog.contains("Response:") &&
                                                         actLog.endsWith("headers=[:status=500]}")));
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/LoggingDecoratorBuilderTest.java
@@ -67,12 +67,6 @@ class LoggingDecoratorBuilderTest {
                 assertThat(content).isNotNull();
                 return SANITIZED_CONTENT;
             };
-    private static final BiFunction<? super RequestContext, ? super Throwable, ?> CAUSE_SANITIZER =
-            (ctx, cause) -> {
-                assertThat(ctx).isNotNull();
-                assertThat(cause).isNotNull();
-                return "dummy cause sanitizer";
-            };
 
     private Builder builder;
     private ServiceRequestContext ctx;

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ResponseLogLevelMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class ResponseLogLevelMapperTest {
+
+    @MethodSource("contexts")
+    @ParameterizedTest
+    void foo(RequestContext ctx, int status) {
+        final ResponseLogLevelMapper logLevelMapper = ResponseLogLevelMapper.of(LogLevel.DEBUG, LogLevel.WARN);
+        final RequestLogBuilder logBuilder = ctx.logBuilder();
+        logBuilder.endRequest();
+        logBuilder.responseHeaders(ResponseHeaders.of(status));
+        logBuilder.endResponse();
+        final LogLevel expected = status == 200 ? LogLevel.DEBUG : LogLevel.WARN;
+        assertThat(logLevelMapper.apply(ctx.log().ensureComplete())).isSameAs(expected);
+    }
+
+    private static Stream<Arguments> contexts() {
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/");
+        return Stream.of(
+                Arguments.of(ClientRequestContext.of(request), 200),
+                Arguments.of(ServiceRequestContext.of(request), 200),
+                Arguments.of(ClientRequestContext.of(request), 500),
+                Arguments.of(ServiceRequestContext.of(request), 500)
+        );
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/healthcheck/HealthCheckServiceTest.java
@@ -143,6 +143,7 @@ class HealthCheckServiceTest {
     void setUp() {
         reset(logger);
         when(logger.isDebugEnabled()).thenReturn(true);
+        when(logger.isWarnEnabled()).thenReturn(true);
         checker.setHealthy(true);
     }
 
@@ -189,7 +190,7 @@ class HealthCheckServiceTest {
                              "connection: close\r\n\r\n" +
                              "{\"healthy\":false}");
         await().untilAsserted(() -> {
-            verify(logger).debug(anyString());
+            verify(logger).warn(anyString());
         });
     }
 
@@ -214,7 +215,7 @@ class HealthCheckServiceTest {
                              "armeria-lphc: 60, 5\r\n" +
                              "content-length: 17\r\n" +
                              "connection: close\r\n\r\n");
-        verify(logger).debug(anyString());
+        verify(logger).warn(anyString());
     }
 
     private static void assertResponseEquals(String request, String expectedResponse) throws Exception {


### PR DESCRIPTION
Motivation:
The `ResponseLogLevelMapper.of()` did not use the `SuccessFunction` to determine whether a response was successful.

Modifications:
- Updated `ResponseLogLevelMapper.of()` to use the `SuccessFunction` when determining the success of a response.

Result:
- Log levels for responses are now correctly mapped based on the `SuccessFunction`.