### PR TITLE
Remove DnsCacheListener from DnsCache when resolver is closed

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
@@ -187,7 +187,7 @@ final class DefaultDnsCache implements DnsCache {
     }
 
     @VisibleForTesting
-    List<DnsCacheListener> getDnsCacheListener() {
+    List<DnsCacheListener> listeners() {
         return listeners;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultDnsCache.java
@@ -33,6 +33,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Objects;
@@ -177,6 +178,17 @@ final class DefaultDnsCache implements DnsCache {
     public void addListener(DnsCacheListener listener) {
         requireNonNull(listener, "listener");
         listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(DnsCacheListener listener) {
+        requireNonNull(listener, "listener");
+        listeners.remove(listener);
+    }
+
+    @VisibleForTesting
+    List<DnsCacheListener> getDnsCacheListener() {
+        return listeners;
     }
 
     private static final class CacheEntry {

--- a/core/src/main/java/com/linecorp/armeria/client/DnsCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DnsCache.java
@@ -109,4 +109,9 @@ public interface DnsCache {
      * occurs.
      */
     void addListener(DnsCacheListener listener);
+
+    /**
+     * Removes the specified {@link DnsCacheListener} from this {@link DnsCache}.
+     */
+    void removeListener(DnsCacheListener listener);
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefreshingAddressResolver.java
@@ -67,6 +67,7 @@ final class RefreshingAddressResolver
     @Nullable
     private final ToLongFunction<String> autoRefreshTimeoutFunction;
     private final boolean autoRefresh;
+    private final DnsCache dnsResolverCache;
 
     private volatile boolean resolverClosed;
 
@@ -78,6 +79,7 @@ final class RefreshingAddressResolver
                               @Nullable ToLongFunction<String> autoRefreshTimeoutFunction) {
         super(eventLoop);
         this.addressResolverCache = addressResolverCache;
+        this.dnsResolverCache = dnsResolverCache;
         this.resolver = resolver;
         this.dnsRecordTypes = dnsRecordTypes;
         this.negativeTtl = negativeTtl;
@@ -258,6 +260,7 @@ final class RefreshingAddressResolver
     @Override
     public void close() {
         resolverClosed = true;
+        dnsResolverCache.removeListener(this);
         resolver.close();
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/NoopDnsCache.java
+++ b/core/src/test/java/com/linecorp/armeria/client/NoopDnsCache.java
@@ -50,4 +50,7 @@ public enum NoopDnsCache implements DnsCache {
 
     @Override
     public void addListener(DnsCacheListener listener) {}
+
+    @Override
+    public void removeListener(DnsCacheListener listener) {}
 }

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -906,7 +906,7 @@ class RefreshingAddressResolverTest {
     }
 
     @Test
-    void shouldRemoveListenerFromCacheWhenClosed() {
+    void shouldRemoveListenerFromDnsCacheWhenClosed() {
         final EventLoop eventLoop = eventLoopExtension.get();
         final DnsCache dnsCache = DnsCache.builder()
                 .executor(eventLoop)
@@ -917,7 +917,7 @@ class RefreshingAddressResolverTest {
             final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
             resolver.close();
             final DefaultDnsCache defaultDnsCache = (DefaultDnsCache) dnsCache;
-            assertThat(defaultDnsCache.getDnsCacheListener()).isEmpty();
+            assertThat(defaultDnsCache.listeners()).isEmpty();
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -905,6 +905,22 @@ class RefreshingAddressResolverTest {
         }
     }
 
+    @Test
+    void shouldRemoveListenerFromCacheWhenClosed() {
+        final EventLoop eventLoop = eventLoopExtension.get();
+        final DnsCache dnsCache = DnsCache.builder()
+                .executor(eventLoop)
+                .build();
+        try (RefreshingAddressResolverGroup group = new DnsResolverGroupBuilder()
+                .dnsCache(dnsCache)
+                .build(eventLoop)) {
+            final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
+            resolver.close();
+            final DefaultDnsCache defaultDnsCache = (DefaultDnsCache) dnsCache;
+            assertThat(defaultDnsCache.getDnsCacheListener()).isEmpty();
+        }
+    }
+
     private static AbstractStringAssert<?> assertIpAddress(Future<InetSocketAddress> staticAddr) {
         await().untilAsserted(() -> assertThat(staticAddr.isSuccess()).isTrue());
         return assertThat(NetUtil.bytesToIpAddress(staticAddr.getNow().getAddress().getAddress()));


### PR DESCRIPTION
Motivation:

The `RefreshingAddressResolver` is added to the `DnsCache` as listener but is never removed from it when the resolver is closed. This makes the `DnsCache` hold a strong reference (internally, in the `CopyOnWriteArrayList` that stores all the listeners) of it even when the resolver is closed, which may cause memory leak if the `DnsCache` is a global one and lives for the lifetime of the JVM.


Modifications:

- Removes the `DnsCacheListener` from the `DnsCache` to make it eligible for GC.

Result:

- Closes https://github.com/line/armeria/issues/6173.
- When the resolver is closed, the `DnsCache` no longer stores it in the list and hence no longer holds a reference of it.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
