### PR TITLE
Allow configuring the maximum age of Kubernetes `Watch`

### DIFF
--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/FaultInjectingKubernetesClientBuilderCustomizer.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/FaultInjectingKubernetesClientBuilderCustomizer.java
@@ -16,9 +16,6 @@
 
 package com.linecorp.armeria.client.kubernetes.endpoints;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientFactory;
 import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
 import com.linecorp.armeria.common.HttpData;
@@ -29,14 +26,12 @@ import com.linecorp.armeria.internal.common.websocket.WebSocketFrameEncoder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesClientBuilderCustomizer;
 
-public class TestKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
-
-    private static final Logger logger = LoggerFactory.getLogger(TestKubernetesClientBuilderCustomizer.class);
+public class FaultInjectingKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
 
     private static volatile boolean shouldInjectFault;
 
     static void injectFault(boolean shouldInjectFault) {
-        TestKubernetesClientBuilderCustomizer.shouldInjectFault = shouldInjectFault;
+        FaultInjectingKubernetesClientBuilderCustomizer.shouldInjectFault = shouldInjectFault;
     }
 
     @Override

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMaxWatchAgeTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMaxWatchAgeTest.java
@@ -26,7 +26,11 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -41,13 +45,21 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 
 @EnableKubernetesMockClient(
         crud = true,
-        kubernetesClientBuilderCustomizer = FaultInjectingKubernetesClientBuilderCustomizer.class)
-class KubernetesEndpointGroupFaultToleranceTest {
+        kubernetesClientBuilderCustomizer = ServiceWatchCoutingKubernetesClientBuilderCustomizer.class)
+class KubernetesEndpointGroupMaxWatchAgeTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(KubernetesEndpointGroupMaxWatchAgeTest.class);
 
     private KubernetesClient client;
 
