### PR TITLE
Improve URI comparison and validation in SAML components

### DIFF
--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
@@ -16,12 +16,14 @@
 package com.linecorp.armeria.server.saml;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.armeria.server.saml.SamlPortConfig.validatePort;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -75,7 +77,17 @@ public final class SamlEndpoint {
     private final SamlBindingProtocol bindingProtocol;
     private final String uriAsString;
 
+    SamlEndpoint(@JsonProperty("uri") String uri,
+                 @JsonProperty("binding") @Nullable String bindingProtocol) throws URISyntaxException {
+        this(new URI(requireNonNull(uri, "uri")),
+             bindingProtocol != null ? SamlBindingProtocol.valueOf(bindingProtocol)
+                                     : SamlBindingProtocol.HTTP_POST);
+    }
+
     private SamlEndpoint(URI uri, SamlBindingProtocol bindingProtocol) {
+        if (isNullOrEmpty(uri.getPath()) || "/".equals(uri.getPath())) {
+            throw new IllegalArgumentException("uri.path is empty: " + uri);
+        }
         this.uri = uri;
         this.bindingProtocol = bindingProtocol;
         uriAsString = uri.toString();
@@ -91,6 +103,7 @@ public final class SamlEndpoint {
     /**
      * Returns a {@link URI} of this endpoint as a string.
      */
+    @JsonProperty("uri")
     public String toUriString() {
         return uriAsString;
     }
@@ -105,17 +118,26 @@ public final class SamlEndpoint {
         requireNonNull(defaultHostname, "defaultHostname");
         validatePort(defaultPort);
 
+
         final StringBuilder sb = new StringBuilder();
         sb.append(firstNonNull(uri.getScheme(), defaultScheme)).append("://")
-          .append(firstNonNull(uri.getHost(), defaultHostname)).append(':')
-          .append(uri.getPort() > 0 ? uri.getPort() : defaultPort)
-          .append(uri.getPath());
+          .append(firstNonNull(uri.getHost(), defaultHostname));
+        if (uri.getHost() != null) {
+            if (uri.getPort() > 0) {
+                sb.append(':').append(uri.getPort());
+            }
+        } else {
+            // Append the default port only when the host is not specified.
+            sb.append(':').append(defaultPort);
+        }
+        sb.append(uri.getPath());
         return sb.toString();
     }
 
     /**
      * Returns a {@link SamlBindingProtocol} of this endpoint.
      */
+    @JsonProperty("bindingProtocol")
     public SamlBindingProtocol bindingProtocol() {
         return bindingProtocol;
     }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlEndpoint.java
@@ -118,7 +118,6 @@ public final class SamlEndpoint {
         requireNonNull(defaultHostname, "defaultHostname");
         validatePort(defaultPort);
 
-
         final StringBuilder sb = new StringBuilder();
         sb.append(firstNonNull(uri.getScheme(), defaultScheme)).append("://")
           .append(firstNonNull(uri.getHost(), defaultHostname));

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlServiceProviderBuilder.java
@@ -378,10 +378,9 @@ public final class SamlServiceProviderBuilder {
                                      new SamlAssertionConsumerConfigBuilder(
                                              this, ofHttpRedirect("/saml/acs/redirect")).build());
         } else {
-            // If there is only one ACS, it will be automatically a default ACS.
-            if (acsConfigBuilders.size() == 1) {
-                acsConfigBuilders.get(0).asDefault();
-            }
+            // Make the first ACS endpoint as default since there's no way to specify a default ACS endpoint
+            // at the moment.
+            acsConfigBuilders.get(0).asDefault();
 
             assertionConsumerConfigs = acsConfigBuilders.stream()
                                                         .map(SamlAssertionConsumerConfigBuilder::build)

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunctionTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunctionTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2025 LINE Corporation
+ * Copyright 2025 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunctionTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlAssertionConsumerFunctionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static com.linecorp.armeria.server.saml.SamlAssertionConsumerFunction.isSameUri;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SamlAssertionConsumerFunctionTest {
+
+    @Test
+    void sameUri() {
+        assertThat(isSameUri("https://example.com/saml/redirect", "http://example.com/saml/redirect"))
+                .isFalse();
+        assertThat(isSameUri("https://example.com/saml/redirect", "https://example1.com/saml/redirect"))
+                .isFalse();
+
+        assertThat(isSameUri("https://example.com:443/saml/redirect", "https://example.com/saml/redirect"))
+                .isTrue();
+        assertThat(isSameUri("http://example.com:80/saml/redirect", "http://example.com/saml/redirect"))
+                .isTrue();
+
+        assertThat(isSameUri("https://example.com/saml/redirect", "https://example.com/saml/redirect"))
+                .isTrue();
+        assertThat(isSameUri("https://example.com:555/saml/redirect", "https://example.com:555/saml/redirect"))
+                .isTrue();
+    }
+}

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlEndpointTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlEndpointTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.saml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.internal.common.JacksonUtil;
+
+class SamlEndpointTest {
+
+    @Test
+    void deserialize() throws Exception {
+        final ObjectMapper objectMapper = JacksonUtil.newDefaultObjectMapper();
+        assertThatThrownBy(() -> objectMapper.readValue(
+                "{\"uri\":\"https://example.com/\",\"binding\":\"HTTP_REDIRECT\"}",
+                SamlEndpoint.class)).hasCauseExactlyInstanceOf(IllegalArgumentException.class)
+                                    .hasMessageContaining("uri.path is empty");
+
+        SamlEndpoint samlEndpoint = objectMapper.readValue("{\"uri\":\"/saml/post\"}",
+                                                           SamlEndpoint.class);
+        // The default binding protocol is HTTP POST.
+        assertThat(samlEndpoint.bindingProtocol()).isSameAs(SamlBindingProtocol.HTTP_POST);
+        URI uri = samlEndpoint.uri();
+        assertThat(uri.getPath()).isEqualTo("/saml/post");
+        assertThat(uri.getScheme()).isNull();
+        assertThat(uri.getHost()).isNull();
+        assertThat(uri.getPort()).isEqualTo(-1);
+        assertThat(samlEndpoint.toUriString("http", "example1.com", 36462)).isEqualTo(
+                "http://example1.com:36462/saml/post");
+
+        samlEndpoint = objectMapper.readValue("{\"uri\":\"https://example.com/saml/post\"}",
+                                              SamlEndpoint.class);
+        uri = samlEndpoint.uri();
+        assertThat(uri.getPath()).isEqualTo("/saml/post");
+        assertThat(uri.getScheme()).isEqualTo("https");
+        assertThat(uri.getHost()).isEqualTo("example.com");
+        assertThat(uri.getPort()).isEqualTo(-1);
+
+        assertThat(samlEndpoint.toUriString("http", "not-used.com", 36462))
+                .isEqualTo("https://example.com/saml/post"); // port is not added.
+    }
+}

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlEndpointTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlEndpointTest.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2025 LINE Corporation
+ * Copyright 2025 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *


### PR DESCRIPTION
Motivation:
Previously, the recipient URI in a SAML assertion was compared using a strict string equality check. This caused false negatives when the URI was semantically equivalent but had minor differences, such as missing default ports.

Modifications:
- Introduced `isSameUri()` in `SamlAssertionConsumerFunction` to compare URIs by scheme, host, path, and port.
- Updated `SamlEndpoint` to reject URIs with empty or root (`/`) paths.
- Improved `SamlEndpoint.toUriString()` to append the default port only when the host is missing.

Result:
- Recipient URIs in SAML assertions are now compared more robustly, reducing the chance of false mismatches.