### PR TITLE
Fixed a bug where the default setting for DNS over TCP was unintentionally disabled

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractDnsResolverBuilder.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.github.benmanes.caffeine.cache.CaffeineSpec;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.Flags;
@@ -522,12 +521,6 @@ public abstract class AbstractDnsResolverBuilder<SELF extends AbstractDnsResolve
                                   boolean retrySocketChannelOnTimeout) {
         requireNonNull(socketChannelType, "channelType");
         this.socketChannelType = socketChannelType;
-        this.retrySocketChannelOnTimeout = retrySocketChannelOnTimeout;
-        return self();
-    }
-
-    @VisibleForTesting
-    SELF retrySocketChannelOnTimeout(boolean retrySocketChannelOnTimeout) {
         this.retrySocketChannelOnTimeout = retrySocketChannelOnTimeout;
         return self();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/DnsOverTcpTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/DnsOverTcpTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static com.linecorp.armeria.client.endpoint.dns.TestDnsServer.newAddressRecord;
+import static io.netty.handler.codec.dns.DnsRecordType.A;
+import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
+import static io.netty.handler.codec.dns.DnsSection.ANSWER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
+import com.linecorp.armeria.client.endpoint.dns.TestTcpDnsServer;
+
+import io.netty.handler.codec.dns.DefaultDnsQuestion;
+import io.netty.handler.codec.dns.DefaultDnsResponse;
+
+class DnsOverTcpTest {
+
+    @Test
+    void shouldFallbackToTcpByDefault() throws Exception {
+        try (TestTcpDnsServer server = new TestTcpDnsServer(ImmutableMap.of(
+                new DefaultDnsQuestion("foo.com.", A),
+                new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "1.1.1.1"))
+                                         .addRecord(ANSWER, newAddressRecord("unrelated.com", "1.2.3.4")),
+                new DefaultDnsQuestion("foo.com.", AAAA),
+                new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("foo.com.", "::1"))))) {
+
+            final DnsAddressEndpointGroupBuilder builder =
+                    DnsAddressEndpointGroup.builder("foo.com")
+                                           .port(8080);
+
+            // Make sure TCP fallback is used on UDP timeout.
+            ((AbstractDnsResolverBuilder<?>) builder).retrySocketChannelOnTimeout(true);
+
+            try (DnsAddressEndpointGroup group =
+                         builder.serverAddresses(server.addr())
+                                .queryTimeoutMillisForEachAttempt(1000)
+                                .dnsCache(NoopDnsCache.INSTANCE)
+                                .build()) {
+
+                assertThat(group.whenReady().get()).containsExactly(
+                        Endpoint.of("foo.com", 8080).withIpAddr("1.1.1.1"));
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
@@ -167,6 +167,7 @@ public final class TestTcpDnsServer implements AutoCloseable {
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, DefaultDnsQuery query) {
             logger.debug("Received TCP query: {}", query);
+            query.touch(ctx);
             final DnsQuestion question = query.recordAt(DnsSection.QUESTION, 0);
             boolean responded = false;
             for (Entry<DnsQuestion, DnsResponse> e : responses.entrySet()) {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
@@ -189,7 +189,11 @@ public final class TestTcpDnsServer implements AutoCloseable {
                         }
                     }
 
-                    ctx.writeAndFlush(res);
+                    ctx.writeAndFlush(res).addListener(future -> {
+                        if (!future.isSuccess()) {
+                            ReferenceCountUtil.safeRelease(res);
+                        }
+                    });
                     responded = true;
                 }
             }
@@ -198,7 +202,11 @@ public final class TestTcpDnsServer implements AutoCloseable {
                 final DnsResponse res = new DefaultDnsResponse(query.id(), query.opCode(),
                                                                DnsResponseCode.NXDOMAIN);
                 res.addRecord(DnsSection.QUESTION, question);
-                ctx.writeAndFlush(res);
+                ctx.writeAndFlush(res).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        ReferenceCountUtil.safeRelease(res);
+                    }
+                });
             }
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.dns;
+
+import static io.netty.handler.codec.dns.DnsRecordType.A;
+import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.TransportType;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.dns.DefaultDnsQuery;
+import io.netty.handler.codec.dns.DefaultDnsRawRecord;
+import io.netty.handler.codec.dns.DefaultDnsResponse;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.handler.codec.dns.DnsSection;
+import io.netty.handler.codec.dns.TcpDnsQueryDecoder;
+import io.netty.handler.codec.dns.TcpDnsResponseEncoder;
+import io.netty.util.NetUtil;
+import io.netty.util.ReferenceCountUtil;
+
+public final class TestTcpDnsServer implements AutoCloseable {
+
+    public static DnsRecord newAddressRecord(String name, String ipAddr) {
+        return newAddressRecord(name, ipAddr, 60);
+    }
+
+    public static DnsRecord newAddressRecord(String name, String ipAddr, long ttl) {
+        return new DefaultDnsRawRecord(
+                name, NetUtil.isValidIpV4Address(ipAddr) ? A : AAAA,
+                ttl, Unpooled.unreleasableBuffer(Unpooled.wrappedBuffer(
+                NetUtil.createByteArrayFromIpAddressString(ipAddr))));
+    }
+
+    private final Channel tcpChannel;
+    private volatile Map<DnsQuestion, DnsResponse> responses;
+
+    public TestTcpDnsServer(Map<DnsQuestion, DnsResponse> responses) {
+        this(responses, null);
+    }
+
+    public TestTcpDnsServer(Map<DnsQuestion, DnsResponse> responses,
+                            @Nullable ChannelHandler beforeDnsServerHandler) {
+        this.responses = ImmutableMap.copyOf(responses);
+
+        final ServerBootstrap tcp = new ServerBootstrap();
+        tcp.channel(TransportType.serverChannelType(CommonPools.workerGroup()));
+        tcp.group(CommonPools.workerGroup());
+        tcp.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                final ChannelPipeline p = ch.pipeline();
+                p.addLast(new TcpDnsQueryDecoder());
+                p.addLast(new TcpDnsResponseEncoder());
+                if (beforeDnsServerHandler != null) {
+                    p.addLast(beforeDnsServerHandler);
+                }
+                p.addLast(new DnsServerHandler());
+            }
+        });
+
+        tcpChannel = tcp.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
+    }
+
+    public InetSocketAddress addr() {
+        return (InetSocketAddress) tcpChannel.localAddress();
+    }
+
+    public void setResponses(Map<DnsQuestion, DnsResponse> responses) {
+        this.responses.values().forEach(DnsResponse::release);
+        this.responses = ImmutableMap.copyOf(responses);
+    }
+
+    @Override
+    public void close() {
+        if (!tcpChannel.isOpen()) {
+            return;
+        }
+
+        tcpChannel.close().syncUninterruptibly();
+        responses.values().forEach(DnsResponse::release);
+    }
+
+    private class DnsServerHandler extends SimpleChannelInboundHandler<DefaultDnsQuery> {
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, DefaultDnsQuery query) {
+            final DnsQuestion question = query.recordAt(DnsSection.QUESTION, 0);
+            boolean responded = false;
+            for (Entry<DnsQuestion, DnsResponse> e : responses.entrySet()) {
+                final DnsQuestion q = e.getKey();
+                final DnsResponse r = e.getValue();
+                if (question.dnsClass() == q.dnsClass() &&
+                    question.name().equals(q.name()) &&
+                    question.type() == q.type()) {
+
+                    final DnsResponse res = new DefaultDnsResponse(query.id(), query.opCode(), r.code());
+
+                    if (r.count(DnsSection.QUESTION) == 0) {
+                        res.addRecord(DnsSection.QUESTION, question);
+                    }
+                    for (DnsSection section : DnsSection.values()) {
+                        final int count = r.count(section);
+                        for (int i = 0; i < count; i++) {
+                            res.addRecord(section, ReferenceCountUtil.retain(r.recordAt(section, i)));
+                        }
+                    }
+
+                    ctx.writeAndFlush(res);
+                    responded = true;
+                }
+            }
+
+            if (!responded) {
+                final DnsResponse res = new DefaultDnsResponse(query.id(), query.opCode(),
+                                                               DnsResponseCode.NXDOMAIN);
+                res.addRecord(DnsSection.QUESTION, question);
+                ctx.writeAndFlush(res);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

DNS over TCP configuration should be enabled by default in DNS resolvers. However, the default setting was unintentionally disabled during the implementation of #6127.

Motifications:

- Revert the default settings to re-enable TCP fallback in DNS resolver.

Result:

The default DNS resolver now correctly performs TCP fallback.
