### PR TITLE
Fix duplicate endpoint handling in `HealthCheckedEndpointGroup`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -23,10 +23,12 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -226,14 +228,17 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
                 return ImmutableList.of();
             }
 
+            // newGroup.candidates() might have duplicate endpoints, so we need to use list instead of set.
             final List<Endpoint> allEndpoints = new ArrayList<>(newGroup.candidates());
+            // This set is used to check if endpoints from old group are already added to allEndpoints.
+            final Set<Endpoint> addedEndpoints = new HashSet<>(newGroup.candidates());
 
             for (HealthCheckContextGroup oldGroup : contextGroupChain) {
                 if (oldGroup == newGroup) {
                     break;
                 }
                 for (Endpoint candidate : oldGroup.candidates()) {
-                    if (!allEndpoints.contains(candidate)) {
+                    if (addedEndpoints.add(candidate)) {
                         // Add old Endpoints that do not exist in newGroup. When the first check for newGroup is
                         // completed, the old Endpoints will be removed.
                         allEndpoints.add(candidate);

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunction.java
@@ -242,7 +242,8 @@ final class SamlAssertionConsumerFunction implements SamlServiceFunction {
 
                 if (!endpointUri.equals(data.getRecipient())) {
                     throw new InvalidSamlRequestException(
-                            "recipient is not matched: " + data.getRecipient());
+                            "recipient is not matched: " + data.getRecipient() +
+                            " (expected: " + endpointUri + ')');
                 }
                 if (now.isAfter(data.getNotOnOrAfter())) {
                     throw new InvalidSamlRequestException(


### PR DESCRIPTION
Motivation:
`HealthCheckedEndpointGroup` uses a list instead of a set to gather all endpoints, allowing for potential duplicates. However, when checking endpoints before adding them from the old group, it iterates over all elements, leading to issues. A separate set is needed to handle this properly.

Modifications:
- Introduced an additional set to track endpoints when updating from the old group.

Result:
- Ensures efficient endpoint updates in `HealthCheckedEndpointGroup`.
