### PR TITLE
Make SystemPropertyFlagsProvider support defaultPreferHttp1 with the same name

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -915,7 +915,7 @@ public final class Flags {
      * {@link ClientFactoryBuilder#preferHttp1(boolean)}.
      *
      * <p>This flag is disabled by default. Specify the
-     * {@code -Dcom.linecorp.armeria.defaultPreferHttp1=true} JVM option to enable it.
+     * {@code -Dcom.linecorp.armeria.preferHttp1=true} JVM option to enable it.
      */
     @UnstableApi
     public static boolean defaultPreferHttp1() {

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -915,7 +915,7 @@ public final class Flags {
      * {@link ClientFactoryBuilder#preferHttp1(boolean)}.
      *
      * <p>This flag is disabled by default. Specify the
-     * {@code -Dcom.linecorp.armeria.preferHttp1=true} JVM option to enable it.
+     * {@code -Dcom.linecorp.armeria.defaultPreferHttp1=true} JVM option to enable it.
      */
     @UnstableApi
     public static boolean defaultPreferHttp1() {

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -275,6 +275,10 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     @Nullable
     @Override
     public Boolean defaultPreferHttp1() {
+        final Boolean defaultPreferHttp1 = getBoolean("defaultPreferHttp1");
+        if (defaultPreferHttp1 != null) {
+            return defaultPreferHttp1;
+        }
         return getBoolean("preferHttp1");
     }
 

--- a/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/FlagsTest.java
@@ -302,6 +302,24 @@ class FlagsTest {
         assertThat(flagsApis).hasSameElementsAs(armeriaOptionsProviderApis);
     }
 
+    @Test
+    @ClearSystemProperty(key = "com.linecorp.armeria.defaultPreferHttp1")
+    void defaultValueOfDefaultUseHttp1Preface() throws Throwable {
+        assertFlags("defaultPreferHttp1").isEqualTo(false);
+    }
+
+    @Test
+    @SetSystemProperty(key = "com.linecorp.armeria.preferHttp1", value = "true")
+    void defaultPreferHttp1BackwardCompatible() throws Throwable {
+        assertFlags("defaultPreferHttp1").isEqualTo(true);
+    }
+
+    @Test
+    @SetSystemProperty(key = "com.linecorp.armeria.defaultPreferHttp1", value = "true")
+    void defaultPreferHttp1() throws Throwable {
+        assertFlags("defaultPreferHttp1").isEqualTo(true);
+    }
+
     private ObjectAssert<Object> assertFlags(String flagsMethod) throws Throwable {
         final Lookup lookup = MethodHandles.publicLookup();
         Class<?> rtype = Flags.class.getMethod(flagsMethod).getReturnType();


### PR DESCRIPTION
Motivation:

Currently we use `com.linecorp.armeria.preferHttp1=true` instead of defaultPreferHttp1. Make it support defaultPreferHttp1 and keep preferHttp1.

Modifications:

- Support defaultPreferHttp1 and fallback to preferHttp1 if we can't find defaultPreferHttp1

Result:

- Using the same property name with javadoc
