### PR TITLE
Fix a race condition in CompositeEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java
@@ -83,7 +83,8 @@ final class CompositeEndpointGroup extends AbstractEndpointGroup implements List
     }
 
     private List<Endpoint> rebuildEndpoints() {
-        while (true) {
+        for (;;) {
+            // Get the current endpoints before making a new endpoints list.
             final List<Endpoint> oldEndpoints = merged.get();
             final ImmutableList.Builder<Endpoint> newEndpointsBuilder = ImmutableList.builder();
             for (EndpointGroup endpointGroup : endpointGroups) {
@@ -93,6 +94,7 @@ final class CompositeEndpointGroup extends AbstractEndpointGroup implements List
             if (merged.compareAndSet(oldEndpoints, newEndpoints)) {
                 return newEndpoints;
             }
+            // Changed by another thread while we were building a new one. Try again.
         }
     }
 


### PR DESCRIPTION
Motivation:
`CompositeEndpointGroup` has a race condition that can occur when multiple child `EndpointGroup`s notify listeners at the same time from different threads. Consider the following sequence of events involving two groups, A and B:

1. A's listener is invoked by thread A. https://github.com/line/armeria/blob/2367de299f71478bd93a618bd40b70a3676656c0/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java#L64
2. Thread A sets `dirty = true`. https://github.com/line/armeria/blob/2367de299f71478bd93a618bd40b70a3676656c0/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java#L65
3. Thread A sets `dirty = false`. https://github.com/line/armeria/blob/2367de299f71478bd93a618bd40b70a3676656c0/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java#L89
4. Thread A builds `newEndpointsA`. https://github.com/line/armeria/blob/2367de299f71478bd93a618bd40b70a3676656c0/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java#L95-L98
5. B's listener is invoked by thread B.
6. Thread B sets `dirty = true`.
7. Thread B sets `dirty = false`.
8. Thread B builds `newEndpointsB` (which includes latest data from both A and B) and sets it.
9. Thread A sets the `newEndpointsA`, which does not contain updates from B. https://github.com/line/armeria/blob/2367de299f71478bd93a618bd40b70a3676656c0/core/src/main/java/com/linecorp/armeria/client/endpoint/CompositeEndpointGroup.java#L100

This results in stale endpoints being set, despite a newer state already being computed and applied.

Modifications:
- Fixed the race condition in `CompositeEndpointGroup`.

Result:
- `CompositeEndpointGroup` now handles concurrent updates correctly.

Motivation:

Explain why you're making this change and what problem you're trying to solve.

Modifications:

- List the modifications you've made in detail.

Result:

- Closes #<GitHub issue number>. (If this resolves the issue.)
- Describe the consequences that a user will face after this PR is merged.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
