### PR TITLE
Allow style customization in the documentation service

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceBuilder.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -61,6 +62,7 @@ public final class DocServiceBuilder {
     private final Map<String, ListMultimap<String, String>> exampleQueries = new HashMap<>();
     private final List<BiFunction<ServiceRequestContext, HttpRequest, String>> injectedScriptSuppliers =
             new ArrayList<>();
+    private final Map<String, String> docServiceExtraInfo = new HashMap<>();
 
     @Nullable
     private DescriptiveTypeInfoProvider descriptiveTypeInfoProvider;
@@ -552,11 +554,91 @@ public final class DocServiceBuilder {
     }
 
     /**
+     * Sets the title of the web application to be used in the documentation service.
+     * @param webAppTitle  * The title cannot be null, empty, or exceed a maximum length of 50 characters.
+     * @return The current {@link DocServiceBuilder} instance for method chaining.
+     */
+    public DocServiceBuilder webAppTitle(String webAppTitle) {
+        final String webAppTitleKey = "webAppTitle";
+        final Integer webAppTitleMaxSize = 50;
+        final String webAppTitlePattern = "<[^>]*>";
+        requireNonNull(webAppTitle, webAppTitleKey);
+        checkArgument(!webAppTitle.trim().isEmpty(), "%s is empty.", webAppTitleKey);
+        checkArgument(webAppTitle.length() <= webAppTitleMaxSize,
+                      "%s length exceeds %s.", webAppTitleKey, webAppTitleMaxSize);
+        final String webAppTitlePatternSanitized = Pattern.compile(webAppTitlePattern).matcher(webAppTitle)
+                                                          .replaceAll("").trim();
+        docServiceExtraInfo.putIfAbsent(webAppTitleKey, webAppTitlePatternSanitized);
+        return this;
+    }
+
+    /**
+     * Sets the header bar background color of the web application to be used in the documentation service.
+     * @param headerBarBackgroundColor The hexadecimal color code for the header bar background.
+     *     Must not be null or empty, and must match the pattern "#RRGGBB".
+     * @return The current {@link DocServiceBuilder} instance for method chaining.
+     */
+    public DocServiceBuilder headerBarBackgroundColor(String headerBarBackgroundColor) {
+        final String headerBarBackgroundColorKey = "headerBarBackgroundColor";
+        final Integer headerBarBackgroundColorMaxSize = 7;
+        final String hexColorPattern = "^#([0-9a-fA-F]{6})$";
+        requireNonNull(headerBarBackgroundColor, headerBarBackgroundColorKey);
+        checkArgument(!headerBarBackgroundColor.trim().isEmpty(), "%s is empty.", headerBarBackgroundColorKey);
+        checkArgument(headerBarBackgroundColor.length() <= headerBarBackgroundColorMaxSize,
+                      "%s length exceeds %s.", headerBarBackgroundColorKey, headerBarBackgroundColorMaxSize);
+        checkArgument(Pattern.compile(hexColorPattern).matcher(headerBarBackgroundColor).matches(),
+                      "%s not in hex format: %s.", headerBarBackgroundColorKey, headerBarBackgroundColor);
+        docServiceExtraInfo.putIfAbsent(headerBarBackgroundColorKey, headerBarBackgroundColor);
+        return this;
+    }
+
+    /**
+     * Sets the background color of the 'Goto' header bar component used in the documentation service.
+     * @param headerGotoBackgroundColor The hexadecimal color code
+     *     Must not be null or empty, and must match the pattern "#RRGGBB".
+     * @return The current {@link DocServiceBuilder} instance for method chaining.
+     */
+    public DocServiceBuilder headerGotoBackgroundColor(String headerGotoBackgroundColor) {
+        final String headerGotoBackgroundColorKey = "headerGotoBackgroundColor";
+        final Integer headerGotoBackgroundColorMaxSize = 7;
+        final String hexColorPattern = "^#([0-9a-fA-F]{6})$";
+        requireNonNull(headerGotoBackgroundColor, headerGotoBackgroundColorKey);
+        checkArgument(!headerGotoBackgroundColor.trim().isEmpty(),
+                      "%s is empty.", headerGotoBackgroundColorKey);
+        checkArgument(headerGotoBackgroundColor.length() <= headerGotoBackgroundColorMaxSize,
+                      "%s length exceeds %s.", headerGotoBackgroundColorKey, headerGotoBackgroundColorMaxSize);
+        checkArgument(Pattern.compile(hexColorPattern).matcher(headerGotoBackgroundColor).matches(),
+                      "%s not in hex format: %s.", headerGotoBackgroundColorKey, headerGotoBackgroundColor);
+        docServiceExtraInfo.putIfAbsent(headerGotoBackgroundColorKey, headerGotoBackgroundColor);
+        return this;
+    }
+
+    /**
+     * Sets the buttons color of the 'DebugPage' component used in the documentation service.
+     * @param debugFormButtonsColor The hexadecimal color code
+     *     Must not be null or empty, and must match the pattern "#RRGGBB".
+     * @return The current {@link DocServiceBuilder} instance for method chaining.
+     */
+    public DocServiceBuilder debugFormButtonsColor(String debugFormButtonsColor) {
+        final String debugFormButtonsColorKey = "debugFormButtonsColor";
+        final Integer debugFormButtonsColorMaxSize = 7;
+        final String hexColorPattern = "^#([0-9a-fA-F]{6})$";
+        requireNonNull(debugFormButtonsColor, debugFormButtonsColorKey);
+        checkArgument(!debugFormButtonsColor.trim().isEmpty(), "%s is empty.", debugFormButtonsColorKey);
+        checkArgument(debugFormButtonsColor.length() <= debugFormButtonsColorMaxSize,
+                      "%s length exceeds %s.", debugFormButtonsColorKey, debugFormButtonsColorMaxSize);
+        checkArgument(Pattern.compile(hexColorPattern).matcher(debugFormButtonsColor).matches(),
+                      "%s not in hex format: %s.", debugFormButtonsColorKey, debugFormButtonsColor);
+        docServiceExtraInfo.putIfAbsent(debugFormButtonsColorKey, debugFormButtonsColor);
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link DocService} based on the properties of this builder.
      */
     public DocService build() {
         return new DocService(exampleHeaders, exampleRequests, examplePaths, exampleQueries,
                               injectedScriptSuppliers, unifyFilter(includeFilter, excludeFilter),
-                              descriptiveTypeInfoProvider);
+                              descriptiveTypeInfoProvider, docServiceExtraInfo);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecification.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecification.java
@@ -128,6 +128,8 @@ public final class ServiceSpecification {
     private final Set<StructInfo> structs;
     private final Set<ExceptionInfo> exceptions;
     private final List<HttpHeaders> exampleHeaders;
+    private Map<String, String> docServiceExtraInfo = new HashMap<>();
+
     @Nullable
     private final Route docServiceRoute;
 
@@ -248,5 +250,21 @@ public final class ServiceSpecification {
     @Nullable
     public Route docServiceRoute() {
         return docServiceRoute;
+    }
+
+    /**
+     * Returns the extra info in this specification.
+     */
+    @JsonProperty
+    public Map<String, String> docServiceExtraInfo() {
+        return docServiceExtraInfo;
+    }
+
+    /**
+     *  * Sets the additional information for the document service.
+     * @param docServiceExtraInfo a map containing the extra information for the document service.
+     */
+    public void setDocServiceExtraInfo(Map<String, String> docServiceExtraInfo) {
+        this.docServiceExtraInfo = requireNonNull(docServiceExtraInfo,"docServiceExtraInfo");
     }
 }

--- a/docs-client/src/components/GotoSelect/index.tsx
+++ b/docs-client/src/components/GotoSelect/index.tsx
@@ -23,6 +23,7 @@ import React, { ChangeEvent, useCallback, useMemo, useRef } from 'react';
 
 import { Specification } from '../../lib/specification';
 import { SelectOption } from '../../lib/types';
+import { getValidHexColor } from '../../lib/colors';
 
 type Option = SelectOption & { group: string };
 
@@ -121,8 +122,17 @@ const GotoSelect: React.FunctionComponent<GotoSelectProps> = ({
     [navigateTo],
   );
 
+  const extraInfo = specification.getDocServiceExtraInfo();
+  const headerGotoBackgroundColor = getValidHexColor(
+    extraInfo,
+    'headerGotoBackgroundColor',
+  );
+
   return (
-    <div className={classes.root}>
+    <div
+      className={classes.root}
+      style={{ backgroundColor: headerGotoBackgroundColor }}
+    >
       <Autocomplete
         autoHighlight
         blurOnSelect

--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -31,7 +31,13 @@ import Typography from '@material-ui/core/Typography';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import MenuIcon from '@material-ui/icons/Menu';
-import React, { useCallback, useEffect, useReducer, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useReducer,
+  useState,
+  useMemo,
+} from 'react';
 import { Helmet } from 'react-helmet';
 import { hot } from 'react-hot-loader/root';
 import { Route, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -58,6 +64,7 @@ import {
 } from '../../lib/versions';
 import { SpecLoadingStatus } from '../../lib/types';
 import LoadingContainer from '../../components/LoadingContainer';
+import { getValidHexColor } from '../../lib/colors';
 
 if (process.env.WEBPACK_DEV === 'true') {
   // DocService must always be accessed at the URL with a trailing slash. In non-dev mode, the server redirects
@@ -456,6 +463,7 @@ const dummySpecification = new Specification({
   services: [],
   structs: [],
   docServiceRoute: undefined,
+  docServiceExtraInfo: {},
 });
 
 const App: React.FunctionComponent<Props> = (props) => {
@@ -478,6 +486,10 @@ const App: React.FunctionComponent<Props> = (props) => {
   const [enumsOpen, toggleEnumsOpen] = useReducer(toggle, true);
   const [structsOpen, toggleStructsOpen] = useReducer(toggle, true);
   const [exceptionsOpen, toggleExceptionsOpen] = useReducer(toggle, true);
+  const [webAppTitle, setWebAppTitle] = useState<string | null>(null);
+  const [headerBarBackgroundColor, setHeaderBarBackgroundColor] = useState<
+    string | undefined
+  >(undefined);
 
   useEffect(() => {
     (async () => {
@@ -485,6 +497,24 @@ const App: React.FunctionComponent<Props> = (props) => {
         const httpResponse = await fetch('specification.json');
         const specificationData: SpecificationData = await httpResponse.json();
         const initialSpecification = new Specification(specificationData);
+        const extraInfo = initialSpecification.getDocServiceExtraInfo();
+
+        const simpleTitle = extraInfo.webAppTitle;
+        const sanitizeTitle = (title: string): string =>
+          title.replace(/<[^>]*>/g, '');
+        if (simpleTitle) {
+          const safeTitle = sanitizeTitle(simpleTitle);
+          setWebAppTitle(safeTitle);
+        }
+
+        const headerBarColor = getValidHexColor(
+          extraInfo,
+          'headerBarBackgroundColor',
+        );
+        if (headerBarColor) {
+          setHeaderBarBackgroundColor(headerBarColor);
+        }
+
         initialSpecification.getServices().forEach((service) => {
           toggleOpenService(service.name);
         });
@@ -517,6 +547,17 @@ const App: React.FunctionComponent<Props> = (props) => {
       setVersions(initialVersions);
     })();
   }, []);
+
+  const defaultTitle = 'Armeria documentation service';
+  const composedTitle = useMemo(() => {
+    const artifactVersion = versions
+      ? extractSimpleArtifactVersion(versions.getArmeriaArtifactVersion())
+      : '';
+    return `${
+      webAppTitle ? `${webAppTitle} - ` : ''
+    }${defaultTitle} ${artifactVersion}
+             `;
+  }, [versions, webAppTitle]);
 
   const classes = useStyles();
 
@@ -588,10 +629,14 @@ const App: React.FunctionComponent<Props> = (props) => {
   return (
     <div className={classes.root}>
       <Helmet>
+        <title>{composedTitle || defaultTitle}</title>
         <script src="injected.js" />
       </Helmet>
       <CssBaseline />
-      <AppBar className={classes.appBar}>
+      <AppBar
+        className={classes.appBar}
+        style={{ backgroundColor: headerBarBackgroundColor }}
+      >
         <Toolbar disableGutters>
           <Hidden mdUp>
             <IconButton color="inherit" onClick={toggleMobileDrawer}>
@@ -605,12 +650,7 @@ const App: React.FunctionComponent<Props> = (props) => {
             noWrap
           >
             <span className={classes.mainHeader}>
-              Armeria documentation service
-              {versions
-                ? ` ${extractSimpleArtifactVersion(
-                    versions.getArmeriaArtifactVersion(),
-                  )}`
-                : ''}
+              {composedTitle || defaultTitle}
             </span>
           </Typography>
           <div style={{ flex: 1 }} />

--- a/docs-client/src/containers/MethodPage/DebugPage.tsx
+++ b/docs-client/src/containers/MethodPage/DebugPage.tsx
@@ -54,10 +54,12 @@ import {
   Route,
   RoutePathType,
   ServiceType,
+  Specification,
 } from '../../lib/specification';
 import { TRANSPORTS } from '../../lib/transports';
 import { SelectOption } from '../../lib/types';
 import DebugInputs from './DebugInputs';
+import { getValidHexColor } from '../../lib/colors';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -85,6 +87,7 @@ interface OwnProps {
   setDebugFormIsOpen: Dispatch<React.SetStateAction<boolean>>;
   jsonSchemas: any[];
   docServiceRoute?: Route;
+  specification: Specification;
 }
 
 type Props = OwnProps & RouteComponentProps;
@@ -145,6 +148,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
   setDebugFormIsOpen,
   jsonSchemas,
   docServiceRoute,
+  specification,
 }) => {
   const [requestBody, setRequestBody] = useState('');
   const [debugResponse, setDebugResponse] = useState('');
@@ -520,6 +524,12 @@ const DebugPage: React.FunctionComponent<Props> = ({
     });
   }, [serviceType, transport, method, examplePaths]);
 
+  const extraInfo = specification.getDocServiceExtraInfo();
+  const debugFormButtonsColor = getValidHexColor(
+    extraInfo,
+    'debugFormButtonsColor',
+  );
+
   return (
     <>
       <Section>
@@ -562,7 +572,12 @@ const DebugPage: React.FunctionComponent<Props> = ({
                 setRequestBody={setRequestBody}
               />
               <Typography variant="body2" paragraph />
-              <Button variant="contained" color="primary" onClick={onSubmit}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={onSubmit}
+                style={{ backgroundColor: debugFormButtonsColor }}
+              >
                 Submit
               </Button>
               <Button variant="text" color="secondary" onClick={onExport}>
@@ -708,7 +723,12 @@ const DebugPage: React.FunctionComponent<Props> = ({
         </DialogContent>
         <DialogActions className={classes.actionDialog}>
           <div>
-            <Button variant="contained" color="primary" onClick={onSubmit}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={onSubmit}
+              style={{ backgroundColor: debugFormButtonsColor }}
+            >
               Submit
             </Button>
             <Button variant="text" color="secondary" onClick={onExport}>
@@ -720,6 +740,7 @@ const DebugPage: React.FunctionComponent<Props> = ({
             onClick={() => setDebugFormIsOpen(false)}
             variant="contained"
             color="primary"
+            style={{ backgroundColor: debugFormButtonsColor }}
           >
             Close
           </Button>

--- a/docs-client/src/containers/MethodPage/index.tsx
+++ b/docs-client/src/containers/MethodPage/index.tsx
@@ -42,6 +42,7 @@ import Endpoints from './Endpoints';
 import Exceptions from './Exceptions';
 import Description from '../../components/Description';
 import ReturnType from './ReturnType';
+import { getValidHexColor } from '../../lib/colors';
 
 interface OwnProps {
   specification: Specification;
@@ -207,6 +208,12 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
     return param;
   });
 
+  const extraInfo = props.specification.getDocServiceExtraInfo();
+  const debugFormButtonsColor = getValidHexColor(
+    extraInfo,
+    'debugFormButtonsColor',
+  );
+
   return (
     <>
       <Grid item container justifyContent="space-between">
@@ -219,7 +226,7 @@ const MethodPage: React.FunctionComponent<Props> = (props) => {
             color="primary"
             onClick={() => setDebugFormIsOpen(true)}
             endIcon={<Launch />}
-            style={{ maxHeight: '3em' }}
+            style={{ maxHeight: '3em', backgroundColor: debugFormButtonsColor }}
           >
             Debug
           </Button>

--- a/docs-client/src/lib/colors.tsx
+++ b/docs-client/src/lib/colors.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const isInHexFormat = (color: string): boolean =>
+  /^#([0-9a-fA-F]{6})$/.test(color);
+
+export const getValidHexColor = (
+  record: Record<string, string>,
+  key: string,
+): string | undefined => {
+  const color = record[key];
+  return color && isInHexFormat(color) ? color : undefined;
+};

--- a/docs-client/src/lib/specification.tsx
+++ b/docs-client/src/lib/specification.tsx
@@ -108,6 +108,7 @@ export interface SpecificationData {
   exceptions: Struct[];
   exampleHeaders: { [name: string]: string }[];
   docServiceRoute?: Route;
+  docServiceExtraInfo: Record<string, string>;
 }
 
 export function simpleName(fullName: string): string {
@@ -221,6 +222,10 @@ export class Specification {
 
   public getDocServiceRoute(): Route | undefined {
     return this.docServiceRoute;
+  }
+
+  public getDocServiceExtraInfo(): Record<string, string> {
+    return this.data.docServiceExtraInfo;
   }
 
   public hasUniqueEnumNames(): boolean {


### PR DESCRIPTION

Related: #5900

**Motivation:**

This change addresses feedback from multiple users requesting the ability to customize the appearance of the documentation service. The customizable elements now include:
- Title
- Browser tab title
- Header bar background color
- Color for the `GotoSelect` component
- Buttons colors in the `Debug` component

**Modifications:**

Backend
- In `DocServiceBuilder`, add a `Map` to store relevant data and a builder method for the documentation title.
- In `DocService`, modify the constructor to include a new attribute.
- In Static Nested `SpecificationLoader`, adjust the constructor and the `generateServiceSpecification` method.
- In `ServiceSpecification`, create a private `Map` and add Getter and Setter methods.

Frontend
- In `lib/specification.tsx`, include a `Record<String, String>` attribute in the `SpecificationData` interface.
- In `lib/colors.tsx`, add reusable method to validate color hex code.
- In `containers/App/index.tsx`, retrieve the style settings and applied them to the app's title and header.
- In `components/GotoSelect/index.tsx`, apply color using inline style.
- In `containers/MethodPage/index.tsx`, apply the custom color styling.
- In `containers/MethodPage/DebugPage.tsx`, apply custom button color styling via inline styles.

**Result:**

We can now customize the appearance of:
- Title
- Browser tab title
- Header bar background color
- Color for the `GotoSelect` component
- Buttons colors in the `Debug` component

Main view
![main_view](https://github.com/user-attachments/assets/aaba711d-7b3e-43f8-82fc-d79c6a6eaed4)

Debug modal
![debug_modal](https://github.com/user-attachments/assets/bd7e5af8-857e-49d6-8ec3-7fb055d16cd0)

