### PR TITLE
Exclude dependabot branches to avoid running the same tests twice.

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - "**"
+      # Exclude branches to avoid running the same tests twice.
+      - '!dependabot/**'
     tags-ignore:
       # The release versions will be verified by 'publish-release.yml'
       - armeria-*


### PR DESCRIPTION
Motivation:

The same tests were run by the `pull_request` and `push` events, which would be a waste of resources.

Modifications:

- Exclude `dependabot/**` branches from the `on.push` event.
  - Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-branches

Result:

Remove redundant tests in CI