### PR TITLE
Register EventLoop as a Non-Blocking Thread in Reactor Scheduler 3.7.0+

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -292,8 +292,6 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
 
     private void updateHealth(Endpoint endpoint, boolean health) {
         if (isClosing()) {
-            logger.debug("HealthCheckedEndpointGroup is closed. Ignoring health update for: {}. (healthy: {})",
-                         endpoint, health);
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CommonPools.java
@@ -16,6 +16,12 @@
 
 package com.linecorp.armeria.common;
 
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.metric.MoreMeterBinders;
@@ -30,6 +36,8 @@ import io.netty.channel.EventLoopGroup;
  */
 public final class CommonPools {
 
+    private static final Logger logger = LoggerFactory.getLogger(CommonPools.class);
+
     // Threads spawned as needed and reused, with a 60s timeout and unbounded work queue.
     private static final BlockingTaskExecutor BLOCKING_TASK_EXECUTOR =
             BlockingTaskExecutor.builder().threadNamePrefix("armeria-common-blocking-tasks").build();
@@ -43,11 +51,17 @@ public final class CommonPools {
                 .bindTo(Flags.meterRegistry());
 
         try {
-            Class.forName("reactor.core.scheduler.Schedulers",
-                          true, CommonPools.class.getClassLoader());
+            final Class<?> aClass = Class.forName("reactor.core.scheduler.Schedulers",
+                                                  true, CommonPools.class.getClassLoader());
+            final Method ignored = aClass.getDeclaredMethod(
+                    "registerNonBlockingThreadPredicate", Predicate.class);
+            // Call only when the method exists.
             ReactorNonBlockingUtil.registerEventLoopAsNonBlocking();
         } catch (ClassNotFoundException e) {
-            // Do nothing.
+            // Do nothing because reactor is not available.
+        } catch (NoSuchMethodException e) {
+            logger.warn("Failed to register the common worker group as non-blocking for Reactor. " +
+                        "Please consider upgrading Reactor to 3.7.0 or newer.");
         }
     }
 


### PR DESCRIPTION
Motivation:
The method `Schedulers.registerNonBlockingThreadPredicate` was introduced in Reactor 3.7.0+. To maintain compatibility with older Reactor versions, we should only register the EventLoop as a non-blocking thread if this method is available. If the method is unavailable (i.e., in Reactor versions lower than 3.7.0), a warning log should be emitted instead of causing an error.

Modifications:
- Check for the existence of `Schedulers.registerNonBlockingThreadPredicate` before invoking it.
- If the method is unavailable, log a warning instead of attempting registration.

Result:
- Ensured compatibility with both newer and older Reactor versions.