### PR TITLE
Add handling for cookies with the same name to `DefaultCookieJar`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
@@ -109,7 +109,9 @@ final class DefaultCookieJar implements CookieJar {
                         cookieSet.add(ensuredCookie);
                         continue;
                     }
-                    if (!uri.getScheme().startsWith("http") && oldCookie.isHttpOnly()) {
+                    if (!(uri.getScheme().equals("http") ||
+                          uri.getScheme().equals("https")) && 
+                         oldCookie.isHttpOnly()) {
                         // if the new cookie is received from a non-HTTP and the old cookie is http-only, skip
                         continue;
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
@@ -109,9 +109,8 @@ final class DefaultCookieJar implements CookieJar {
                         cookieSet.add(ensuredCookie);
                         continue;
                     }
-                    if (!(uri.getScheme().equals("http") ||
-                          uri.getScheme().equals("https")) && 
-                         oldCookie.isHttpOnly()) {
+                    if (!("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) &&
+                        oldCookie.isHttpOnly()) {
                         // if the new cookie is received from a non-HTTP and the old cookie is http-only, skip
                         continue;
                     }

--- a/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
+++ b/core/src/main/java/com/linecorp/armeria/client/cookie/DefaultCookieJar.java
@@ -90,16 +90,31 @@ final class DefaultCookieJar implements CookieJar {
         lock.lock();
         try {
             for (Cookie cookie : cookies) {
-                cookie = ensureDomainAndPath(cookie, uri);
+                final Cookie ensuredCookie = ensureDomainAndPath(cookie, uri);
                 // remove similar cookie if present
-                store.removeLong(cookie);
-                if ((cookie.maxAge() == Cookie.UNDEFINED_MAX_AGE || cookie.maxAge() > 0) &&
-                    cookiePolicy.accept(uri, cookie)) {
-                    store.put(cookie, createdTimeMillis);
-                    final Set<Cookie> cookieSet = filter.computeIfAbsent(cookie.domain(), s -> new HashSet<>());
-                    // remove similar cookie if present
-                    cookieSet.remove(cookie);
-                    cookieSet.add(cookie);
+                store.removeLong(ensuredCookie);
+                if ((ensuredCookie.maxAge() == Cookie.UNDEFINED_MAX_AGE || ensuredCookie.maxAge() > 0) &&
+                    cookiePolicy.accept(uri, ensuredCookie)) {
+                    store.put(ensuredCookie, createdTimeMillis);
+                    final Set<Cookie> cookieSet = filter.computeIfAbsent(ensuredCookie.domain(),
+                                                                         s -> new HashSet<>());
+
+                    // remove the cookie with the same name, domain, and path if present
+                    // https://datatracker.ietf.org/doc/html/rfc6265#page-24
+                    final Cookie oldCookie = cookieSet.stream()
+                                                      .filter(c -> isSameNameAndPath(c, ensuredCookie))
+                                                      .findFirst()
+                                                      .orElse(null);
+                    if (oldCookie == null) {
+                        cookieSet.add(ensuredCookie);
+                        continue;
+                    }
+                    if (!uri.getScheme().startsWith("http") && oldCookie.isHttpOnly()) {
+                        // if the new cookie is received from a non-HTTP and the old cookie is http-only, skip
+                        continue;
+                    }
+                    cookieSet.remove(oldCookie);
+                    cookieSet.add(ensuredCookie);
                 }
             }
         } finally {
@@ -212,5 +227,11 @@ final class DefaultCookieJar implements CookieJar {
         assert cookiePath != null;
         final boolean pathMatched = path.startsWith(cookiePath);
         return satisfiedHostOnly && satisfiedSecure && pathMatched;
+    }
+
+    private static boolean isSameNameAndPath(Cookie oldCookie, Cookie newCookie) {
+        final String oldCookiePath = oldCookie.path();
+        assert oldCookiePath != null;
+        return oldCookie.name().equals(newCookie.name()) && oldCookiePath.equals(newCookie.path());
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/cookie/DefaultCookieJarTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/cookie/DefaultCookieJarTest.java
@@ -200,4 +200,23 @@ class DefaultCookieJarTest {
         assertThat(cookieJar.state(expectCookie, currentTimeMillis + 1000)).isEqualTo(CookieState.EXISTENT);
         assertThat(cookieJar.state(expectCookie, currentTimeMillis + 1001)).isEqualTo(CookieState.EXPIRED);
     }
+
+    @Test
+    void overwrite() {
+        final CookieJar cookieJar = new DefaultCookieJar();
+        final URI foo = URI.create("https://foo.com");
+        cookieJar.set(foo, Cookies.of(Cookie.ofSecure("name", "value1")));
+        cookieJar.set(foo, Cookies.of(Cookie.ofSecure("name", "value2")));
+
+        assertThat(cookieJar.get(foo)).hasSize(1).contains(
+                Cookie.secureBuilder("name", "value2").domain("foo.com").path("/").build()
+        );
+
+        final URI nonHttp = URI.create("foo://foo.com");
+        cookieJar.set(nonHttp, Cookies.of(Cookie.ofSecure("name", "value3")));
+
+        assertThat(cookieJar.get(foo)).hasSize(1).contains(
+                Cookie.secureBuilder("name", "value2").domain("foo.com").path("/").build()
+        );
+    }
 }


### PR DESCRIPTION
Motivation:

The `DefaultCookieJar` does not handle cases where cookies with the same name are set.

Modifications:

- Added processing in accordance with [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#page-24):
  - Overwrites existing cookies when a cookie with the same name, domain, and path is set.
  - If the existing cookie has the `HttpOnly` flag set and the new cookie is created by a non-HTTP API, the new cookie is ignored.

Result:

- Correctly handles setting cookies with the same name.
- Closes #5870.
