### PR TITLE
Stop updating endpoints when `HealthCheckedEndpointGroup` is closing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -291,6 +291,12 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
     }
 
     private void updateHealth(Endpoint endpoint, boolean health) {
+        if (isClosing()) {
+            logger.debug("HealthCheckedEndpointGroup is closed. Ignoring health update for: {}. (healthy: {})",
+                         endpoint, health);
+            return;
+        }
+
         final boolean updated;
         // A healthy endpoint should be a valid checker context.
         if (health && findContext(endpoint) != null) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -194,7 +194,7 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 }
                 initialized = true;
                 destroyOldContexts(contextGroup);
-                setEndpoints(allHealthyEndpoints());
+                setEndpoints0(allHealthyEndpoints());
                 return null;
             });
         } finally {
@@ -303,8 +303,15 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
         // Each new health status will be updated after initialization of the first context group.
         if (updated && initialized) {
-            setEndpoints(allHealthyEndpoints());
+            setEndpoints0(allHealthyEndpoints());
         }
+    }
+
+    private void setEndpoints0(List<Endpoint> endpoints) {
+        if (isClosing()) {
+            return;
+        }
+        setEndpoints(endpoints);
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -617,7 +617,7 @@ class HealthCheckedEndpointGroupTest {
         final MockEndpointGroup delegate = new MockEndpointGroup();
         delegate.set(candidate1, candidate2, candidate2);
 
-        HealthCheckedEndpointGroup endpointGroup =
+        final HealthCheckedEndpointGroup endpointGroup =
                 new HealthCheckedEndpointGroup(delegate, true,
                                                10000, 10000,
                                                SessionProtocol.HTTP, 80,

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -602,6 +602,38 @@ class HealthCheckedEndpointGroupTest {
         }
     }
 
+    @Test
+    void shouldStopUpdatingEndpointsWhenClosing() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        final Function<? super HealthCheckerContext, ? extends AsyncCloseable> checkFactory = ctx -> {
+            counter.incrementAndGet();
+            ctx.updateHealth(HEALTHY, null, null, null);
+            return AsyncCloseableSupport.of();
+        };
+
+        final Endpoint candidate1 = Endpoint.of("candidate1");
+        final Endpoint candidate2 = Endpoint.of("candidate2");
+
+        final MockEndpointGroup delegate = new MockEndpointGroup();
+        delegate.set(candidate1, candidate2, candidate2);
+
+        HealthCheckedEndpointGroup endpointGroup =
+                new HealthCheckedEndpointGroup(delegate, true,
+                                               10000, 10000,
+                                               SessionProtocol.HTTP, 80,
+                                               DEFAULT_HEALTH_CHECK_RETRY_BACKOFF,
+                                               ClientOptions.of(), checkFactory,
+                                               HealthCheckStrategy.all(),
+                                               DEFAULT_ENDPOINT_PREDICATE);
+        assertThat(counter.get()).isEqualTo(2);
+        final EndpointComparator comparator = new EndpointComparator();
+        assertThat(endpointGroup.endpoints()).usingElementComparator(comparator)
+                                             .containsOnly(candidate1, candidate2);
+        endpointGroup.close();
+        assertThat(endpointGroup.endpoints()).usingElementComparator(comparator)
+                                             .containsOnly(candidate1, candidate2);
+    }
+
     static final class MockEndpointGroup extends DynamicEndpointGroup {
 
         MockEndpointGroup() {}


### PR DESCRIPTION
Motivation:

When `HealthCheckedEndpointGroup` is closing, the internally managed endpoints are cleared.
https://github.com/line/armeria/blob/011741dc51cf328b78488655e78ceca1cdc0a1b3/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/DefaultHealthCheckerContext.java#L135 In fact, the closing process is not a problem. However, when the endpoints change, the change is propagated to `EndpointSelector`. Some `EndpointSelector` implementations warn about the empty endpoints. The warning is not a real problem but a false positive alarm.
https://github.com/line/armeria/blob/62da203bd9e11d669476e6999937352749cd7339/core/src/main/java/com/linecorp/armeria/client/endpoint/WeightedRoundRobinStrategy.java#L81 

For better compatibility with `EndpointSelector` implementations, I propose to stop additional endpoints from being updated when `HealthCheckedEndpointGroup` is closed. As a result, `EndpointSelector` will not updated with empty endpoints.

Modifications:

- Stop updating endpoints when `HealthCheckedEndpointGroup` is closing

Result:

You no loger see a false positive warning log when `HealthCheckedEndpointGroup` is closing.
