### PR TITLE
fix: don't bind Jetty if server.port is -1

### DIFF
--- a/examples/spring-boot-jetty/src/main/java/example/springframework/boot/jetty/HelloConfiguration.java
+++ b/examples/spring-boot-jetty/src/main/java/example/springframework/boot/jetty/HelloConfiguration.java
@@ -27,7 +27,7 @@ import jakarta.servlet.Servlet;
 public class HelloConfiguration {
 
     /**
-     * Returns a new {@link HealthChecker} that marks the server as unhealthy when Tomcat becomes unavailable.
+     * Returns a new {@link HealthChecker} that marks the server as unhealthy when Jetty becomes unavailable.
      */
     @Bean
     public HealthChecker jettyHealthChecker(ServletWebServerApplicationContext applicationContext) {

--- a/examples/spring-boot-jetty/src/main/resources/config/application.yml
+++ b/examples/spring-boot-jetty/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 spring.profiles.active: local
-# Prevent the embedded Tomcat from opening a TCP/IP port.
+# Prevent the embedded Jetty from opening a TCP/IP port.
 server.port: -1
 ---
 spring.config.activate.on-profile: local

--- a/examples/spring-boot-jetty/src/test/resources/application-testbed.yml
+++ b/examples/spring-boot-jetty/src/test/resources/application-testbed.yml
@@ -1,4 +1,4 @@
-# Prevent the embedded Tomcat from opening a TCP/IP port.
+# Prevent the embedded Jetty from opening a TCP/IP port.
 server.port: -1
 ---
 armeria:

--- a/it/spring/boot3-jetty12/src/main/java/com/linecorp/armeria/spring/jetty/SpringJettyApplication.java
+++ b/it/spring/boot3-jetty12/src/main/java/com/linecorp/armeria/spring/jetty/SpringJettyApplication.java
@@ -39,19 +39,20 @@ import jakarta.servlet.Servlet;
 @SpringBootApplication
 public class SpringJettyApplication {
 
-    /**
-     * Bean to configure Armeria Jetty service.
-     */
     @Bean
-    public ArmeriaServerConfigurator armeriaTomcat(WebServerApplicationContext applicationContext) {
+    public JettyWebServer jettyWebServer(WebServerApplicationContext applicationContext) {
         final WebServer webServer = applicationContext.getWebServer();
         if (webServer instanceof JettyWebServer) {
-            final Server jettyServer = ((JettyWebServer) webServer).getServer();
-
-            return serverBuilder -> serverBuilder.service("prefix:/jetty/api/rest/v1",
-                                                          JettyService.of(jettyServer));
+            return ((JettyWebServer) webServer);
         }
-        return serverBuilder -> {};
+        throw new IllegalStateException("The web server is not Jetty: " + webServer);
+    }
+
+    @Bean
+    public ArmeriaServerConfigurator armeriaJetty(JettyWebServer jettyWebServer) {
+        final Server jettyServer = jettyWebServer.getServer();
+        return serverBuilder -> serverBuilder.service("prefix:/jetty/api/rest/v1",
+                                                      JettyService.of(jettyServer));
     }
 
     @Configuration(proxyBeanMethods = false)

--- a/it/spring/boot3-jetty12/src/main/resources/config/application.yml
+++ b/it/spring/boot3-jetty12/src/main/resources/config/application.yml
@@ -1,3 +1,5 @@
+server.port: -1
+---
 armeria:
   ports:
     - port: 0

--- a/it/spring/boot3-jetty12/src/test/java/com/linecorp/armeria/spring/jetty/SpringJettyApplicationItTest.java
+++ b/it/spring/boot3-jetty12/src/test/java/com/linecorp/armeria/spring/jetty/SpringJettyApplicationItTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.embedded.jetty.JettyWebServer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -44,6 +45,8 @@ class SpringJettyApplicationItTest {
     private TestRestTemplate restTemplate;
     @Inject
     private GreetingController greetingController;
+    @Inject
+    private JettyWebServer jettyWebServer;
 
     @BeforeEach
     public void init() throws Exception {
@@ -67,6 +70,14 @@ class SpringJettyApplicationItTest {
         assertThat(restTemplate.getForObject("http://localhost:" + httpPort + JETTY_BASE_PATH + "/greeting",
                                              String.class))
                 .contains("Hello, World!");
+    }
+
+    @Test
+    void greetingDirectlyToJettyShouldReturnDefaultMessage() throws Exception {
+        assertThat(restTemplate.getForEntity("http://localhost:" + jettyWebServer.getPort() + "/greeting",
+                                             Void.class)
+                           .getStatusCode().value()).isEqualByComparingTo(404);
+
     }
 
     @Test

--- a/it/spring/boot3-jetty12/src/test/resources/application-testbed.yml
+++ b/it/spring/boot3-jetty12/src/test/resources/application-testbed.yml
@@ -1,4 +1,3 @@
-# This currently doesn't work. See https://github.com/line/armeria/issues/5039
 server.port: -1
 ---
 armeria:


### PR DESCRIPTION
Motivation:
 
Make behavior in Tomcat and Jetty consistent when `server.port` is set to -1.

Modifications:

- Configure `JettyServlet` to remove the binding to a random port if `server.port` is -1 and an armeria connector is added.

Result:

- Closes #5039.
- Jetty no longer spawns the servlet on a random port if `server.port` is assigned to `-1`.
