### PR TITLE
fix: prevent spring auto-configuration from assigning a random port if a port with number -1 is given

### DIFF
--- a/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationNetUtil.java
+++ b/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/internal/spring/ArmeriaConfigurationNetUtil.java
@@ -48,7 +48,7 @@ public final class ArmeriaConfigurationNetUtil {
     public static void configurePorts(ServerBuilder server, List<Port> ports) {
         requireNonNull(server, "server");
         requireNonNull(ports, "ports");
-        ports.forEach(p -> {
+        ports.stream().filter(x -> x.getPort() >= 0).forEach(p -> {
             final String iface = p.getIface();
             final int port = p.getPort();
             final List<SessionProtocol> protocols = firstNonNull(p.getProtocols(),


### PR DESCRIPTION
Motivation:

I woud like to configure my Spring Boot application's port dynamically using `ArmeriaServerConfigurator`. However, if I leave the armeria ports section empty, it defaults to 8080. 

https://github.com/line/armeria/blob/845192b5dfd549fac5388d6d9bc4ec9e2daa0d07/spring/boot3-autoconfigure/src/main/java/com/linecorp/armeria/spring/AbstractArmeriaAutoConfiguration.java#L90-L93

I think we should prevent this default behavior to not break anyone's compatibility. So I updated the code so that we filter out any ports that are `-1`. Default behavior was throwing an exception during initialization, so I think it is fine to change this behavior.

Modifications:

- Don't initialize server ports that are less than 0.
- Somewhat relates to #5039

Result:

I have tested this manually by modifying `it/spring/boot3-jetty12` to have -1 as the armeria port. After this change, it assigned a random port. My second test was to update `ArmeriaServerConfigurator` to assign a port manually. After this test, armeria did not assign a random port but it used the one I have assigned inside the configurator.