### PR TITLE
Fix a memory leak in `DnsOverTcpTest`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsMessageUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsMessageUtil.java
@@ -13,6 +13,21 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client.endpoint.dns;
 
 import io.netty.buffer.ByteBuf;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsMessageUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsMessageUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.handler.codec.dns.DnsOpCode;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordDecoder;
+import io.netty.handler.codec.dns.DnsSection;
+
+/**
+ * Provides some utility methods for DNS message implementations.
+ */
+final class DnsMessageUtil {
+
+    // Forked from https://github.com/netty/netty/blob/d639d876aa577eea21acebaa970c8cc60644a851/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java#L28
+    // TODO(ikhoon): Remove this class once https://github.com/netty/netty/pull/15033 is merged.
+
+    static DnsQuery decodeDnsQuery(DnsRecordDecoder decoder, ByteBuf buf, DnsQueryFactory supplier)
+            throws Exception {
+        final DnsQuery query = newQuery(buf, supplier);
+        boolean success = false;
+        try {
+            final int questionCount = buf.readUnsignedShort();
+            final int answerCount = buf.readUnsignedShort();
+            final int authorityRecordCount = buf.readUnsignedShort();
+            final int additionalRecordCount = buf.readUnsignedShort();
+            decodeQuestions(decoder, query, buf, questionCount);
+            decodeRecords(decoder, query, DnsSection.ANSWER, buf, answerCount);
+            decodeRecords(decoder, query, DnsSection.AUTHORITY, buf, authorityRecordCount);
+            decodeRecords(decoder, query, DnsSection.ADDITIONAL, buf, additionalRecordCount);
+            success = true;
+            return query;
+        } finally {
+            if (!success) {
+                query.release();
+            }
+        }
+    }
+
+    private static DnsQuery newQuery(ByteBuf buf, DnsQueryFactory supplier) {
+        final int id = buf.readUnsignedShort();
+        final int flags = buf.readUnsignedShort();
+        if (flags >> 15 == 1) {
+            throw new CorruptedFrameException("not a query");
+        }
+
+        final DnsQuery query = supplier.newQuery(id, DnsOpCode.valueOf((byte) (flags >> 11 & 0xf)));
+        query.setRecursionDesired((flags >> 8 & 1) == 1);
+        query.setZ(flags >> 4 & 0x7);
+        return query;
+    }
+
+    private static void decodeQuestions(DnsRecordDecoder decoder,
+                                        DnsQuery query, ByteBuf buf, int questionCount) throws Exception {
+        for (int i = questionCount; i > 0; --i) {
+            query.addRecord(DnsSection.QUESTION, decoder.decodeQuestion(buf));
+        }
+    }
+
+    private static void decodeRecords(DnsRecordDecoder decoder, DnsQuery query, DnsSection section,
+                                      ByteBuf buf, int count) throws Exception {
+        for (int i = count; i > 0; --i) {
+            final DnsRecord r = decoder.decodeRecord(buf);
+            if (r == null) {
+                break;
+            }
+            query.addRecord(section, r);
+        }
+    }
+
+    interface DnsQueryFactory {
+        DnsQuery newQuery(int id, DnsOpCode dnsOpCode);
+    }
+
+    private DnsMessageUtil() {
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TcpDnsQueryDecoder.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TcpDnsQueryDecoder.java
@@ -13,6 +13,21 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+/*
+ * Copyright 2021 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.armeria.client.endpoint.dns;
 
 import io.netty.buffer.ByteBuf;

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TcpDnsQueryDecoder.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TcpDnsQueryDecoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client.endpoint.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.dns.DefaultDnsQuery;
+import io.netty.handler.codec.dns.DnsOpCode;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsRecordDecoder;
+import io.netty.util.internal.ObjectUtil;
+
+public final class TcpDnsQueryDecoder extends LengthFieldBasedFrameDecoder {
+    private final DnsRecordDecoder decoder;
+
+    // Forked from https://github.com/netty/netty/blob/d639d876aa577eea21acebaa970c8cc60644a851/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryDecoder.java
+    // TODO(ikhoon): Remove this class once https://github.com/netty/netty/pull/15033 is merged.
+
+    /**
+     * Creates a new decoder with {@linkplain DnsRecordDecoder#DEFAULT the default record decoder}.
+     */
+    public TcpDnsQueryDecoder() {
+        this(DnsRecordDecoder.DEFAULT, 65535);
+    }
+
+    /**
+     * Creates a new decoder with the specified {@code decoder}.
+     */
+    public TcpDnsQueryDecoder(DnsRecordDecoder decoder, int maxFrameLength) {
+        super(maxFrameLength, 0, 2, 0, 2);
+        this.decoder = ObjectUtil.checkNotNull(decoder, "decoder");
+    }
+
+    @Override
+    protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+        final ByteBuf frame = (ByteBuf) super.decode(ctx, in);
+        if (frame == null) {
+            return null;
+        }
+
+        try {
+            return DnsMessageUtil.decodeDnsQuery(decoder, frame.slice(), new DnsMessageUtil.DnsQueryFactory() {
+                @Override
+                public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
+                    return new DefaultDnsQuery(id, dnsOpCode);
+                }
+            });
+        } finally {
+            frame.release();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/TestTcpDnsServer.java
@@ -47,13 +47,11 @@ import io.netty.handler.codec.dns.DatagramDnsResponseEncoder;
 import io.netty.handler.codec.dns.DefaultDnsQuery;
 import io.netty.handler.codec.dns.DefaultDnsRawRecord;
 import io.netty.handler.codec.dns.DefaultDnsResponse;
-import io.netty.handler.codec.dns.DnsOpCode;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.handler.codec.dns.DnsSection;
-import io.netty.handler.codec.dns.TcpDnsQueryDecoder;
 import io.netty.handler.codec.dns.TcpDnsResponseEncoder;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -121,14 +119,8 @@ public final class TestTcpDnsServer implements AutoCloseable {
 
                         logger.debug("Response is too large for UDP. Fallback to TCP. query: {}", query);
                         // Create a truncated response to fallback to TCP.
-                        final DefaultDnsResponse response = new DefaultDnsResponse(query.id());
-                        response.setCode(DnsResponseCode.NOERROR);
-                        response.setOpCode(DnsOpCode.QUERY);
-                        response.setTruncated(true);
-                        response.addRecord(DnsSection.QUESTION, question);
-
                         final DatagramDnsResponse reply = new DatagramDnsResponse(
-                                query.recipient(), query.sender(), response.id());
+                                query.recipient(), query.sender(), query.id());
                         reply.setCode(DnsResponseCode.NOERROR);
                         reply.setTruncated(true);
                         reply.addRecord(DnsSection.QUESTION, question);
@@ -189,11 +181,7 @@ public final class TestTcpDnsServer implements AutoCloseable {
                         }
                     }
 
-                    ctx.writeAndFlush(res).addListener(future -> {
-                        if (!future.isSuccess()) {
-                            ReferenceCountUtil.safeRelease(res);
-                        }
-                    });
+                    ctx.writeAndFlush(res);
                     responded = true;
                 }
             }
@@ -202,11 +190,7 @@ public final class TestTcpDnsServer implements AutoCloseable {
                 final DnsResponse res = new DefaultDnsResponse(query.id(), query.opCode(),
                                                                DnsResponseCode.NXDOMAIN);
                 res.addRecord(DnsSection.QUESTION, question);
-                ctx.writeAndFlush(res).addListener(future -> {
-                    if (!future.isSuccess()) {
-                        ReferenceCountUtil.safeRelease(res);
-                    }
-                });
+                ctx.writeAndFlush(res);
             }
         }
     }


### PR DESCRIPTION
Motivation:

A memory leak was detected while running `DnsOverTcpTest`. Related: https://github.com/netty/netty/pull/15033

Modifications:

- Forked `TcpDnsQueryDecoder` and applied a patch to fix the memory leak.

Result:

Stabilize CI builds
