### PR TITLE
Prioritize Binding of Services with Custom Verbs in HttpJsonTranscodi…

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePlugin.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePlugin.java
@@ -350,6 +350,13 @@ public final class GrpcDocServicePlugin implements DocServicePlugin {
 
     @VisibleForTesting
     static String convertRegexPath(String patternString) {
+        if (patternString.charAt(patternString.length() - 1) == '$') {
+            patternString = patternString.substring(0, patternString.length() - 1);
+        }
+        if (patternString.charAt(0) == '^') {
+            patternString = patternString.substring(1);
+        }
+
         // map '/a/(?<p0>[^/]+):get' to '/a/p0:get'
         return PATH_PARAM_PATTERN.matcher(patternString).replaceAll("$1");
     }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingRouteAndPathVariables.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingRouteAndPathVariables.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.grpc;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.HttpRule;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.server.RouteUtil;
+import com.linecorp.armeria.server.Route;
+import com.linecorp.armeria.server.RouteBuilder;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.PathSegment;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.PathSegment.PathMappingType;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.Stringifier;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingPathParser.VerbPathSegment;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingService.PathVariable;
+import com.linecorp.armeria.server.grpc.HttpJsonTranscodingService.PathVariable.ValueDefinition.Type;
+
+final class HttpJsonTranscodingRouteAndPathVariables {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(HttpJsonTranscodingRouteAndPathVariables.class);
+
+    @Nullable
+    static HttpJsonTranscodingRouteAndPathVariables of(HttpRule httpRule) {
+        final RouteBuilder builder = Route.builder();
+        final String path;
+        switch (httpRule.getPatternCase()) {
+            case GET:
+                builder.methods(HttpMethod.GET);
+                path = httpRule.getGet();
+                break;
+            case PUT:
+                builder.methods(HttpMethod.PUT);
+                path = httpRule.getPut();
+                break;
+            case POST:
+                builder.methods(HttpMethod.POST);
+                path = httpRule.getPost();
+                break;
+            case DELETE:
+                builder.methods(HttpMethod.DELETE);
+                path = httpRule.getDelete();
+                break;
+            case PATCH:
+                builder.methods(HttpMethod.PATCH);
+                path = httpRule.getPatch();
+                break;
+            case CUSTOM:
+            default:
+                logger.warn("Ignoring unsupported route pattern: pattern={}, httpRule={}",
+                            httpRule.getPatternCase(), httpRule);
+                return null;
+        }
+
+        // Check whether the path is Armeria-native.
+        if (path.startsWith(RouteUtil.EXACT) ||
+            path.startsWith(RouteUtil.PREFIX) ||
+            path.startsWith(RouteUtil.GLOB) ||
+            path.startsWith(RouteUtil.REGEX)) {
+
+            final Route route = builder.path(path).build();
+            final List<PathVariable> vars =
+                    route.paramNames().stream()
+                         .map(name -> new PathVariable(
+                                 null, name, ImmutableList.of(
+                                         new PathVariable.ValueDefinition(Type.REFERENCE, name))))
+                         .collect(toImmutableList());
+            boolean hasVerb = false;
+            if (path.startsWith(RouteUtil.EXACT)) {
+                hasVerb = containsVerbPath(path, true);
+            } else if (path.startsWith(RouteUtil.GLOB) || path.startsWith(RouteUtil.REGEX)) {
+                hasVerb = containsVerbPath(route.paths().get(0), false);
+            }
+
+            return new HttpJsonTranscodingRouteAndPathVariables(route, vars, hasVerb);
+        }
+
+        final List<PathSegment> segments = HttpJsonTranscodingPathParser.parse(path);
+
+        PathMappingType pathMappingType =
+                segments.stream().allMatch(segment -> segment.support(PathMappingType.PARAMETERIZED)) ?
+                PathMappingType.PARAMETERIZED : PathMappingType.GLOB;
+        final boolean hasVerb;
+        if (segments.get(segments.size() - 1) instanceof VerbPathSegment) {
+            pathMappingType = PathMappingType.REGEX;
+            hasVerb = true;
+        } else {
+            hasVerb = false;
+        }
+
+        if (pathMappingType == PathMappingType.PARAMETERIZED) {
+            builder.path(Stringifier.segmentsToPath(PathMappingType.PARAMETERIZED, segments, true));
+        } else if (pathMappingType == PathMappingType.GLOB) {
+            builder.glob(Stringifier.segmentsToPath(PathMappingType.GLOB, segments, true));
+        } else {
+            builder.regex(Stringifier.segmentsToPath(PathMappingType.REGEX, segments, true));
+        }
+        return new HttpJsonTranscodingRouteAndPathVariables(
+                builder.build(), PathVariable.from(segments, pathMappingType), hasVerb);
+    }
+
+    private static boolean containsVerbPath(String path, boolean exact) {
+        final String verbPathRegex;
+        if (exact) {
+            verbPathRegex = "(?<!/):[A-Za-z0-9]+$";
+        } else {
+            verbPathRegex = "(?<!/):[A-Za-z]+\\$(?!/)";
+        }
+
+        final Pattern pattern = Pattern.compile(verbPathRegex);
+        final Matcher matcher = pattern.matcher(path);
+        return matcher.find();
+    }
+
+    private final Route route;
+    private final List<PathVariable> pathVariables;
+    private final boolean hasVerb;
+
+    private HttpJsonTranscodingRouteAndPathVariables(Route route, List<PathVariable> pathVariables,
+                                                     boolean hasVerb) {
+        this.route = route;
+        this.pathVariables = pathVariables;
+        this.hasVerb = hasVerb;
+    }
+
+    Route route() {
+        return route;
+    }
+
+    List<PathVariable> pathVariables() {
+        return pathVariables;
+    }
+
+    boolean hasVerb() {
+        return hasVerb;
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingRouteAndPathVariables.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingRouteAndPathVariables.java
@@ -117,7 +117,7 @@ final class HttpJsonTranscodingRouteAndPathVariables {
         } else if (pathMappingType == PathMappingType.GLOB) {
             builder.glob(Stringifier.segmentsToPath(PathMappingType.GLOB, segments, true));
         } else {
-            builder.regex(Stringifier.segmentsToPath(PathMappingType.REGEX, segments, true));
+            builder.regex('^' + Stringifier.segmentsToPath(PathMappingType.REGEX, segments, true) + '$');
         }
         return new HttpJsonTranscodingRouteAndPathVariables(
                 builder.build(), PathVariable.from(segments, pathMappingType), hasVerb);

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePluginTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/GrpcDocServicePluginTest.java
@@ -457,7 +457,8 @@ class GrpcDocServicePluginTest {
 
     @Test
     void pathParamRegexIsConvertedCorrectly() {
-        assertThat(convertRegexPath("/a/(?<p0>[^/]+):get"))
-                .isEqualTo("/a/p0:get");
+        assertThat(convertRegexPath("/a/(?<p0>[^/]+):get")).isEqualTo("/a/p0:get");
+        assertThat(convertRegexPath("^/a/(?<p0>[^/]+):get")).isEqualTo("/a/p0:get");
+        assertThat(convertRegexPath("^/a/(?<p0>[^/]+):get$")).isEqualTo("/a/p0:get");
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingVerbServiceBindingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/HttpJsonTranscodingVerbServiceBindingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.CustomVerbServiceBindingTestServiceGrpc.CustomVerbServiceBindingTestServiceImplBase;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.stub.StreamObserver;
+
+class HttpJsonTranscodingVerbServiceBindingTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(GrpcService.builder()
+                                  .addService(new CustomVerbServiceBindingTestServiceImpl())
+                                  .enableHttpJsonTranscoding(true)
+                                  .build());
+        }
+    };
+
+    private static class CustomVerbServiceBindingTestServiceImpl
+            extends CustomVerbServiceBindingTestServiceImplBase {
+
+        @Override
+        public void foo(NameRequest request,
+                        StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "foo");
+        }
+
+        private static void reply(NameRequest request,
+                                  StreamObserver<MethodNameReply> responseObserver,
+                                  String message) {
+            if (!"a/b".equals(request.getName())) {
+                responseObserver.onError(new IllegalArgumentException("unexpected name: " + request.getName()));
+            } else {
+                responseObserver.onNext(MethodNameReply.newBuilder().setMessage(message).build());
+                responseObserver.onCompleted();
+            }
+        }
+
+        @Override
+        public void bar(NameRequest request,
+                        StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "bar");
+        }
+
+        @Override
+        public void fooCustomVerb(NameRequest request,
+                                  StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "fooCustomVerb");
+        }
+
+        @Override
+        public void barCustomVerb(NameRequest request,
+                                  StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "barCustomVerb");
+        }
+
+        @Override
+        public void fooCustomVerb2(NameRequest request,
+                                   StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "fooCustomVerb2");
+        }
+
+        @Override
+        public void barCustomVerb2(NameRequest request,
+                                  StreamObserver<MethodNameReply> responseObserver) {
+            reply(request, responseObserver, "barCustomVerb2");
+        }
+    }
+
+    @CsvSource({
+            "/v1/foo/a/b, foo",
+            "/v1/foo/a/b:verb, fooCustomVerb",
+            "/v1/foo/a/b:verb2, fooCustomVerb2",
+            "/v1/bar/a/b, bar",
+            "/v1/bar/a/b:verb, barCustomVerb",
+            "/v1/bar/a/b:verb2, barCustomVerb2"
+    })
+    @ParameterizedTest
+    void customVerbTakes(String path, String expectedMessage) {
+        final String actual = server.blockingWebClient().get(path).contentUtf8();
+        assertThat(actual).isEqualTo("{\"message\":\"" + expectedMessage + "\"}");
+    }
+}

