### PR TITLE
Support for HTTP GET map parameters

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -56,7 +56,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -466,9 +465,7 @@ final class AnnotatedValueResolver {
                 if (DefaultValues.isSpecified(param.value())) {
                     throw new IllegalArgumentException(
                         String.format("Invalid @Param annotation on Map parameter: '%s'. " +
-                                "The @Param annotation specifies a value ('%s'), which is not allowed. " +
-                                "When using a Map, @Param must not specify a value. " +
-                                "Please use @Param Map<String, Object> param without a value.",
+                                "The @Param annotation specifies a value ('%s'), which is not allowed. ",
                             annotatedElement, param.value()));
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
@@ -611,7 +608,7 @@ final class AnnotatedValueResolver {
             .description(description)
             .aggregation(AggregationStrategy.FOR_FORM_DATA)
             .resolver((resolver, ctx) -> ctx.queryParams().stream()
-                .collect(Collectors.toMap(
+                .collect(toImmutableMap(
                     Entry::getKey,
                     Entry::getValue,
                     (existing, replacement) -> replacement

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -465,7 +465,8 @@ final class AnnotatedValueResolver {
                 if (DefaultValues.isSpecified(param.value())) {
                     throw new IllegalArgumentException(
                             String.format("Invalid @Param annotation on Map parameter: '%s'. " +
-                                          "The @Param annotation specifies a value ('%s'), which is not allowed. ",
+                                          "The @Param annotation specifies a value ('%s'), " +
+                                          "which is not allowed. ",
                                           annotatedElement, param.value()));
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -56,8 +56,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -464,9 +464,9 @@ final class AnnotatedValueResolver {
             if (Map.class.isAssignableFrom(type)) {
                 if (DefaultValues.isSpecified(param.value())) {
                     throw new IllegalArgumentException(
-                        String.format("Invalid @Param annotation on Map parameter: '%s'. " +
-                                "The @Param annotation specifies a value ('%s'), which is not allowed. ",
-                            annotatedElement, param.value()));
+                            String.format("Invalid @Param annotation on Map parameter: '%s'. " +
+                                          "The @Param annotation specifies a value ('%s'), which is not allowed. ",
+                                          annotatedElement, param.value()));
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
             }
@@ -598,22 +598,22 @@ final class AnnotatedValueResolver {
     }
 
     private static AnnotatedValueResolver ofQueryParamMap(String name,
-        AnnotatedElement annotatedElement,
-        AnnotatedElement typeElement, Class<?> type,
-        DescriptionInfo description) {
+                                                          AnnotatedElement annotatedElement,
+                                                          AnnotatedElement typeElement, Class<?> type,
+                                                          DescriptionInfo description) {
 
         return new Builder(annotatedElement, type, name)
-            .annotationType(Param.class)
-            .typeElement(typeElement)
-            .description(description)
-            .aggregation(AggregationStrategy.FOR_FORM_DATA)
-            .resolver((resolver, ctx) -> ctx.queryParams().stream()
-                .collect(toImmutableMap(
-                    Entry::getKey,
-                    Entry::getValue,
-                    (existing, replacement) -> replacement
-                )))
-            .build();
+                .annotationType(Param.class)
+                .typeElement(typeElement)
+                .description(description)
+                .aggregation(AggregationStrategy.FOR_FORM_DATA)
+                .resolver((resolver, ctx) -> ctx.queryParams().stream()
+                                                .collect(toImmutableMap(
+                                                        Entry::getKey,
+                                                        Entry::getValue,
+                                                        (existing, replacement) -> replacement
+                                                )))
+                .build();
     }
 
     private static AnnotatedValueResolver ofFileParam(String name,

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -462,7 +462,15 @@ final class AnnotatedValueResolver {
             final String name = findName(typeElement, param.value());
             // If the parameter is of type Map and the @Param annotation does not specify a value,
             // map all query parameters into the Map.
-            if (Map.class.isAssignableFrom(type) && DefaultValues.isUnspecified(param.value())) {
+            if (Map.class.isAssignableFrom(type)) {
+                if (DefaultValues.isSpecified(param.value())) {
+                    throw new IllegalArgumentException(
+                        String.format("Invalid @Param annotation on Map parameter: '%s'. " +
+                                "The @Param annotation specifies a value ('%s'), which is not allowed. " +
+                                "When using a Map, @Param must not specify a value. " +
+                                "Please use @Param Map<String, Object> param without a value.",
+                            annotatedElement, param.value()));
+                }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
             }
             if (type == File.class || type == Path.class || type == MultipartFile.class) {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -636,8 +636,8 @@ class AnnotatedServiceTest {
         public String map(RequestContext ctx, @Param Map<String, Object> map) {
             validateContext(ctx);
             return map.isEmpty() ? "empty" : map.entrySet().stream()
-                .map(entry -> entry.getKey() + '=' + entry.getValue())
-                .collect(Collectors.joining(", "));
+                                                .map(entry -> entry.getKey() + '=' + entry.getValue())
+                                                .collect(Collectors.joining(", "));
         }
     }
 
@@ -1078,7 +1078,7 @@ class AnnotatedServiceTest {
 
             // Case all query parameters test map
             testBody(hc, get("/7/param/map?key1=value1&key2=value2"),
-                "key1=value1, key2=value2");
+                     "key1=value1, key2=value2");
             testBody(hc, get("/7/param/map"), "empty");
         }
     }
@@ -1379,13 +1379,13 @@ class AnnotatedServiceTest {
     @Test
     void testInvalidParamAnnotationUsageOnMap() {
         assertThatThrownBy(() ->
-            Server.builder()
-                .annotatedService()
-                .build(new MyAnnotationService16())
-                .build()
+                                   Server.builder()
+                                         .annotatedService()
+                                         .build(new MyAnnotationService16())
+                                         .build()
         )
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid @Param annotation on Map parameter");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid @Param annotation on Map parameter");
     }
 
     private enum UserLevel {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -631,7 +631,7 @@ class AnnotatedServiceTest {
         }
 
         @Get("/param/map")
-        public String map (RequestContext ctx, @Param Map<String, Object> map) {
+        public String map(RequestContext ctx, @Param Map<String, Object> map) {
             validateContext(ctx);
             return map.isEmpty() ? "empty" : map.entrySet().stream()
                 .map(entry -> entry.getKey() + "=" + entry.getValue())

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedServiceTest.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -628,6 +629,14 @@ class AnnotatedServiceTest {
             validateContext(ctx);
             return username + '/' + password;
         }
+
+        @Get("/param/map")
+        public String map (RequestContext ctx, @Param Map<String, Object> map) {
+            validateContext(ctx);
+            return map.isEmpty() ? "empty" : map.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining(", "));
+        }
     }
 
     @ResponseConverter(UnformattedStringConverterFunction.class)
@@ -1057,6 +1066,11 @@ class AnnotatedServiceTest {
             testStatusCode(hc, get("/7/param/default2"), 400);
 
             testBody(hc, get("/7/param/default_null"), "(null)");
+
+            // Case all query parameters test map
+            testBody(hc, get("/7/param/map?key1=value1&key2=value2"),
+                "key1=value1, key2=value2");
+            testBody(hc, get("/7/param/map"), "empty");
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -380,8 +380,8 @@ class AnnotatedValueResolverTest {
                     assertThat(value).isNotNull();
                     assertThat(value).isInstanceOf(Map.class);
                     assertThat((Map<?, ?>) value).size()
-                                                 .isEqualTo(existingHttpParameters.size()
-                                                            + existingWithoutValueParameters.size());
+                                                 .isEqualTo(existingHttpParameters.size() +
+                                                            existingWithoutValueParameters.size());
                 } else {
                     assertThat(value).isEqualTo(resolver.defaultValue());
                 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -380,7 +380,8 @@ class AnnotatedValueResolverTest {
                     assertThat(value).isNotNull();
                     assertThat(value).isInstanceOf(Map.class);
                     assertThat((Map<?, ?>) value).size()
-                        .isEqualTo(existingHttpParameters.size() + existingWithoutValueParameters.size());
+                                                 .isEqualTo(existingHttpParameters.size()
+                                                            + existingWithoutValueParameters.size());
                 } else {
                     assertThat(value).isEqualTo(resolver.defaultValue());
                 }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -359,8 +359,6 @@ class AnnotatedValueResolverTest {
                 } else {
                     if (String.class.isAssignableFrom(resolver.elementType())) {
                         assertThat(value).isEqualTo("");
-                    } else if (QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
-                        assertThat(value).isNotNull();
                     } else {
                         assertThat(value).isNull();
                     }

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -112,6 +112,7 @@ class AnnotatedValueResolverTest {
     static final ServiceRequestContext context;
     static final HttpRequest request;
     static final RequestHeaders originalHeaders;
+    static final String QUERY_PARAM_MAP = "queryParamMap";
     static Map<String, AttributeKey<?>> successExpectAttrKeys;
     static Map<String, AttributeKey<?>> failExpectAttrKeys;
 
@@ -358,12 +359,18 @@ class AnnotatedValueResolverTest {
                 } else {
                     if (String.class.isAssignableFrom(resolver.elementType())) {
                         assertThat(value).isEqualTo("");
+                    } else if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                        assertThat(value).isNotNull();
                     } else {
                         assertThat(value).isNull();
                     }
                 }
             } else {
-                assertThat(resolver.defaultValue()).isNotNull();
+                if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                    assertThat(resolver.defaultValue()).isNull();
+                } else {
+                    assertThat(resolver.defaultValue()).isNotNull();
+                }
                 if (resolver.hasContainer() && List.class.isAssignableFrom(resolver.containerType())) {
                     assertThat((List<Object>) value).hasSize(1)
                                                     .containsOnly(resolver.defaultValue());
@@ -371,6 +378,11 @@ class AnnotatedValueResolverTest {
                             .isEqualTo(resolver.elementType());
                 } else if (resolver.shouldWrapValueAsOptional()) {
                     assertThat(value).isEqualTo(Optional.of(resolver.defaultValue()));
+                } else if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                    assertThat(value).isNotNull();
+                    assertThat(value).isInstanceOf(Map.class);
+                    assertThat((Map<?, ?>) value).size()
+                        .isEqualTo(existingHttpParameters.size() + existingWithoutValueParameters.size());
                 } else {
                     assertThat(value).isEqualTo(resolver.defaultValue());
                 }
@@ -447,6 +459,7 @@ class AnnotatedValueResolverTest {
                      @Param @Default Integer emptyParam2,
                      @Param @Default List<String> emptyParam3,
                      @Param @Default List<Integer> emptyParam4,
+                     @Param Map<String, Object> queryParamMap,
                      @Header List<String> header1,
                      @Header("header1") Optional<List<ValueEnum>> optionalHeader1,
                      @Header String header2,

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolverTest.java
@@ -359,14 +359,14 @@ class AnnotatedValueResolverTest {
                 } else {
                     if (String.class.isAssignableFrom(resolver.elementType())) {
                         assertThat(value).isEqualTo("");
-                    } else if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                    } else if (QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
                         assertThat(value).isNotNull();
                     } else {
                         assertThat(value).isNull();
                     }
                 }
             } else {
-                if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                if (QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
                     assertThat(resolver.defaultValue()).isNull();
                 } else {
                     assertThat(resolver.defaultValue()).isNotNull();
@@ -378,7 +378,7 @@ class AnnotatedValueResolverTest {
                             .isEqualTo(resolver.elementType());
                 } else if (resolver.shouldWrapValueAsOptional()) {
                     assertThat(value).isEqualTo(Optional.of(resolver.defaultValue()));
-                } else if(QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
+                } else if (QUERY_PARAM_MAP.equals(resolver.httpElementName())) {
                     assertThat(value).isNotNull();
                     assertThat(value).isInstanceOf(Map.class);
                     assertThat((Map<?, ?>) value).size()


### PR DESCRIPTION
## Motivation:

This pull request addresses #6058 

Currently, `@Param` cannot be mapped to a Map, but this change enables that functionality, allowing query parameters to be handled as a Map.
## Modifications:

- Introduced logic in `AnnotatedValueResolver` to detect when a parameter is of type Map and the `@Param` annotation has an unspecified value.
  - Future enhancements may include supporting the mapping of specific values to a Map when the `@Param` value is explicitly specified.
- Added a new method `ofQueryParamMap` to handle the creation of an AnnotatedValueResolver for mapping all query parameters into a Map.
  - Query parameters are collected into a Map using the stream-based collector.
- Updated the existing logic to ensure this behavior only applies when the `@Param` value is unspecified and the parameter type is Map.

## Result:

- Closes #6058 
- Users can now define a method parameter annotated with `@Param` as `Map<String, Object>` to handle all query parameters.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
