### PR TITLE
Add request context information to unexpected exception logs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -286,7 +286,7 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
         final StringBuilder logMsg = new StringBuilder(UNEXPECTED_EXCEPTION_MSG);
         final HttpRequest request = ctx.request();
         assert request != null;
-        final String authority = request.authority();
+        final String authority = ctx.authority();
         if (authority != null) {
             logMsg.append(" to ").append(authority);
         }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java
@@ -61,7 +61,7 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
     private final ClientRequestContext ctx;
     private final long maxContentLength;
     @VisibleForTesting
-    static final String UNEXPECTED_EXCEPTION_MSG = "Unexpected exception while closing a request";
+    static final String UNEXPECTED_EXCEPTION_MSG = "{} Unexpected exception while closing a request";
 
     private boolean responseStarted;
     private long contentLengthHeaderValue = -1;
@@ -283,15 +283,7 @@ class HttpResponseWrapper implements StreamWriter<HttpObject> {
             return;
         }
 
-        final StringBuilder logMsg = new StringBuilder(UNEXPECTED_EXCEPTION_MSG);
-        final HttpRequest request = ctx.request();
-        assert request != null;
-        final String authority = ctx.authority();
-        if (authority != null) {
-            logMsg.append(" to ").append(authority);
-        }
-
-        logger.warn(logMsg.append(':').toString(), cause);
+        logger.warn(UNEXPECTED_EXCEPTION_MSG, ctx, cause);
     }
 
     void initTimeout() {


### PR DESCRIPTION
Motivation:

If an `EndpointGroup` is used to send the request, `request.authority()` will be null. Consequently, log messages for unexpected exceptions lack the remote peer information, making it harder for users to identify the root cause.

Modification:

- Prepend `ClientRequestContext` to the expected warning mesage.

Result:

Remote peer information is correctly logged when an unexpected request failure occurs on the client side.

