### PR TITLE
Expose experimental settings for dns

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
@@ -510,8 +510,7 @@ public abstract class AbstractDnsResolverBuilder<SELF extends AbstractDnsResolve
     /**
      * Enables <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> using the specified
      * {@link SocketChannel} type.
-     * <p>
-     * TCP fallback is disabled by default.
+     * Note that TCP fallback is disabled by default.
      * @param socketChannelType the type of {@link SocketChannel} to use for TCP fallback.
      * @param retrySocketChannelOnTimeout if {@code true} the {@link DnsNameResolver} will also fallback to
      *                                    TCP if a timeout was detected, if {@code false} it will only try to

--- a/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
@@ -508,7 +508,7 @@ public abstract class AbstractDnsResolverBuilder<SELF extends AbstractDnsResolve
     }
 
     /**
-     * Enables <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> using the specified
+     * Enables <a href="https://datatracker.ietf.org/doc/html/rfc7766">TCP fallback</a> using the specified
      * {@link SocketChannel} type.
      * Note that TCP fallback is disabled by default.
      * @param socketChannelType the type of {@link SocketChannel} to use for TCP fallback.


### PR DESCRIPTION
Motivation:

We received a report where it seemed like DNS nameservers do not correctly reflect changes in `/etc/resolv.conf`.
The following issue has been pointed out to be a likely culprit:
https://github.com/netty/netty/issues/14364

Given that we don't release as often recently and the cause isn't very clear, I propose that we expose methods that might solve the issue.
`servicetalk` seems to have also applied a similar fix recently: https://github.com/apple/servicetalk/pull/3073/files.

Modifications:

- Expose `datagramChannelStrategy` which provides an option to create a channel per-resolution
- Expose `socketChannelType` so that users may use tcp-fallback in case resolution via udp doesn't work as expected
- Given that it is difficult to test these settings, added a basic regression test to ensure that applying the settings doesn't interfere with based `DnsEndpointGroup` functionality.

Result:

- Closes #6122

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
