### PR TITLE
Use ubicloud-standard-16 to run CI builds

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build with Gradle (Shading only)
         run: |
           ./gradlew --no-daemon --stacktrace shadedJar shadedTestJar trimShadedJar \
-          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=12' || '--max-workers=2' }} --parallel \
+          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=8' || '--max-workers=2' }} --parallel \
           ${{ matrix.coverage && '-Pcoverage' || '' }} \
           -PnoLint \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
@@ -115,7 +115,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew --no-daemon --stacktrace build \
-          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=12' || '--max-workers=2' }} --parallel \
+          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=8' || '--max-workers=2' }} --parallel \
           ${{ matrix.coverage && '-Pcoverage' || '' }} \
           ${{ matrix.leak && '-Pleak' || '' }} \
           ${{ matrix.blockhound && '-Pblockhound' || '' }} \

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -32,25 +32,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        on: [ ubicloud-standard-8, macos-latest, windows-latest ]
+        on: [ ubicloud-standard-16, macos-latest, windows-latest ]
         java: [ 21 ]
         include:
           - java: 8
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
           - java: 11
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
           - java: 17
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
             leak: true
           - java: 17
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
             min-java: 11
           - java: 17
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
             min-java: 17
             coverage: true
           - java: 21
-            on: ubicloud-standard-8
+            on: ubicloud-standard-16
             snapshot: true
             # blockhound makes the build run about 10 minutes slower
             blockhound: true
@@ -96,7 +96,7 @@ jobs:
       - name: Build with Gradle (Shading only)
         run: |
           ./gradlew --no-daemon --stacktrace shadedJar shadedTestJar trimShadedJar \
-          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=8' || '--max-workers=2' }} --parallel \
+          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=12' || '--max-workers=2' }} --parallel \
           ${{ matrix.coverage && '-Pcoverage' || '' }} \
           -PnoLint \
           -PbuildJdkVersion=${{ env.BUILD_JDK_VERSION }} \
@@ -115,7 +115,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew --no-daemon --stacktrace build \
-          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=8' || '--max-workers=2' }} --parallel \
+          ${{ startsWith(matrix.on, 'ubicloud') && '--max-workers=12' || '--max-workers=2' }} --parallel \
           ${{ matrix.coverage && '-Pcoverage' || '' }} \
           ${{ matrix.leak && '-Pleak' || '' }} \
           ${{ matrix.blockhound && '-Pblockhound' || '' }} \
@@ -236,7 +236,7 @@ jobs:
 
       - name: Run the linters
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel lint
+          ./gradlew --no-daemon --stacktrace --max-workers=4 --parallel lint
 
   site:
     if: github.repository == 'line/armeria'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,7 +13,7 @@ jobs:
   publish:
     name: Publish final artifacts
     if: github.repository == 'line/armeria'
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-16
     steps:
       - uses: actions/checkout@v4
 
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          ./gradlew --no-daemon --stacktrace --max-workers=8 --parallel -PflakyTests=false \
+          ./gradlew --no-daemon --stacktrace --max-workers=12 --parallel -PflakyTests=false \
           -Pretry=true -PfailOnPassedAfterRetry=false \
           build
         shell: bash


### PR DESCRIPTION
To get more benefits from parallelism.


YAML runner tag | vCPU | Memory
-- | -- | --
ubicloud-standard-16 | 16 | 64GB


