### PR TITLE
Prevent Execution of Delayed Tasks for Cancelled gRPC Requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -94,7 +94,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private static final Logger logger = LoggerFactory.getLogger(HttpServerHandler.class);
 
-    private static final CompletableFuture<?>[] EMPTY_FUTURES = {};
     private static final String ALLOWED_METHODS_STRING =
             HttpMethod.knownMethods().stream().map(HttpMethod::name).collect(Collectors.joining(","));
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -382,6 +382,11 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     protected final void invokeOnReady() {
+        if (blockingExecutor != null && cancelled) {
+            // Do not call listener.onReady() if the call is cancelled after
+            // this task was scheduled to blockingTaskExecutor.
+            return;
+        }
         try {
             if (listener != null) {
                 listener.onReady();
@@ -392,6 +397,12 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private void invokeOnMessage(I request, boolean halfClose) {
+        if (blockingExecutor != null && cancelled) {
+            // Do not call listener.onMessage() if the call is cancelled after
+            // this task was scheduled to blockingTaskExecutor.
+            return;
+        }
+        System.err.println("invokeOnMessage 111111 " + request);
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onMessage(request);
@@ -404,6 +415,11 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     protected final void invokeHalfClose() {
+        if (blockingExecutor != null && cancelled) {
+            // Do not call listener.onHalfClose() if the call is cancelled after
+            // this task was scheduled to blockingTaskExecutor.
+            return;
+        }
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onHalfClose();

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 
 import com.linecorp.armeria.common.HttpData;
@@ -111,8 +112,9 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     private final String clientAcceptEncoding;
     private final boolean autoCompression;
 
+    @VisibleForTesting
     @Nullable
-    private final Executor blockingExecutor;
+    final Executor blockingExecutor;
     private final InternalGrpcExceptionHandler exceptionHandler;
 
     // Only set once.

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -402,7 +402,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
             // this task was scheduled to blockingTaskExecutor.
             return;
         }
-        System.err.println("invokeOnMessage 111111 " + request);
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onMessage(request);

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.util.BlockingTaskExecutor;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import testing.grpc.Messages.StreamingInputCallRequest;
+import testing.grpc.Messages.StreamingInputCallResponse;
+import testing.grpc.TestServiceGrpc;
+import testing.grpc.TestServiceGrpc.TestServiceStub;
+
+class AbstractServerCallTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            // Use a single-threaded executor to run the blocking task once at a time without accessing
+            // the sequential executor.
+            final ScheduledExecutorService scheduledExecutorService =
+                    Executors.newSingleThreadScheduledExecutor();
+            sb.blockingTaskExecutor(BlockingTaskExecutor.of(scheduledExecutorService), true);
+
+            final AtomicReference<ServerCall<?, ?>> serverCallCaptor = new AtomicReference<>();
+            final GrpcService grpcService =
+                    GrpcService.builder()
+                               .useBlockingTaskExecutor(true)
+                               .useClientTimeoutHeader(false)
+                               .addService(ServerInterceptors.intercept(
+                                       new FooTestServiceImpl(),
+                                       new ServerInterceptor() {
+                                           @Override
+                                           public <ReqT, RespT> Listener<ReqT> interceptCall(
+                                                   ServerCall<ReqT, RespT> call, Metadata headers,
+                                                   ServerCallHandler<ReqT, RespT> next) {
+                                               serverCallCaptor.set(call);
+                                               return next.startCall(call, headers);
+                                           }
+                                       }))
+                               .build();
+            sb.service(grpcService);
+            sb.decorator((delegate, ctx, req) -> {
+                final HttpRequest newReq = req.mapData(data -> {
+                    // This is called right before
+                    // blockingExecutor.execute(() -> invokeOnMessage(request, endOfStream)); is called
+                    // in AbstractServerCall.
+                    // https://github.com/line/armeria/blob/0960d091bfc7f350c17e68f57cc627de584b9705/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java#L363
+                    scheduledExecutorService.execute(() -> {
+                        final ServerCall<?, ?> serverCall = serverCallCaptor.get();
+                        assertThat(serverCall).isNotNull();
+                        // invokeOnMessage is not called until the request is cancelled.
+                        await().until(serverCall::isCancelled);
+                        // Now, AbstractServerCall.invokeOnMessage() is called and it doesn't call
+                        // listener.onMessage() because the request is cancelled.
+                    });
+                    return data;
+                });
+                ctx.updateRequest(newReq);
+                return delegate.serve(ctx, newReq);
+            });
+            sb.requestTimeoutMillis(100);
+        }
+    };
+
+    private static final AtomicBoolean isOnNextCalled = new AtomicBoolean();
+
+    @Test
+    void onMessageIsNotCalledWhenRequestCancelled() throws InterruptedException {
+        final TestServiceStub testServiceStub = GrpcClients.newClient(server.httpUri(), TestServiceStub.class);
+        final CompletableFuture<Throwable> future = new CompletableFuture<>();
+        final StreamObserver<StreamingInputCallRequest> streamingInputCallRequestStreamObserver =
+                testServiceStub.streamingInputCall(new StreamObserver<StreamingInputCallResponse>() {
+                    @Override
+                    public void onNext(StreamingInputCallResponse value) {}
+
+                    @Override
+                    public void onError(Throwable t) {
+                        future.completeExceptionally(t);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                    }
+                });
+        streamingInputCallRequestStreamObserver.onNext(StreamingInputCallRequest.newBuilder().build());
+        assertThatThrownBy(future::get).hasCauseInstanceOf(StatusRuntimeException.class)
+                                       .hasMessageContaining("CANCELLED");
+        // Sleep additional 1 second to make sure that the onNext() is not called.
+        Thread.sleep(1000);
+        assertThat(isOnNextCalled).isFalse();
+    }
+
+    private static class FooTestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
+
+        @Override
+        public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+                StreamObserver<StreamingInputCallResponse> responseObserver) {
+            return new StreamObserver<StreamingInputCallRequest>() {
+                @Override
+                public void onNext(StreamingInputCallRequest value) {
+                    // If this method is called that means listener.onMessage() in AbstractServerCall is called.
+                    isOnNextCalled.set(true);
+                }
+
+                @Override
+                public void onError(Throwable t) {}
+
+                @Override
+                public void onCompleted() {}
+            };
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
@@ -68,10 +68,11 @@ class AbstractServerCallTest {
                                .addService(ServerInterceptors.intercept(
                                        new FooTestServiceImpl(),
                                        new ServerInterceptor() {
+
                                            @Override
-                                           public <ReqT, RespT> Listener<ReqT> interceptCall(
-                                                   ServerCall<ReqT, RespT> call, Metadata headers,
-                                                   ServerCallHandler<ReqT, RespT> next) {
+                                           public <T, U> Listener<T> interceptCall(
+                                                   ServerCall<T, U> call, Metadata headers,
+                                                   ServerCallHandler<T, U> next) {
                                                serverCallCaptor.set(call);
                                                return next.startCall(call, headers);
                                            }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServiceJsonSchemaTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServiceJsonSchemaTest.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.ServiceDescriptor;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -47,10 +46,6 @@ import testing.grpc.TestServiceGrpc;
 import testing.grpc.TestServiceGrpc.TestServiceImplBase;
 
 class GrpcDocServiceJsonSchemaTest {
-
-    private static final ServiceDescriptor TEST_SERVICE_DESCRIPTOR =
-            testing.grpc.Test.getDescriptor()
-                                                  .findServiceByName("TestService");
 
     private static class TestService extends TestServiceImplBase {
         @Override


### PR DESCRIPTION
Motivation:
When blockingTaskExecutor is used in a gRPC service, tasks handling gRPC requests are queued if the executor is busy with heavy blocking jobs. https://github.com/line/armeria/blob/0960d091bfc7f350c17e68f57cc627de584b9705/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java#L363 If these tasks are delayed for too long, the corresponding gRPC requests may time out and get cancelled. Despite the cancellation, the queued tasks are still executed once the executor becomes available, leading to unnecessary processing. https://github.com/line/armeria/blob/0960d091bfc7f350c17e68f57cc627de584b9705/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java#L394-L404

Modifications:
- Updated `AbstractServerCall.invokeOnMessage()` to check if the request is cancelled before calling `listener.onMessage`.

Result:
- Prevents execution of delayed tasks for gRPC requests that have already been cancelled.

Co-authored-by: szymon.habrainski <szymon.habrainski@rwth-aachen.de>