### PR TITLE
Handle a race condition where `onSubscribe` may be emitted downstream after `onError`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -148,8 +148,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
             // 'invokedOnSubscribe' should be set after 'subscribe0()' is completed.
             // 'onComplete()' could be invoked by a subclass which overrides 'subscribe0()' to subscribe
             // to other Publishers.
-            invokedOnSubscribe = true;
-            subscriber.onSubscribe(subscription);
+            maybeInvokeOnSubscribe(subscription, subscriber);
             if (!queue.isEmpty()) {
                 notifySubscriber0();
             }
@@ -163,6 +162,14 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
                             subscriber, t);
             }
         }
+    }
+
+    private void maybeInvokeOnSubscribe(SubscriptionImpl subscription, Subscriber<Object> subscriber) {
+        if (invokedOnSubscribe) {
+            return;
+        }
+        invokedOnSubscribe = true;
+        subscriber.onSubscribe(subscription);
     }
 
     /**
@@ -300,6 +307,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
 
     private void notifySubscriberOfCloseEvent0(SubscriptionImpl subscription, CloseEvent event) {
         try {
+            maybeInvokeOnSubscribe(subscription, subscription.subscriber());
             event.notifySubscriber(subscription, whenComplete());
         } finally {
             subscription.clearSubscriber();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -52,9 +52,6 @@ class DefaultStreamMessageTest {
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
 
-    @RegisterExtension
-    static final EventLoopExtension eventLoop2 = new EventLoopExtension();
-
     /**
      * Makes sure {@link Subscriber#onComplete()} is always invoked after
      * {@link Subscriber#onSubscribe(Subscription)} even if
@@ -341,7 +338,7 @@ class DefaultStreamMessageTest {
 
             @Override
             public void onComplete() {
-                queue.add("onError");
+                queue.add("onComplete");
             }
         }, eventLoop.get());
         latch.countDown();

--- a/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/DefaultStreamMessageTest.java
@@ -22,6 +22,8 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,6 +51,9 @@ class DefaultStreamMessageTest {
 
     @RegisterExtension
     static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop2 = new EventLoopExtension();
 
     /**
      * Makes sure {@link Subscriber#onComplete()} is always invoked after
@@ -301,5 +306,45 @@ class DefaultStreamMessageTest {
             }
         }, executor);
         await().untilTrue(onError);
+    }
+
+    @Test
+    void abortAndSubscribe() throws Exception {
+        final DefaultStreamMessage<String> streamMessage = new DefaultStreamMessage<>();
+        final BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        eventLoop.get().execute(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            streamMessage.abort();
+        });
+        streamMessage.subscribe(new Subscriber<String>() {
+            @Override
+            public void onSubscribe(Subscription subscription) {
+                assertThat(eventLoop.get().inEventLoop()).isTrue();
+                queue.add("onSubscribe");
+            }
+
+            @Override
+            public void onNext(String s) {
+                queue.add("onNext");
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                assertThat(eventLoop.get().inEventLoop()).isTrue();
+                queue.add("onError");
+            }
+
+            @Override
+            public void onComplete() {
+                queue.add("onError");
+            }
+        }, eventLoop.get());
+        latch.countDown();
+        await().untilAsserted(() -> assertThat(queue).containsExactly("onSubscribe", "onError"));
     }
 }


### PR DESCRIPTION
Motivation:

While debugging https://github.com/line/armeria/issues/5880#issuecomment-2735723709, I found that `onSubscribe` could be emitted after `onError`.
This is a clear violation of specifications https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.7 and https://github.com/reactive-streams/reactive-streams-jvm?tab=readme-ov-file#1.9.

I propose that before aborting, `onSubscribe` is called if it hasn't been called yet. To prevent `onSubscribe` being called multiple times, `invokedOnSubscribe` is used as a guard.

Modifications:

- Extracted `maybeInvokeOnSubscribe` and called it also from `notifySubscriberOfCloseEvent0`

Result:

- We no longer observe race conditions between `onSubscribe` and `onError` when aborting a `StreamMessage`.

