### PR TITLE
Introduce `AbstractAsyncSelector`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -88,7 +88,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
     @UnstableApi
     protected void updateNewEndpoints(List<Endpoint> endpoints) {}
 
-    private static class EndpointAsyncSelector extends AbstractAsyncSelector<Endpoint> {
+    private class EndpointAsyncSelector extends AbstractAsyncSelector<Endpoint> {
 
         private final EndpointGroup endpointGroup;
 
@@ -106,7 +106,7 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         @Nullable
         @Override
         protected Endpoint selectNow(ClientRequestContext ctx) {
-            return endpointGroup.selectNow(ctx);
+            return AbstractEndpointSelector.this.selectNow(ctx);
         }
 
         @VisibleForTesting

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -20,24 +20,16 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.client.AbstractAsyncSelector;
 import com.linecorp.armeria.internal.client.ClientPendingThrowableUtil;
-import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
-import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
-
-import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
 
 /**
  * A skeletal {@link EndpointSelector} implementation. This abstract class implements the
@@ -47,16 +39,14 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
 public abstract class AbstractEndpointSelector implements EndpointSelector {
 
     private final EndpointGroup endpointGroup;
-    private final ReentrantShortLock lock = new ReentrantShortLock();
-    @GuardedBy("lock")
-    private final Set<ListeningFuture> pendingFutures =
-            new ObjectLinkedOpenCustomHashSet<>(IdentityHashStrategy.of());
+    private final EndpointAsyncSelector asyncSelector;
 
     /**
      * Creates a new instance that selects an {@link Endpoint} from the specified {@link EndpointGroup}.
      */
     protected AbstractEndpointSelector(EndpointGroup endpointGroup) {
         this.endpointGroup = requireNonNull(endpointGroup, "endpointGroup");
+        asyncSelector = new EndpointAsyncSelector(endpointGroup);
     }
 
     /**
@@ -64,76 +54,6 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
      */
     protected final EndpointGroup group() {
         return endpointGroup;
-    }
-
-    @SuppressWarnings("GuardedBy")
-    @VisibleForTesting
-    final Set<ListeningFuture> pendingFutures() {
-        return pendingFutures;
-    }
-
-    @Deprecated
-    @Override
-    public final CompletableFuture<Endpoint> select(ClientRequestContext ctx,
-                                                    ScheduledExecutorService executor,
-                                                    long timeoutMillis) {
-        return select(ctx, executor);
-    }
-
-    @Override
-    public final CompletableFuture<Endpoint> select(ClientRequestContext ctx,
-                                                    ScheduledExecutorService executor) {
-        final Endpoint endpoint = selectNow(ctx);
-        if (endpoint != null) {
-            return UnmodifiableFuture.completedFuture(endpoint);
-        }
-
-        final ListeningFuture listeningFuture = new ListeningFuture(ctx, executor);
-        addPendingFuture(listeningFuture);
-
-        // The EndpointGroup have just been updated after adding ListeningFuture.
-        if (listeningFuture.isDone()) {
-            return listeningFuture;
-        }
-        if (endpointGroup.whenReady().isDone()) {
-            final Endpoint endpoint0 = selectNow(ctx);
-            if (endpoint0 != null) {
-                // The EndpointGroup have just been updated before adding ListeningFuture.
-                listeningFuture.complete(endpoint0);
-                return listeningFuture;
-            }
-        }
-
-        final long selectionTimeoutMillis = endpointGroup.selectionTimeoutMillis();
-        if (selectionTimeoutMillis == 0) {
-            // A static EndpointGroup.
-            return UnmodifiableFuture.completedFuture(null);
-        }
-
-        // Schedule the timeout task.
-        if (selectionTimeoutMillis < Long.MAX_VALUE) {
-            final ScheduledFuture<?> timeoutFuture = executor.schedule(() -> {
-                final EndpointSelectionTimeoutException ex =
-                        EndpointSelectionTimeoutException.get(endpointGroup, selectionTimeoutMillis);
-                ClientPendingThrowableUtil.setPendingThrowable(ctx, ex);
-                // Don't complete exceptionally so that the throwable
-                // can be handled after executing the attached decorators
-                listeningFuture.complete(null);
-            }, selectionTimeoutMillis, TimeUnit.MILLISECONDS);
-            listeningFuture.timeoutFuture = timeoutFuture;
-
-            // Cancel the timeout task if listeningFuture is done already.
-            // This guards against the following race condition:
-            // 1) (Current thread) Timeout task is scheduled.
-            // 2) ( Other thread ) listeningFuture is completed, but the timeout task is not cancelled
-            // 3) (Current thread) timeoutFuture is assigned to listeningFuture.timeoutFuture, but it's too
-            // late.
-            if (listeningFuture.isDone()) {
-                timeoutFuture.cancel(false);
-            }
-        }
-
-        return listeningFuture;
     }
 
     /**
@@ -145,15 +65,21 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         endpointGroup.addListener(this::refreshEndpoints, true);
     }
 
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx, ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return asyncSelector.select(ctx, executor, endpointGroup.selectionTimeoutMillis());
+    }
+
     private void refreshEndpoints(List<Endpoint> endpoints) {
         // Allow subclasses to update the endpoints first.
         updateNewEndpoints(endpoints);
-        lock.lock();
-        try {
-            pendingFutures.removeIf(ListeningFuture::tryComplete);
-        } finally {
-            lock.unlock();
-        }
+        asyncSelector.refresh();
+    }
+
+    @VisibleForTesting
+    Set<? extends CompletableFuture<Endpoint>> pendingFutures() {
+        return asyncSelector.pendingFutures();
     }
 
     /**
@@ -162,97 +88,31 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
     @UnstableApi
     protected void updateNewEndpoints(List<Endpoint> endpoints) {}
 
-    private void addPendingFuture(ListeningFuture future) {
-        lock.lock();
-        try {
-            pendingFutures.add(future);
-        } finally {
-            lock.unlock();
-        }
-    }
+    private static class EndpointAsyncSelector extends AbstractAsyncSelector<Endpoint> {
 
-    private void removePendingFuture(ListeningFuture future) {
-        lock.lock();
-        try {
-            pendingFutures.remove(future);
-        } finally {
-            lock.unlock();
-        }
-    }
+        private final EndpointGroup endpointGroup;
 
-    @VisibleForTesting
-    final class ListeningFuture extends CompletableFuture<Endpoint> {
-        private final ClientRequestContext ctx;
-        private final Executor executor;
-        @Nullable
-        private volatile Endpoint selectedEndpoint;
-        @Nullable
-        private volatile ScheduledFuture<?> timeoutFuture;
-
-        ListeningFuture(ClientRequestContext ctx, Executor executor) {
-            this.ctx = ctx;
-            this.executor = executor;
-        }
-
-        /**
-         * Returns {@code true} if an {@link Endpoint} has been selected.
-         */
-        public boolean tryComplete() {
-            if (selectedEndpoint != null || isDone()) {
-                return true;
-            }
-
-            try {
-                final Endpoint endpoint = selectNow(ctx);
-                if (endpoint == null) {
-                    return false;
-                }
-
-                cleanup(false);
-                // Complete with the selected endpoint.
-                selectedEndpoint = endpoint;
-                executor.execute(() -> super.complete(endpoint));
-                return true;
-            } catch (Throwable t) {
-                cleanup(false);
-                super.completeExceptionally(t);
-                return true;
-            }
+        EndpointAsyncSelector(EndpointGroup endpointGroup) {
+            this.endpointGroup = endpointGroup;
         }
 
         @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            cleanup(true);
-            return super.cancel(mayInterruptIfRunning);
-        }
-
-        @Override
-        public boolean complete(@Nullable Endpoint value) {
-            cleanup(true);
-            return super.complete(value);
-        }
-
-        @Override
-        public boolean completeExceptionally(Throwable ex) {
-            cleanup(true);
-            return super.completeExceptionally(ex);
-        }
-
-        private void cleanup(boolean removePendingFuture) {
-            if (removePendingFuture) {
-                removePendingFuture(this);
-            }
-            final ScheduledFuture<?> timeoutFuture = this.timeoutFuture;
-            if (timeoutFuture != null) {
-                this.timeoutFuture = null;
-                timeoutFuture.cancel(false);
-            }
+        protected void onTimeout(ClientRequestContext ctx, long selectionTimeoutMillis) {
+            final EndpointSelectionTimeoutException ex =
+                    EndpointSelectionTimeoutException.get(endpointGroup, selectionTimeoutMillis);
+            ClientPendingThrowableUtil.setPendingThrowable(ctx, ex);
         }
 
         @Nullable
+        @Override
+        protected Endpoint selectNow(ClientRequestContext ctx) {
+            return endpointGroup.selectNow(ctx);
+        }
+
         @VisibleForTesting
-        ScheduledFuture<?> timeoutFuture() {
-            return timeoutFuture;
+        @Override
+        protected Set<? extends CompletableFuture<Endpoint>> pendingFutures() {
+            return super.pendingFutures();
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/AbstractAsyncSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/AbstractAsyncSelector.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.common.util.IdentityHashStrategy;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
+
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenCustomHashSet;
+
+/**
+ * A helper class which allows users to easily implement asynchronous selection of elements of type {@link T}.
+ * Users are expected to implement the synchronous method {@link #selectNow(ClientRequestContext)}.
+ * When {@link #selectNow(ClientRequestContext)} is expected to have changed its value, {@link #refresh()}
+ * must be called to notify pending futures.
+ * <pre>{@code
+ * class MySelector extends AbstractAsyncSelector<String> {
+ *     private String value;
+ *     @Override
+ *     protected String selectNow(ClientRequestContext ctx) {
+ *         return value;
+ *     }
+ * }
+ *
+ * MySelector mySelector = new MySelector();
+ * val selected1 = mySelector.selectNow(); // null
+ *
+ * mySelector.value = "hello";
+ * val selected2 = mySelector.selectNow(); // null
+ *
+ * mySelector.refresh(); // pending futures will now try to select again
+ * val selected3 = mySelector.selectNow(); // hello
+ * }</pre>
+ */
+@UnstableApi
+public abstract class AbstractAsyncSelector<T> {
+
+    private final ReentrantShortLock lock = new ReentrantShortLock();
+    @GuardedBy("lock")
+    private final Set<ListeningFuture> pendingFutures =
+            new ObjectLinkedOpenCustomHashSet<>(IdentityHashStrategy.of());
+
+    /**
+     * Creates a new instance.
+     */
+    protected AbstractAsyncSelector() {
+    }
+
+    @SuppressWarnings("GuardedBy")
+    @VisibleForTesting
+    protected Set<? extends CompletableFuture<T>> pendingFutures() {
+        return pendingFutures;
+    }
+
+    /**
+     * Selects an element based on the provided {@link ClientRequestContext}.
+     * Users may return {@code null} to indicate that it isn't possible to select a value now.
+     */
+    @Nullable
+    protected abstract T selectNow(ClientRequestContext ctx);
+
+    /**
+     * Select an element asynchronously. If an element is readily available, this method will return
+     * immediately. Otherwise, a future will be queued and wait for the next {@link #refresh()} invocation.
+     * If the specified timeout is passed, the future will complete with {@code null}.
+     *
+     * @param executor the executor which will schedule a timeout
+     * @param selectionTimeoutMillis the amount of time to wait before completing a pending future
+     */
+    public CompletableFuture<T> select(ClientRequestContext ctx, ScheduledExecutorService executor,
+                                       long selectionTimeoutMillis) {
+        checkArgument(selectionTimeoutMillis >= 0, "selectionTimeoutMillis: %s (expected: >= 0)",
+                      selectionTimeoutMillis);
+        T selected = selectNow(ctx);
+        if (selected != null) {
+            return UnmodifiableFuture.completedFuture(selected);
+        }
+
+        final ListeningFuture listeningFuture = new ListeningFuture(ctx, executor);
+        addPendingFuture(listeningFuture);
+
+        // The EndpointGroup have just been updated after adding ListeningFuture.
+        if (listeningFuture.isDone()) {
+            return listeningFuture;
+        }
+
+        selected = selectNow(ctx);
+        if (selected != null) {
+            // The state has just been updated before adding ListeningFuture.
+            listeningFuture.complete(selected);
+            return listeningFuture;
+        }
+
+        if (selectionTimeoutMillis == 0) {
+            return UnmodifiableFuture.completedFuture(null);
+        }
+
+        // Schedule the timeout task.
+        if (selectionTimeoutMillis < Long.MAX_VALUE) {
+            final ScheduledFuture<?> timeoutFuture = executor.schedule(() -> {
+                onTimeout(ctx, selectionTimeoutMillis);
+                // Don't complete exceptionally so that the throwable
+                // can be handled after executing the attached decorators
+                listeningFuture.complete(null);
+            }, selectionTimeoutMillis, TimeUnit.MILLISECONDS);
+            listeningFuture.timeoutFuture = timeoutFuture;
+
+            // Cancel the timeout task if listeningFuture is done already.
+            // This guards against the following race condition:
+            // 1) (Current thread) Timeout task is scheduled.
+            // 2) ( Other thread ) listeningFuture is completed, but the timeout task is not cancelled
+            // 3) (Current thread) timeoutFuture is assigned to listeningFuture.timeoutFuture, but it's too
+            // late.
+            if (listeningFuture.isDone()) {
+                timeoutFuture.cancel(false);
+            }
+        }
+
+        return listeningFuture;
+    }
+
+    /**
+     * A hook which is executed when a timeout has been triggered.
+     */
+    @UnstableApi
+    protected void onTimeout(ClientRequestContext ctx, long selectionTimeoutMillis) {
+    }
+
+    /**
+     * Triggers pending futures to try and select a value by calling {@link #selectNow(ClientRequestContext)}.
+     */
+    public void refresh() {
+        lock.lock();
+        try {
+            pendingFutures.removeIf(ListeningFuture::tryComplete);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void addPendingFuture(ListeningFuture future) {
+        lock.lock();
+        try {
+            pendingFutures.add(future);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void removePendingFuture(ListeningFuture future) {
+        lock.lock();
+        try {
+            pendingFutures.remove(future);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @VisibleForTesting
+    final class ListeningFuture extends CompletableFuture<T> {
+        private final ClientRequestContext ctx;
+        private final Executor executor;
+        @Nullable
+        private volatile T selected;
+        @Nullable
+        private volatile ScheduledFuture<?> timeoutFuture;
+
+        ListeningFuture(ClientRequestContext ctx, Executor executor) {
+            this.ctx = ctx;
+            this.executor = executor;
+        }
+
+        private boolean tryComplete() {
+            if (selected != null || isDone()) {
+                return true;
+            }
+
+            try {
+                final T selected = selectNow(ctx);
+                if (selected == null) {
+                    return false;
+                }
+
+                cleanup(false);
+                // Complete with the selected endpoint.
+                this.selected = selected;
+                executor.execute(() -> super.complete(selected));
+                return true;
+            } catch (Throwable t) {
+                cleanup(false);
+                super.completeExceptionally(t);
+                return true;
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cleanup(true);
+            return super.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean complete(@Nullable T value) {
+            cleanup(true);
+            return super.complete(value);
+        }
+
+        @Override
+        public boolean completeExceptionally(Throwable ex) {
+            cleanup(true);
+            return super.completeExceptionally(ex);
+        }
+
+        private void cleanup(boolean removePendingFuture) {
+            if (removePendingFuture) {
+                removePendingFuture(this);
+            }
+            final ScheduledFuture<?> timeoutFuture = this.timeoutFuture;
+            if (timeoutFuture != null) {
+                this.timeoutFuture = null;
+                timeoutFuture.cancel(false);
+            }
+        }
+
+        @Nullable
+        @VisibleForTesting
+        ScheduledFuture<?> timeoutFuture() {
+            return timeoutFuture;
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/SelectionTimeoutTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.AbstractLongAssert;
@@ -34,7 +33,6 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RequestOptions;
-import com.linecorp.armeria.client.endpoint.AbstractEndpointSelector.ListeningFuture;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsServiceEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsTextEndpointGroup;
@@ -312,23 +310,6 @@ class SelectionTimeoutTest {
                 assertThat(BlockingUtils.blockingRun(result::join)).isNull();
                 assertThat(stopwatch.elapsed())
                         .isGreaterThanOrEqualTo(Duration.ofSeconds(2));
-            }
-            return null;
-        }, ctx.eventLoop());
-        future.join();
-    }
-
-    @Test
-    void select_unlimited() {
-        final CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
-            ctx.clearResponseTimeout();
-            try (MockEndpointGroup endpointGroup = new MockEndpointGroup(Long.MAX_VALUE)) {
-                final ListeningFuture result =
-                        (ListeningFuture) endpointGroup.select(ctx, CommonPools.blockingTaskExecutor());
-                // No timeout is scheduled
-                assertThat((Future<?>) result.timeoutFuture()).isNull();
-                final Endpoint endpoint = Endpoint.of("foo", 8080);
-                endpointGroup.set(endpoint);
             }
             return null;
         }, ctx.eventLoop());

--- a/core/src/test/java/com/linecorp/armeria/internal/client/AbstractAsyncSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/AbstractAsyncSelectorTest.java
@@ -65,7 +65,7 @@ class AbstractAsyncSelectorTest {
         assertThat(cf).isNotDone();
 
         await().atLeast(10, TimeUnit.MILLISECONDS)
-               .atMost(30, TimeUnit.MILLISECONDS)
+               .atMost(1000, TimeUnit.MILLISECONDS)
                .pollInterval(10, TimeUnit.MILLISECONDS)
                .untilAsserted(() -> assertThat(cf).isDone().isCompletedWithValue(null));
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/client/AbstractAsyncSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/client/AbstractAsyncSelectorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.client.AbstractAsyncSelector.ListeningFuture;
+
+class AbstractAsyncSelectorTest {
+
+    @Test
+    void basicCase() {
+        final MySelector mySelector = new MySelector();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(mySelector.selectNow(ctx)).isNull();
+        final CompletableFuture<String> cf =
+                mySelector.select(ctx, CommonPools.workerGroup().next(), Long.MAX_VALUE);
+        assertThat(cf).isNotDone();
+
+        final String hello = "Hello";
+        mySelector.value = hello;
+        assertThat(cf).isNotDone();
+
+        mySelector.refresh();
+        await().untilAsserted(() -> assertThat(cf).isDone().isCompletedWithValue(hello));
+    }
+
+    @Test
+    void timeout() {
+        final MySelector mySelector = new MySelector();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(mySelector.selectNow(ctx)).isNull();
+        final CompletableFuture<String> cf =
+                mySelector.select(ctx, CommonPools.workerGroup().next(), 10);
+        assertThat(cf).isNotDone();
+
+        await().atLeast(10, TimeUnit.MILLISECONDS)
+               .atMost(30, TimeUnit.MILLISECONDS)
+               .pollInterval(10, TimeUnit.MILLISECONDS)
+               .untilAsserted(() -> assertThat(cf).isDone().isCompletedWithValue(null));
+    }
+
+    @Test
+    void zeroTimeout() {
+        final MySelector mySelector = new MySelector();
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        assertThat(mySelector.selectNow(ctx)).isNull();
+        final CompletableFuture<String> cf =
+                mySelector.select(ctx, CommonPools.workerGroup().next(), 0);
+        assertThat(cf).isDone().isCompletedWithValue(null);
+    }
+
+    @Test
+    void select_unlimited() {
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
+            ctx.clearResponseTimeout();
+            try (MockEndpointGroup endpointGroup = new MockEndpointGroup(Long.MAX_VALUE)) {
+                final ListeningFuture result =
+                        (ListeningFuture) endpointGroup.select(ctx, CommonPools.blockingTaskExecutor());
+                // No timeout is scheduled
+                assertThat((Future<?>) result.timeoutFuture()).isNull();
+                final Endpoint endpoint = Endpoint.of("foo", 8080);
+                endpointGroup.set(endpoint);
+            }
+            return null;
+        }, ctx.eventLoop());
+        future.join();
+    }
+
+    private static class MySelector extends AbstractAsyncSelector<String> {
+
+        @Nullable
+        private String value;
+
+        @Override
+        protected String selectNow(ClientRequestContext ctx) {
+            return value;
+        }
+    }
+
+    private static final class MockEndpointGroup extends DynamicEndpointGroup {
+        MockEndpointGroup(long selectionTimeoutMillis) {
+            super(true, selectionTimeoutMillis);
+        }
+
+        void set(Endpoint... endpoints) {
+            setEndpoints(ImmutableList.copyOf(endpoints));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

`AbstractEndpointSelector` is a useful abstract which allows users to select and `Endpoint` asynchronously only by implementing `AbstractEndpointSelector#selectNow`. However, the current implementation has limitations in that 1) Only `Endpoint` can be selected 2) It is difficult to customize the timing when the pending futures must be reconsidered for completion.

While working on the introduction of an `XdsPreprocessor` https://github.com/line/armeria/pull/6096, I found it is useful to be able to select a value asynchronously in the following locations:
1) When a request is executed, the request must wait until a `ListenerSnapshot` is fetched
https://github.com/line/armeria/blob/6bbc2ac0a0ae74014bd686979d34767ba9a8236d/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsPreprocessor.java#L60

2) The `XdsLoadBalancer` which selects an endpoint must be refreshed either when the encompassed `EndpointGroup` is updated or when the local cluster is updated.
https://github.com/line/armeria/blob/6bbc2ac0a0ae74014bd686979d34767ba9a8236d/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/UpdatableLoadBalancer.java#L110

For ease of implementation and maintainability, I propose that `AbstractAsyncSelector` is abstracted out of `AbstractEndpointSelector`. Since it is unclear whether this abstraction is useful for other situations, the class is located in the `internal` package.

Modifications:

- Abstracted out selection related logic from `AbstractEndpointSelector` to `AbstractAsyncSelector`
  - Now `AbstractEndpointSelector` contains an internal `AbstractAsyncSelector` implementation
- Moved `SelectionTimeoutTest#select_unlimited` to the internal package since it relies on visibility of `ListenableFuture#timeoutFuture`

Result:

- Users can implement async selection logic easily

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
