### PR TITLE
Fetch all resources before watching them individually in `KubernetesEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -319,6 +319,15 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
         }
     }
 
+    /**
+     * Fails the initialization of this {@link DynamicEndpointGroup} with the specified {@link Throwable}.
+     */
+    @UnstableApi
+    protected final void failInit(Throwable cause) {
+        requireNonNull(cause, "cause");
+        initialEndpointsFuture.completeExceptionally(cause);
+    }
+
     private void maybeCompleteInitialEndpointsFuture(List<Endpoint> endpoints) {
         if (endpoints != UNINITIALIZED_ENDPOINTS && !initialEndpointsFuture.isDone()) {
             initialEndpointsFuture.complete(endpoints);

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -90,17 +90,12 @@ class KubernetesEndpointGroupMockServerTest {
 
         final KubernetesEndpointGroup endpointGroup = KubernetesEndpointGroup.of(client, "test",
                                                                                  "nginx-service");
-        endpointGroup.whenReady().join();
-
         // Initial state
-        await().untilAsserted(() -> {
-            final List<Endpoint> endpoints = endpointGroup.endpoints();
-            // Wait until all endpoints are ready
-            assertThat(endpoints).containsExactlyInAnyOrder(
-                    Endpoint.of("1.1.1.1", nodePort),
-                    Endpoint.of("2.2.2.2", nodePort)
-            );
-        });
+        final List<Endpoint> initialEndpoints = endpointGroup.whenReady().join();
+        assertThat(initialEndpoints).containsExactlyInAnyOrder(
+                Endpoint.of("1.1.1.1", nodePort),
+                Endpoint.of("2.2.2.2", nodePort)
+        );
 
         // Add a new pod
         client.pods().resource(pods.get(2)).create();


### PR DESCRIPTION
Motivation:

If `whenReady()` in `KubernetesEndpointGroup` is complete with partial endpoints, the nodes could receive heavy loads unexpectedly. To prevent this, it would be better to fetch all resources using `GET` methods at the beginning instead of watching, and then use `WATCH` incrementally to update the information.

Modifications:

- Add `start()` method to initialize the resources at the beginning.
- Remove the debounce logic, which is no longer necessary.
- Add `failInit()` in `DynamicEndpointGroup` to notify an initialization failure.
- Breaking) `KubernetesEndpointGroup` now requires `get` verbs in the RBAC rules to fetch endpoints.

Result:

`KubernetesEndpointGroup.whenReady()` is now complete after collecting all endpoints.

