### PR TITLE
Introduce `Preprocessor`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractClientOptionsBuilder.java
@@ -57,6 +57,7 @@ public class AbstractClientOptionsBuilder {
 
     private final Map<ClientOption<?>, ClientOptionValue<?>> options = new LinkedHashMap<>();
     private final ClientDecorationBuilder decoration = ClientDecoration.builder();
+    private final ClientPreprocessorsBuilder clientPreprocessorsBuilder = new ClientPreprocessorsBuilder();
     private final HttpHeadersBuilder headers = HttpHeaders.builder();
 
     @Nullable
@@ -127,6 +128,8 @@ public class AbstractClientOptionsBuilder {
         } else if (opt == ClientOptions.HEADERS) {
             final HttpHeaders h = (HttpHeaders) optionValue.value();
             setHeaders(h);
+        } else if (opt == ClientOptions.PREPROCESSORS) {
+            clientPreprocessorsBuilder.add((ClientPreprocessors) optionValue.value());
         } else {
             options.put(opt, optionValue);
         }
@@ -521,6 +524,28 @@ public class AbstractClientOptionsBuilder {
     }
 
     /**
+     * Adds the specified HTTP-level {@code preprocessor}.
+     *
+     * @param preprocessor the {@link HttpPreprocessor} that preprocesses an invocation
+     */
+    @UnstableApi
+    public AbstractClientOptionsBuilder preprocessor(HttpPreprocessor preprocessor) {
+        clientPreprocessorsBuilder.add(preprocessor);
+        return this;
+    }
+
+    /**
+     * Adds the specified RPC-level {@code rpcPreprocessor}.
+     *
+     * @param rpcPreprocessor the {@link RpcPreprocessor} that preprocesses an invocation
+     */
+    @UnstableApi
+    public AbstractClientOptionsBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        clientPreprocessorsBuilder.addRpc(rpcPreprocessor);
+        return this;
+    }
+
+    /**
      * Builds {@link ClientOptions} with the given options and the
      * {@linkplain ClientOptions#of() default options}.
      */