-    @Test
-    void shouldReconnectOnWatcherException() throws InterruptedException {
+    @BeforeEach
+    void setUp() {
+        ServiceWatchCoutingKubernetesClientBuilderCustomizer.reset();
+    }
+
+    @ValueSource(ints = { 0, 500, 1000 })
+    @ParameterizedTest
+    void periodicallyCreateNewWatch(int maxWatchAgeMillis) throws InterruptedException {
         // Prepare Kubernetes resources
         final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"), newNode("3.3.3.3"));
         final Deployment deployment = newDeployment();
@@ -67,8 +79,13 @@ class KubernetesEndpointGroupFaultToleranceTest {
         client.apps().deployments().resource(deployment).create();
         client.services().resource(service).create();
 
-        final KubernetesEndpointGroup endpointGroup = KubernetesEndpointGroup.of(client, "test",
-                                                                                 "nginx-service");
+        final int oldNum = ServiceWatchCoutingKubernetesClientBuilderCustomizer.numRequests();
+        final KubernetesEndpointGroup endpointGroup =
+                KubernetesEndpointGroup.builder(client)
+                                       .namespace("test")
+                                       .serviceName("nginx-service")
+                                       .maxWatchAgeMillis(maxWatchAgeMillis)
+                                       .build();
         endpointGroup.whenReady().join();
 
         // Initial state
@@ -81,18 +98,12 @@ class KubernetesEndpointGroupFaultToleranceTest {
             );
         });
 
-        FaultInjectingKubernetesClientBuilderCustomizer.injectFault(true);
         // Add a new pod
         client.pods().resource(pods.get(2)).create();
 
-        Thread.sleep(2000);
+        final int sleepMillis = 2000;
+        Thread.sleep(sleepMillis);
 
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(
-                Endpoint.of("1.1.1.1", nodePort),
-                Endpoint.of("2.2.2.2", nodePort)
-        );
-
-        FaultInjectingKubernetesClientBuilderCustomizer.injectFault(false);
         // Make sure the new pod is added when the fault is recovered.
         await().untilAsserted(() -> {
             final List<Endpoint> endpoints = endpointGroup.endpoints();
@@ -102,5 +113,15 @@ class KubernetesEndpointGroupFaultToleranceTest {
                     Endpoint.of("3.3.3.3", nodePort)
             );
         });
+
+        final int newNum = ServiceWatchCoutingKubernetesClientBuilderCustomizer.numRequests();
+        logger.debug("maxWatchAgeMillis: {}, oldNum: {}, newNum: {}", maxWatchAgeMillis, oldNum, newNum);
+        if (maxWatchAgeMillis == 0) {
+           // Should create one watch
+           assertThat(newNum - oldNum).isEqualTo(1);
+        } else {
+            // Create more than N new watches, where N = sleepMillis / maxWatchAgeMillis
+            assertThat(newNum - oldNum).isGreaterThan(sleepMillis / maxWatchAgeMillis);
+        }
     }
 }

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMaxWatchAgeTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMaxWatchAgeTest.java
@@ -45,7 +45,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 
 @EnableKubernetesMockClient(
         crud = true,
-        kubernetesClientBuilderCustomizer = ServiceWatchCoutingKubernetesClientBuilderCustomizer.class)
+        kubernetesClientBuilderCustomizer = ServiceWatchCountingKubernetesClientBuilderCustomizer.class)
 class KubernetesEndpointGroupMaxWatchAgeTest {
 
     private static final Logger logger = LoggerFactory.getLogger(KubernetesEndpointGroupMaxWatchAgeTest.class);
@@ -54,7 +54,7 @@ class KubernetesEndpointGroupMaxWatchAgeTest {
 
     @BeforeEach
     void setUp() {
-        ServiceWatchCoutingKubernetesClientBuilderCustomizer.reset();
+        ServiceWatchCountingKubernetesClientBuilderCustomizer.reset();
     }
 
     @ValueSource(ints = { 0, 500, 1000 })
@@ -79,7 +79,7 @@ class KubernetesEndpointGroupMaxWatchAgeTest {
         client.apps().deployments().resource(deployment).create();
         client.services().resource(service).create();
 
-        final int oldNum = ServiceWatchCoutingKubernetesClientBuilderCustomizer.numRequests();
+        final int oldNum = ServiceWatchCountingKubernetesClientBuilderCustomizer.numRequests();
         final KubernetesEndpointGroup endpointGroup =
                 KubernetesEndpointGroup.builder(client)
                                        .namespace("test")
@@ -114,7 +114,7 @@ class KubernetesEndpointGroupMaxWatchAgeTest {
             );
         });
 
-        final int newNum = ServiceWatchCoutingKubernetesClientBuilderCustomizer.numRequests();
+        final int newNum = ServiceWatchCountingKubernetesClientBuilderCustomizer.numRequests();
         logger.debug("maxWatchAgeMillis: {}, oldNum: {}, newNum: {}", maxWatchAgeMillis, oldNum, newNum);
         if (maxWatchAgeMillis == 0) {
            // Should create one watch

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCountingKubernetesClientBuilderCustomizer.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCountingKubernetesClientBuilderCustomizer.java
@@ -25,7 +25,7 @@ import com.linecorp.armeria.internal.common.websocket.WebSocketUtil;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.server.mock.KubernetesClientBuilderCustomizer;
 
-public class ServiceWatchCoutingKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
+public class ServiceWatchCountingKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
 
     private static final AtomicInteger numRequests = new AtomicInteger();
 

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCoutingKubernetesClientBuilderCustomizer.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCoutingKubernetesClientBuilderCustomizer.java
@@ -48,7 +48,6 @@ public class ServiceWatchCoutingKubernetesClientBuilderCustomizer extends Kubern
                         WebSocketUtil.isHttp1WebSocketUpgradeRequest(req.headers())) {
                         numRequests.incrementAndGet();
                     }
-                    // Do something with the request.
                     return delegate.execute(ctx, req);
                 });
             }

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCoutingKubernetesClientBuilderCustomizer.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/ServiceWatchCoutingKubernetesClientBuilderCustomizer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes.endpoints;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.linecorp.armeria.client.kubernetes.ArmeriaHttpClientFactory;
+import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
+import com.linecorp.armeria.internal.common.websocket.WebSocketUtil;
+
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.server.mock.KubernetesClientBuilderCustomizer;
+
+public class ServiceWatchCoutingKubernetesClientBuilderCustomizer extends KubernetesClientBuilderCustomizer {
+
+    private static final AtomicInteger numRequests = new AtomicInteger();
+
+    static int numRequests() {
+        return numRequests.get();
+    }
+
+    static void reset() {
+        numRequests.set(0);
+    }
+
+    @Override
+    public void accept(KubernetesClientBuilder kubernetesClientBuilder) {
+        kubernetesClientBuilder.withHttpClientFactory(new ArmeriaHttpClientFactory() {
+
+            @Override
+            protected void additionalWebSocketConfig(WebSocketClientBuilder builder) {
+                builder.decorator((delegate, ctx, req) -> {
+                    if (ctx.path().startsWith("/api/v1/namespaces/test/services") &&
+                        WebSocketUtil.isHttp1WebSocketUpgradeRequest(req.headers())) {
+                        numRequests.incrementAndGet();
+                    }
+                    // Do something with the request.
+                    return delegate.execute(ctx, req);
+                });
+            }
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, the KubernetesEndpointGroup watch is designed to stay active for as long as possible and automatically restart when an error occurs. However, in practice, maintaining a long-running watch session inevitably leads to errors, causing it to terminate and restart. From the perspective of monitoring observers, these errors could be false-positive noise.

To help prevent these errors, I would suggest periodically closing the watch when it reaches a certain lifespan and creating a new one.

Modifications:

- Add `maxWatchAge()` option to `KubernetesEndpointGroupBuilder`
  - If unset, the maximum age of a `Watch` defaults to 10 minutes.
- Refactor `KubernetesEndpointGroup` to start a new watch service when the maximum age is reached.

Result:

You can now set the maximum age of a `Watch` used in `KubernetesEndpointGroup`.
