### PR TITLE
Fix a bug where the trailers of a streaming response was dropped by RetryingClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -394,7 +394,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
 
             derivedCtx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).thenRun(() -> {
                 if (retryConfig.needsContentInRule() && responseCause == null) {
-                    final HttpResponse response0 = HttpResponse.of(headers, splitResponse.body());
+                    final HttpResponse response0 = splitResponse.unsplit();
                     final HttpResponseDuplicator duplicator =
                             response0.toDuplicator(derivedCtx.eventLoop().withoutContext(),
                                                    derivedCtx.maxResponseLength());
@@ -426,7 +426,7 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
                         splitResponse.body().abort(responseCause);
                         response0 = HttpResponse.ofFailure(responseCause);
                     } else {
-                        response0 = HttpResponse.of(headers, splitResponse.body());
+                        response0 = splitResponse.unsplit();
                     }
                     handleResponseWithoutContent(retryConfig, ctx, rootReqDuplicator, originalReq, returnedRes,
                                                  future, derivedCtx, response0, responseCause);

--- a/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/PublisherBasedHttpResponse.java
@@ -27,14 +27,10 @@ import com.linecorp.armeria.internal.common.stream.SurroundingPublisher;
 
 final class PublisherBasedHttpResponse extends PublisherBasedStreamMessage<HttpObject> implements HttpResponse {
 
-    static PublisherBasedHttpResponse from(ResponseHeaders headers, Publisher<? extends HttpObject> publisher) {
-        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, unused -> null));
-    }
-
     static PublisherBasedHttpResponse from(ResponseHeaders headers,
                                            Publisher<? extends HttpData> publisher,
                                            Function<@Nullable Throwable, HttpHeaders> trailersFunction) {
-        return new PublisherBasedHttpResponse(new SurroundingPublisher<>(headers, publisher, trailersFunction));
+        return new PublisherBasedHttpResponse(SurroundingPublisher.of(headers, publisher, trailersFunction));
     }
 
     PublisherBasedHttpResponse(Publisher<? extends HttpObject> publisher) {

--- a/core/src/main/java/com/linecorp/armeria/common/SplitHttpMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SplitHttpMessage.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.stream.ByteStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 
@@ -41,4 +42,12 @@ public interface SplitHttpMessage {
      * returned {@link CompletableFuture} will be completed with an {@linkplain HttpHeaders#of() empty headers}.
      */
     CompletableFuture<HttpHeaders> trailers();
+
+    /**
+     * Combines the split {@link #body()}, {@link #trailers()} into a single {@link HttpMessage}.
+     *
+     * <p>Note that this method can only be used before subscribing to {@link #body()}.
+     */
+    @UnstableApi
+    HttpMessage unsplit();
 }

--- a/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/StreamMessage.java
@@ -1192,7 +1192,7 @@ public interface StreamMessage<T> extends Publisher<T> {
      */
     @UnstableApi
     default StreamMessage<T> endWith(Function<@Nullable Throwable, ? extends @Nullable T> finalizer) {
-        return new SurroundingPublisher<>(null, this, finalizer);
+        return SurroundingPublisher.of(null, this, finalizer);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
@@ -72,7 +72,7 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
     }
 
     public static <T> SurroundingPublisher<T> of(@Nullable T head, Publisher<? extends T> publisher,
-                                                 CompletableFuture<? extends T> tail) {
+                                                 CompletableFuture<? extends @Nullable T> tail) {
         // The tail is ignored when the cause is not null.
         return new SurroundingPublisher<>(head, publisher, cause -> cause != null ? null : tail);
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisher.java
@@ -39,6 +39,7 @@ import com.linecorp.armeria.common.stream.PublisherBasedStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.SubscriptionOption;
 import com.linecorp.armeria.common.util.EventLoopCheckingFuture;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 
 import io.netty.util.concurrent.EventExecutor;
 
@@ -50,10 +51,36 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
     private static final AtomicIntegerFieldUpdater<SurroundingPublisher> subscribedUpdater =
             AtomicIntegerFieldUpdater.newUpdater(SurroundingPublisher.class, "subscribed");
 
+    public static <T> SurroundingPublisher<T> of(@Nullable T head, Publisher<? extends T> publisher, T tail) {
+        // The tail is ignored when the cause is not null.
+        return of(head, publisher, cause -> cause != null ? null : tail);
+    }
+
+    public static <T> SurroundingPublisher<T> of(
+            @Nullable T head, Publisher<? extends T> publisher,
+            Function<@Nullable Throwable, ? extends @Nullable T> finalizer) {
+        requireNonNull(finalizer, "finalizer");
+        final Function<@Nullable Throwable, @Nullable CompletableFuture<T>> asyncFinalizer = cause -> {
+            final T tail = finalizer.apply(cause);
+            if (tail == null) {
+                return null;
+            } else {
+                return UnmodifiableFuture.completedFuture(tail);
+            }
+        };
+        return new SurroundingPublisher<>(head, publisher, asyncFinalizer);
+    }
+
+    public static <T> SurroundingPublisher<T> of(@Nullable T head, Publisher<? extends T> publisher,
+                                                 CompletableFuture<? extends T> tail) {
+        // The tail is ignored when the cause is not null.
+        return new SurroundingPublisher<>(head, publisher, cause -> cause != null ? null : tail);
+    }
+
     @Nullable
     private final T head;
     private final StreamMessage<T> publisher;
-    private final Function<@Nullable Throwable, ? extends @Nullable T> finalizer;
+    private final Function<@Nullable Throwable, ? extends @Nullable CompletableFuture<T>> finalizer;
 
     private volatile int subscribed;
     private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
@@ -61,8 +88,9 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
     @Nullable
     private volatile SurroundingSubscriber<T> surroundingSubscriber;
 
-    public SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher,
-                                Function<@Nullable Throwable, ? extends @Nullable T> finalizer) {
+    SurroundingPublisher(@Nullable T head, Publisher<? extends T> publisher,
+                         Function<@Nullable Throwable,
+                                 ? extends @Nullable CompletableFuture<? extends T>> finalizer) {
         requireNonNull(publisher, "publisher");
         requireNonNull(finalizer, "finalizer");
         this.head = head;
@@ -72,7 +100,8 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
         } else {
             this.publisher = new PublisherBasedStreamMessage<>(publisher);
         }
-        this.finalizer = finalizer;
+        //noinspection unchecked
+        this.finalizer = (Function<Throwable, ? extends CompletableFuture<T>>) finalizer;
     }
 
     @Override
@@ -190,7 +219,7 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
         @Nullable
         private T head;
         private final StreamMessage<T> publisher;
-        private final Function<@Nullable Throwable, ? extends @Nullable T> finalizer;
+        private final Function<@Nullable Throwable, ? extends @Nullable CompletableFuture<T>> finalizer;
 
         private Subscriber<? super T> downstream;
         private final EventExecutor executor;
@@ -206,7 +235,7 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
         private final SubscriptionOption[] options;
 
         SurroundingSubscriber(@Nullable T head, StreamMessage<T> publisher,
-                              Function<@Nullable Throwable, ? extends @Nullable T> finalizer,
+                              Function<@Nullable Throwable, ? extends @Nullable CompletableFuture<T>> finalizer,
                               Subscriber<? super T> downstream, EventExecutor executor,
                               CompletableFuture<Void> completionFuture, SubscriptionOption... options) {
             requireNonNull(publisher, "publisher");
@@ -305,9 +334,9 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
         }
 
         private void finalize(@Nullable Throwable cause) {
-            final T tail;
+            final CompletableFuture<T> tailFuture;
             try {
-                tail = finalizer.apply(cause);
+                tailFuture = finalizer.apply(cause);
             } catch (Throwable ex) {
                 if (cause != null) {
                     logger.warn("Unexpected exception from finalizer:", ex);
@@ -318,11 +347,28 @@ public final class SurroundingPublisher<T> implements StreamMessage<T> {
                 return;
             }
 
-            if (tail == null) {
+            if (tailFuture == null) {
                 // Immediately close the stream if the finalizer returns null.
                 close0(cause);
             } else {
-                downstream.onNext(tail);
+                tailFuture.handle((tail, cause0) -> {
+                    if (executor.inEventLoop()) {
+                        handleTail(tail, cause0);
+                    } else {
+                        executor.execute(() -> handleTail(tail, cause0));
+                    }
+                    return null;
+                });
+            }
+        }
+
+        private void handleTail(@Nullable T tail, @Nullable Throwable cause) {
+            if (cause != null) {
+                close0(cause);
+            } else {
+                if (tail != null) {
+                    downstream.onNext(tail);
+                }
                 close0(null);
             }
         }

--- a/core/src/test/java/com/linecorp/armeria/common/SplitHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/SplitHttpMessageTest.java
@@ -67,7 +67,6 @@ class SplitHttpMessageTest {
                     .verify();
     }
 
-
     @Test
     void unsplit_request_emptyTrailers() {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/foo",
@@ -127,7 +126,6 @@ class SplitHttpMessageTest {
                     .expectComplete()
                     .verify();
     }
-
 
     @Test
     void unsplit_response_failed() {

--- a/core/src/test/java/com/linecorp/armeria/common/SplitHttpMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/SplitHttpMessageTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.internal.testing.AnticipatedException;
+
+import reactor.test.StepVerifier;
+
+class SplitHttpMessageTest {
+
+    @Test
+    void unsplit_request_trailers() {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/foo",
+                                                         HttpHeaderNames.CONTENT_LENGTH, 11);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpHeaders trailers = HttpHeaders.of("foo", "bar");
+        final HttpRequest request = HttpRequest.of(headers, body, trailers);
+        final SplitHttpRequest split = request.split();
+        assertThat(split.headers()).isEqualTo(headers);
+
+        final HttpRequest unsplit = split.unsplit();
+        assertThat(unsplit.headers()).isEqualTo(headers);
+        StepVerifier.create(unsplit)
+                    .expectNext(HttpData.ofUtf8("Hello "))
+                    .expectNext(HttpData.ofUtf8("World"))
+                    .expectNext(trailers)
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void unsplit_failed_request() {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/foo",
+                                                         HttpHeaderNames.CONTENT_LENGTH, 11);
+        final StreamMessage<HttpData> body = StreamMessage.aborted(new AnticipatedException("Failed!"));
+        final HttpRequest request = HttpRequest.of(headers, body);
+        final SplitHttpRequest split = request.split();
+
+        final HttpRequest unsplit = split.unsplit();
+        assertThat(unsplit.headers()).isEqualTo(headers);
+        StepVerifier.create(unsplit)
+                    .expectErrorSatisfies(t -> {
+                        assertThat(t)
+                                .hasMessageContaining("Failed!")
+                                .isInstanceOf(AnticipatedException.class);
+                    })
+                    .verify();
+    }
+
+
+    @Test
+    void unsplit_request_emptyTrailers() {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/foo",
+                                                         HttpHeaderNames.CONTENT_LENGTH, 11);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpRequest request = HttpRequest.of(headers, body);
+        final SplitHttpRequest split = request.split();
+        assertThat(split.headers()).isEqualTo(headers);
+
+        final HttpRequest unsplit = split.unsplit();
+        assertThat(unsplit.headers()).isEqualTo(headers);
+        StepVerifier.create(unsplit)
+                    .expectNext(HttpData.ofUtf8("Hello "))
+                    .expectNext(HttpData.ofUtf8("World"))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void unsplit_request_subscribed() {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/foo",
+                                                         HttpHeaderNames.CONTENT_LENGTH, 11);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpRequest request = HttpRequest.of(headers, body);
+        final SplitHttpRequest split = request.split();
+        split.body().collect();
+
+        final HttpRequest unsplit = split.unsplit();
+        assertThat(unsplit.headers()).isEqualTo(headers);
+        StepVerifier.create(unsplit)
+                    .expectErrorSatisfies(t -> {
+                        assertThat(t)
+                                .hasMessageContaining("Only single subscriber is allowed")
+                                .isInstanceOf(IllegalStateException.class);
+                    })
+                    .verify();
+    }
+
+    @Test
+    void unsplit_response_trailers() {
+        final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpHeaders trailers = HttpHeaders.of("foo", "bar");
+        final HttpResponse response = HttpResponse.of(headers, body, trailers);
+        final SplitHttpResponse split = response.split();
+        assertThat(split.headers().join()).isEqualTo(headers);
+
+        final HttpResponse unsplit = split.unsplit();
+        StepVerifier.create(unsplit)
+                    .expectNext(headers)
+                    .expectNext(HttpData.ofUtf8("Hello "))
+                    .expectNext(HttpData.ofUtf8("World"))
+                    .expectNext(trailers)
+                    .expectComplete()
+                    .verify();
+    }
+
+
+    @Test
+    void unsplit_response_failed() {
+        final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK);
+        final StreamMessage<HttpData> body = StreamMessage.aborted(new AnticipatedException("Failed!"));
+        final HttpHeaders trailers = HttpHeaders.of("foo", "bar");
+        final HttpResponse response = HttpResponse.of(headers, body, trailers);
+        final SplitHttpResponse split = response.split();
+        assertThat(split.headers().join()).isEqualTo(headers);
+
+        final HttpResponse unsplit = split.unsplit();
+        StepVerifier.create(unsplit)
+                    .expectNext(headers)
+                    .expectErrorSatisfies(t -> {
+                        assertThat(t)
+                                .hasMessageContaining("Failed!")
+                                .isInstanceOf(AnticipatedException.class);
+                    })
+                    .verify();
+    }
+
+    @Test
+    void unsplit_response_emptyTrailers() {
+        final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpResponse response = HttpResponse.of(headers, body);
+        final SplitHttpResponse split = response.split();
+        assertThat(split.headers().join()).isEqualTo(headers);
+
+        final HttpResponse unsplit = split.unsplit();
+        StepVerifier.create(unsplit)
+                    .expectNext(headers)
+                    .expectNext(HttpData.ofUtf8("Hello "))
+                    .expectNext(HttpData.ofUtf8("World"))
+                    .expectComplete()
+                    .verify();
+    }
+
+    @Test
+    void unsplit_response_subscribed() {
+        final ResponseHeaders headers = ResponseHeaders.of(HttpStatus.OK);
+        final StreamMessage<HttpData> body = StreamMessage.of(HttpData.ofUtf8("Hello "),
+                                                              HttpData.ofUtf8("World"));
+        final HttpResponse response = HttpResponse.of(headers, body);
+        final SplitHttpResponse split = response.split();
+        assertThat(split.headers().join()).isEqualTo(headers);
+        split.body().collect();
+
+        final HttpResponse unsplit = split.unsplit();
+        StepVerifier.create(unsplit)
+                    .expectNext(headers)
+                    .expectErrorSatisfies(t -> {
+                        assertThat(t)
+                                .hasMessageContaining("Only single subscriber is allowed")
+                                .isInstanceOf(IllegalStateException.class);
+                    })
+                    .verify();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTckTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/stream/SurroundingPublisherTckTest.java
@@ -44,18 +44,18 @@ public class SurroundingPublisherTckTest extends StreamMessageVerification<Objec
     @Override
     public StreamMessage<Object> createPublisher(long elements) {
         if (elements == 0) {
-            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), unused -> null);
+            final StreamMessage<Object> publisher = SurroundingPublisher.of(null, Mono.empty(), unused -> null);
             // `SurroundingPublisher` doesn't check head, tail, publisher's availability before subscribed so manually set complete.
             publisher.whenComplete().complete(null);
             return publisher;
         }
         if (elements == 1) {
-            return new SurroundingPublisher<>("head", Mono.empty(), unused -> null);
+            return SurroundingPublisher.of("head", Mono.empty(), unused -> null);
         }
         if (elements == 2) {
-            return new SurroundingPublisher<>(null, Mono.just(1), unused -> "tail");
+            return SurroundingPublisher.of(null, Mono.just(1), unused -> "tail");
         }
-        return new SurroundingPublisher<>("head", Flux.fromStream(LongStream.range(0, elements - 2).boxed()), unused -> "tail");
+        return SurroundingPublisher.of("head", Flux.fromStream(LongStream.range(0, elements - 2).boxed()), unused -> "tail");
     }
 
     /**
@@ -71,13 +71,13 @@ public class SurroundingPublisherTckTest extends StreamMessageVerification<Objec
      */
     @Override
     public StreamMessage<Object> createFailedPublisher() {
-        return new SurroundingPublisher<>(null, Mono.error(new RuntimeException()), unused -> null);
+        return SurroundingPublisher.of(null, Mono.error(new RuntimeException()), unused -> null);
     }
 
     @Override
     public @Nullable StreamMessage<Object> createAbortedPublisher(long elements) {
         if (elements == 0) {
-            final StreamMessage<Object> publisher = new SurroundingPublisher<>(null, Mono.empty(), unused -> null);
+            final StreamMessage<Object> publisher = SurroundingPublisher.of(null, Mono.empty(), unused -> null);
             publisher.abort();
             return publisher;
         }

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientRetryTest.java
@@ -16,16 +16,26 @@
 package com.linecorp.armeria.client.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.retry.RetryRule;
 import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.HttpResponse;
@@ -37,13 +47,22 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.grpc.Status;
 import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import testing.grpc.Messages.Payload;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
+import testing.grpc.Messages.StreamingInputCallRequest;
+import testing.grpc.Messages.StreamingInputCallResponse;
+import testing.grpc.Messages.StreamingOutputCallRequest;
+import testing.grpc.Messages.StreamingOutputCallResponse;
 import testing.grpc.TestServiceGrpc;
 import testing.grpc.TestServiceGrpc.TestServiceBlockingStub;
+import testing.grpc.TestServiceGrpc.TestServiceStub;
 
 final class GrpcClientRetryTest {
+
+    private static final AtomicInteger retryCounter = new AtomicInteger();
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -54,6 +73,11 @@ final class GrpcClientRetryTest {
                                   .build());
         }
     };
+
+    @BeforeEach
+    void setUp() {
+        retryCounter.set(0);
+    }
 
     @Test
     void childrenContextsHaveSameRpcRequest() {
@@ -74,6 +98,211 @@ final class GrpcClientRetryTest {
         }
     }
 
+    @Test
+    void retry_streamingOutputCall_withoutTrailers() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(RetryRule.failsafe()))
+                           .build(TestServiceBlockingStub.class);
+        final Iterator<StreamingOutputCallResponse> res =
+                client.streamingOutputCall(StreamingOutputCallRequest.getDefaultInstance());
+        assertThatThrownBy(res::next)
+                .isInstanceOf(StatusRuntimeException.class)
+                .hasMessageContaining("INTERNAL");
+        assertThat(retryCounter).hasValue(1);
+    }
+
+    @Test
+    void retry_streamingOutputCall_withTrailers() {
+        final TestServiceBlockingStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(retryRuleWithContent()))
+                           .build(TestServiceBlockingStub.class);
+        final Iterator<StreamingOutputCallResponse> res =
+                client.streamingOutputCall(StreamingOutputCallRequest.getDefaultInstance());
+        int count = 0;
+        while (res.hasNext()) {
+            final StreamingOutputCallResponse next = res.next();
+            assertThat(next.getPayload().getTypeValue()).isEqualTo(++count);
+        }
+        assertThat(count).isEqualTo(2);
+        assertThat(retryCounter).hasValue(3);
+    }
+
+    @Test
+    void retry_streamingInputCall_withoutTrailers() {
+        final TestServiceStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(RetryRule.failsafe()))
+                           .build(TestServiceStub.class);
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final StreamObserver<StreamingInputCallRequest> req =
+                client.streamingInputCall(new StreamObserver<StreamingInputCallResponse>() {
+                    @Override
+                    public void onNext(StreamingInputCallResponse message) {}
+
+                    @Override
+                    public void onError(Throwable t) {
+                        causeRef.set(t);
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                });
+
+        req.onNext(StreamingInputCallRequest.newBuilder()
+                                            .setPayload(Payload.newBuilder()
+                                                               .setBody(ByteString.copyFromUtf8("12345"))
+                                                               .build())
+                                            .build());
+
+        req.onNext(StreamingInputCallRequest.newBuilder()
+                                            .setPayload(Payload.newBuilder()
+                                                               .setBody(ByteString.copyFromUtf8("123456"))
+                                                               .build())
+                                            .build());
+        req.onCompleted();
+
+        await().untilAsserted(() -> {
+            final Throwable cause = causeRef.get();
+            assertThat(cause).isInstanceOf(StatusRuntimeException.class)
+                             .hasMessageContaining("INTERNAL");
+        });
+        assertThat(retryCounter).hasValue(1);
+    }
+
+    @Test
+    void retry_streamingInputCall_withTrailers() {
+        final TestServiceStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(retryRuleWithContent()))
+                           .build(TestServiceStub.class);
+        final AtomicInteger payloadSize = new AtomicInteger();
+        final AtomicBoolean completed = new AtomicBoolean();
+        final StreamObserver<StreamingInputCallRequest> req =
+                client.streamingInputCall(new StreamObserver<StreamingInputCallResponse>() {
+                    @Override
+                    public void onNext(StreamingInputCallResponse message) {
+                        payloadSize.set(message.getAggregatedPayloadSize());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onCompleted() {
+                        completed.set(true);
+                    }
+                });
+
+        req.onNext(StreamingInputCallRequest.newBuilder()
+                                            .setPayload(Payload.newBuilder()
+                                                               .setBody(ByteString.copyFromUtf8("12345"))
+                                                               .build())
+                                            .build());
+
+        req.onNext(StreamingInputCallRequest.newBuilder()
+                                            .setPayload(Payload.newBuilder()
+                                                               .setBody(ByteString.copyFromUtf8("123456"))
+                                                               .build())
+                                            .build());
+        req.onCompleted();
+
+        await().untilTrue(completed);
+        assertThat(payloadSize).hasValue(11);
+        assertThat(retryCounter).hasValue(3);
+    }
+
+    @Test
+    void retry_fullDuplex_withoutTrailers() {
+        final TestServiceStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(RetryRule.failsafe()))
+                           .build(TestServiceStub.class);
+        final List<String> responses = new ArrayList<>();
+        final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+        final StreamObserver<StreamingOutputCallRequest> req =
+                client.fullDuplexCall(new StreamObserver<StreamingOutputCallResponse>() {
+                    @Override
+                    public void onNext(StreamingOutputCallResponse message) {
+                        responses.add(message.getPayload().getBody().toStringUtf8());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        causeRef.set(t);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                    }
+                });
+
+        req.onNext(StreamingOutputCallRequest.newBuilder()
+                                             .setPayload(Payload.newBuilder()
+                                                                .setBody(ByteString.copyFromUtf8("12345"))
+                                                                .build())
+                                             .build());
+
+        req.onNext(StreamingOutputCallRequest.newBuilder()
+                                             .setPayload(Payload.newBuilder()
+                                                                .setBody(ByteString.copyFromUtf8("67890"))
+                                                                .build())
+                                             .build());
+        req.onCompleted();
+
+        await().untilAsserted(() -> {
+            final Throwable cause = causeRef.get();
+            assertThat(cause).isInstanceOf(StatusRuntimeException.class)
+                             .hasMessageContaining("INTERNAL");
+        });
+        // 200 status is returned for the first request.
+        assertThat(retryCounter).hasValue(1);
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    void retry_fullDuplex_withTrailers() {
+        final TestServiceStub client =
+                GrpcClients.builder(server.httpUri())
+                           .decorator(RetryingClient.newDecorator(retryRuleWithContent()))
+                           .build(TestServiceStub.class);
+        final List<String> responses = new ArrayList<>();
+        final AtomicBoolean completed = new AtomicBoolean();
+        final StreamObserver<StreamingOutputCallRequest> req =
+                client.fullDuplexCall(new StreamObserver<StreamingOutputCallResponse>() {
+                    @Override
+                    public void onNext(StreamingOutputCallResponse message) {
+                        responses.add(message.getPayload().getBody().toStringUtf8());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onCompleted() {
+                        completed.set(true);
+                    }
+                });
+
+        req.onNext(StreamingOutputCallRequest.newBuilder()
+                                             .setPayload(Payload.newBuilder()
+                                                                .setBody(ByteString.copyFromUtf8("12345"))
+                                                                .build())
+                                             .build());
+
+        req.onNext(StreamingOutputCallRequest.newBuilder()
+                                             .setPayload(Payload.newBuilder()
+                                                                .setBody(ByteString.copyFromUtf8("67890"))
+                                                                .build())
+                                             .build());
+        req.onCompleted();
+
+        await().untilTrue(completed);
+        assertThat(responses).containsExactly("12345", "67890");
+        assertThat(retryCounter).hasValue(3);
+    }
+
     private static RetryRuleWithContent<HttpResponse> retryRuleWithContent() {
         return RetryRuleWithContent
                 .<HttpResponse>builder()
@@ -82,8 +311,6 @@ final class GrpcClientRetryTest {
     }
 
     private static class TestServiceImpl extends TestServiceGrpc.TestServiceImplBase {
-
-        private final AtomicInteger retryCounter = new AtomicInteger();
 
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
@@ -100,6 +327,109 @@ final class GrpcClientRetryTest {
                     responseObserver.onCompleted();
                     break;
             }
+        }
+
+        @Override
+        public void streamingOutputCall(StreamingOutputCallRequest request,
+                                        StreamObserver<StreamingOutputCallResponse> responseObserver) {
+            switch (retryCounter.getAndIncrement()) {
+                case 0:
+                    responseObserver.onError(new StatusException(Status.INTERNAL));
+                    break;
+                case 1:
+                    responseObserver.onNext(
+                            StreamingOutputCallResponse.newBuilder()
+                                                       .setPayload(Payload.newBuilder().setTypeValue(1))
+                                                       .build());
+                    responseObserver.onError(new StatusException(Status.INTERNAL));
+                    break;
+                default:
+                    responseObserver.onNext(
+                            StreamingOutputCallResponse.newBuilder()
+                                                       .setPayload(Payload.newBuilder().setTypeValue(1))
+                                                       .build());
+                    responseObserver.onNext(
+                            StreamingOutputCallResponse.newBuilder()
+                                                       .setPayload(Payload.newBuilder().setTypeValue(2))
+                                                       .build());
+                    responseObserver.onCompleted();
+                    break;
+            }
+        }
+
+        @Override
+        public StreamObserver<StreamingInputCallRequest> streamingInputCall(
+                StreamObserver<StreamingInputCallResponse> responseObserver) {
+
+            return new StreamObserver<StreamingInputCallRequest>() {
+                private int totalPayloadSize;
+
+                @Override
+                public void onNext(StreamingInputCallRequest message) {
+                    totalPayloadSize += message.getPayload().getBody().size();
+                }
+
+                @Override
+                public void onCompleted() {
+                    switch (retryCounter.getAndIncrement()) {
+                        case 0:
+                            responseObserver.onError(new StatusException(Status.INTERNAL));
+                            break;
+                        case 1:
+                            responseObserver.onNext(StreamingInputCallResponse.newBuilder()
+                                                                              .setAggregatedPayloadSize(
+                                                                                      totalPayloadSize)
+                                                                              .build());
+                            responseObserver.onError(new StatusException(Status.INTERNAL));
+                            break;
+                        default:
+                            responseObserver.onNext(StreamingInputCallResponse.newBuilder()
+                                                                              .setAggregatedPayloadSize(
+                                                                                      totalPayloadSize)
+                                                                              .build());
+                            responseObserver.onCompleted();
+                            break;
+                    }
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    responseObserver.onError(cause);
+                }
+            };
+        }
+
+        @Override
+        public StreamObserver<StreamingOutputCallRequest> fullDuplexCall(
+                StreamObserver<StreamingOutputCallResponse> responseObserver) {
+            final int retryCount = retryCounter.getAndIncrement();
+            return new StreamObserver<StreamingOutputCallRequest>() {
+
+                @Override
+                public void onNext(StreamingOutputCallRequest message) {
+                    if (retryCount == 0) {
+                        responseObserver.onError(new StatusException(Status.INTERNAL));
+                    } else {
+                        responseObserver.onNext(StreamingOutputCallResponse.newBuilder()
+                                                                           .setPayload(message.getPayload())
+                                                                           .build());
+                    }
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    responseObserver.onError(cause);
+                }
+
+                @Override
+                public void onCompleted() {
+                    if (retryCount == 1) {
+                        responseObserver.onError(new StatusException(Status.INTERNAL));
+                    } else {
+                        responseObserver.onCompleted();
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Motivation:

During the implementation of #5714, `HttpResponse.split()` was used to extract the headers from a streaming response. After applying a `RetryRule`, the new response was reconstructed in
https://github.com/line/armeria/blob/3a35abe68c80c0af8594600ce677df49e09a9e0e/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java#L429 
However, because `SplitHttpResponse.body()` only publishes the data payloads and handles trailers separately, the trailers was missing in the reconstructed response, leading to a bug.

Modifications:

- Fixed `SurroundingPublisher` to allow the last element to be emitted asynchronously.
- Added `SplitHttpRequest.unsplit()` and `SplitHttpResponse.unsplit()` to re-create an `HttpResponse` from the split headers, body and trailers.
- Fixed `RetryingClient` to use `.unsplit()` for deliveriong trailers correctly.

Result:

Fix a regression where RetryingClient dropped trailers of streaming responses (since 1.32.4)