@@ -538,6 +563,7 @@ public class AbstractClientOptionsBuilder {
                 ImmutableList.builder();
         additionalValues.addAll(optVals);
         additionalValues.add(ClientOptions.DECORATION.newValue(decoration.build()));
+        additionalValues.add(ClientOptions.PREPROCESSORS.newValue(clientPreprocessorsBuilder.build()));
         additionalValues.add(ClientOptions.HEADERS.newValue(headers.build()));
         additionalValues.add(ClientOptions.CONTEXT_HOOK.newValue(contextHook));
         if (contextCustomizer != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractWebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractWebClientBuilder.java
@@ -184,4 +184,16 @@ public abstract class AbstractWebClientBuilder extends AbstractClientOptionsBuil
     public AbstractWebClientBuilder rpcDecorator(DecoratingRpcClientFunction decorator) {
         throw new UnsupportedOperationException("RPC decorator cannot be added to the web client builder.");
     }
+
+    /**
+     * Raises an {@link UnsupportedOperationException} because this builder doesn't support RPC-level but only
+     * HTTP-level preprocessors.
+     *
+     * @deprecated RPC preprocessor cannot be added to the web client builder.
+     */
+    @Deprecated
+    @Override
+    public AbstractClientOptionsBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        throw new UnsupportedOperationException("RPC preprocessor cannot be added to the web client builder.");
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientBuilder.java
@@ -300,4 +300,14 @@ public final class ClientBuilder extends AbstractClientOptionsBuilder {
     public ClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (ClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
+
+    @Override
+    public ClientBuilder preprocessor(HttpPreprocessor decorator) {
+        return (ClientBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    public ClientBuilder rpcPreprocessor(RpcPreprocessor decorator) {
+        return (ClientBuilder) super.rpcPreprocessor(decorator);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptions.java
@@ -160,6 +160,19 @@ public final class ClientOptions
     public static final ClientOption<ResponseTimeoutMode> RESPONSE_TIMEOUT_MODE =
             ClientOption.define("RESPONSE_TIMEOUT_MODE", Flags.responseTimeoutMode());
 
+    @UnstableApi
+    public static final ClientOption<ClientPreprocessors> PREPROCESSORS =
+            ClientOption.define("PREPROCESSORS", ClientPreprocessors.of(), Function.identity(),
+                                (oldValue, newValue) -> {
+                                    final ClientPreprocessors newPreprocessors = newValue.value();
+                                    final ClientPreprocessors oldPreprocessors = oldValue.value();
+                                    return newValue.option().newValue(
+                                            ClientPreprocessors.builder()
+                                                               .add(oldPreprocessors)
+                                                               .add(newPreprocessors)
+                                                               .build());
+                                });
+
     private static final List<AsciiString> PROHIBITED_HEADER_NAMES = ImmutableList.of(
             HttpHeaderNames.HTTP2_SETTINGS,
             HttpHeaderNames.METHOD,
@@ -408,6 +421,14 @@ public final class ClientOptions
     @UnstableApi
     public ResponseTimeoutMode responseTimeoutMode() {
         return get(RESPONSE_TIMEOUT_MODE);
+    }
+
+    /**
+     * Returns the {@link Preprocessor}s that preprocesses the components of a client.
+     */
+    @UnstableApi
+    public ClientPreprocessors clientPreprocessors() {
+        return get(PREPROCESSORS);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientOptionsBuilder.java
@@ -227,4 +227,14 @@ public final class ClientOptionsBuilder extends AbstractClientOptionsBuilder {
     public ClientOptionsBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (ClientOptionsBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
+
+    @Override
+    public ClientOptionsBuilder preprocessor(HttpPreprocessor decorator) {
+        return (ClientOptionsBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    public ClientOptionsBuilder rpcPreprocessor(RpcPreprocessor decorator) {
+        return (ClientOptionsBuilder) super.rpcPreprocessor(decorator);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessors.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessors.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * A set of {@link Function}s that transforms a {@link HttpPreprocessor} or
+ * {@link RpcPreprocessor} into another.
+ */
+@UnstableApi
+public final class ClientPreprocessors {
+
+    private static final ClientPreprocessors NONE =
+            new ClientPreprocessors(ImmutableList.of(), ImmutableList.of());
+
+    /**
+     * Returns an empty {@link ClientDecoration} which does not decorate a {@link Client}.
+     */
+    public static ClientPreprocessors of() {
+        return NONE;
+    }
+
+    /**
+     * Creates a new instance from a single {@link HttpPreprocessor}.
+     *
+     * @param preprocessor the {@link HttpPreprocessor} that transforms an
+     *                     {@link HttpPreClient} to another
+     */
+    public static ClientPreprocessors of(HttpPreprocessor preprocessor) {
+        return builder().add(preprocessor).build();
+    }
+
+    /**
+     * Creates a new instance from a single {@link RpcPreprocessor}.
+     *
+     * @param preprocessor the {@link RpcPreprocessor} that transforms an {@link RpcPreClient}
+     *                     to another
+     */
+    public static ClientPreprocessors ofRpc(RpcPreprocessor preprocessor) {
+        return builder().addRpc(preprocessor).build();
+    }
+
+    static ClientPreprocessorsBuilder builder() {
+        return new ClientPreprocessorsBuilder();
+    }
+
+    private final List<HttpPreprocessor> preprocessors;
+    private final List<RpcPreprocessor> rpcPreprocessors;
+
+    ClientPreprocessors(List<HttpPreprocessor> preprocessors, List<RpcPreprocessor> rpcPreprocessors) {
+        this.preprocessors = ImmutableList.copyOf(preprocessors);
+        this.rpcPreprocessors = ImmutableList.copyOf(rpcPreprocessors);
+    }
+
+    /**
+     * Returns the HTTP-level preprocessors.
+     */
+    public List<HttpPreprocessor> preprocessors() {
+        return preprocessors;
+    }
+
+    /**
+     * Returns the RPC-level preprocessors.
+     */
+    public List<RpcPreprocessor> rpcPreprocessors() {
+        return rpcPreprocessors;
+    }
+
+    /**
+     * Decorates the specified {@link HttpPreClient} using preprocessors.
+     *
+     * @param execution the {@link HttpPreClient} being decorated
+     */
+    public HttpPreClient decorate(HttpPreClient execution) {
+        for (HttpPreprocessor preprocessor : preprocessors) {
+            final HttpPreClient execution0 = execution;
+            execution = (ctx, req) -> preprocessor.execute(execution0, ctx, req);
+        }
+        return execution;
+    }
+
+    /**
+     * Decorates the specified {@link RpcPreClient} using preprocessors.
+     *
+     * @param execution the {@link RpcPreClient} being decorated
+     */
+    public RpcPreClient rpcDecorate(RpcPreClient execution) {
+        for (RpcPreprocessor rpcPreprocessor : rpcPreprocessors) {
+            final RpcPreClient execution0 = execution;
+            execution = (ctx, req) -> rpcPreprocessor.execute(execution0, ctx, req);
+        }
+        return execution;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        final ClientPreprocessors that = (ClientPreprocessors) object;
+        return Objects.equals(preprocessors, that.preprocessors) &&
+               Objects.equals(rpcPreprocessors, that.rpcPreprocessors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(preprocessors, rpcPreprocessors);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("preprocessors", preprocessors)
+                          .add("rpcPreprocessors", rpcPreprocessors)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessors.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessors.java
@@ -62,7 +62,10 @@ public final class ClientPreprocessors {
         return builder().addRpc(preprocessor).build();
     }
 
-    static ClientPreprocessorsBuilder builder() {
+    /**
+     * Returns a newly created {@link ClientPreprocessorsBuilder}.
+     */
+    public static ClientPreprocessorsBuilder builder() {
         return new ClientPreprocessorsBuilder();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessorsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessorsBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Creates a new {@link ClientPreprocessors} using the builder pattern.
+ */
+@UnstableApi
+public final class ClientPreprocessorsBuilder {
+
+    private final List<HttpPreprocessor> preprocessors = new ArrayList<>();
+    private final List<RpcPreprocessor> rpcPreprocessors = new ArrayList<>();
+
+    /**
+     * Adds the specified {@link ClientPreprocessors}.
+     */
+    public ClientPreprocessorsBuilder add(ClientPreprocessors preprocessors) {
+        requireNonNull(preprocessors, "preprocessors");
+        preprocessors.preprocessors().forEach(this::add);
+        preprocessors.rpcPreprocessors().forEach(this::addRpc);
+        return this;
+    }
+
+    /**
+     * Adds the specified HTTP-level {@code preprocessor}.
+     *
+     * @param preprocessor the {@link HttpPreprocessor} that preprocesses an invocation
+     */
+    public ClientPreprocessorsBuilder add(HttpPreprocessor preprocessor) {
+        preprocessors.add(requireNonNull(preprocessor, "preprocessor"));
+        return this;
+    }
+
+    /**
+     * Adds the specified RPC-level {@code preprocessor}.
+     *
+     * @param rpcPreprocessor the {@link HttpPreprocessor} that preprocesses an invocation
+     */
+    public ClientPreprocessorsBuilder addRpc(RpcPreprocessor rpcPreprocessor) {
+        rpcPreprocessors.add(requireNonNull(rpcPreprocessor, "rpcPreprocessor"));
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link ClientPreprocessors} based on the decorators added to this builder.
+     */
+    public ClientPreprocessors build() {
+        return new ClientPreprocessors(preprocessors, rpcPreprocessors);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessorsBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientPreprocessorsBuilder.java
@@ -32,6 +32,8 @@ public final class ClientPreprocessorsBuilder {
     private final List<HttpPreprocessor> preprocessors = new ArrayList<>();
     private final List<RpcPreprocessor> rpcPreprocessors = new ArrayList<>();
 
+    ClientPreprocessorsBuilder() {}
+
     /**
      * Adds the specified {@link ClientPreprocessors}.
      */

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -251,9 +251,8 @@ public interface ClientRequestContext extends RequestContext {
      * Returns the {@link EndpointGroup} used for the current {@link Request}.
      *
      * @return the {@link EndpointGroup} if a user specified an {@link EndpointGroup} when initiating
-     *         a {@link Request}. {@code null} if a user specified an {@link Endpoint}.
+     *         a {@link Request}.
      */
-    @Nullable
     EndpointGroup endpointGroup();
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -130,12 +130,13 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
             responseCancellationScheduler = CancellationScheduler.ofClient(0);
         }
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
-                eventLoop(), meterRegistry(), sessionProtocol(), id(), method(), requestTarget(), options,
+                eventLoop(), meterRegistry(), sessionProtocol(), id(), method(), requestTarget(),
+                endpointGroup, options,
                 request(), rpcRequest(), requestOptions, responseCancellationScheduler,
                 isRequestStartTimeSet() ? requestStartTimeNanos() : System.nanoTime(),
                 isRequestStartTimeSet() ? requestStartTimeMicros() : SystemInfo.currentTimeMicros());
 
-        ctx.init(endpointGroup).handle((unused, cause) -> {
+        ctx.init().handle((unused, cause) -> {
             ctx.finishInitialization(cause == null);
             if (!timedOut()) {
                 ctx.responseCancellationScheduler().initAndStart(ctx.eventLoop(), noopCancellationTask);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.armeria.client;
 
-import static com.linecorp.armeria.internal.common.CancellationScheduler.noopCancellationTask;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetSocketAddress;
@@ -123,24 +122,17 @@ public final class ClientRequestContextBuilder extends AbstractRequestContextBui
             endpointGroup = Endpoint.parse(authority());
         }
 
-        final CancellationScheduler responseCancellationScheduler;
-        if (timedOut()) {
-            responseCancellationScheduler = CancellationScheduler.finished(false);
-        } else {
-            responseCancellationScheduler = CancellationScheduler.ofClient(0);
-        }
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
                 eventLoop(), meterRegistry(), sessionProtocol(), id(), method(), requestTarget(),
                 endpointGroup, options,
-                request(), rpcRequest(), requestOptions, responseCancellationScheduler,
+                request(), rpcRequest(), requestOptions, CancellationScheduler.ofClient(0),
                 isRequestStartTimeSet() ? requestStartTimeNanos() : System.nanoTime(),
                 isRequestStartTimeSet() ? requestStartTimeMicros() : SystemInfo.currentTimeMicros());
-
+        if (timedOut()) {
+            ctx.timeoutNow();
+        }
         ctx.init().handle((unused, cause) -> {
             ctx.finishInitialization(cause == null);
-            if (!timedOut()) {
-                ctx.responseCancellationScheduler().initAndStart(ctx.eventLoop(), noopCancellationTask);
-            }
             return null;
         });
         ctx.logBuilder().session(fakeChannel(ctx.eventLoop()), sessionProtocol(), sslSession(),

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -52,7 +52,6 @@ public class ClientRequestContextWrapper
         return unwrap().newDerivedContext(id, req, rpcReq, endpoint);
     }
 
-    @Nullable
     @Override
     public EndpointGroup endpointGroup() {
         return unwrap().endpointGroup();

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultWebClient.java
@@ -121,7 +121,8 @@ final class DefaultWebClient extends UserClient<HttpRequest, HttpResponse> imple
         }
 
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
-                protocol, newReq, null, reqTarget, endpointGroup, requestOptions, options());
+                protocol, newReq, newReq.method(), null, reqTarget, endpointGroup, requestOptions, options(),
+                meterRegistry());
         return ClientUtil.executeWithFallback(preClient, ctx, newReq, errorResponseFactory());
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -43,6 +43,7 @@ import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
@@ -572,7 +573,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             final DefaultClientRequestContext reqCtx = new DefaultClientRequestContext(
                     ctx.channel().eventLoop(), Flags.meterRegistry(), H1C, RequestId.random(),
                     com.linecorp.armeria.common.HttpMethod.OPTIONS,
-                    REQ_TARGET_ASTERISK, ClientOptions.of(),
+                    REQ_TARGET_ASTERISK, EndpointGroup.of(), ClientOptions.of(),
                     HttpRequest.of(com.linecorp.armeria.common.HttpMethod.OPTIONS, "*"),
                     null, REQUEST_OPTIONS_FOR_UPGRADE_REQUEST, CancellationScheduler.noop(),
                     System.nanoTime(), SystemInfo.currentTimeMicros());

--- a/core/src/main/java/com/linecorp/armeria/client/HttpPreClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpPreClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Prepares a {@link HttpRequest} before sending it to a remote {@link Endpoint}.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface HttpPreClient extends PreClient<HttpRequest, HttpResponse> {
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * An HTTP-based preprocessor that intercepts an outgoing request and allows users to
+ * customize certain properties before entering the decorating chain. The following
+ * illustrates a sample use-case:
+ * <pre>{@code
+ * HttpPreprocessor preprocessor = (delegate, ctx, req) -> {
+ *     ctx.endpointGroup(Endpoint.of("overriding-host"));
+ *     return delegate.execute(ctx, req);
+ * };
+ * WebClient client = WebClient.builder()
+ *                             .preprocessor(preprocessor)
+ *                             .build();
+ * }</pre>
+ */
+@UnstableApi
+@FunctionalInterface
+public interface HttpPreprocessor extends Preprocessor<HttpRequest, HttpResponse> {
+
+    /**
+     * A simple {@link HttpPreprocessor} which overwrites the {@link SessionProtocol},
+     * {@link EndpointGroup}, and {@link EventLoop} for a request.
+     */
+    static HttpPreprocessor of(SessionProtocol sessionProtocol, EndpointGroup endpointGroup,
+                               EventLoop eventLoop) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(eventLoop, "eventLoop");
+        return (delegate, ctx, req) -> {
+            ctx.sessionProtocol(sessionProtocol);
+            ctx.endpointGroup(endpointGroup);
+            ctx.eventLoop(eventLoop);
+            return delegate.execute(ctx, req);
+        };
+    }
+
+    /**
+     * A simple {@link HttpPreprocessor} which overwrites the {@link SessionProtocol} and
+     * {@link EndpointGroup} for a request.
+     */
+    static HttpPreprocessor of(SessionProtocol sessionProtocol, EndpointGroup endpointGroup) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return (delegate, ctx, req) -> {
+            ctx.sessionProtocol(sessionProtocol);
+            ctx.endpointGroup(endpointGroup);
+            return delegate.execute(ctx, req);
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
@@ -32,7 +32,7 @@ import io.netty.channel.EventLoop;
  * illustrates a sample use-case:
  * <pre>{@code
  * HttpPreprocessor preprocessor = (delegate, ctx, req) -> {
- *     ctx.endpointGroup(Endpoint.of("overriding-host"));
+ *     ctx.setEndpointGroup(Endpoint.of("overriding-host"));
  *     return delegate.execute(ctx, req);
  * };
  * WebClient client = WebClient.builder()

--- a/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpPreprocessor.java
@@ -54,9 +54,9 @@ public interface HttpPreprocessor extends Preprocessor<HttpRequest, HttpResponse
         requireNonNull(endpointGroup, "endpointGroup");
         requireNonNull(eventLoop, "eventLoop");
         return (delegate, ctx, req) -> {
-            ctx.sessionProtocol(sessionProtocol);
-            ctx.endpointGroup(endpointGroup);
-            ctx.eventLoop(eventLoop);
+            ctx.setSessionProtocol(sessionProtocol);
+            ctx.setEndpointGroup(endpointGroup);
+            ctx.setEventLoop(eventLoop);
             return delegate.execute(ctx, req);
         };
     }
@@ -69,8 +69,8 @@ public interface HttpPreprocessor extends Preprocessor<HttpRequest, HttpResponse
         requireNonNull(sessionProtocol, "sessionProtocol");
         requireNonNull(endpointGroup, "endpointGroup");
         return (delegate, ctx, req) -> {
-            ctx.sessionProtocol(sessionProtocol);
-            ctx.endpointGroup(endpointGroup);
+            ctx.setSessionProtocol(sessionProtocol);
+            ctx.setEndpointGroup(endpointGroup);
             return delegate.execute(ctx, req);
         };
     }

--- a/core/src/main/java/com/linecorp/armeria/client/PreClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/PreClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Prepares a {@link Request} before sending it to a remote {@link Endpoint}.
+ *
+ * <p>Note that this interface is not a user's entry point for sending a {@link Request}. It is rather
+ * a generic request processor interface which intercepts a {@link Request}.
+ * A user should implement {@link Preprocessor} and add it to the client instead.
+ *
+ * @param <I> the type of outgoing {@link Request}. Must be {@link HttpRequest} or {@link RpcRequest}.
+ * @param <O> the type of incoming {@link Response}. Must be {@link HttpResponse} or {@link RpcResponse}.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface PreClient<I extends Request, O extends Response> {
+
+    /**
+     * Prepares a {@link Request} before sending it to a remote {@link Endpoint}.
+     *
+     * @return the {@link Response} to the specified {@link Request}
+     */
+    O execute(PreClientRequestContext ctx, I req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/client/PreClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/PreClientRequestContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * A {@link ClientRequestContext} which allows certain properties to be mutable before
+ * initialization is finalized.
+ */
+@UnstableApi
+public interface PreClientRequestContext extends ClientRequestContext {
+
+    /**
+     * Sets the {@link EndpointGroup} used for the current {@link Request}.
+     */
+    void endpointGroup(EndpointGroup endpointGroup);
+
+    /**
+     * Sets the {@link SessionProtocol} of the current {@link Request}.
+     */
+    void sessionProtocol(SessionProtocol sessionProtocol);
+
+    /**
+     * Sets the {@link EventLoop} which will handle this request. Because changing
+     * the assigned {@link EventLoop} can lead to unexpected behavior, this property
+     * can be set only once. Because the assigned {@link EventLoop} can influence the number of
+     * connections made to an {@link Endpoint}, it is recommended to understand {@link EventLoopScheduler}
+     * before manually setting this value.
+     *
+     * @see EventLoopScheduler
+     */
+    void eventLoop(EventLoop eventLoop);
+}

--- a/core/src/main/java/com/linecorp/armeria/client/PreClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/PreClientRequestContext.java
@@ -33,12 +33,12 @@ public interface PreClientRequestContext extends ClientRequestContext {
     /**
      * Sets the {@link EndpointGroup} used for the current {@link Request}.
      */
-    void endpointGroup(EndpointGroup endpointGroup);
+    void setEndpointGroup(EndpointGroup endpointGroup);
 
     /**
      * Sets the {@link SessionProtocol} of the current {@link Request}.
      */
-    void sessionProtocol(SessionProtocol sessionProtocol);
+    void setSessionProtocol(SessionProtocol sessionProtocol);
 
     /**
      * Sets the {@link EventLoop} which will handle this request. Because changing
@@ -49,5 +49,5 @@ public interface PreClientRequestContext extends ClientRequestContext {
      *
      * @see EventLoopScheduler
      */
-    void eventLoop(EventLoop eventLoop);
+    void setEventLoop(EventLoop eventLoop);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Preprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Preprocessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+
+/**
+ * Decorates a {@link PreClient}. Use either {@link HttpPreClient} or {@link RpcPreClient}
+ * depending on whether the client is HTTP-based or RPC-based.
+ *
+ * @param <I> the {@link Request} type of the {@link Client} being decorated
+ * @param <O> the {@link Response} type of the {@link Client} being decorated
+ */
+@FunctionalInterface
+public interface Preprocessor<I extends Request, O extends Response> {
+
+    /**
+     * Creates a new instance that decorates the specified {@link PreClient}.
+     */
+    O execute(PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception;
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RedirectingClient.java
@@ -192,8 +192,11 @@ final class RedirectingClient extends SimpleDecoratingHttpClient {
             return;
         }
 
+        final HttpRequest req = derivedCtx.request();
+        assert req != null;
         final HttpResponse response = executeWithFallback(unwrap(), derivedCtx,
-                                                          (context, cause) -> HttpResponse.ofFailure(cause));
+                                                          (context, cause) -> HttpResponse.ofFailure(cause),
+                                                          req);
         derivedCtx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).thenAccept(log -> {
             if (log.isAvailable(RequestLogProperty.RESPONSE_CAUSE)) {
                 final Throwable cause = log.responseCause();

--- a/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RestClientBuilder.java
@@ -259,4 +259,15 @@ public final class RestClientBuilder extends AbstractWebClientBuilder {
     public RestClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (RestClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
+
+    @Override
+    public RestClientBuilder preprocessor(HttpPreprocessor decorator) {
+        return (RestClientBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    @Deprecated
+    public RestClientBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        return (RestClientBuilder) super.rpcPreprocessor(rpcPreprocessor);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RpcPreClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RpcPreClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Prepares a {@link RpcRequest} before sending it to a remote {@link Endpoint}.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface RpcPreClient extends PreClient<RpcRequest, RpcResponse> {
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * An RPC-based preprocessor that intercepts an outgoing request and allows users to
+ * customize certain properties before entering the decorating chain. The following
+ * illustrates a sample use-case:
+ * <pre>{@code
+ * RpcPreprocessor preprocessor = (delegate, ctx, req) -> {
+ *     ctx.endpointGroup(Endpoint.of("overriding-host"));
+ *     return delegate.execute(ctx, req);
+ * };
+ * Iface iface = ThriftClients.builder(Endpoint.of("overridden-host"))
+ *                            .rpcPreprocessor(rpcPreprocessor)
+ *                            .build(Iface.class);
+ * }</pre>
+ */
+@UnstableApi
+@FunctionalInterface
+public interface RpcPreprocessor extends Preprocessor<RpcRequest, RpcResponse> {
+
+    /**
+     * A simple {@link RpcPreprocessor} which overwrites the {@link SessionProtocol},
+     * {@link EndpointGroup}, and {@link EventLoop} for a request.
+     */
+    static RpcPreprocessor of(SessionProtocol sessionProtocol, EndpointGroup endpointGroup,
+                              EventLoop eventLoop) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        requireNonNull(eventLoop, "eventLoop");
+        return (delegate, ctx, req) -> {
+            ctx.sessionProtocol(sessionProtocol);
+            ctx.endpointGroup(endpointGroup);
+            ctx.eventLoop(eventLoop);
+            return delegate.execute(ctx, req);
+        };
+    }
+
+    /**
+     * A simple {@link RpcPreprocessor} which overwrites the {@link SessionProtocol},
+     * {@link EndpointGroup}, and {@link EventLoop} for a request.
+     */
+    static RpcPreprocessor of(SessionProtocol sessionProtocol, EndpointGroup endpointGroup) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        requireNonNull(endpointGroup, "endpointGroup");
+        return (delegate, ctx, req) -> {
+            ctx.sessionProtocol(sessionProtocol);
+            ctx.endpointGroup(endpointGroup);
+            return delegate.execute(ctx, req);
+        };
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
@@ -32,7 +32,7 @@ import io.netty.channel.EventLoop;
  * illustrates a sample use-case:
  * <pre>{@code
  * RpcPreprocessor preprocessor = (delegate, ctx, req) -> {
- *     ctx.endpointGroup(Endpoint.of("overriding-host"));
+ *     ctx.setEndpointGroup(Endpoint.of("overriding-host"));
  *     return delegate.execute(ctx, req);
  * };
  * Iface iface = ThriftClients.builder(Endpoint.of("overridden-host"))

--- a/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RpcPreprocessor.java
@@ -54,9 +54,9 @@ public interface RpcPreprocessor extends Preprocessor<RpcRequest, RpcResponse> {
         requireNonNull(endpointGroup, "endpointGroup");
         requireNonNull(eventLoop, "eventLoop");
         return (delegate, ctx, req) -> {
-            ctx.sessionProtocol(sessionProtocol);
-            ctx.endpointGroup(endpointGroup);
-            ctx.eventLoop(eventLoop);
+            ctx.setSessionProtocol(sessionProtocol);
+            ctx.setEndpointGroup(endpointGroup);
+            ctx.setEventLoop(eventLoop);
             return delegate.execute(ctx, req);
         };
     }
@@ -69,8 +69,8 @@ public interface RpcPreprocessor extends Preprocessor<RpcRequest, RpcResponse> {
         requireNonNull(sessionProtocol, "sessionProtocol");
         requireNonNull(endpointGroup, "endpointGroup");
         return (delegate, ctx, req) -> {
-            ctx.sessionProtocol(sessionProtocol);
-            ctx.endpointGroup(endpointGroup);
+            ctx.setSessionProtocol(sessionProtocol);
+            ctx.setEndpointGroup(endpointGroup);
             return delegate.execute(ctx, req);
         };
     }

--- a/core/src/main/java/com/linecorp/armeria/client/UserClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/UserClient.java
@@ -54,6 +54,7 @@ public abstract class UserClient<I extends Request, O extends Response>
         implements ClientBuilderParams {
 
     private final ClientBuilderParams params;
+    private final MeterRegistry meterRegistry;
     private final Function<CompletableFuture<O>, O> futureConverter;
     private final BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory;
 
@@ -74,6 +75,7 @@ public abstract class UserClient<I extends Request, O extends Response>
                          BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
         super(delegate);
         this.params = params;
+        this.meterRegistry = meterRegistry;
         this.futureConverter = futureConverter;
         this.errorResponseFactory = errorResponseFactory;
     }
@@ -125,13 +127,23 @@ public abstract class UserClient<I extends Request, O extends Response>
     }
 
     /**
+     * The {@link MeterRegistry} used for requests produced by this client.
+     */
+    protected MeterRegistry meterRegistry() {
+        return meterRegistry;
+    }
+
+    /**
      * Executes the specified {@link Request} via the delegate.
      *
      * @param protocol the {@link SessionProtocol} to use
      * @param method the method of the {@link Request}
      * @param reqTarget the {@link RequestTarget} of the {@link Request}
      * @param req the {@link Request}
+     *
+     * @deprecated prefer {@link ClientOptions#clientPreprocessors()} to execute requests
      */
+    @Deprecated
     protected final O execute(SessionProtocol protocol, HttpMethod method, RequestTarget reqTarget, I req) {
         return execute(protocol, method, reqTarget, req, RequestOptions.of());
     }
@@ -144,7 +156,10 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param reqTarget the {@link RequestTarget} of the {@link Request}
      * @param req the {@link Request}
      * @param requestOptions the {@link RequestOptions} of the {@link Request}
+     *
+     * @deprecated prefer {@link ClientOptions#clientPreprocessors()} to execute requests
      */
+    @Deprecated
     protected final O execute(SessionProtocol protocol, HttpMethod method, RequestTarget reqTarget,
                               I req, RequestOptions requestOptions) {
         return execute(protocol, endpointGroup(), method, reqTarget, req, requestOptions);
@@ -158,7 +173,10 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param method the method of the {@link Request}
      * @param reqTarget the {@link RequestTarget} of the {@link Request}
      * @param req the {@link Request}
+     *
+     * @deprecated prefer {@link ClientOptions#clientPreprocessors()} to execute requests
      */
+    @Deprecated
     protected final O execute(SessionProtocol protocol, EndpointGroup endpointGroup, HttpMethod method,
                               RequestTarget reqTarget, I req) {
         return execute(protocol, endpointGroup, method, reqTarget, req, RequestOptions.of());
@@ -173,7 +191,10 @@ public abstract class UserClient<I extends Request, O extends Response>
      * @param reqTarget the {@link RequestTarget} of the {@link Request}
      * @param req the {@link Request}
      * @param requestOptions the {@link RequestOptions} of the {@link Request}
+     *
+     * @deprecated prefer {@link ClientOptions#clientPreprocessors()} to execute requests
      */
+    @Deprecated
     protected final O execute(SessionProtocol protocol, EndpointGroup endpointGroup, HttpMethod method,
                               RequestTarget reqTarget, I req, RequestOptions requestOptions) {
 
@@ -190,7 +211,7 @@ public abstract class UserClient<I extends Request, O extends Response>
 
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
                 protocol, httpReq, method, rpcReq, reqTarget, endpointGroup,
-                requestOptions, options());
+                requestOptions, options(), meterRegistry);
 
         return initContextAndExecuteWithFallback(unwrap(), ctx, futureConverter, errorResponseFactory, req);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/WebClientBuilder.java
@@ -255,4 +255,15 @@ public final class WebClientBuilder extends AbstractWebClientBuilder {
     public WebClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (WebClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
     }
+
+    @Override
+    public WebClientBuilder preprocessor(HttpPreprocessor decorator) {
+        return (WebClientBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    @Deprecated
+    public WebClientBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        return (WebClientBuilder) super.rpcPreprocessor(rpcPreprocessor);
+    }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -179,11 +179,11 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
             // clear the pending throwable to retry endpoint selection
             ClientPendingThrowableUtil.removePendingThrowable(derivedCtx);
             // if the endpoint hasn't been selected, try to initialize the ctx with a new endpoint/event loop
-            res = initContextAndExecuteWithFallback(unwrap(), ctxExtension, endpointGroup, RpcResponse::from,
-                                                    (context, cause) -> RpcResponse.ofFailure(cause));
+            res = initContextAndExecuteWithFallback(unwrap(), ctxExtension, RpcResponse::from,
+                                                    (context, cause) -> RpcResponse.ofFailure(cause), req);
         } else {
             res = executeWithFallback(unwrap(), derivedCtx,
-                                      (context, cause) -> RpcResponse.ofFailure(cause));
+                                      (context, cause) -> RpcResponse.ofFailure(cause), req);
         }
 
         final RetryConfig<RpcResponse> retryConfig = mappedRetryConfig(ctx);

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
@@ -45,8 +45,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
@@ -395,5 +397,24 @@ public final class WebSocketClientBuilder extends AbstractWebClientBuilder {
     @Override
     public WebSocketClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (WebSocketClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    /**
+     * Raises an {@link UnsupportedOperationException} because {@link WebSocketClient} does
+     * not support {@link HttpPreprocessor}.
+     *
+     * @deprecated HTTP preprocessor cannot be added to the {@link WebSocketClient}.
+     */
+    @Override
+    @Deprecated
+    public WebSocketClientBuilder preprocessor(HttpPreprocessor preprocessor) {
+        throw new UnsupportedOperationException(
+                "RPC preprocessor cannot be added to the websocket client builder.");
+    }
+
+    @Override
+    @Deprecated
+    public WebSocketClientBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        return (WebSocketClientBuilder) super.rpcPreprocessor(rpcPreprocessor);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/WebSocketClientBuilder.java
@@ -409,7 +409,7 @@ public final class WebSocketClientBuilder extends AbstractWebClientBuilder {
     @Deprecated
     public WebSocketClientBuilder preprocessor(HttpPreprocessor preprocessor) {
         throw new UnsupportedOperationException(
-                "RPC preprocessor cannot be added to the websocket client builder.");
+                "WebSocketClientBuilder does not support preprocessor.");
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
@@ -41,7 +41,7 @@ public interface ClientRequestContextExtension extends ClientRequestContext, Req
      * Returns a {@link CompletableFuture} that will be completed
      * if this {@link ClientRequestContext} is initialized with an {@link EndpointGroup}.
      *
-     * @see #init(EndpointGroup)
+     * @see #init()
      */
     CompletableFuture<Boolean> whenInitialized();
 
@@ -53,7 +53,7 @@ public interface ClientRequestContextExtension extends ClientRequestContext, Req
      *         {@code false} if the initialization has failed and this context's {@link RequestLog} has been
      *         completed with the cause of the failure.
      */
-    CompletableFuture<Boolean> init(EndpointGroup endpointGroup);
+    CompletableFuture<Boolean> init();
 
     /**
      * Completes the {@link #whenInitialized()} with the specified value.

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
@@ -75,4 +75,18 @@ public interface ClientRequestContextExtension extends ClientRequestContext, Req
     HttpHeaders internalRequestHeaders();
 
     long remainingTimeoutNanos();
+
+    /**
+     * The context customizer must be run before the following conditions.
+     * <li>
+     *     <ul>
+     *         EndpointSelector.select() so that the customizer can inject the attributes which may be
+     *         required by the EndpointSelector.</ul>
+     *     <ul>
+     *         mapEndpoint() to give an opportunity to override an Endpoint when using
+     *         an additional authority.
+     *     </ul>
+     * </li>
+     */
+    void runContextCustomizer();
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientRequestContextExtension.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointSelector;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.logging.RequestLog;
@@ -80,8 +81,8 @@ public interface ClientRequestContextExtension extends ClientRequestContext, Req
      * The context customizer must be run before the following conditions.
      * <li>
      *     <ul>
-     *         EndpointSelector.select() so that the customizer can inject the attributes which may be
-     *         required by the EndpointSelector.</ul>
+     *         {@link EndpointSelector#selectNow(ClientRequestContext)} so that the customizer
+     *         can inject the attributes which may be required by the EndpointSelector.</ul>
      *     <ul>
      *         mapEndpoint() to give an opportunity to override an Endpoint when using
      *         an additional authority.

--- a/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/ClientUtil.java
@@ -157,11 +157,16 @@ public final class ClientUtil {
     O executeWithFallback(U execution,
                           PreClientRequestContext ctx, I req,
                           BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
+        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
+        if (ctxExt != null) {
+            ctxExt.runContextCustomizer();
+        }
         try {
             return execution.execute(ctx, req);
         } catch (Exception e) {
-            fail(ctx, e);
-            return errorResponseFactory.apply(ctx, e);
+            final UnprocessedRequestException upe = UnprocessedRequestException.of(e);
+            fail(ctx, upe);
+            return errorResponseFactory.apply(ctx, upe);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -187,6 +187,17 @@ public final class DefaultClientRequestContext
     public DefaultClientRequestContext(SessionProtocol sessionProtocol, @Nullable HttpRequest httpRequest,
                                        HttpMethod method, @Nullable RpcRequest rpcRequest,
                                        RequestTarget requestTarget, EndpointGroup endpointGroup,
+                                       RequestOptions requestOptions, ClientOptions clientOptions,
+                                       MeterRegistry meterRegistry) {
+        this(null, meterRegistry,
+             sessionProtocol, nextRequestId(clientOptions), method, requestTarget,
+             endpointGroup, clientOptions, httpRequest, rpcRequest, requestOptions, serviceRequestContext(),
+             null, System.nanoTime(), SystemInfo.currentTimeMicros());
+    }
+
+    public DefaultClientRequestContext(SessionProtocol sessionProtocol, @Nullable HttpRequest httpRequest,
+                                       HttpMethod method, @Nullable RpcRequest rpcRequest,
+                                       RequestTarget requestTarget, EndpointGroup endpointGroup,
                                        RequestOptions requestOptions, ClientOptions clientOptions) {
         this(null, clientOptions.factory().meterRegistry(),
              sessionProtocol, nextRequestId(clientOptions), method, requestTarget,
@@ -648,7 +659,7 @@ public final class DefaultClientRequestContext
     }
 
     @Override
-    public void sessionProtocol(SessionProtocol sessionProtocol) {
+    public void setSessionProtocol(SessionProtocol sessionProtocol) {
         checkState(!initialized, "Cannot update sessionProtocol after initialization");
         this.sessionProtocol = desiredSessionProtocol(requireNonNull(sessionProtocol, "sessionProtocol"),
                                                       options);
@@ -754,7 +765,7 @@ public final class DefaultClientRequestContext
     }
 
     @Override
-    public void eventLoop(EventLoop eventLoop) {
+    public void setEventLoop(EventLoop eventLoop) {
         checkState(!initialized, "Cannot update eventLoop after initialization");
         checkState(this.eventLoop == null, "eventLoop can be updated only once");
         this.eventLoop = requireNonNull(eventLoop, "eventLoop");
@@ -785,7 +796,7 @@ public final class DefaultClientRequestContext
     }
 
     @Override
-    public void endpointGroup(EndpointGroup endpointGroup) {
+    public void setEndpointGroup(EndpointGroup endpointGroup) {
         checkState(!initialized, "Cannot update endpointGroup after initialization");
         this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -758,6 +758,7 @@ public final class DefaultClientRequestContext
         checkState(!initialized, "Cannot update eventLoop after initialization");
         checkState(this.eventLoop == null, "eventLoop can be updated only once");
         this.eventLoop = requireNonNull(eventLoop, "eventLoop");
+        initializeResponseCancellationScheduler();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/client/TailPreClient.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/TailPreClient.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.Client;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.PreClient;
+import com.linecorp.armeria.client.PreClientRequestContext;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+
+public final class TailPreClient<I extends Request, O extends Response> implements PreClient<I, O> {
+
+    private final Client<I, O> delegate;
+    private final Function<CompletableFuture<O>, O> futureConverter;
+    private final BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory;
+
+    private TailPreClient(Client<I, O> delegate,
+                          Function<CompletableFuture<O>, O> futureConverter,
+                          BiFunction<ClientRequestContext, Throwable, O> errorResponseFactory) {
+        this.delegate = delegate;
+        this.futureConverter = futureConverter;
+        this.errorResponseFactory = errorResponseFactory;
+    }
+
+    public static HttpPreClient of(
+            HttpClient httpClient,
+            Function<CompletableFuture<HttpResponse>, HttpResponse> futureConverter,
+            BiFunction<ClientRequestContext, Throwable, HttpResponse> errorResponseFactory) {
+        final TailPreClient<HttpRequest, HttpResponse> tail =
+                new TailPreClient<>(httpClient, futureConverter, errorResponseFactory);
+        return tail::execute;
+    }
+
+    public static RpcPreClient ofRpc(
+            RpcClient rpcClient,
+            Function<CompletableFuture<RpcResponse>, RpcResponse> futureConverter,
+            BiFunction<ClientRequestContext, Throwable, RpcResponse> errorResponseFactory) {
+        final TailPreClient<RpcRequest, RpcResponse> tail =
+                new TailPreClient<>(rpcClient, futureConverter, errorResponseFactory);
+        return tail::execute;
+    }
+
+    @Override
+    public O execute(PreClientRequestContext ctx, I req) {
+        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
+        assert ctxExt != null;
+        return ClientUtil.initContextAndExecuteWithFallback(delegate, ctxExt,
+                                                            futureConverter, errorResponseFactory, req);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/CancellationScheduler.java
@@ -20,6 +20,8 @@ import static com.linecorp.armeria.internal.common.DefaultCancellationScheduler.
 
 import java.util.concurrent.CompletableFuture;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 
@@ -127,6 +129,9 @@ public interface CancellationScheduler {
      * {@link CancellationTask} will be executed after the currently set task has finished executing.
      */
     void updateTask(CancellationTask cancellationTask);
+
+    @VisibleForTesting
+    State state();
 
     enum State {
         INIT,

--- a/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/DefaultCancellationScheduler.java
@@ -389,8 +389,9 @@ final class DefaultCancellationScheduler implements CancellationScheduler {
         return cause;
     }
 
+    @Override
     @VisibleForTesting
-    State state() {
+    public State state() {
         return state;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NonWrappingRequestContext.java
@@ -39,7 +39,6 @@ import com.linecorp.armeria.common.RequestId;
 import com.linecorp.armeria.common.RequestTarget;
 import com.linecorp.armeria.common.RequestTargetForm;
 import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
@@ -60,7 +59,6 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
 
     private final MeterRegistry meterRegistry;
     private final ConcurrentAttributes attrs;
-    private SessionProtocol sessionProtocol;
     private final RequestId id;
     private final HttpMethod method;
     private RequestTarget reqTarget;
@@ -82,9 +80,8 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
      * Creates a new instance.
      */
     protected NonWrappingRequestContext(
-            MeterRegistry meterRegistry, SessionProtocol sessionProtocol,
-            RequestId id, HttpMethod method, RequestTarget reqTarget, ExchangeType exchangeType,
-            long requestAutoAbortDelayMillis,
+            MeterRegistry meterRegistry, RequestId id, HttpMethod method, RequestTarget reqTarget,
+            ExchangeType exchangeType, long requestAutoAbortDelayMillis,
             @Nullable HttpRequest req, @Nullable RpcRequest rpcReq,
             @Nullable AttributesGetters rootAttributeMap, Supplier<? extends AutoCloseable> contextHook) {
         assert req != null || rpcReq != null;
@@ -96,7 +93,6 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
             attrs = ConcurrentAttributes.fromParent(rootAttributeMap);
         }
 
-        this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
         this.id = requireNonNull(id, "id");
         this.method = requireNonNull(method, "method");
         this.reqTarget = requireNonNull(reqTarget, "reqTarget");
@@ -152,11 +148,6 @@ public abstract class NonWrappingRequestContext implements RequestContextExtensi
      */
     @Nullable
     protected abstract RequestTarget validateHeaders(RequestHeaders headers);
-
-    @Override
-    public final SessionProtocol sessionProtocol() {
-        return sessionProtocol;
-    }
 
     /**
      * Returns the {@link Channel} that is handling this request, or {@code null} if the connection is not

--- a/core/src/main/java/com/linecorp/armeria/internal/common/NoopCancellationScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/NoopCancellationScheduler.java
@@ -30,8 +30,6 @@ final class NoopCancellationScheduler implements CancellationScheduler {
 
     private static final CompletableFuture<Throwable> THROWABLE_FUTURE =
             UnmodifiableFuture.wrap(new CompletableFuture<>());
-    private static final CompletableFuture<Void> VOID_FUTURE =
-            UnmodifiableFuture.wrap(new CompletableFuture<>());
 
     private NoopCancellationScheduler() {
     }
@@ -112,5 +110,10 @@ final class NoopCancellationScheduler implements CancellationScheduler {
 
     @Override
     public void updateTask(CancellationTask cancellationTask) {
+    }
+
+    @Override
+    public State state() {
+        return State.INIT;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -92,6 +92,7 @@ public final class DefaultServiceRequestContext
             additionalResponseTrailersUpdater = AtomicReferenceFieldUpdater.newUpdater(
             DefaultServiceRequestContext.class, HttpHeaders.class, "additionalResponseTrailers");
 
+    private final SessionProtocol sessionProtocol;
     private final Channel ch;
     private final EventLoop eventLoop;
     private final ServiceConfig cfg;
@@ -170,11 +171,12 @@ public final class DefaultServiceRequestContext
             HttpHeaders additionalResponseHeaders, HttpHeaders additionalResponseTrailers,
             Supplier<? extends AutoCloseable> contextHook) {
 
-        super(meterRegistry, sessionProtocol, id,
+        super(meterRegistry, id,
               requireNonNull(routingContext, "routingContext").method(),
               routingContext.requestTarget(), exchangeType, cfg.requestAutoAbortDelayMillis(),
               requireNonNull(req, "req"), null, null, contextHook);
 
+        this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
         this.ch = requireNonNull(ch, "ch");
         this.eventLoop = requireNonNull(eventLoop, "eventLoop");
         this.cfg = requireNonNull(cfg, "cfg");
@@ -229,6 +231,11 @@ public final class DefaultServiceRequestContext
     public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
         // Don't check the root attributes; root is always null.
         return ownAttrs();
+    }
+
+    @Override
+    public SessionProtocol sessionProtocol() {
+        return sessionProtocol;
     }
 
     @Nonnull

--- a/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientOptionsTest.java
@@ -19,6 +19,7 @@ import static com.linecorp.armeria.client.ClientOptions.DECORATION;
 import static com.linecorp.armeria.client.ClientOptions.ENDPOINT_REMAPPER;
 import static com.linecorp.armeria.client.ClientOptions.HEADERS;
 import static com.linecorp.armeria.client.ClientOptions.MAX_RESPONSE_LENGTH;
+import static com.linecorp.armeria.client.ClientOptions.PREPROCESSORS;
 import static com.linecorp.armeria.client.ClientOptions.REQUEST_ID_GENERATOR;
 import static com.linecorp.armeria.client.ClientOptions.RESPONSE_TIMEOUT_MILLIS;
 import static com.linecorp.armeria.client.ClientOptions.WRITE_TIMEOUT_MILLIS;
@@ -42,6 +43,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestId;
 
 class ClientOptionsTest {
@@ -124,7 +126,9 @@ class ClientOptionsTest {
                     arguments(HEADERS, HttpHeaders.of(HttpHeaderNames.USER_AGENT, "armeria")),
                     arguments(DECORATION, ClientDecoration.of(LoggingClient.newDecorator())),
                     arguments(REQUEST_ID_GENERATOR, requestIdGenerator),
-                    arguments(ENDPOINT_REMAPPER, Function.identity()));
+                    arguments(ENDPOINT_REMAPPER, Function.identity()),
+                    arguments(PREPROCESSORS, ClientPreprocessors.of(
+                            (delegate, ctx, req) -> HttpResponse.of(200))));
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpPreprocessorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpPreprocessorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+class HttpPreprocessorTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void overwriteByCustomPreprocessor() {
+        final HttpPreprocessor preprocessor =
+                HttpPreprocessor.of(SessionProtocol.HTTP, Endpoint.of("127.0.0.1"),
+                                    eventLoop.get());
+        final WebClient client = WebClient.builder()
+                                          .preprocessor(preprocessor)
+                                          .decorator((delegate, ctx, req) -> HttpResponse.of(200))
+                                          .build();
+        final ClientRequestContext ctx;
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final AggregatedHttpResponse res = client.get("https://127.0.0.2").aggregate().join();
+            assertThat(res.status().code()).isEqualTo(200);
+            ctx = captor.get();
+        }
+        assertThat(ctx.sessionProtocol()).isEqualTo(SessionProtocol.HTTP);
+        assertThat(ctx.authority()).isEqualTo("127.0.0.1");
+        assertThat(ctx.eventLoop().withoutContext()).isSameAs(eventLoop.get());
+    }
+
+    @Test
+    void preprocessorOrder() {
+        final List<String> list = new ArrayList<>();
+        final HttpPreprocessor p1 = RunnablePreprocessor.of(() -> list.add("1"));
+        final HttpPreprocessor p2 = RunnablePreprocessor.of(() -> list.add("2"));
+        final HttpPreprocessor p3 = RunnablePreprocessor.of(() -> list.add("3"));
+
+        final WebClient client = WebClient.builder()
+                                          .preprocessor(p1)
+                                          .preprocessor(p2)
+                                          .preprocessor(p3)
+                                          .decorator((delegate, ctx, req) -> HttpResponse.of(200))
+                                          .build();
+        final AggregatedHttpResponse res = client.get("http://127.0.0.1").aggregate().join();
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(list).containsExactly("3", "2", "1");
+    }
+
+    private static final class RunnablePreprocessor implements HttpPreprocessor {
+
+        private static HttpPreprocessor of(Runnable runnable) {
+            return new RunnablePreprocessor(runnable);
+        }
+
+        private final Runnable runnable;
+
+        private RunnablePreprocessor(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public HttpResponse execute(PreClient<HttpRequest, HttpResponse> delegate,
+                                    PreClientRequestContext ctx, HttpRequest req) throws Exception {
+            runnable.run();
+            return delegate.execute(ctx, req);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpPreprocessorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpPreprocessorTest.java
@@ -78,7 +78,7 @@ class HttpPreprocessorTest {
     @Test
     void cancellationSchedulerIsInitializedCorrectly() {
         final HttpPreprocessor preprocessor = (delegate, ctx, req) -> {
-            ctx.eventLoop(eventLoop.get());
+            ctx.setEventLoop(eventLoop.get());
             return delegate.execute(ctx, req);
         };
         final BlockingWebClient client =

--- a/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/DefaultClientRequestContextTest.java
@@ -293,6 +293,7 @@ class DefaultClientRequestContextTest {
                 HttpHeaderNames.AUTHORITY, "example.com:8080"));
         final DefaultClientRequestContext ctx = newContext(ClientOptions.of(), request,
                                                            Endpoint.of("example.com", 8080));
+        ctx.runContextCustomizer();
         ctx.init();
         return ctx;
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/client/DerivedClientRequestContextClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/DerivedClientRequestContextClientTest.java
@@ -55,8 +55,9 @@ class DerivedClientRequestContextClientTest {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext parent = new DefaultClientRequestContext(
                 new SimpleMeterRegistry(), SessionProtocol.H2C, RequestId.random(), HttpMethod.GET,
-                RequestTarget.forClient("/"), ClientOptions.of(), request, null, RequestOptions.of(), 0, 0);
-        parent.init(group);
+                RequestTarget.forClient("/"), group, ClientOptions.of(), request, null, RequestOptions.of(),
+                0, 0);
+        parent.init();
         assertThat(parent.endpoint()).isEqualTo(endpointA);
         final ClientRequestContext child =
                 ClientUtil.newDerivedContext(parent, request, null, false);
@@ -70,8 +71,9 @@ class DerivedClientRequestContextClientTest {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext parent = new DefaultClientRequestContext(
                 new SimpleMeterRegistry(), SessionProtocol.H2C, RequestId.random(), HttpMethod.GET,
-                RequestTarget.forClient("/"), ClientOptions.of(), request, null, RequestOptions.of(), 0, 0);
-        parent.init(group);
+                RequestTarget.forClient("/"), group,
+                ClientOptions.of(), request, null, RequestOptions.of(), 0, 0);
+        parent.init();
         assertThat(parent.endpoint()).isEqualTo(endpointA);
         final ClientRequestContext childA0 =
                 ClientUtil.newDerivedContext(parent, HttpRequest.of(HttpMethod.GET, "/"), null, true);
@@ -104,8 +106,9 @@ class DerivedClientRequestContextClientTest {
         final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/");
         final DefaultClientRequestContext parent = new DefaultClientRequestContext(
                 new SimpleMeterRegistry(), SessionProtocol.H2C, RequestId.random(), HttpMethod.GET,
-                RequestTarget.forClient("/"), ClientOptions.of(), request, null, RequestOptions.of(), 0, 0);
-        parent.init(group);
+                RequestTarget.forClient("/"), group, ClientOptions.of(),
+                request, null, RequestOptions.of(), 0, 0);
+        parent.init();
         assertThat(parent.endpoint()).isEqualTo(endpointA);
         final ClientRequestContext child =
                 ClientUtil.newDerivedContext(parent, HttpRequest.of(HttpMethod.GET, "/"), null, true);

--- a/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/client/eureka/EurekaEndpointGroupBuilder.java
@@ -42,8 +42,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.AbstractDynamicEndpointGroupBuilder;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroupSetters;
@@ -436,6 +438,17 @@ public final class EurekaEndpointGroupBuilder extends AbstractWebClientBuilder
     @Override
     public EurekaEndpointGroupBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (EurekaEndpointGroupBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    @Override
+    public EurekaEndpointGroupBuilder preprocessor(HttpPreprocessor decorator) {
+        return (EurekaEndpointGroupBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    @Deprecated
+    public EurekaEndpointGroupBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        return (EurekaEndpointGroupBuilder) super.rpcPreprocessor(rpcPreprocessor);
     }
 
     @Override

--- a/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
+++ b/eureka/src/main/java/com/linecorp/armeria/server/eureka/EurekaUpdatingListenerBuilder.java
@@ -41,8 +41,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.retry.RetryRule;
@@ -556,5 +558,16 @@ public final class EurekaUpdatingListenerBuilder extends AbstractWebClientBuilde
     @Override
     public EurekaUpdatingListenerBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (EurekaUpdatingListenerBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    @Override
+    public EurekaUpdatingListenerBuilder preprocessor(HttpPreprocessor decorator) {
+        return (EurekaUpdatingListenerBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    @Deprecated
+    public EurekaUpdatingListenerBuilder rpcPreprocessor(RpcPreprocessor rpcPreprocessor) {
+        return (EurekaUpdatingListenerBuilder) super.rpcPreprocessor(rpcPreprocessor);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
+++ b/grpc/src/main/java/com/linecorp/armeria/client/grpc/GrpcClientBuilder.java
@@ -55,8 +55,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
 import com.linecorp.armeria.common.RequestContext;
@@ -599,6 +601,18 @@ public final class GrpcClientBuilder extends AbstractClientOptionsBuilder {
     @Override
     public GrpcClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (GrpcClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    @Override
+    public GrpcClientBuilder preprocessor(HttpPreprocessor decorator) {
+        return (GrpcClientBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    @Deprecated
+    public GrpcClientBuilder rpcPreprocessor(RpcPreprocessor decorator) {
+        throw new UnsupportedOperationException("rpcPreprocessor() does not support gRPC. " +
+                                                "Use preprocessor() instead.");
     }
 
     /**

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -168,7 +168,6 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
 
         return new ArmeriaClientCall<>(
                 ctx,
-                params.endpointGroup(),
                 client,
                 req,
                 method,
@@ -183,7 +182,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 jsonMarshaller,
                 unsafeWrapResponseBuffers,
                 exceptionHandler,
-                useMethodMarshaller);
+                useMethodMarshaller,
+                options().clientPreprocessors());
     }
 
     @Override
@@ -248,6 +248,7 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 options().requestIdGenerator().get(),
                 method,
                 reqTarget,
+                endpointGroup(),
                 options(),
                 req,
                 null,

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaChannel.java
@@ -21,13 +21,16 @@ import static com.linecorp.armeria.internal.common.grpc.GrpcExchangeTypeUtil.toE
 import java.net.URI;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 
 import com.linecorp.armeria.client.ClientBuilderParams;
 import com.linecorp.armeria.client.ClientOptions;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.grpc.GrpcClientOptions;
@@ -36,6 +39,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.RequestHeadersBuilder;
 import com.linecorp.armeria.common.RequestTarget;
@@ -49,8 +53,10 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.Unwrappable;
 import com.linecorp.armeria.internal.client.DefaultClientRequestContext;
+import com.linecorp.armeria.internal.client.TailPreClient;
 import com.linecorp.armeria.internal.common.RequestTargetCache;
 import com.linecorp.armeria.internal.common.grpc.InternalGrpcExceptionHandler;
+import com.linecorp.armeria.internal.common.grpc.StatusAndMetadata;
 
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
@@ -61,6 +67,7 @@ import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.MethodType;
+import io.grpc.Status;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.handler.codec.http.HttpHeaderValues;
 
@@ -166,9 +173,21 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
             client = httpClient;
         }
 
+        final BiFunction<ClientRequestContext, Throwable, HttpResponse> errorResponseFactory =
+                (unused, cause) -> {
+                    final StatusAndMetadata statusAndMetadata = exceptionHandler.handle(ctx, cause);
+                    Status status = statusAndMetadata.status();
+                    if (status.getDescription() == null) {
+                        status = status.withDescription(cause.getMessage());
+                    }
+                    return HttpResponse.ofFailure(status.asRuntimeException());
+                };
+        final HttpPreClient preClient =
+                options().clientPreprocessors()
+                         .decorate(TailPreClient.of(client, HttpResponse::of, errorResponseFactory));
+
         return new ArmeriaClientCall<>(
                 ctx,
-                client,
                 req,
                 method,
                 simpleMethodNames,
@@ -183,7 +202,8 @@ final class ArmeriaChannel extends Channel implements ClientBuilderParams, Unwra
                 unsafeWrapResponseBuffers,
                 exceptionHandler,
                 useMethodMarshaller,
-                options().clientPreprocessors());
+                preClient,
+                errorResponseFactory);
     }
 
     @Override

--- a/oauth2/src/main/java/com/linecorp/armeria/client/auth/oauth2/OAuth2Client.java
+++ b/oauth2/src/main/java/com/linecorp/armeria/client/auth/oauth2/OAuth2Client.java
@@ -72,7 +72,7 @@ public final class OAuth2Client extends SimpleDecoratingHttpClient {
                             HttpHeaderNames.AUTHORIZATION, token.authorization()).build());
                     ctx.updateRequest(newReq);
                     return executeWithFallback(unwrap(), ctx,
-                                               (context, cause0) -> HttpResponse.ofFailure(cause0));
+                                               (context, cause0) -> HttpResponse.ofFailure(cause0), newReq);
                 });
         return HttpResponse.of(future);
     }

--- a/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
+++ b/retrofit2/src/main/java/com/linecorp/armeria/client/retrofit2/ArmeriaRetrofitBuilder.java
@@ -43,8 +43,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
@@ -455,5 +457,15 @@ public final class ArmeriaRetrofitBuilder extends AbstractClientOptionsBuilder {
     @Override
     public ArmeriaRetrofitBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (ArmeriaRetrofitBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    @Override
+    public ArmeriaRetrofitBuilder preprocessor(HttpPreprocessor decorator) {
+        return (ArmeriaRetrofitBuilder) super.preprocessor(decorator);
+    }
+
+    @Override
+    public ArmeriaRetrofitBuilder rpcPreprocessor(RpcPreprocessor decorator) {
+        return (ArmeriaRetrofitBuilder) super.rpcPreprocessor(decorator);
     }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/client/thrift/ThriftClientBuilder.java
@@ -42,8 +42,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutMode;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.redirect.RedirectConfig;
 import com.linecorp.armeria.common.RequestId;
@@ -378,5 +380,17 @@ public final class ThriftClientBuilder extends AbstractClientOptionsBuilder {
     @Override
     public ThriftClientBuilder responseTimeoutMode(ResponseTimeoutMode responseTimeoutMode) {
         return (ThriftClientBuilder) super.responseTimeoutMode(responseTimeoutMode);
+    }
+
+    @Override
+    @Deprecated
+    public ThriftClientBuilder preprocessor(HttpPreprocessor decorator) {
+        throw new UnsupportedOperationException("preprocessor() does not support Thrift. " +
+                                                "Use rpcPreprocessor() instead.");
+    }
+
+    @Override
+    public ThriftClientBuilder rpcPreprocessor(RpcPreprocessor decorator) {
+        return (ThriftClientBuilder) super.rpcPreprocessor(decorator);
     }
 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/DefaultTHttpClient.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/client/thrift/DefaultTHttpClient.java
@@ -88,7 +88,7 @@ final class DefaultTHttpClient extends UserClient<RpcRequest, RpcResponse> imple
         final RpcRequest call = RpcRequest.of(serviceType, method, args);
         final DefaultClientRequestContext ctx = new DefaultClientRequestContext(
                 scheme().sessionProtocol(), null, HttpMethod.POST, call, reqTarget, endpointGroup(),
-                UNARY_REQUEST_OPTIONS, options());
+                UNARY_REQUEST_OPTIONS, options(), meterRegistry());
         return ClientUtil.executeWithFallback(preClient, ctx, call, errorResponseFactory());
     }
 

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/RpcPreprocessorTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/RpcPreprocessorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.PreClient;
+import com.linecorp.armeria.client.PreClientRequestContext;
+import com.linecorp.armeria.client.RpcPreprocessor;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import testing.thrift.main.HelloService;
+
+class RpcPreprocessorTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void overwriteByCustomPreprocessor() throws Exception {
+        final RpcPreprocessor rpcPreprocessor =
+                RpcPreprocessor.of(SessionProtocol.HTTP, Endpoint.of("127.0.0.1"),
+                                   eventLoop.get());
+        final HelloService.Iface iface =
+                ThriftClients.builder("http://127.0.0.2")
+                             .rpcPreprocessor(rpcPreprocessor)
+                             .rpcDecorator((delegate, ctx, req) -> RpcResponse.of("world"))
+                             .build(HelloService.Iface.class);
+        final ClientRequestContext ctx;
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            assertThat(iface.hello("world")).isEqualTo("world");
+            ctx = captor.get();
+        }
+        assertThat(ctx.sessionProtocol()).isEqualTo(SessionProtocol.HTTP);
+        assertThat(ctx.authority()).isEqualTo("127.0.0.1");
+        assertThat(ctx.eventLoop().withoutContext()).isSameAs(eventLoop.get());
+    }
+
+    @Test
+    void preprocessorOrder() throws Exception {
+        final List<String> list = new ArrayList<>();
+        final RpcPreprocessor p1 = RunnablePreprocessor.of(() -> list.add("1"));
+        final RpcPreprocessor p2 = RunnablePreprocessor.of(() -> list.add("2"));
+        final RpcPreprocessor p3 = RunnablePreprocessor.of(() -> list.add("3"));
+
+        final HelloService.Iface iface =
+                ThriftClients.builder("http://127.0.0.2")
+                             .rpcPreprocessor(p1)
+                             .rpcPreprocessor(p2)
+                             .rpcPreprocessor(p3)
+                             .rpcDecorator((delegate, ctx, req) -> RpcResponse.of("world"))
+                             .build(HelloService.Iface.class);
+        assertThat(iface.hello("world")).isEqualTo("world");
+        assertThat(list).containsExactly("3", "2", "1");
+    }
+
+    private static final class RunnablePreprocessor implements RpcPreprocessor {
+
+        private static RpcPreprocessor of(Runnable runnable) {
+            return new RunnablePreprocessor(runnable);
+        }
+
+        private final Runnable runnable;
+
+        private RunnablePreprocessor(Runnable runnable) {
+            this.runnable = runnable;
+        }
+
+        @Override
+        public RpcResponse execute(PreClient<RpcRequest, RpcResponse> delegate,
+                                   PreClientRequestContext ctx, RpcRequest req) throws Exception {
+            runnable.run();
+            return delegate.execute(ctx, req);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

This PR introduces the notion of `Preprocessor`s and allows users to configure these to clients as options.
The second part of this PR will introduce a way for users to solely create a client based on `Preprocessor`s. The eventual POC can be found here: https://github.com/jrhee17/armeria/pull/36/files

Eventually this extension point will also make it easier/clearer for users to use xDS with existing Armeria APIs.

The full capability/limitations/design of `Preprocessors` are better described in the following PR: https://github.com/line/armeria/pull/6051

Modifications:

- Introduced `Preprocessor` and `PreClient` APIs
- Added `ClientPreprocessors` and `ClientPreprocessorsBuilder` to allow users to easily add `Preprocessor`s to clients as options
- Modified `DefaultWebClient`, `DefaultTHttpClient`, and `ArmeriaClientCall` to use `Preprocessor`s
- In order to allow users a way to overwrite the chosen `EndpointGroup`, the `EndpointGroup` is now specified when creating a `ClientRequestContext` instead of at initialization time.
- Modified `ClientUtil` methods to pass an additional `req` field which signifies the original request for type-safety.

Result:

- Users can specify `Preprocessor`s when creating a client.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
