### PR TITLE
expose dns name resolver builder for dns resolver configuration

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroupBuilder.java
@@ -154,8 +154,8 @@ abstract class DnsEndpointGroupBuilder<SELF extends DnsEndpointGroupBuilder<SELF
 
     final DefaultDnsResolver buildResolver(Consumer<DnsNameResolverBuilder> customizer, EventLoop eventLoop) {
         final DnsNameResolverBuilder resolverBuilder = new DnsNameResolverBuilder(eventLoop);
-        customizer.accept(resolverBuilder);
         buildConfigurator(eventLoop.parent()).accept(resolverBuilder);
+        customizer.accept(resolverBuilder);
 
         return DefaultDnsResolver.of(resolverBuilder.build(), maybeCreateDnsCache(), eventLoop,
                                      searchDomains(), ndots(), queryTimeoutMillis(),

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsServiceEndpointGroupBuilder.java
@@ -18,6 +18,9 @@ package com.linecorp.armeria.client.endpoint.dns;
 import com.linecorp.armeria.client.Endpoint;
 
 import io.netty.channel.EventLoop;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+
+import java.util.function.Consumer;
 
 /**
  * Builds a new {@link DnsServiceEndpointGroup} that sources its {@link Endpoint} list from the {@code SRV}
@@ -37,6 +40,17 @@ public final class DnsServiceEndpointGroupBuilder
         final EventLoop eventLoop = getOrAcquireEventLoop();
         return new DnsServiceEndpointGroup(selectionStrategy(), shouldAllowEmptyEndpoints(),
                                            selectionTimeoutMillis(), buildResolver(eventLoop),
+                                           eventLoop, backoff(), minTtl(), maxTtl(),
+                                           hostname(), dnsQueryListeners());
+    }
+
+    /**
+     * Returns a newly created {@link DnsServiceEndpointGroup}. This builder exposes the {@link DnsNameResolverBuilder}.
+     */
+    public DnsServiceEndpointGroup build(Consumer<DnsNameResolverBuilder> customizer) {
+        final EventLoop eventLoop = getOrAcquireEventLoop();
+        return new DnsServiceEndpointGroup(selectionStrategy(), shouldAllowEmptyEndpoints(),
+                                           selectionTimeoutMillis(), buildResolver(customizer, eventLoop),
                                            eventLoop, backoff(), minTtl(), maxTtl(),
                                            hostname(), dnsQueryListeners());
     }


### PR DESCRIPTION
Motivation:

We have run into an issue where the DNS ip address of our coreDNS pods has been cached. When coreDNS pods get a new ip address the following issue occurs in a loop.

```
09:28:58.171 [armeria-common-worker-epoll-3-6] WARN com.linecorp.armeria.client.endpoint.dns.DefaultDnsQueryListener -- api.tcp.payment-service.app-frontend-dmz.svc DNS query failed; retrying in 32079 ms (attempts so far: 1726):                                                                                                                                                                                                  
com.linecorp.armeria.client.DnsTimeoutException: DnsQuestion(api.tcp.payment-service.app-frontend-dmz.svc IN SRV) is timed out after 5000 milliseconds.                                                            
    at com.linecorp.armeria.internal.client.dns.DefaultDnsResolver.lambda$resolveOne$0(DefaultDnsResolver.java:93)                                                                                                 
    at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)                                                                                                                      
    at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)                                                                                                              
    at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)                                                                                                                   
    at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2512)                                                                                                                        
    at com.linecorp.armeria.internal.client.dns.DnsQuestionContext.lambda$new$0(DnsQuestionContext.java:35)                                                                                                        
    at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:96)                                                                                                                                           
    at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:156)                                                                                                                              
    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)                                                                                                                      
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)                                                                                                                  
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)                                                                                                          
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:416)                                                                                                                                          
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)                                                                                                                
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)                                                                                                                                   
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)                                                                                                                       
    at java.base/java.lang.Thread.run(Thread.java:1583)                                                                                                                                                                                                                                                                                                                
```

More information in #6122 , this was also addressed in https://github.com/netty/netty/issues/14364#issuecomment-2393085871
But armeria does not expose all the latest functionalities of netty.


Modifications:

- Exposed the `DnsNameResolverBuilder` by adding `DnsServiceEndpointGroupBuilder` build method with a `Consumer<DnsNameResolverBuilder>`.

Result:

- Closes #6122.
- Users will be able to directly access the `DnsNameResolverBuilder` from netty.

