### PR TITLE
Fix the `VirtualHost#normalizeHostnamePattern` method to not perform unnecessary operations

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHost.java
@@ -217,10 +217,12 @@ public final class VirtualHost {
             hostnamePattern = IDN.toASCII(hostnamePattern, IDN.ALLOW_UNASSIGNED);
         }
 
-        final String withoutWildCard = hostnamePattern.startsWith("*.") ? hostnamePattern.substring(2)
-                                                                        : hostnamePattern;
-        if (!"*".equals(hostnamePattern) && !HOSTNAME_WITH_NO_PORT_PATTERN.matcher(withoutWildCard).matches()) {
-            throw new IllegalArgumentException("hostnamePattern: " + hostnamePattern);
+        if (!"*".equals(hostnamePattern)) {
+            final String withoutWildCard = hostnamePattern.startsWith("*.") ? hostnamePattern.substring(2)
+                                                                            : hostnamePattern;
+            if (!HOSTNAME_WITH_NO_PORT_PATTERN.matcher(withoutWildCard).matches()) {
+                throw new IllegalArgumentException("hostnamePattern: " + hostnamePattern);
+            }
         }
 
         return Ascii.toLowerCase(hostnamePattern);


### PR DESCRIPTION

Motivation:

I found that the `VirtualHost#normalizeHostnamePattern` method was performing unnecessary operations.

Modifications:

- Moved the code to remove the wildcard from `hostnamePattern` inside the `if then` scope.

Result:

- I expect that operations to be performed only if `hostnamePattern` is not a wildcard.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