--- a/grpc/src/test/proto/testing/grpc/transcoding_custom_verb.proto
+++ b/grpc/src/test/proto/testing/grpc/transcoding_custom_verb.proto
@@ -1,0 +1,68 @@
+// Copyright 2025 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+package hello.service.v1;
+
+import "google/api/annotations.proto";
+
+option java_package = "com.linecorp.armeria.server.grpc";
+option java_multiple_files = true;
+
+message NameRequest {
+  string name = 1;
+}
+
+message MethodNameReply {
+  string message = 1;
+}
+
+service CustomVerbServiceBindingTestService {
+  rpc Foo (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}"
+    };
+  }
+
+  rpc FooCustomVerb (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}:verb"
+    };
+  }
+
+  rpc FooCustomVerb2 (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}:verb2"
+    };
+  }
+
+  rpc BarCustomVerb (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}:verb"
+    };
+  }
+
+  rpc BarCustomVerb2 (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}:verb2"
+    };
+  }
+
+  rpc Bar (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}"
+    };
+  }
+}

--- a/it/grpc/protobuf4/src/test/proto/testing/grpc/transcoding_custom_verb.proto
+++ b/it/grpc/protobuf4/src/test/proto/testing/grpc/transcoding_custom_verb.proto
@@ -1,0 +1,68 @@
+// Copyright 2025 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+package hello.service.v1;
+
+import "google/api/annotations.proto";
+
+option java_package = "com.linecorp.armeria.server.grpc";
+option java_multiple_files = true;
+
+message NameRequest {
+  string name = 1;
+}
+
+message MethodNameReply {
+  string message = 1;
+}
+
+service CustomVerbServiceBindingTestService {
+  rpc Foo (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}"
+    };
+  }
+
+  rpc FooCustomVerb (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}:verb"
+    };
+  }
+
+  rpc FooCustomVerb2 (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/foo/{name=**}:verb2"
+    };
+  }
+
+  rpc BarCustomVerb (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}:verb"
+    };
+  }
+
+  rpc BarCustomVerb2 (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}:verb2"
+    };
+  }
+
+  rpc Bar (NameRequest) returns (MethodNameReply) {
+    option (google.api.http) = {
+      get: "/v1/bar/{name=**}"
+    };
+  }
+}


### PR DESCRIPTION
…ngService

Motivation:
In `HttpJsonTranscodingService`, services with custom verb paths should be bound to the server first. This ensures that these services are prioritized over other services with the same pattern but without the verb path.

Modifications:
- Updated `HttpJsonTranscodingService` to bind services with custom verb paths before others.

Result:
- Ensures that requests are correctly routed to the intended service when multiple services share the same pattern.