### PR TITLE
Use namespace when retreiving k8s services

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
@@ -292,7 +292,11 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         final PodList pods;
         try {
             logger.info("[{}/{}] Fetching the service...", namespace, serviceName);
-            service = client.services().withName(serviceName).get();
+            if (namespace == null) {
+                service = client.services().withName(serviceName).get();
+            } else {
+                service = client.services().inNamespace(namespace).withName(serviceName).get();
+            }
             if (service == null) {
                 logger.warn("[{}/{}] Service not found.", namespace, serviceName);
                 throw new IllegalStateException(

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -23,6 +23,8 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -65,31 +67,44 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 @EnableKubernetesMockClient(crud = true)
 class KubernetesEndpointGroupMockServerTest {
 
+    private static final String NON_DEFAULT_NAMESPACE = "non-default-namespace";
+
     private KubernetesClient client;
 
-    @Test
-    void createEndpointsWithNodeIpAndPort() throws InterruptedException {
+    @CsvSource({ "true", "false" })
+    @ParameterizedTest
+    void createEndpointsWithNodeIpAndPort(boolean useNamespace) throws InterruptedException {
         // Prepare Kubernetes resources
         final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"), newNode("3.3.3.3"));
-        final Deployment deployment = newDeployment();
+        final Deployment deployment = newDeployment("nginx", useNamespace);
         final int nodePort = 30000;
-        final Service service = newService(nodePort);
+        final Service service = newService(nodePort, useNamespace);
         final List<Pod> pods = nodes.stream()
                                     .map(node -> node.getMetadata().getName())
-                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
+                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(),
+                                                            nodeName, useNamespace))
                                     .collect(toImmutableList());
 
         // Create Kubernetes resources
         for (Node node : nodes) {
             client.nodes().resource(node).create();
         }
-        client.pods().resource(pods.get(0)).create();
-        client.pods().resource(pods.get(1)).create();
-        client.apps().deployments().resource(deployment).create();
-        client.services().resource(service).create();
-
-        final KubernetesEndpointGroup endpointGroup = KubernetesEndpointGroup.of(client, "test",
-                                                                                 "nginx-service");
+        if (useNamespace) {
+            client.pods().inNamespace(NON_DEFAULT_NAMESPACE).resource(pods.get(0)).create();
+            client.pods().inNamespace(NON_DEFAULT_NAMESPACE).resource(pods.get(1)).create();
+            client.apps().deployments().inNamespace(NON_DEFAULT_NAMESPACE).resource(deployment).create();
+            client.services().inNamespace(NON_DEFAULT_NAMESPACE).resource(service).create();
+        } else {
+            client.pods().resource(pods.get(0)).create();
+            client.pods().resource(pods.get(1)).create();
+            client.apps().deployments().resource(deployment).create();
+            client.services().resource(service).create();
+        }
+        final KubernetesEndpointGroupBuilder builder = KubernetesEndpointGroup.builder(client);
+        if (useNamespace) {
+            builder.namespace(NON_DEFAULT_NAMESPACE);
+        }
+        final KubernetesEndpointGroup endpointGroup = builder.serviceName("nginx-service").build();
         // Initial state
         final List<Endpoint> initialEndpoints = endpointGroup.whenReady().join();
         assertThat(initialEndpoints).containsExactlyInAnyOrder(
@@ -121,7 +136,8 @@ class KubernetesEndpointGroupMockServerTest {
         // Add a new node and a new pod
         final Node node4 = newNode("4.4.4.4");
         client.nodes().resource(node4).create();
-        final Pod pod4 = newPod(deployment.getSpec().getTemplate(), node4.getMetadata().getName());
+        final Pod pod4 = newPod(deployment.getSpec().getTemplate(), node4.getMetadata().getName(),
+                                useNamespace);
         client.pods().resource(pod4).create();
         await().untilAsserted(() -> {
             final List<Endpoint> endpoints = endpointGroup.endpoints();
@@ -185,7 +201,7 @@ class KubernetesEndpointGroupMockServerTest {
         // Update service and deployment with new selector
         final int newNodePort = 30001;
         final String newSelectorName = "nginx-updated";
-        final Service updatedService = newService(newNodePort, newSelectorName);
+        final Service updatedService = newService(newNodePort, newSelectorName, false);
         client.services().resource(updatedService).update();
         final Deployment updatedDeployment = newDeployment(newSelectorName);
         client.apps().deployments().resource(updatedDeployment).update();
@@ -334,13 +350,19 @@ class KubernetesEndpointGroupMockServerTest {
     }
 
     static Service newService(@Nullable Integer nodePort) {
-        return newService(nodePort, "nginx");
+        return newService(nodePort, false);
     }
 
-    static Service newService(@Nullable Integer nodePort, String selectorName) {
-        final ObjectMeta metadata = new ObjectMetaBuilder()
-                .withName("nginx-service")
-                .build();
+    private static Service newService(@Nullable Integer nodePort, boolean useNamespace) {
+        return newService(nodePort, "nginx", useNamespace);
+    }
+
+    static Service newService(@Nullable Integer nodePort, String selectorName, boolean useNamespace) {
+        final ObjectMetaBuilder objectMetaBuilder = new ObjectMetaBuilder().withName("nginx-service");
+        if (useNamespace) {
+            objectMetaBuilder.withNamespace(NON_DEFAULT_NAMESPACE);
+        }
+        final ObjectMeta metadata = objectMetaBuilder.build();
         final ServicePort servicePort = new ServicePortBuilder()
                 .withPort(80)
                 .withNodePort(nodePort)
@@ -356,9 +378,20 @@ class KubernetesEndpointGroupMockServerTest {
                 .build();
     }
 
+    static Deployment newDeployment() {
+        return newDeployment("nginx");
+    }
+
     static Deployment newDeployment(String selectorName) {
-        final ObjectMeta metadata = new ObjectMetaBuilder()
-                .withName("nginx-deployment")
+        return newDeployment(selectorName, false);
+    }
+
+    private static Deployment newDeployment(String selectorName, boolean useNamespace) {
+        final ObjectMetaBuilder objectMetaBuilder = new ObjectMetaBuilder().withName("nginx-deployment");
+        if (useNamespace) {
+            objectMetaBuilder.withNamespace(NON_DEFAULT_NAMESPACE);
+        }
+        final ObjectMeta metadata = objectMetaBuilder
                 .build();
         final LabelSelector selector = new LabelSelectorBuilder()
                 .withMatchLabels(ImmutableMap.of("app", selectorName))
@@ -372,10 +405,6 @@ class KubernetesEndpointGroupMockServerTest {
                 .withMetadata(metadata)
                 .withSpec(deploymentSpec)
                 .build();
-    }
-
-    static Deployment newDeployment() {
-        return newDeployment("nginx");
     }
 
     private static PodTemplateSpec newPodTemplate(String selectorName) {
@@ -399,14 +428,21 @@ class KubernetesEndpointGroupMockServerTest {
     }
 
     static Pod newPod(PodTemplateSpec template, String newNodeName) {
+        return newPod(template, newNodeName, false);
+    }
+
+    private static Pod newPod(PodTemplateSpec template, String newNodeName, boolean useNamespace) {
         final PodSpec spec = template.getSpec()
                                      .toBuilder()
                                      .withNodeName(newNodeName)
                                      .build();
-        final ObjectMeta metadata = template.getMetadata()
-                                            .toBuilder()
-                                            .withName("nginx-pod-" + newNodeName)
-                                            .build();
+        final ObjectMetaBuilder objectMetaBuilder = template.getMetadata()
+                                                            .toBuilder()
+                                                            .withName("nginx-pod-" + newNodeName);
+        if (useNamespace) {
+            objectMetaBuilder.withNamespace(NON_DEFAULT_NAMESPACE);
+        }
+        final ObjectMeta metadata = objectMetaBuilder.build();
         return new PodBuilder()
                 .withMetadata(metadata)
                 .withSpec(spec)


### PR DESCRIPTION
Motivation:
We need to specify the k8s namespace if it's specified.

Result:
- `KubernetesEndpointGroup` works properly even when the namespace is specified.