### PR TITLE
fix documents for client-thrift and client-entry

### DIFF
--- a/site/src/pages/docs/client-retry.mdx
+++ b/site/src/pages/docs/client-retry.mdx
@@ -221,7 +221,10 @@ the maximum number of total attempts to 10 by default. You can change this value
 `maxTotalAttempts` when you build a <type://RetryingClient>:
 
 ```java
-RetryingClient.newDecorator(rule, maxTotalAttempts);
+RetryConfig config = RetryConfig.builder(rule)
+    .maxTotalAttempts(maxTotalAttempts)
+    .build();
+RetryingClient.newDecorator(config);
 ```
 
 Or, you can override the default value of 10 using the JVM system property
@@ -246,8 +249,11 @@ Second, it occurs when the time of individual attempt in retry has passed the ti
 You can configure it when you create the decorator:
 
 ```java
-RetryingClient.newDecorator(rule, maxTotalAttempts,
-                            responseTimeoutMillisForEachAttempt);
+RetryConfig config = RetryConfig.builder(rule)
+    .maxTotalAttempts(maxTotalAttempts)
+    .responseTimeoutMillisForEachAttempt(responseTimeoutMillisForEachAttempt)
+    .build();
+RetryingClient.newDecorator(config);
 ```
 
 You can retry on this <type://ResponseTimeoutException>.

--- a/site/src/pages/docs/client-thrift.mdx
+++ b/site/src/pages/docs/client-thrift.mdx
@@ -41,10 +41,10 @@ using <type://ThriftClientBuilder#serializationFormat(SerializationFormat)>.
 import com.linecorp.armeria.common.thrift.ThriftSerializationFormats;
 
 HelloService.Iface helloService =
-    ThriftClient.builder("http://127.0.0.1:8080")
-                .path("/hello")
-                .serializationFormat(ThriftSerializationFormats.JSON)
-                .build(HelloService.Iface.class); // or AsyncIface.class
+    ThriftClients.builder("http://127.0.0.1:8080")
+                 .path("/hello")
+                 .serializationFormat(ThriftSerializationFormats.JSON)
+                 .build(HelloService.Iface.class); // or AsyncIface.class
 ```
 
 Since we specified `HelloService.Iface` as the client type, `ThriftClients.newClient()` will return a


### PR DESCRIPTION
Motivation:

I found an incorrect class name and the use of deprecated functions in the document.
Therefore I fixed it to use the recommended function instead.

Modifications:

- Change `ThriftClient` to `ThriftClients`
- Use `RetryConfig` instead of deprecated functions.

Result:

- The corrected document will be displayed.


