### PR TITLE
Remove assumption that namespace always exists for thrift docs

### DIFF
--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocStringExtractor.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocStringExtractor.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.server.docs.DocService;
@@ -65,7 +64,9 @@ final class ThriftDocStringExtractor extends DocStringExtractor {
                 final Map<String, Object> namespaces =
                         (Map<String, Object>) json.getOrDefault("namespaces", ImmutableMap.of());
                 final String packageName = (String) namespaces.get("java");
-                assert packageName != null : "Missing namespace for Java? " + namespaces;
+                if (packageName == null) {
+                    continue;
+                }
                 json.forEach((key, children) -> {
                     if (children instanceof Collection) {
                         @SuppressWarnings("unchecked")
@@ -91,7 +92,7 @@ final class ThriftDocStringExtractor extends DocStringExtractor {
             final String doc = (String) map.get("doc");
             final String childPrefix;
             if (name != null) {
-                childPrefix = MoreObjects.firstNonNull(prefix, "") + delimiter + name;
+                childPrefix = prefix + delimiter + name;
                 if (doc != null) {
                     docStrings.put(childPrefix, doc.trim());
                 }

--- a/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocStringExtractor.java
+++ b/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocStringExtractor.java
@@ -63,7 +63,8 @@ final class ThriftDocStringExtractor extends DocStringExtractor {
         final ImmutableMap.Builder<String, String> docStrings = ImmutableMap.builder();
         for (Map.Entry<String, byte[]> entry : files.entrySet()) {
             try {
-                final Map<String, Object> json = new ObjectMapper().readValue(entry.getValue(), JSON_VALUE_TYPE);
+                final Map<String, Object> json =
+                        new ObjectMapper().readValue(entry.getValue(), JSON_VALUE_TYPE);
                 @SuppressWarnings("unchecked")
                 final Map<String, Object> namespaces =
                         (Map<String, Object>) json.getOrDefault("namespaces", ImmutableMap.of());


### PR DESCRIPTION
Motivation:

We encountered an issue where namespace doesn't exist for central dogma artifacts.
https://mvnrepository.com/artifact/com.linecorp.centraldogma/centraldogma-common-legacy

While the cause in this case is unknown, it is definitely possible that namespaces doesn't exist given the `merge` option.

https://github.com/apache/thrift/blob/ef6a6c282a659a3e80add7e2d23ddb6855df34e2/compiler/cpp/src/thrift/generate/t_json_generator.cc#L352-L354

Since it is unlikely thrift docs for files without namespaces will be correctly mapped anyways, I propose that we just ignore thrift docs without package names instead of the assertion so that users can at least view the doc service.

Modifications:

- Continue thrift docstring extraction when the java namespace isn't available instead of asserting

Result:

- Users do not encounter errors when a thrift-json generated file doesn't have `namespaces`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
