### PR TITLE
Migrate Documentation > Tutorials MDX content

### DIFF
--- a/site-new/docs/advanced/flags-provider.mdx
+++ b/site-new/docs/advanced/flags-provider.mdx
@@ -36,7 +36,7 @@ You can also override these properties by setting JVM system properties. For exa
 Create your own [FlagsProvider](type) and load it via [Java SPI](https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html).
 If there are multiple implementations of [FlagsProvider](type), the implementation with the highest priority will take precedence over the others.
 
-```java filename=MyFlagsProvider.java
+```java title="MyFlagsProvider.java"
 package com.example.providers;
 
 public class MyFlagsProvider implements FlagsProvider {
@@ -78,6 +78,6 @@ public class MyFlagsProvider implements FlagsProvider {
 
 Add the following text file to your classpath or JAR file.
 
-```text filename=META-INF/services/com.linecorp.armeria.common.FlagsProvider
+```text title="META-INF/services/com.linecorp.armeria.common.FlagsProvider"
 com.example.providers.MyFlagsProvider
 ```

--- a/site-new/docs/advanced/spring-boot-integration.mdx
+++ b/site-new/docs/advanced/spring-boot-integration.mdx
@@ -40,7 +40,7 @@ First, add the following dependency to your application.
 
 Serve the embedded [TomcatService](type) via Armeria by using the [ArmeriaServerConfigurator](type) bean.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 import com.linecorp.armeria.server.tomcat.TomcatService;
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
 import org.apache.catalina.connector.Connector;
@@ -73,7 +73,7 @@ Add the following properties to your `application.yml` (or `application.properti
 This configuration will prevent the exposure of the embedded Tomcat service and instead expose your Armeria service.
 You can explore additional configuration options in [ArmeriaSettings](type).
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 # Prevent the embedded Tomcat from opening a TCP/IP port.
 server:
   port: -1
@@ -119,7 +119,7 @@ Armeria's [annotated service](/docs/server/annotated-service) is similar to a Sp
 You can declare the annotated service as a bean and inject it into the [ServerBuilder](type).
 Here's an example:
 
-```java filename=TodoAnnotatedService.java
+```java title="TodoAnnotatedService.java"
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.annotation.*;
@@ -164,7 +164,7 @@ public class TodoAnnotatedService {
 
 To inject the annotated service into the [ArmeriaServerConfigurator](type) bean, you can follow this approach:
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public ArmeriaServerConfigurator armeriaServerConfigurator(TodoAnnotatedService todoAnnotatedService) {
    return serverBuilder -> {
@@ -177,7 +177,7 @@ public ArmeriaServerConfigurator armeriaServerConfigurator(TodoAnnotatedService 
 
 The following configuration prevents the execution of Spring's embedded web server and instead runs Armeria.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.webserver.disable.
 # The application should not run as a web application and should not start an embedded web server.
 spring.main.web-application-type: none
@@ -195,7 +195,7 @@ Armeria supports four internal services that are useful for monitoring and manag
 You can enable these services by including their service IDs in your `application.yml` (or `application.properties`) file.
 Service ids are `docs`, `health`, `metrics`, and `actuator`. You can include one or multiple service IDs based on your requirements.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   ports:
     - port: 8080
@@ -227,7 +227,7 @@ For instance, it allows you to test RPC protocols in a web browser console, simi
 Add the service ID `docs` to `armeria.internal-services.include` configuration.
 The `armeria.docs-path` is not necessary, as the default path for the documentation service is `/internal/docs`.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   internal-services:
     include: docs
@@ -236,7 +236,7 @@ armeria:
 
 To add custom configuration to your documentation service, you can utilize the [DocServiceConfigurator](type) bean.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public DocServiceConfigurator docServiceConfigurator() {
     return docServiceBuilder -> docServiceBuilder
@@ -251,7 +251,7 @@ To customize the health check operation, you can utilize the [HealthChecker](typ
 Add the service ID `health` to the `armeria.internal-services.include` configuration.
 The `armeria.health-check-path` is not necessary, as the default path for the health check service is `/internal/healthcheck`.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   internal-services:
     include: health
@@ -261,7 +261,7 @@ armeria:
 You can create a [HealthChecker](type) bean that implements your custom health check logic.
 For example, the below code determines if the server is healthy using Tomcat connector state.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public HealthChecker tomcatConnectorHealthChecker(ServletWebServerApplicationContext applicationContext) {
     final Connector connector = getConnector(applicationContext);
@@ -271,7 +271,7 @@ public HealthChecker tomcatConnectorHealthChecker(ServletWebServerApplicationCon
 
 You can also add custom configuration to the service using the [HealthCheckServiceConfigurator](type) bean, similar to the documentation service.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public HealthCheckServiceConfigurator healthCheckServiceConfigurator() {
     return healthCheckServiceBuilder -> healthCheckServiceBuilder
@@ -289,7 +289,7 @@ for comprehensive monitoring and analysis.
 To include the metrics service, simply add the service ID `metrics` to the `armeria.internal-services.include` configuration.
 You do not need to specify `armeria.enable-metrics` or `armeria.metrics-path` as the default path for the metrics service is `/internal/metrics`.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   internal-services:
     include: metrics
@@ -309,7 +309,7 @@ We will illustrate the bean configuration using an example with the Prometheus m
 First, create a [`PrometheusMeterRegistry`](https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/latest/io/micrometer/prometheus/PrometheusMeterRegistry.html) bean.
 If you are using a different monitoring system, create a bean of [`MeterRegistry`](https://www.javadoc.io/doc/io.micrometer/micrometer-core/latest/io/micrometer/core/instrument/MeterRegistry.html) type.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public PrometheusMeterRegistry prometheusMeterRegistry() {
     return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
@@ -327,7 +327,7 @@ public PrometheusMeterRegistry prometheusMeterRegistry() {
 To add a prefix to the ID of collected metrics, you can use the [MeterIdPrefixFunction](type) bean.
 Additionally, you can customize the configuration of the service by utilizing the [MetricCollectingServiceConfigurator](type) bean.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public MeterIdPrefixFunction meterIdPrefixFunction() {
     return MeterIdPrefixFunction.ofDefault("my.armeria.service");
@@ -363,7 +363,7 @@ In order to use the actuator service, you need to first add the following depend
 
 To include the actuator service, add the service ID `actuator` to the `armeria.internal-services.include` configuration.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   internal-services:
     include: actuator
@@ -392,7 +392,7 @@ You can refer to the example in the [1.17.0 release notes](/release-notes/1.17.0
 Create the [DependencyInjector](type) bean, which will replace the default dependency injector.
 It's important to note that in this case dependencies that were automatically injected before may not be injected anymore.
 
-```java filename=ArmeriaConfiguration.java
+```java title="ArmeriaConfiguration.java"
 @Bean
 public DependencyInjector dependencyInjector() {
     return DependencyInjector.ofSingletons(
@@ -406,7 +406,7 @@ public DependencyInjector dependencyInjector() {
 You can also utilize a dependency injector that leverages the [`BeanFactory`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/BeanFactory.html)
 of Spring. After configuring the properties, you can effortlessly create beans to be injected, similar to how you would do it in a Spring-based setup.
 
-```yaml filename=application.yml
+```yaml title="application.yml"
 armeria:
   enable-auto-injection: true
 ```

--- a/site-new/docs/server/timeouts.mdx
+++ b/site-new/docs/server/timeouts.mdx
@@ -100,7 +100,7 @@ Server server = sb.http(port)
 
 You can use the [@RequestTimeout](type) annotation for annotated services and gRPC services.
 
-```java filename=HelloService.java
+```java title="HelloService.java"
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Get;

--- a/site-new/docs/tutorials/grpc/01-define-a-service.mdx
+++ b/site-new/docs/tutorials/grpc/01-define-a-service.mdx
@@ -1,1 +1,0 @@
-# 1. Define a service

--- a/site-new/docs/tutorials/grpc/01-define-service.mdx
+++ b/site-new/docs/tutorials/grpc/01-define-service.mdx
@@ -1,0 +1,126 @@
+---
+menuTitle: "Define a service"
+order: 1
+type: step
+targetLang: java
+---
+
+# Defining a blog service and messages
+
+Let's begin by defining our gRPC blog service in a proto file.
+
+<TutorialSteps current={1} />
+
+## What you need
+
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/grpc/blog/#prerequisites).
+
+## 1. Create a proto file
+
+Create a file, `blog.proto` inside the directory, `{project_root}/src/main/proto`. This tutorial uses [Protocol Buffers version 3](https://developers.google.com/protocol-buffers/docs/proto3).
+
+```protobuf filename=blog.proto
+syntax = "proto3";
+
+package example.armeria.blog.grpc;
+option java_package = "example.armeria.blog.grpc";
+option java_multiple_files = true;
+```
+
+<Tip>
+
+  See [Sample service structure](/tutorials/grpc/blog#sample-service) for the overall folder structure.
+
+</Tip>
+
+## 2. Define a blog post
+
+In the proto file, define the `BlogPost` message type with minimal data.
+
+```protobuf filename=blog.proto
+message BlogPost {
+  int32 id = 1;
+  string title = 2;
+  string content = 3;
+  int64 createdAt = 4;
+  int64 modifiedAt = 5;
+}
+```
+
+## 3. Add service methods
+
+Add service methods to the blog service. We have two methods for retrieving blog posts; one is for retrieving a single post and another for multiple posts.
+
+<Tip>
+
+  The APIs are designed based on the [Google's API design decisions](https://google.aip.dev/general).
+
+</Tip>
+
+```protobuf filename=blog.proto
+import "google/protobuf/empty.proto";
+
+service BlogService {
+  rpc CreateBlogPost (CreateBlogPostRequest) returns (BlogPost) {}
+  rpc GetBlogPost (GetBlogPostRequest) returns (BlogPost) {}
+  rpc ListBlogPosts (ListBlogPostsRequest) returns (ListBlogPostsResponse) {}
+  rpc UpdateBlogPost (UpdateBlogPostRequest) returns (BlogPost) {}
+  rpc DeleteBlogPost (DeleteBlogPostRequest) returns (google.protobuf.Empty) {}
+}
+```
+
+## 4. Add request types
+
+Add request types for create, retrieve, update, and delete operations.
+
+```protobuf filename=blog.proto
+message CreateBlogPostRequest {
+  string title = 1;
+  string content = 2;
+}
+
+message GetBlogPostRequest {    // For retrieving a single post
+  int32 id = 1;
+}
+
+message ListBlogPostsRequest {  // For retrieving multiple posts
+  bool descending = 1;
+}
+
+message UpdateBlogPostRequest {
+  int32 id = 1;
+  string title = 2;
+  string content = 3;
+}
+
+message DeleteBlogPostRequest {
+  int32 id = 1;
+}
+```
+
+## 5. Add a response type
+
+Add a response type to return multiple blog posts.
+
+```protobuf filename=blog.proto
+message ListBlogPostsResponse {
+    repeated BlogPost blogs = 1;
+}
+```
+
+## 6. Compile the proto file
+
+Compile the `blog.proto` file to generate Java code.
+You can refer to the full [build.gradle](https://github.com/line/armeria-examples/tree/main/tutorials/grpc/build.gradle) file for generating code with [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin).
+
+```bash
+./gradlew generateProto
+```
+
+You'll see the generated Java code in the `{project_root}/build/generated/source/proto/main` folder.
+
+## Next step
+
+In this step, we've defined a proto file for our service and generated Java code. Next, we'll [run a service](/tutorials/grpc/blog/run-service) and test the connection.
+
+<TutorialSteps current={1} />

--- a/site-new/docs/tutorials/grpc/01-define-service.mdx
+++ b/site-new/docs/tutorials/grpc/01-define-service.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Define a service"
-order: 1
+sidebar_label: "1. Define a service"
 type: step
 targetLang: java
 ---
@@ -13,13 +12,13 @@ Let's begin by defining our gRPC blog service in a proto file.
 
 ## What you need
 
-No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/grpc/blog/#prerequisites).
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/docs/tutorials/grpc/#prerequisites).
 
 ## 1. Create a proto file
 
 Create a file, `blog.proto` inside the directory, `{project_root}/src/main/proto`. This tutorial uses [Protocol Buffers version 3](https://developers.google.com/protocol-buffers/docs/proto3).
 
-```protobuf filename=blog.proto
+```protobuf title="blog.proto"
 syntax = "proto3";
 
 package example.armeria.blog.grpc;
@@ -27,17 +26,17 @@ option java_package = "example.armeria.blog.grpc";
 option java_multiple_files = true;
 ```
 
-<Tip>
+:::tip
 
-  See [Sample service structure](/tutorials/grpc/blog#sample-service) for the overall folder structure.
+  See [Sample service structure](/docs/tutorials/grpc#sample-service) for the overall folder structure.
 
-</Tip>
+:::
 
 ## 2. Define a blog post
 
 In the proto file, define the `BlogPost` message type with minimal data.
 
-```protobuf filename=blog.proto
+```protobuf title="blog.proto"
 message BlogPost {
   int32 id = 1;
   string title = 2;
@@ -51,13 +50,13 @@ message BlogPost {
 
 Add service methods to the blog service. We have two methods for retrieving blog posts; one is for retrieving a single post and another for multiple posts.
 
-<Tip>
+:::tip
 
   The APIs are designed based on the [Google's API design decisions](https://google.aip.dev/general).
 
-</Tip>
+:::
 
-```protobuf filename=blog.proto
+```protobuf title="blog.proto"
 import "google/protobuf/empty.proto";
 
 service BlogService {
@@ -73,7 +72,7 @@ service BlogService {
 
 Add request types for create, retrieve, update, and delete operations.
 
-```protobuf filename=blog.proto
+```protobuf title="blog.proto"
 message CreateBlogPostRequest {
   string title = 1;
   string content = 2;
@@ -102,7 +101,7 @@ message DeleteBlogPostRequest {
 
 Add a response type to return multiple blog posts.
 
-```protobuf filename=blog.proto
+```protobuf title="blog.proto"
 message ListBlogPostsResponse {
     repeated BlogPost blogs = 1;
 }
@@ -121,6 +120,6 @@ You'll see the generated Java code in the `{project_root}/build/generated/source
 
 ## Next step
 
-In this step, we've defined a proto file for our service and generated Java code. Next, we'll [run a service](/tutorials/grpc/blog/run-service) and test the connection.
+In this step, we've defined a proto file for our service and generated Java code. Next, we'll [run a service](/docs/tutorials/grpc/run-service) and test the connection.
 
 <TutorialSteps current={1} />

--- a/site-new/docs/tutorials/grpc/02-run-service.mdx
+++ b/site-new/docs/tutorials/grpc/02-run-service.mdx
@@ -1,0 +1,151 @@
+---
+menuTitle: "Run a service"
+order: 2
+category: grpc
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Running a service
+
+In this step, we'll do three things with the code we obtained from our proto file; we'll create a server instance, add an empty gRPC service, and then lastly test connecting to the server.
+
+<TutorialSteps current={2} />
+
+## What you need
+
+You need to have the [generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file) obtained from the previous step.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
+
+## 1. Declare an empty service
+
+Create a file `BlogService.java` and declare an empty blog service. We'll implement the service methods later on in this file. For now, leave it empty.
+
+```java filename=BlogService.java
+package example.armeria.blog.grpc;
+
+final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {}
+```
+
+## 2. Add a service to a server
+
+Build a service and server using Armeria's <type://ServerBuilder> to serve our service.
+
+1. Create a main class for our server. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/Main.java).
+
+  ```java filename=Main.java
+  package example.armeria.blog.grpc;
+
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+  public final class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+  }
+  ```
+2. Create a service instance using Armeria's <type://GrpcService#builder()>.
+  ```java filename=Main.java
+  import com.linecorp.armeria.server.grpc.GrpcService;
+  import com.linecorp.armeria.server.Server;
+
+  public final class Main {
+  ...
+    static Server newServer(int port) throws Exception {
+      final GrpcService grpcService =
+        GrpcService.builder()
+                   .addService(new BlogService())
+                   .build();
+    }
+  }
+  ```
+3. Build and return a new server instance using Armeria's <type://ServerBuilder>.
+  ```java filename=Main.java
+    public final class Main {
+      static Server newServer(int port) throws Exception {
+        ...
+        return Server.builder()
+                     .http(port)
+                     .service(grpcService)
+                     .build();
+
+      }
+  ```
+
+## 3. Run the server and service
+
+Create a server instance and run the blog service.
+
+1. Create a server instance in the `main()` method.
+  ```java filename=Main.java
+  public static void main(String[] args) throws Exception {
+      final Server server = newServer(8080);
+
+      server.closeOnJvmShutdown().thenRun(() -> {
+          logger.info("Server has been stopped.");
+      });
+
+      server.start().join();
+  }
+  ```
+2. Start the server by running the `Main.main()` method on your IDE or using Gradle.
+  ```bash
+  ./gradlew run
+  ```
+  Your server is running if you see the following message.
+  ```bash
+  [armeria-boss-http-*:8080] INFO com.linecorp.armeria.server.Server - Serving HTTP at /[0:0:0:0:0:0:0:0%0]:8080 - http://127.0.0.1:8080/
+  ```
+
+## 4. Test connecting to the server
+
+Let's create test code and connect to the server by sending a request using a client stub.
+Note that we'll use test code to verify what we implement along the way.
+
+1. Create a file, `BlogServiceTest.java`, under `{project_root}/src/test/java/example/armeria/blog/grpc` as follows.
+You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/grpc/src/test/java/example/armeria/server/blog/grpc/BlogServiceTest.java).
+  ```java filename=BlogServiceTest.java
+  package example.armeria.blog.grpc;
+  import example.armeria.blog.grpc.BlogServiceGrpc.BlogServiceBlockingStub;
+
+  class BlogServiceTest {
+    static BlogServiceBlockingStub client;
+  }
+  ```
+2. In the `BlogServiceTest` class, add a test method as follows.
+Although we haven't implemented any service methods, we'll call one just to check whether we can connect to the server.
+
+  ```java filename=BlogServiceTest.java
+  import org.junit.jupiter.api.Test;
+  import com.linecorp.armeria.client.grpc.GrpcClients;
+
+  @Test
+  void connect() {
+    client = GrpcClients.newClient("http://127.0.0.1:8080/",
+                                   BlogServiceBlockingStub.class);
+    client.createBlogPost(CreateBlogPostRequest.newBuilder().build());
+  }
+  ```
+3. Make sure that your server is running.
+  If you have not stopped the server, it should already be running.
+  Otherwise, restart the server by running the `Main.main()` method.
+4. Run the test case on your IDE or using Gradle.
+  ```
+  ./gradlew test
+  ```
+  Your client sent a request to the service successfully if the test fails and throws an "UNIMPLEMENTED" exception.
+
+  ```bash
+  UNIMPLEMENTED: Method example.armeria.blog.grpc.BlogService/CreateBlogPost is unimplemented
+  ```
+
+  This is because we are yet to implement the service method to create a blog post. One thing we did check is that our service does return something to a client call.
+
+## What's next
+
+In this step, we've created and added an empty gRPC service to a server. We've also written a test and made a call to the server.
+
+Next, we'll get on with implementing a service method for [creating blog posts](/tutorials/grpc/blog/implement-create).
+
+<TutorialSteps current={2} />

--- a/site-new/docs/tutorials/grpc/02-run-service.mdx
+++ b/site-new/docs/tutorials/grpc/02-run-service.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Run a service"
-order: 2
+sidebar_label: "2. Run a service"
 category: grpc
 tags:
   - server
@@ -16,14 +15,14 @@ In this step, we'll do three things with the code we obtained from our proto fil
 
 ## What you need
 
-You need to have the [generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file) obtained from the previous step.
+You need to have the [generated Java code](/docs/tutorials/grpc/define-service#6-compile-the-proto-file) obtained from the previous step.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
 
 ## 1. Declare an empty service
 
 Create a file `BlogService.java` and declare an empty blog service. We'll implement the service methods later on in this file. For now, leave it empty.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
 package example.armeria.blog.grpc;
 
 final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {}
@@ -31,11 +30,11 @@ final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {}
 
 ## 2. Add a service to a server
 
-Build a service and server using Armeria's <type://ServerBuilder> to serve our service.
+Build a service and server using Armeria's [ServerBuilder](type) to serve our service.
 
 1. Create a main class for our server. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/grpc/src/main/java/example/armeria/server/blog/grpc/Main.java).
 
-  ```java filename=Main.java
+  ```java title="Main.java"
   package example.armeria.blog.grpc;
 
   import org.slf4j.Logger;
@@ -45,8 +44,8 @@ Build a service and server using Armeria's <type://ServerBuilder> to serve our s
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
   }
   ```
-2. Create a service instance using Armeria's <type://GrpcService#builder()>.
-  ```java filename=Main.java
+2. Create a service instance using Armeria's [GrpcService#builder()](type).
+  ```java title="Main.java"
   import com.linecorp.armeria.server.grpc.GrpcService;
   import com.linecorp.armeria.server.Server;
 
@@ -60,8 +59,8 @@ Build a service and server using Armeria's <type://ServerBuilder> to serve our s
     }
   }
   ```
-3. Build and return a new server instance using Armeria's <type://ServerBuilder>.
-  ```java filename=Main.java
+3. Build and return a new server instance using Armeria's [ServerBuilder](type).
+  ```java title="Main.java"
     public final class Main {
       static Server newServer(int port) throws Exception {
         ...
@@ -78,7 +77,7 @@ Build a service and server using Armeria's <type://ServerBuilder> to serve our s
 Create a server instance and run the blog service.
 
 1. Create a server instance in the `main()` method.
-  ```java filename=Main.java
+  ```java title="Main.java"
   public static void main(String[] args) throws Exception {
       final Server server = newServer(8080);
 
@@ -105,7 +104,7 @@ Note that we'll use test code to verify what we implement along the way.
 
 1. Create a file, `BlogServiceTest.java`, under `{project_root}/src/test/java/example/armeria/blog/grpc` as follows.
 You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/grpc/src/test/java/example/armeria/server/blog/grpc/BlogServiceTest.java).
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   package example.armeria.blog.grpc;
   import example.armeria.blog.grpc.BlogServiceGrpc.BlogServiceBlockingStub;
 
@@ -116,7 +115,7 @@ You can see the full version of the file [here](https://github.com/line/armeria-
 2. In the `BlogServiceTest` class, add a test method as follows.
 Although we haven't implemented any service methods, we'll call one just to check whether we can connect to the server.
 
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import org.junit.jupiter.api.Test;
   import com.linecorp.armeria.client.grpc.GrpcClients;
 
@@ -146,6 +145,6 @@ Although we haven't implemented any service methods, we'll call one just to chec
 
 In this step, we've created and added an empty gRPC service to a server. We've also written a test and made a call to the server.
 
-Next, we'll get on with implementing a service method for [creating blog posts](/tutorials/grpc/blog/implement-create).
+Next, we'll get on with implementing a service method for [creating blog posts](/docs/tutorials/grpc/implement-create).
 
 <TutorialSteps current={2} />

--- a/site-new/docs/tutorials/grpc/03-implement-create.mdx
+++ b/site-new/docs/tutorials/grpc/03-implement-create.mdx
@@ -1,0 +1,158 @@
+---
+menuTitle: "Implement CREATE"
+order: 3
+category: grpc
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing CREATE operation
+
+In the previous step, we defined service methods.
+In this step, we'll implement one of the service methods to create a blog post and again, try making a call to a service method.
+Also, we'll use Armeria's <type://ServerExtension> for testing.
+
+<TutorialSteps current={3} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- `BlogService.java`
+- `Main.java`
+- `BlogServiceTest.java`
+
+## 1. Implement server-side
+
+Let's implement a service method `createBlogPost()` in the `BlogService` class.
+
+1. Create an ID generator to issue temporary blog post IDs and a map to contain blogs posts.
+  ```java filename=BlogService.java
+  import java.util.Map;
+  import java.util.concurrent.ConcurrentHashMap;
+  import java.util.concurrent.atomic.AtomicInteger;
+
+  public final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+    private final AtomicInteger idGenerator = new AtomicInteger();
+    private final Map<Integer, BlogPost> blogPosts = new ConcurrentHashMap<>();
+  }
+  ```
+2. Add a service method, `createBlogPost()`:
+    1. Create a `BlogPost` object with request parameters.
+    2. Save the post information in the map.
+    3. Return the information of the blog post created.
+  ```java filename=BlogService.java
+  import java.time.Instant;
+  import io.grpc.stub.StreamObserver;
+
+  final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+    @Override
+    public void createBlogPost(CreateBlogPostRequest request, StreamObserver<BlogPost> responseObserver) {
+      final int id = idGenerator.getAndIncrement(); // Generate post ID
+      final Instant now = Instant.now();            // Get current time
+      final BlogPost updated = BlogPost.newBuilder()
+                       .setId(id)
+                       .setTitle(request.getTitle())
+                       .setContent(request.getContent())
+                       .setModifiedAt(now.toEpochMilli())
+                       .setCreatedAt(now.toEpochMilli())
+                       .build();
+      blogPosts.put(id, updated);
+      responseObserver.onNext(updated);
+      responseObserver.onCompleted();
+    }
+  }
+  ```
+
+## 2. Register a ServerExtension
+
+In the previous test code, we've connected directly to the server.
+This time, let's use Armeria's <type://ServerExtension> instead.
+This approach automatically handles set-up and tear-down of a server for testing.
+Now we don't have to invoke the main method to set up a server before running our tests.
+
+1. In the `BlogServiceTest` class, remove the `connect()` method to eliminate dependency on the main method.
+  ```java filename=BlogServiceTest.java
+  public class BlogServiceTest {
+    ...
+    @Test
+    void connect() {...} // Remove this method
+  }
+  ```
+2. Register a <type://ServerExtension> as follows.
+  Note that the service instance is added to the configuration.
+  ```java filename=BlogServiceTest.java
+  import org.junit.jupiter.api.extension.RegisterExtension;
+  import com.linecorp.armeria.server.ServerBuilder;
+  import com.linecorp.armeria.server.grpc.GrpcService;
+  import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+  public class BlogServiceTest {
+    ...
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+      @Override
+      protected void configure(ServerBuilder sb) throws Exception {
+        sb.service(GrpcService.builder()
+                      // Add the service to the configuration
+                      .addService(new BlogService())
+                      .build());
+      }
+    };
+  }
+  ```
+
+## 3. Set up a client for testing
+
+In the `BlogServiceTest` class, add a method as follows.
+This will set up a client before executing each test cases.
+
+```java filename=BlogServiceTest.java
+import org.junit.jupiter.api.BeforeAll;
+
+@BeforeAll
+static void beforeAll() {
+  client = GrpcClients.newClient(server.httpUri(),
+                 BlogServiceBlockingStub.class);
+}
+```
+
+## 4. Test creating a blog post
+
+Let's test if we can create a blog post.
+
+1. In the `BlogServiceTest` class, add a test method as follows.
+  ```java filename=BlogServiceTest.java
+  import static org.assertj.core.api.Assertions.assertThat;
+  import com.fasterxml.jackson.core.JsonProcessingException;
+
+  @Test
+  void createBlogPost() throws JsonProcessingException {
+    final CreateBlogPostRequest request = CreateBlogPostRequest.newBuilder()
+                     .setTitle("My first blog")
+                     .setContent("Hello Armeria!")
+                     .build();
+    final BlogPost response = client.createBlogPost(request);
+    assertThat(response.getTitle()).isEqualTo(request.getTitle());
+    assertThat(response.getContent()).isEqualTo(request.getContent());
+  }
+  ```
+2. Run the test case on your IDE or using Gradle.
+  ```bash
+  ./gradlew test
+  ```
+
+The service worked as expected if you see the test case passed.
+
+## What's next
+
+In this step, we've implemented a method for creating a blog post.
+We've also registered <type://ServerExtension> to our test.
+
+Next, at [Step 4. Implement READ](/tutorials/grpc/blog/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
+
+<TutorialSteps current={3} />

--- a/site-new/docs/tutorials/grpc/03-implement-create.mdx
+++ b/site-new/docs/tutorials/grpc/03-implement-create.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement CREATE"
-order: 3
+sidebar_label: "3. Implement CREATE"
 category: grpc
 tags:
   - server
@@ -12,7 +11,7 @@ type: step
 
 In the previous step, we defined service methods.
 In this step, we'll implement one of the service methods to create a blog post and again, try making a call to a service method.
-Also, we'll use Armeria's <type://ServerExtension> for testing.
+Also, we'll use Armeria's [ServerExtension](type) for testing.
 
 <TutorialSteps current={3} />
 
@@ -21,7 +20,7 @@ Also, we'll use Armeria's <type://ServerExtension> for testing.
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- [Generated Java code](/docs/tutorials/grpc/define-service#6-compile-the-proto-file)
 - `BlogService.java`
 - `Main.java`
 - `BlogServiceTest.java`
@@ -31,7 +30,7 @@ You can always [download](https://github.com/line/armeria-examples/tree/main/tut
 Let's implement a service method `createBlogPost()` in the `BlogService` class.
 
 1. Create an ID generator to issue temporary blog post IDs and a map to contain blogs posts.
-  ```java filename=BlogService.java
+  ```java title="BlogService.java"
   import java.util.Map;
   import java.util.concurrent.ConcurrentHashMap;
   import java.util.concurrent.atomic.AtomicInteger;
@@ -45,7 +44,7 @@ Let's implement a service method `createBlogPost()` in the `BlogService` class.
     1. Create a `BlogPost` object with request parameters.
     2. Save the post information in the map.
     3. Return the information of the blog post created.
-  ```java filename=BlogService.java
+  ```java title="BlogService.java"
   import java.time.Instant;
   import io.grpc.stub.StreamObserver;
 
@@ -71,21 +70,21 @@ Let's implement a service method `createBlogPost()` in the `BlogService` class.
 ## 2. Register a ServerExtension
 
 In the previous test code, we've connected directly to the server.
-This time, let's use Armeria's <type://ServerExtension> instead.
+This time, let's use Armeria's [ServerExtension](type) instead.
 This approach automatically handles set-up and tear-down of a server for testing.
 Now we don't have to invoke the main method to set up a server before running our tests.
 
 1. In the `BlogServiceTest` class, remove the `connect()` method to eliminate dependency on the main method.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   public class BlogServiceTest {
     ...
     @Test
     void connect() {...} // Remove this method
   }
   ```
-2. Register a <type://ServerExtension> as follows.
+2. Register a [ServerExtension](type) as follows.
   Note that the service instance is added to the configuration.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import org.junit.jupiter.api.extension.RegisterExtension;
   import com.linecorp.armeria.server.ServerBuilder;
   import com.linecorp.armeria.server.grpc.GrpcService;
@@ -111,7 +110,7 @@ Now we don't have to invoke the main method to set up a server before running ou
 In the `BlogServiceTest` class, add a method as follows.
 This will set up a client before executing each test cases.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import org.junit.jupiter.api.BeforeAll;
 
 @BeforeAll
@@ -126,7 +125,7 @@ static void beforeAll() {
 Let's test if we can create a blog post.
 
 1. In the `BlogServiceTest` class, add a test method as follows.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import static org.assertj.core.api.Assertions.assertThat;
   import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -151,8 +150,8 @@ The service worked as expected if you see the test case passed.
 ## What's next
 
 In this step, we've implemented a method for creating a blog post.
-We've also registered <type://ServerExtension> to our test.
+We've also registered [ServerExtension](type) to our test.
 
-Next, at [Step 4. Implement READ](/tutorials/grpc/blog/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
+Next, at [Step 4. Implement READ](/docs/tutorials/grpc/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
 
 <TutorialSteps current={3} />

--- a/site-new/docs/tutorials/grpc/04-implement-read.mdx
+++ b/site-new/docs/tutorials/grpc/04-implement-read.mdx
@@ -1,0 +1,199 @@
+---
+menuTitle: "Implement READ"
+order: 4
+type: step
+category: grpc
+tags:
+  - server
+level: basic
+---
+
+# Implementing READ operation
+
+In the earlier step, we created blog posts.
+In this step, we'll implement a read operation and make a call to read blog posts.
+We'll write two service methods, one for reading a single post and another for multiple posts.
+
+<TutorialSteps current={4} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- `BlogService.java`
+- `Main.java`
+- `BlogServiceTest.java`
+
+## 1. Implement server-side
+
+Let's write two methods for retrieving blog posts; one for a single post and
+another for multiple posts.
+
+<Tabs>
+<TabPane tab="Single post" key="1">
+
+Add a service method in `BlogService.java` to retrieve a single post.
+
+```java filename=BlogService.java
+import example.armeria.blog.grpc.GetBlogPostRequest;
+
+public final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+
+  @Override
+  public void getBlogPost(GetBlogPostRequest request, StreamObserver<BlogPost> responseObserver) {
+    final BlogPost blogPost = blogPosts.get(request.getId());
+    if (blogPost == null) {
+      responseObserver.onError(
+        Status.NOT_FOUND.withDescription("The blog post does not exist. ID: " + request.getId())
+                        .asRuntimeException());
+    } else {
+        responseObserver.onNext(blogPost);
+        responseObserver.onCompleted();
+    }
+  }
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+Add a service method in `BlogService.java` to retrieve multiple posts.
+
+```java filename=BlogService.java
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map.Entry;
+
+import example.armeria.blog.grpc.ListBlogPostsRequest;
+import example.armeria.blog.grpc.ListBlogPostsResponse;
+
+final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+  @Override
+  public void listBlogPosts(ListBlogPostsRequest request,
+                            StreamObserver<ListBlogPostsResponse> responseObserver) {
+      final Collection<BlogPost> blogPosts;
+      if (request.getDescending()) {
+          blogPosts = this.blogPosts.entrySet()
+                      .stream()
+                      .sorted(Collections.reverseOrder(Comparator.comparingInt(Entry::getKey)))
+                      .map(Entry::getValue).collect(Collectors.toList());
+      } else {
+          blogPosts = this.blogPosts.values();
+      }
+      responseObserver.onNext(ListBlogPostsResponse.newBuilder().addAllBlogs(blogPosts).build());
+      responseObserver.onCompleted();
+  }
+}
+```
+
+</TabPane>
+</Tabs>
+
+## 2. Test retrieving a single post
+
+Let's test if we can retrieve a blog post we created.
+
+1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
+  ```java filename=BlogServiceTest.java
+  @Test
+  void getBlogPost() throws JsonProcessingException {
+    final BlogPost blogPost = client.getBlogPost(GetBlogPostRequest.newBuilder().setId(0).build());
+
+    assertThat(blogPost.getTitle()).isEqualTo("My first blog");
+    assertThat(blogPost.getContent()).isEqualTo("Hello Armeria!");
+  }
+  ```
+2. Add annotations to configure the order our test methods will be executed.
+  The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
+  ```java filename=BlogServiceTest.java
+  import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+  import org.junit.jupiter.api.Order;
+  import org.junit.jupiter.api.TestMethodOrder;
+
+  @TestMethodOrder(OrderAnnotation.class) // Add this
+  class BlogServiceTest {
+    ...
+
+    @Test
+    @Order(1) // Add this
+    void createBlogPost() throws JsonProcessingException {
+      ...
+    }
+
+    @Test
+    @Order(2) // Add this
+    void getBlogPost() throws JsonProcessingException {
+      ...
+    }
+  }
+  ```
+3. Run all the test cases on your IDE or using Gradle.
+
+  Your client retrieved a blog post from the server successfully if the test is passed.
+
+## 4. Test an error case
+
+Let's try retrieving a blog post that does not exist.
+Add a test method to retrieve a blog post with an invalid ID, asserting an exception is thrown.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(3)
+void getInvalidBlogPost() throws JsonProcessingException {
+  final Throwable exception = catchThrowable(() -> {
+      client.getBlogPost(GetBlogPostRequest.newBuilder().setId(Integer.MAX_VALUE).build());
+  });
+  final StatusRuntimeException statusException = (StatusRuntimeException) exception;
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.NOT_FOUND);
+    assertThat(statusException)
+          .hasMessageContaining("The blog post does not exist. ID: " + Integer.MAX_VALUE);
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 5. Test retrieving multiple posts
+
+Finally, let's test if we can retrieve multiple posts.
+Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(4)
+void listBlogPosts() throws JsonProcessingException {
+  final CreateBlogPostRequest newBlogPost = CreateBlogPostRequest.newBuilder()
+                .setTitle("My second blog")
+                .setContent("Armeria is awesome!")
+                .build();
+  client.createBlogPost(newBlogPost);
+  final ListBlogPostsResponse
+          response = client.listBlogPosts(ListBlogPostsRequest.newBuilder()
+                .setDescending(false)
+                .build());
+
+  final List<BlogPost> blogs = response.getBlogsList();
+  assertThat(blogs).hasSize(2);
+  final BlogPost firstBlog = blogs.get(0);
+  assertThat(firstBlog.getTitle()).isEqualTo("My first blog");
+  assertThat(firstBlog.getContent()).isEqualTo("Hello Armeria!");
+
+  final BlogPost secondBlog = blogs.get(1);
+  assertThat(secondBlog.getTitle()).isEqualTo("My second blog");
+  assertThat(secondBlog.getContent()).isEqualTo("Armeria is awesome!");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## What's next
+
+In this step, we've implemented service methods to retrieve blog posts.
+
+Next, at [Step 5. Implement UPDATE](/tutorials/grpc/blog/implement-update), we'll implement an UPDATE operation to update a blog post.
+
+<TutorialSteps current={4} />

--- a/site-new/docs/tutorials/grpc/04-implement-read.mdx
+++ b/site-new/docs/tutorials/grpc/04-implement-read.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement READ"
-order: 4
+sidebar_label: "4. Implement READ"
 type: step
 category: grpc
 tags:
@@ -21,7 +20,7 @@ We'll write two service methods, one for reading a single post and another for m
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- [Generated Java code](/docs/tutorials/grpc/define-service#6-compile-the-proto-file)
 - `BlogService.java`
 - `Main.java`
 - `BlogServiceTest.java`
@@ -31,12 +30,12 @@ You can always [download](https://github.com/line/armeria-examples/tree/main/tut
 Let's write two methods for retrieving blog posts; one for a single post and
 another for multiple posts.
 
-<Tabs>
-<TabPane tab="Single post" key="1">
+<Tabs groupId="grpc-read">
+<TabItem label="Single post" value="1">
 
 Add a service method in `BlogService.java` to retrieve a single post.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
 import example.armeria.blog.grpc.GetBlogPostRequest;
 
 public final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
@@ -56,12 +55,12 @@ public final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 Add a service method in `BlogService.java` to retrieve multiple posts.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -89,7 +88,7 @@ final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
 }
 ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 2. Test retrieving a single post
@@ -97,7 +96,7 @@ final class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
 Let's test if we can retrieve a blog post we created.
 
 1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @Test
   void getBlogPost() throws JsonProcessingException {
     final BlogPost blogPost = client.getBlogPost(GetBlogPostRequest.newBuilder().setId(0).build());
@@ -108,7 +107,7 @@ Let's test if we can retrieve a blog post we created.
   ```
 2. Add annotations to configure the order our test methods will be executed.
   The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
   import org.junit.jupiter.api.Order;
   import org.junit.jupiter.api.TestMethodOrder;
@@ -139,7 +138,7 @@ Let's test if we can retrieve a blog post we created.
 Let's try retrieving a blog post that does not exist.
 Add a test method to retrieve a blog post with an invalid ID, asserting an exception is thrown.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(3)
 void getInvalidBlogPost() throws JsonProcessingException {
@@ -161,7 +160,7 @@ Check that you see the test is passed.
 Finally, let's test if we can retrieve multiple posts.
 Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(4)
 void listBlogPosts() throws JsonProcessingException {
@@ -194,6 +193,6 @@ Check that you see the test is passed.
 
 In this step, we've implemented service methods to retrieve blog posts.
 
-Next, at [Step 5. Implement UPDATE](/tutorials/grpc/blog/implement-update), we'll implement an UPDATE operation to update a blog post.
+Next, at [Step 5. Implement UPDATE](/docs/tutorials/grpc/implement-update), we'll implement an UPDATE operation to update a blog post.
 
 <TutorialSteps current={4} />

--- a/site-new/docs/tutorials/grpc/05-implement-update.mdx
+++ b/site-new/docs/tutorials/grpc/05-implement-update.mdx
@@ -1,0 +1,184 @@
+---
+menuTitle: "Implement UPDATE"
+order: 5
+category: grpc
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing UPDATE operation
+
+Previously, we created and read blog posts.
+Now, let's implement and make a call to update a blog post.
+We'll also learn how to handle an exception with a custom exception handler.
+
+<TutorialSteps current={5} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- `BlogService.java`
+- `Main.java`
+- `BlogServiceTest.java`
+
+## 1. Implement server-side
+
+Let's implement the server-side for updating blog posts.
+This time, we'll use a custom exception handler.
+
+### Add an exception handler
+
+First, add a custom exception handler for the blog service.
+
+1. Create a class for the exception to be thrown when a specified blog post ID doesn't exist.
+  ```java filename=BlogNotFoundException.java
+  package example.armeria.server.blog.grpc;
+
+  final class BlogNotFoundException extends IllegalStateException {
+    BlogNotFoundException(String s) {
+        super(s);
+    }
+  }
+  ```
+2. Add an exception handler class for the blog service.
+  ```java filename=GrpcExceptionHandler.java
+  package example.armeria.server.blog.grpc;
+
+  import com.linecorp.armeria.common.RequestContext;
+  import com.linecorp.armeria.common.annotation.Nullable;
+  import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
+
+  import io.grpc.Metadata;
+  import io.grpc.Status;
+
+  public class GrpcExceptionHandler implements GrpcExceptionHandlerFunction {
+
+    @Nullable
+    @Override
+    public Status apply(RequestContext ctx, Throwable cause, Metadata metadata) {
+      if (cause instanceof IllegalArgumentException) {
+          return Status.INVALID_ARGUMENT.withCause(cause);
+      }
+      if (cause instanceof BlogNotFoundException) {
+          return Status.NOT_FOUND.withCause(cause).withDescription(cause.getMessage());
+      }
+
+      // The default mapping function will be applied.
+      return null;
+    }
+  }
+  ```
+3. In the `Main` class, bind the `GrpcExceptionHandler` to our service.
+  ```java filename=Main.java
+  private static Server newServer(int port) throws Exception {
+    final GrpcService grpcService =
+       GrpcService.builder()
+                  .addService(new BlogService())
+                  .exceptionMapping(new GrpcExceptionHandler()) // Add this
+                  .build();
+    ...
+  }
+  ```
+
+### Implement the service method
+
+In the `BlogServiceImpl` class, add a service method for updating a blog post.
+```java filename=BlogService.java
+import example.armeria.blog.grpc.UpdateBlogPostRequest;
+
+public class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+  @Override
+  public void updateBlogPost(UpdateBlogPostRequest request, StreamObserver<BlogPost> responseObserver) {
+    final BlogPost oldBlogPost = blogPosts.get(request.getId());
+    if (oldBlogPost == null) {
+      throw new BlogNotFoundException("The blog post does not exist. ID: " + request.getId());
+    } else {
+      final BlogPost newBlogPost = oldBlogPost.toBuilder()
+                .setTitle(request.getTitle())
+                .setContent(request.getContent())
+                .setModifiedAt(Instant.now().toEpochMilli())
+                .build();
+      blogPosts.put(request.getId(), newBlogPost);
+      responseObserver.onNext(newBlogPost);
+      responseObserver.onCompleted();
+    }
+  }
+}
+```
+
+## 3. Test updating a blog post
+
+Let's try updating the content of the first blog post.
+Add a method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(5)
+void updateBlogPosts() throws JsonProcessingException {
+  final UpdateBlogPostRequest request = UpdateBlogPostRequest.newBuilder()
+              .setId(0)
+              .setTitle("My first blog")
+              .setContent("Hello awesome Armeria!")
+              .build();
+  final BlogPost updated = client.updateBlogPost(request);
+  assertThat(updated.getId()).isZero();
+  assertThat(updated.getTitle()).isEqualTo("My first blog");
+  assertThat(updated.getContent()).isEqualTo("Hello awesome Armeria!");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 4. Test an error case
+
+To check that our exception handler is working, let's try updating a post which does not exist.
+
+1. Bind the exception handler to the service for the test server.
+  ```java filename=BlogServiceTest.java
+  @RegisterExtension
+  static final ServerExtension server = new ServerExtension() {
+    @Override
+    protected void configure(ServerBuilder sb) throws Exception {
+      sb.service(GrpcService.builder()
+                .addService(new BlogService())
+                .exceptionHandler(new GrpcExceptionHandler()) // Add this
+                .build());
+    }
+  };
+  ```
+2. Add a test method to update a blog post with an invalid ID, asserting an exception is thrown as expected.
+  ```java filename=BlogServiceTest.java
+  @Test
+  @Order(6)
+  void updateInvalidBlogPost() {
+    final Throwable exception = catchThrowable(() -> {
+       client.updateBlogPost(UpdateBlogPostRequest.newBuilder()
+                .setId(Integer.MAX_VALUE)
+                .setTitle("My first blog")
+                .setContent("Hello awesome Armeria!")
+                .build());
+    });
+    final StatusRuntimeException statusException = (StatusRuntimeException) exception;
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.NOT_FOUND);
+    assertThat(statusException)
+                .hasMessageContaining("The blog post does not exist. ID: " + Integer.MAX_VALUE);
+  }
+  ```
+3. Run all the test cases on your IDE or using Gradle.
+  Check that you see the test is passed.
+
+## What's next
+
+In this step, we've implemented a service method for updating a blog post.
+We've also added an exception handler.
+
+Next, at [Step 6. Implement DELETE](/tutorials/grpc/blog/implement-delete), we'll implement a method
+for deleting a blog post and add a [Documentation Service](/docs/server-docservice) to our service.
+
+<TutorialSteps current={5} />

--- a/site-new/docs/tutorials/grpc/05-implement-update.mdx
+++ b/site-new/docs/tutorials/grpc/05-implement-update.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement UPDATE"
-order: 5
+sidebar_label: "5. Implement UPDATE"
 category: grpc
 tags:
   - server
@@ -21,7 +20,7 @@ We'll also learn how to handle an exception with a custom exception handler.
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- [Generated Java code](/docs/tutorials/grpc/define-service#6-compile-the-proto-file)
 - `BlogService.java`
 - `Main.java`
 - `BlogServiceTest.java`
@@ -36,7 +35,7 @@ This time, we'll use a custom exception handler.
 First, add a custom exception handler for the blog service.
 
 1. Create a class for the exception to be thrown when a specified blog post ID doesn't exist.
-  ```java filename=BlogNotFoundException.java
+  ```java title="BlogNotFoundException.java"
   package example.armeria.server.blog.grpc;
 
   final class BlogNotFoundException extends IllegalStateException {
@@ -46,7 +45,7 @@ First, add a custom exception handler for the blog service.
   }
   ```
 2. Add an exception handler class for the blog service.
-  ```java filename=GrpcExceptionHandler.java
+  ```java title="GrpcExceptionHandler.java"
   package example.armeria.server.blog.grpc;
 
   import com.linecorp.armeria.common.RequestContext;
@@ -74,7 +73,7 @@ First, add a custom exception handler for the blog service.
   }
   ```
 3. In the `Main` class, bind the `GrpcExceptionHandler` to our service.
-  ```java filename=Main.java
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
     final GrpcService grpcService =
        GrpcService.builder()
@@ -88,7 +87,7 @@ First, add a custom exception handler for the blog service.
 ### Implement the service method
 
 In the `BlogServiceImpl` class, add a service method for updating a blog post.
-```java filename=BlogService.java
+```java title="BlogService.java"
 import example.armeria.blog.grpc.UpdateBlogPostRequest;
 
 public class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
@@ -116,7 +115,7 @@ public class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
 Let's try updating the content of the first blog post.
 Add a method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(5)
 void updateBlogPosts() throws JsonProcessingException {
@@ -140,7 +139,7 @@ Check that you see the test is passed.
 To check that our exception handler is working, let's try updating a post which does not exist.
 
 1. Bind the exception handler to the service for the test server.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @RegisterExtension
   static final ServerExtension server = new ServerExtension() {
     @Override
@@ -153,7 +152,7 @@ To check that our exception handler is working, let's try updating a post which 
   };
   ```
 2. Add a test method to update a blog post with an invalid ID, asserting an exception is thrown as expected.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @Test
   @Order(6)
   void updateInvalidBlogPost() {
@@ -178,7 +177,7 @@ To check that our exception handler is working, let's try updating a post which 
 In this step, we've implemented a service method for updating a blog post.
 We've also added an exception handler.
 
-Next, at [Step 6. Implement DELETE](/tutorials/grpc/blog/implement-delete), we'll implement a method
-for deleting a blog post and add a [Documentation Service](/docs/server-docservice) to our service.
+Next, at [Step 6. Implement DELETE](/docs/tutorials/grpc/implement-delete), we'll implement a method
+for deleting a blog post and add a [Documentation Service](/docs/server/docservice) to our service.
 
 <TutorialSteps current={5} />

--- a/site-new/docs/tutorials/grpc/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/grpc/06-implement-delete.mdx
@@ -1,0 +1,235 @@
+---
+menuTitle: "Implement DELETE"
+order: 6
+category: grpc
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing DELETE operation
+
+So far, we created, read, and updated a blog post.
+Now, let's implement and make a call to delete a blog post.
+Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for testing our blog service.
+
+<TutorialSteps current={6} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- `BlogService.java`
+- `Main.java`
+- `BlogServiceTest.java`
+- `BlogNotFoundException.java`
+- `GrpcExceptionHandler.java`
+
+## 1. Implement server-side
+
+Let's implement a service method `deleteBlogPost()` in the `BlogService` class.
+
+1. Add a service method, `deleteBlogPost()`.
+
+  ```java filename=BlogService.java
+  import example.armeria.blog.grpc.DeleteBlogPostRequest;
+
+  public class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
+    @Override
+    public void deleteBlogPost(DeleteBlogPostRequest request, StreamObserver<Empty> responseObserver) {
+      try {
+        // Simulate a blocking API call.
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+
+      final BlogPost removed = blogPosts.remove(request.getId());
+      if (removed == null) {
+        responseObserver.onError(
+          new BlogNotFoundException("The blog post does not exist. ID: " + request.getId()));
+      } else {
+          responseObserver.onNext(Empty.getDefaultInstance());
+          responseObserver.onCompleted();
+      }
+   }
+  }
+  ```
+2. Add Armeria's <type://GrpcServiceBuilder>'s blocking task executor to make all gRPC methods executed
+  in the blocking task executor's thread pool.
+
+  By default, service methods are executed on the event loop and are expected to be implemented asynchronously.
+  To implement blocking logic, call `useBlockingTaskExecutor(true)`.
+
+  ```java filename=Main.java
+  private static Server newServer(int port) throws Exception {
+    final GrpcService grpcService =
+            GrpcService.builder().addService(new BlogService())
+                                 .exceptionMapping(new GrpcExceptionHandler())
+                                 .useBlockingTaskExecutor(true) // Add this
+                                 .build();
+    ...
+  }
+  ```
+
+## 2. Test deleting a blog post
+
+Let's test deleting a blog post.
+We'll delete the blog post with ID `1`, and try retrieving with the same ID to verify it is indeed deleted.
+Add a test method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(7)
+void deleteBlogPost() {
+  final DeleteBlogPostRequest request = DeleteBlogPostRequest.newBuilder()
+                                                             .setId(1)
+                                                             .build();
+  client.deleteBlogPost(request);
+  final Throwable exception = catchThrowable(() -> {
+    client.getBlogPost(GetBlogPostRequest.newBuilder().setId(1).build());
+  });
+
+  final StatusRuntimeException statusException = (StatusRuntimeException) exception;
+  assertThat(statusException.getStatus().getCode()).isEqualTo(Code.NOT_FOUND);
+  assertThat(statusException)
+          .hasMessageContaining("The blog post does not exist. ID: 1");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 3. Test an error case
+
+Let's test deleting a blog post that does not exist.
+Add a test method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(8)
+void badRequestExceptionHandlerWhenTryingDeleteMissingBlogPost() throws JsonProcessingException {
+  final Throwable exception = catchThrowable(() -> {
+    client.deleteBlogPost(DeleteBlogPostRequest.newBuilder().setId(100).build());
+  });
+  final StatusRuntimeException statusException = (StatusRuntimeException) exception;
+  assertThat(statusException.getStatus().getCode()).isEqualTo(Code.NOT_FOUND);
+  assertThat(statusException)
+          .hasMessageContaining("The blog post does not exist. ID: 100");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 4. Add the Documentation service
+
+This time, we'll add Armeria's [Documentation service](/docs/server-docservice).
+The Documentation service automatically creates documentation of your service methods, as well as providing means to test out the methods.
+
+1. In the `newServer()` method, add a <type://DocService> instance and a request example for [creating blog posts](/tutorials/grpc/blog/implement-create),
+  using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
+  ```java filename=Main.java
+  import com.linecorp.armeria.server.docs.DocService;
+  import com.linecorp.armeria.server.docs.DocServiceFilter;
+  import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
+
+  final class Main {
+    private static Server newServer(int port) throws Exception {
+      final BlogPost exampleRequest =
+        BlogPost.newBuilder()
+                .setTitle("Example title")
+                .setContent("Example content")
+                .build();
+      final DocService docService =
+        DocService.builder()
+                  .exampleRequests(BlogServiceGrpc.SERVICE_NAME,
+                                   "CreateBlogPost", exampleRequest)
+                  .exclude(DocServiceFilter.ofServiceName(
+                           ServerReflectionGrpc.SERVICE_NAME))
+                  .build();
+
+    }
+  }
+  ```
+2. Enable unframed requests by setting <type://GrpcServiceBuilder#enableUnframedRequests(boolean)> to `true`.
+  This makes the blog service support requests that are not framed in gRPC wire format.
+  For us, this enables making calls from a web browser.
+  ```java filename=Main.java
+  private static Server newServer(int port) throws Exception {
+  ...
+  final GrpcService grpcService =
+          GrpcService.builder()
+                     .addService(new BlogService())
+                     .enableUnframedRequests(true) // Add this
+                     .exceptionMapping(new GrpcExceptionHandler())
+                     .useBlockingTaskExecutor(true)
+                     .build();
+  ...
+  }
+  ```
+3. Add the <type://DocService> to the server builder.
+  ```java filename=Main.java
+  private static Server newServer(int port) throws Exception {
+    ...
+    return Server.builder()
+                 .http(port)
+                 .service(grpcService)
+                 .serviceUnder("/docs", docService) // Add this
+                 .build();
+  }
+  ```
+4. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
+  ```java filename=Main.java highlight=2
+  public static void main(String[] args) throws Exception {
+    ...
+    logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
+                server.activeLocalPort());
+  }
+  ```
+5. Otherwise, restart the server by running the `Main.main()` method.
+
+  The server and services are launched successfully if you see this message.
+  ```bash
+  Server has been started. Serving DocService at http://127.0.0.1:8080/docs
+  ```
+
+## 5. Check the DocService page
+
+Let's test and call our service operations using Armeria's Documentation service.
+
+1. Click the URL http://127.0.0.1:8080/docs from the log message or open up the URL on a web browser.
+
+  If you see the Document service page, you've successfully launched the <type://DocService> and server.
+
+  ![](../../../../images/tutorial_blogservice_grpc_docservice_start.png)
+
+2. Click the **CreateBlogPost()** method link in the left panel. You can make calls to the method from the page.
+
+  ![](../../../../images/tutorial_blogservice_grpc_reqex.png)
+
+  Note that in the **REQUEST BODY** section the values specified in the `exampleRequest` are automatically displayed on the page.
+
+  ```java filename=Main.java
+  final BlogPost exampleRequest = BlogPost.newBuilder()
+                     .setTitle("Example title")
+                     .setContent("Example content")
+                     .build();
+  ```
+
+3. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
+
+  ![](../../../../images/tutorial_blogservice_grpc_return.png)
+
+## What's next
+
+In this step, we've implemented a service method and client method for deleting a blog post.
+We've also added [Documentation service](/docs/server-docservice) to our server.
+
+We've come to the end of this tutorial.
+Next, try adding more service methods to the tutorial or have a go at developing a service of your own.
+
+<TutorialSteps current={6} />

--- a/site-new/docs/tutorials/grpc/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/grpc/06-implement-delete.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement DELETE"
-order: 6
+sidebar_label: "6. Implement DELETE"
 category: grpc
 tags:
   - server
@@ -12,7 +11,7 @@ type: step
 
 So far, we created, read, and updated a blog post.
 Now, let's implement and make a call to delete a blog post.
-Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for testing our blog service.
+Also, we'll add Armeria's [Documentation Service](/docs/server/docservice) for testing our blog service.
 
 <TutorialSteps current={6} />
 
@@ -21,7 +20,7 @@ Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for t
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/grpc/blog/define-service#6-compile-the-proto-file)
+- [Generated Java code](/docs/tutorials/grpc/define-service#6-compile-the-proto-file)
 - `BlogService.java`
 - `Main.java`
 - `BlogServiceTest.java`
@@ -34,7 +33,7 @@ Let's implement a service method `deleteBlogPost()` in the `BlogService` class.
 
 1. Add a service method, `deleteBlogPost()`.
 
-  ```java filename=BlogService.java
+  ```java title="BlogService.java"
   import example.armeria.blog.grpc.DeleteBlogPostRequest;
 
   public class BlogService extends BlogServiceGrpc.BlogServiceImplBase {
@@ -58,13 +57,13 @@ Let's implement a service method `deleteBlogPost()` in the `BlogService` class.
    }
   }
   ```
-2. Add Armeria's <type://GrpcServiceBuilder>'s blocking task executor to make all gRPC methods executed
+2. Add Armeria's [GrpcServiceBuilder](type)'s blocking task executor to make all gRPC methods executed
   in the blocking task executor's thread pool.
 
   By default, service methods are executed on the event loop and are expected to be implemented asynchronously.
   To implement blocking logic, call `useBlockingTaskExecutor(true)`.
 
-  ```java filename=Main.java
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
     final GrpcService grpcService =
             GrpcService.builder().addService(new BlogService())
@@ -81,7 +80,7 @@ Let's test deleting a blog post.
 We'll delete the blog post with ID `1`, and try retrieving with the same ID to verify it is indeed deleted.
 Add a test method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(7)
 void deleteBlogPost() {
@@ -108,7 +107,7 @@ Check that you see the test is passed.
 Let's test deleting a blog post that does not exist.
 Add a test method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(8)
 void badRequestExceptionHandlerWhenTryingDeleteMissingBlogPost() throws JsonProcessingException {
@@ -127,12 +126,12 @@ Check that you see the test is passed.
 
 ## 4. Add the Documentation service
 
-This time, we'll add Armeria's [Documentation service](/docs/server-docservice).
+This time, we'll add Armeria's [Documentation service](/docs/server/docservice).
 The Documentation service automatically creates documentation of your service methods, as well as providing means to test out the methods.
 
-1. In the `newServer()` method, add a <type://DocService> instance and a request example for [creating blog posts](/tutorials/grpc/blog/implement-create),
-  using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
-  ```java filename=Main.java
+1. In the `newServer()` method, add a [DocService](type) instance and a request example for [creating blog posts](/docs/tutorials/grpc/implement-create),
+  using [DocServiceBuilder#exampleRequests(Class,String,Iterable)](type). Feel free to add more examples for other service methods.
+  ```java title="Main.java"
   import com.linecorp.armeria.server.docs.DocService;
   import com.linecorp.armeria.server.docs.DocServiceFilter;
   import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
@@ -155,10 +154,10 @@ The Documentation service automatically creates documentation of your service me
     }
   }
   ```
-2. Enable unframed requests by setting <type://GrpcServiceBuilder#enableUnframedRequests(boolean)> to `true`.
+2. Enable unframed requests by setting [GrpcServiceBuilder#enableUnframedRequests(boolean)](type) to `true`.
   This makes the blog service support requests that are not framed in gRPC wire format.
   For us, this enables making calls from a web browser.
-  ```java filename=Main.java
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
   ...
   final GrpcService grpcService =
@@ -171,8 +170,8 @@ The Documentation service automatically creates documentation of your service me
   ...
   }
   ```
-3. Add the <type://DocService> to the server builder.
-  ```java filename=Main.java
+3. Add the [DocService](type) to the server builder.
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
     ...
     return Server.builder()
@@ -183,7 +182,7 @@ The Documentation service automatically creates documentation of your service me
   }
   ```
 4. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
-  ```java filename=Main.java highlight=2
+  ```java title="Main.java" highlight=2
   public static void main(String[] args) throws Exception {
     ...
     logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
@@ -203,17 +202,17 @@ Let's test and call our service operations using Armeria's Documentation service
 
 1. Click the URL http://127.0.0.1:8080/docs from the log message or open up the URL on a web browser.
 
-  If you see the Document service page, you've successfully launched the <type://DocService> and server.
+  If you see the Document service page, you've successfully launched the [DocService](type) and server.
 
-  ![](../../../../images/tutorial_blogservice_grpc_docservice_start.png)
+  ![](/img/tutorial_blogservice_grpc_docservice_start.png)
 
 2. Click the **CreateBlogPost()** method link in the left panel. You can make calls to the method from the page.
 
-  ![](../../../../images/tutorial_blogservice_grpc_reqex.png)
+  ![](/img/tutorial_blogservice_grpc_reqex.png)
 
   Note that in the **REQUEST BODY** section the values specified in the `exampleRequest` are automatically displayed on the page.
 
-  ```java filename=Main.java
+  ```java title="Main.java"
   final BlogPost exampleRequest = BlogPost.newBuilder()
                      .setTitle("Example title")
                      .setContent("Example content")
@@ -222,12 +221,12 @@ Let's test and call our service operations using Armeria's Documentation service
 
 3. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
 
-  ![](../../../../images/tutorial_blogservice_grpc_return.png)
+  ![](/img/tutorial_blogservice_grpc_return.png)
 
 ## What's next
 
 In this step, we've implemented a service method and client method for deleting a blog post.
-We've also added [Documentation service](/docs/server-docservice) to our server.
+We've also added [Documentation service](/docs/server/docservice) to our server.
 
 We've come to the end of this tutorial.
 Next, try adding more service methods to the tutorial or have a go at developing a service of your own.

--- a/site-new/docs/tutorials/grpc/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/grpc/06-implement-delete.mdx
@@ -182,7 +182,7 @@ The Documentation service automatically creates documentation of your service me
   }
   ```
 4. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
-  ```java title="Main.java" highlight=2
+  ```java title="Main.java"
   public static void main(String[] args) throws Exception {
     ...
     logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",

--- a/site-new/docs/tutorials/grpc/index.mdx
+++ b/site-new/docs/tutorials/grpc/index.mdx
@@ -3,7 +3,7 @@ type: tutorial
 level: basic
 ---
 
-import versions from '/gen-src/versions.json';
+import versions from '../../../gen-src-temp/versions.json';
 
 # gRPC tutorial introduction
 
@@ -29,12 +29,12 @@ Armeria supports features that the upstream (gRPC-Java) does not support.
 - Serialization format - Unframed
   - Protobuf: application/protobuf
   - JSON: application/json
-- [HTTP level decorator](/docs/server-grpc#decorating-a-grpcservice)
+- [HTTP level decorator](/docs/server/grpc#decorating-a-grpcservice)
 - Richer error handling
 - [HTTP-to-JSON transcoding](https://google.aip.dev/127)
 - Customizing service method paths
-- [gRPC documentation service](/docs/server-docservice)
-- gRPC status monitoring with <type://MetricCollectingService>
+- [gRPC documentation service](/docs/server/docservice)
+- gRPC status monitoring with [MetricCollectingService](type)
 
 ## Assumptions
 
@@ -80,17 +80,17 @@ grpc/
 └─ build.gradle
 ```
 
-<Tip>
+:::tip
 
   To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
 
-</Tip>
+:::
 
 ## Build and run sample service
 
 The sample service provides you implementations of CRUD operations with corresponding service methods.
 Have a go at running the sample gRPC service and see the outcome of this tutorial.
-Using Armeria's [Documentation Service](/docs/server-docservice), you can easily verify a server is running, receiving requests and sending responses.
+Using Armeria's [Documentation Service](/docs/server/docservice), you can easily verify a server is running, receiving requests and sending responses.
 
 1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/grpc).
 2. Build the sample service using the Gradle Wrapper.
@@ -129,10 +129,10 @@ dependencies {
 
 Start writing the blog service yourself by following the tutorial step by step:
 
-1. [Define a service](/tutorials/grpc/blog/define-service)
-2. [Run a service](/tutorials/grpc/blog/run-service)
-3. [Implement CREATE](/tutorials/grpc/blog/implement-create)
-4. [Implement READ](/tutorials/grpc/blog/implement-read)
-5. [Implement UPDATE](/tutorials/grpc/blog/implement-update)
-6. [Implement DELETE](/tutorials/grpc/blog/implement-delete)
+1. [Define a service](/docs/tutorials/grpc/define-service)
+2. [Run a service](/docs/tutorials/grpc/run-service)
+3. [Implement CREATE](/docs/tutorials/grpc/implement-create)
+4. [Implement READ](/docs/tutorials/grpc/implement-read)
+5. [Implement UPDATE](/docs/tutorials/grpc/implement-update)
+6. [Implement DELETE](/docs/tutorials/grpc/implement-delete)
 

--- a/site-new/docs/tutorials/grpc/index.mdx
+++ b/site-new/docs/tutorials/grpc/index.mdx
@@ -1,1 +1,138 @@
+---
+type: tutorial
+level: basic
+---
+
+import versions from '/gen-src/versions.json';
+
 # gRPC tutorial introduction
+
+In this tutorial, you'll learn how to build a [gRPC](https://grpc.io/) service with Armeria.
+This tutorial is based on a [sample service](#sample-service), a minimal blog service, with which you can create, read, update, and delete blog posts.
+
+Follow this tutorial to write a service yourself or try [running the sample service](#build-and-run-sample-service) right away.
+
+## Background
+
+Before we get our hands on the tutorial, let's swiftly go over Armeria's gRPC features.
+Armeria supports features that the upstream (gRPC-Java) does not support.
+
+- Protocol
+  - HTTP/1.1
+  - HTTP/2 (upstream)
+- Serialization format - Framed
+  - gRPC protobuf: application/grpc+proto (upstream)
+  - gRPC JSON: application/grpc+json
+  - gRPC Web: application/grpc-web+proto
+  - gRPC Web JSON: application/grpc-web+json
+  - gRPC Web Text: application/grpc-web-text+proto
+- Serialization format - Unframed
+  - Protobuf: application/protobuf
+  - JSON: application/json
+- [HTTP level decorator](/docs/server-grpc#decorating-a-grpcservice)
+- Richer error handling
+- [HTTP-to-JSON transcoding](https://google.aip.dev/127)
+- Customizing service method paths
+- [gRPC documentation service](/docs/server-docservice)
+- gRPC status monitoring with <type://MetricCollectingService>
+
+## Assumptions
+
+This tutorial assumes that you have:
+
+- Experience in building services in Java
+- Experience in Java frameworks for server-side programming
+- Understanding of gRPC and experience in implementing gRPC services
+
+## Prerequisites
+
+To run and develop the sample service, you need JDK 11 or higher.
+
+## Sample service
+
+The [sample service](https://github.com/line/armeria-examples/tree/main/tutorials/grpc) provides implementations of CRUD operations as specified below.
+
+| Operation | Method |
+| -- | -- |
+| Create | `createBlogPost()` |
+| Read | `getBlogPost()`, `listBlogPosts()` |
+| Update | `updateBlogPost()` |
+| Delete | `deleteBlogPost()` |
+
+The sample service code consists of the following folders and files.
+
+```
+grpc/
+├─ src/
+│  ├─ main/
+│  │  ├─ java/
+│  │  │  ├─ example.armeria.server.blog.grpc/
+│  │  │  │  ├─ BlogNotFoundException.java
+│  │  │  │  ├─ BlogService.java
+│  │  │  │  ├─ GrpcExceptionHandler.java
+│  │  │  │  └─ Main.java
+│  │  ├─ proto/
+│  │  │  └─ blog.proto
+│  └─ test/
+│     └─ java/
+│        └─ example.armeria.server.blog.grpc/
+│           └─ BlogServiceTest.java
+└─ build.gradle
+```
+
+<Tip>
+
+  To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
+
+</Tip>
+
+## Build and run sample service
+
+The sample service provides you implementations of CRUD operations with corresponding service methods.
+Have a go at running the sample gRPC service and see the outcome of this tutorial.
+Using Armeria's [Documentation Service](/docs/server-docservice), you can easily verify a server is running, receiving requests and sending responses.
+
+1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/grpc).
+2. Build the sample service using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew build
+  ```
+3. Run the sample service again, using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew run
+  ```
+4. Open the Documentation service page on your web browser at http://127.0.0.1:8080/docs.
+
+## Try writing blog service yourself
+
+Use the sample service's [build.gradle](https://github.com/line/armeria-examples/blob/main/tutorials/grpc/build.gradle) file to start building the service from scratch.
+Below is a part of the `build.gradle` file for the sample service.
+This tutorial uses [protobuf-gradle-plugin](https://github.com/google/protobuf-gradle-plugin) to generate stubs from `proto` files.
+
+<CodeBlock language="groovy" filename="build.gradle">{`
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'eclipse'\n
+repositories {
+  mavenCentral()
+}\n
+dependencies {
+  implementation "com.linecorp.armeria:armeria:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  implementation "com.linecorp.armeria:armeria-grpc:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  // Logging
+  runtimeOnly "ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}"\n
+  testImplementation "org.junit.jupiter:junit-jupiter:${versions['org.junit:junit-bom']}"\n
+  testImplementation "com.linecorp.armeria:armeria-junit5:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  testImplementation "org.assertj:assertj-core:${versions['org.assertj:assertj-core']}"
+}
+`}</CodeBlock>
+
+Start writing the blog service yourself by following the tutorial step by step:
+
+1. [Define a service](/tutorials/grpc/blog/define-service)
+2. [Run a service](/tutorials/grpc/blog/run-service)
+3. [Implement CREATE](/tutorials/grpc/blog/implement-create)
+4. [Implement READ](/tutorials/grpc/blog/implement-read)
+5. [Implement UPDATE](/tutorials/grpc/blog/implement-update)
+6. [Implement DELETE](/tutorials/grpc/blog/implement-delete)
+

--- a/site-new/docs/tutorials/index.mdx
+++ b/site-new/docs/tutorials/index.mdx
@@ -6,9 +6,11 @@ These tutorials take you through steps based on a sample service, a blog service
 
 We've prepared three different tutorials for you:
 
-- [REST tutorial](/docs/tutorials/rest): Learn how to build a REST service with Armeria.
-- [gRPC tutorial](/docs/tutorials/grpc): Learn how to build a [gRPC](https://grpc.io/) service with Armeria.
-- [Thrift tutorial](/docs/tutorials/thrift): Learn how to build a service using [Apache Thrift](https://thrift.apache.org/) with Armeria.
+<DocCardList items={[
+  {type: 'link', label: 'REST tutorial', href: '/docs/tutorials/rest', description: 'Learn how to build a REST service with Armeria.'},
+  {type: 'link', label: 'gRPC tutorial', href: '/docs/tutorials/grpc', description: 'Learn how to build a gRPC service with Armeria.'},
+  {type: 'link', label: 'Thrift tutorial', href: '/docs/tutorials/thrift', description: 'Learn how to build a service using Apache Thrift with Armeria.'},
+]} className='doc-card-list-expanded'/>
 
 You can choose any tutorial that interests you.
 Each one is designed to be clear and simple, so you'll be able to build your own service with Armeria by the time you're done.

--- a/site-new/docs/tutorials/index.mdx
+++ b/site-new/docs/tutorials/index.mdx
@@ -6,9 +6,9 @@ These tutorials take you through steps based on a sample service, a blog service
 
 We've prepared three different tutorials for you:
 
-- [REST tutorial](/tutorials/rest/blog): Learn how to build a REST service with Armeria.
-- [gRPC tutorial](/tutorials/grpc/blog): Learn how to build a [gRPC](https://grpc.io/) service with Armeria.
-- [Thrift tutorial](/tutorials/thrift/blog): Learn how to build a service using [Apache Thrift](https://thrift.apache.org/) with Armeria.
+- [REST tutorial](/docs/tutorials/rest): Learn how to build a REST service with Armeria.
+- [gRPC tutorial](/docs/tutorials/grpc): Learn how to build a [gRPC](https://grpc.io/) service with Armeria.
+- [Thrift tutorial](/docs/tutorials/thrift): Learn how to build a service using [Apache Thrift](https://thrift.apache.org/) with Armeria.
 
 You can choose any tutorial that interests you.
 Each one is designed to be clear and simple, so you'll be able to build your own service with Armeria by the time you're done.

--- a/site-new/docs/tutorials/rest/01-create-server.mdx
+++ b/site-new/docs/tutorials/rest/01-create-server.mdx
@@ -23,7 +23,7 @@ Let's create a server instance using Armeria's [ServerBuilder](type):
 
 1. Create a `Main` class. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/Main.java).
 
-  ```java filename=Main.java
+  ```java title="Main.java"
   package example.armeria.server.blog;
 
   import org.slf4j.Logger;
@@ -36,7 +36,7 @@ Let's create a server instance using Armeria's [ServerBuilder](type):
 
 2. In the `Main` class, add the method, `newServer()`. Since a server instance requires at least one service to run with, let's add a dummy service returning `"Hello, Armeria!"` for now.
 
-  ```java filename=Main.java highlight=10
+  ```java title="Main.java" {10}
   import com.linecorp.armeria.common.HttpResponse;
   import com.linecorp.armeria.server.Server;
   import com.linecorp.armeria.server.ServerBuilder;
@@ -62,7 +62,7 @@ Now that we have a server, have a go at starting the server with the dummy servi
 2. Call the `newServer()` method we implemented in step 2. Let's set the port to `8080` as in line 2.
 3. Start the server as in line 9.
 
-```java filename=Main.java highlight=2,9 showlineno=true
+```java title="Main.java" {2,9} showLineNumbers
 public static void main(String[] args) throws Exception {
   Server server = newServer(8080);
 

--- a/site-new/docs/tutorials/rest/01-create-server.mdx
+++ b/site-new/docs/tutorials/rest/01-create-server.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Create a server"
-order: 1
+sidebar_label: "1. Create a server"
 type: step
 tags:
   - server
@@ -10,17 +9,17 @@ level: basic
 # Creating a server
 
 As the first step of the tutorial, we create a server instance and run a dummy service to check that the server and service are launched.
-We'll use Armeria's <type://ServerBuilder> for this task.
+We'll use Armeria's [ServerBuilder](type) for this task.
 
 <TutorialSteps current={1} />
 
 ## What you need
 
-No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/rest/blog/#prerequisites).
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/docs/tutorials/rest#prerequisites).
 
 ## 1. Create a server instance
 
-Let's create a server instance using Armeria's <type://ServerBuilder>:
+Let's create a server instance using Armeria's [ServerBuilder](type):
 
 1. Create a `Main` class. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/Main.java).
 
@@ -53,7 +52,7 @@ Let's create a server instance using Armeria's <type://ServerBuilder>:
     ...
   ```
 
-  To learn how to add the actual blog service, see [Step 3. Add services to a server](/tutorials/rest/blog/add-services-to-server).
+  To learn how to add the actual blog service, see [Step 3. Add services to a server](/docs/tutorials/rest/add-services-to-server).
 
 ## 2. Start the server
 
@@ -86,12 +85,12 @@ As the last step, launch the server and run the service to check if you're all s
 
 Open the URL `http://127.0.0.1:8080` on a web browser and check the message `Hello, Armeria!` is displayed in the page.
 
-![](../../../../images/tutorial_test_run.png)
+![](/img/tutorial_test_run.png)
 
 ## What's next
 
 In this step, you've built a server, added a dummy service and launched a server.
 
-Next, at [Step 2. Prepare a data object](/tutorials/rest/blog/prepare-data-object), you'll write a data object to specify and contain blog post information.
+Next, at [Step 2. Prepare a data object](/docs/tutorials/rest/prepare-data-object), you'll write a data object to specify and contain blog post information.
 
 <TutorialSteps current={1} />

--- a/site-new/docs/tutorials/rest/01-create-server.mdx
+++ b/site-new/docs/tutorials/rest/01-create-server.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "1. Create a server"
+menuTitle: "Create a server"
+order: 1
 type: step
 tags:
   - server
@@ -9,6 +10,88 @@ level: basic
 # Creating a server
 
 As the first step of the tutorial, we create a server instance and run a dummy service to check that the server and service are launched.
-We'll use Armeria's [ServerBuilder](type) for this task.
+We'll use Armeria's <type://ServerBuilder> for this task.
+
+<TutorialSteps current={1} />
+
+## What you need
+
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/rest/blog/#prerequisites).
+
+## 1. Create a server instance
+
+Let's create a server instance using Armeria's <type://ServerBuilder>:
+
+1. Create a `Main` class. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/Main.java).
+
+  ```java filename=Main.java
+  package example.armeria.server.blog;
+
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+  public final class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+  }
+  ```
+
+2. In the `Main` class, add the method, `newServer()`. Since a server instance requires at least one service to run with, let's add a dummy service returning `"Hello, Armeria!"` for now.
+
+  ```java filename=Main.java highlight=10
+  import com.linecorp.armeria.common.HttpResponse;
+  import com.linecorp.armeria.server.Server;
+  import com.linecorp.armeria.server.ServerBuilder;
+
+  public final class Main {
+    ...
+    static Server newServer(int port) {
+      ServerBuilder sb = Server.builder();
+      return sb.http(port)
+               .service("/", (ctx, req) -> HttpResponse.of("Hello, Armeria!"))
+               .build();
+    }
+    ...
+  ```
+
+  To learn how to add the actual blog service, see [Step 3. Add services to a server](/tutorials/rest/blog/add-services-to-server).
+
+## 2. Start the server
+
+Now that we have a server, have a go at starting the server with the dummy service.
+
+1. In the `Main` class, add the `main()` method.
+2. Call the `newServer()` method we implemented in step 2. Let's set the port to `8080` as in line 2.
+3. Start the server as in line 9.
+
+```java filename=Main.java highlight=2,9 showlineno=true
+public static void main(String[] args) throws Exception {
+  Server server = newServer(8080);
+
+  server.closeOnJvmShutdown();
+
+  server.start().join();
+
+  logger.info("Server has been started. Serving dummy service at http://127.0.0.1:{}",
+              server.activeLocalPort());
+}
+```
+
+## 3. Run the server and service
+
+As the last step, launch the server and run the service to check if you're all set to go. To run the server, run the `main()` method in your IDE. The server and service are launched successfully if you see the following message.
+
+```bash
+ Server has been started. Serving dummy service at http://127.0.0.1:8080
+```
+
+Open the URL `http://127.0.0.1:8080` on a web browser and check the message `Hello, Armeria!` is displayed in the page.
+
+![](../../../../images/tutorial_test_run.png)
+
+## What's next
+
+In this step, you've built a server, added a dummy service and launched a server.
+
+Next, at [Step 2. Prepare a data object](/tutorials/rest/blog/prepare-data-object), you'll write a data object to specify and contain blog post information.
 
 <TutorialSteps current={1} />

--- a/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
+++ b/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Prepare a data object"
-order: 2
+sidebar_label: "2. Prepare a data object"
 type: step
 tags:
   - rest
@@ -84,7 +83,7 @@ public final class BlogPost {
 
 In this step, we've implemented a data object specifying and containing blog post objects.
 
-Next, at [Step 3. Add services to a server](/tutorials/rest/blog/add-services-to-server), we'll write and 
+Next, at [Step 3. Add services to a server](/docs/tutorials/rest/add-services-to-server), we'll write and 
 add an 
 empty service to the server we created earlier.
 

--- a/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
+++ b/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
@@ -41,7 +41,7 @@ public final class BlogPost {
 
 You need to create a blog post instance when you create or update blog posts. Let's add constructors in the `BlogPost` class.
 
-```java filename=BlogPost.java
+```java title="BlogPost.java"
 BlogPost(int id, String title, String content) {
   this(id, title, content, System.currentTimeMillis());
 }

--- a/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
+++ b/site-new/docs/tutorials/rest/02-prepare-data-object.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "2. Prepare a data object"
+menuTitle: "Prepare a data object"
+order: 2
 type: step
 tags:
   - rest
@@ -13,5 +14,78 @@ level: basic
 Before we get into writing a blog service, first prepare a data object to contain blog post information. This object is used also in handling requests and sending responses.
 
 If you want a quick start, skip this step and copy off the [BlogPost.java](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/BlogPost.java) of the sample service code.
+
+<TutorialSteps current={2} />
+
+## What you need
+
+No preparation is required for this step.
+
+## 1. Define blog post data
+
+Our blog service needs a container for blog post information.
+Let's define a `BlogPost` class containing the following information.
+
+```java
+package example.armeria.server.blog;
+
+public final class BlogPost {
+  private final int id;           // The post ID
+  private final String title;     // The post title
+  private final String content;   // The post content
+  private final long createdAt;   // The time post is created at
+  private final long modifiedAt;  // The time post is modified at
+}
+```
+
+## 2. Add constructors
+
+You need to create a blog post instance when you create or update blog posts. Let's add constructors in the `BlogPost` class.
+
+```java filename=BlogPost.java
+BlogPost(int id, String title, String content) {
+  this(id, title, content, System.currentTimeMillis());
+}
+
+BlogPost(int id, String title, String content, long createdAt) {
+  this(id, title, content, createdAt, createdAt);
+}
+
+BlogPost(int id, String title, String content, long createdAt, long modifiedAt) {
+  this.id = id;
+  this.title = title;
+  this.content = content;
+  this.createdAt = createdAt;
+  this.modifiedAt = modifiedAt;
+}
+```
+
+## 3. Add getters
+
+Add the following block of code in the blog service.
+
+```java
+public final class BlogPost {
+  ...
+
+  public int getId() { return id; }
+
+  public String getTitle() { return title; }
+
+  public String getContent() { return content; }
+
+  public long getCreatedAt() { return createdAt; }
+
+  public long getModifiedAt() { return modifiedAt; }
+}
+```
+
+## What's next?
+
+In this step, we've implemented a data object specifying and containing blog post objects.
+
+Next, at [Step 3. Add services to a server](/tutorials/rest/blog/add-services-to-server), we'll write and 
+add an 
+empty service to the server we created earlier.
 
 <TutorialSteps current={2} />

--- a/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
+++ b/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "3. Add services to a server"
+menuTitle: "Add services to a server"
+order: 3
 type: step
 tags:
   - docservice
@@ -10,5 +11,149 @@ level: basic
 # Adding services to a server
 
 In this step, we'll add an empty blog service to the server we created in [Step 1. Create a server](/tutorials/rest/blog/create-server). Also, we'll add Armeria's [Documentation service](/docs/server-docservice) for testing our blog service.
+
+<TutorialSteps current={3} />
+
+## What you need
+
+You need to have the following file obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/) the full version, instead of creating one yourself.
+
+- `Main.java`
+
+## 1. Create a service file
+
+Create a service file, `BlogService.java`. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/BlogService.java). We'll add on service methods in this class in later steps.
+
+```java filename=BlogService.java
+package example.armeria.server.blog;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class BlogService {
+  private final Map<Integer, BlogPost> blogPosts = new ConcurrentHashMap<>();
+}
+```
+
+## 2. Add a blog service to server
+
+In [Step 1. Create a server](/tutorials/rest/blog/create-server), we added a dummy service just to check that a server is launched. Now, let's remove the dummy service and add an empty blog service, instead.
+
+1. From `Main.java`, remove the dummy service at line 4.
+  ```java filename=Main.java highlight=4 showlineno=true
+  static Server newServer(int port) {
+    ...
+    return sb.http(port)
+             .service("/", (ctx, req) -> HttpResponse.of("Hello, Armeria!")) // Remove this
+             .build();
+  ```
+2. Add our service by adding line 4.
+  ```java filename=Main.java highlight=4 showlineno=true
+  static Server newServer(int port) {
+    ...
+    return sb.http(port)
+             .annotatedService(new BlogService())   // Add this
+             .build();
+  }
+  ```
+
+## 3. Add the Documentation service
+
+This time, we'll add Armeria's [Documentation service](/docs/server-docservice):
+
+1. In the `newServer()` method, add a <type://DocService> and a request example for [creating blog posts](/tutorials/rest/blog/implement-create),
+   using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
+
+  ```java filename=Main.java highlight=1,6-13
+  import com.linecorp.armeria.server.docs.DocService;
+
+  public final class Main {
+    static Server newServer(int port) {
+      ServerBuilder sb = Server.builder();
+      DocService docService =
+              DocService.builder()
+                        .exampleRequests(BlogService.class,
+                            "createBlogPost", // Name of service method
+                            "{\"title\":\"My first blog\", \"content\":\"Hello Armeria!\"}")
+                        .build();
+  ```
+
+2. Inside the `newServer()` method, add the <type://DocService> to our server builder.
+
+  ```java filename=Main.java highlight=5
+  static Server newServer(int port) {
+    ...
+    return sb.http(port)
+             .annotatedService(new BlogService())
+             .serviceUnder("/docs", docService)  // Add Documentation service
+             .build();
+  }
+  ```
+
+3. (Optional) To access the Documentation service result easily, edit the log message we added in [Step 1. Create a server](/tutorials/rest/blog/create-server) to the one specified below.
+
+  ```java filename=Main.java highlight=2
+  public static void main(String[] args) throws Exception {
+      logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
+                  server.activeLocalPort());
+  }
+  ```
+
+## 4. Run the server and services
+
+Like we did in _Step 1. Create a server_, [build and run](/tutorials/rest/blog/create-server#3-run-the-server-and-service) the service by running the `main()` method or using Gradle.
+
+The server and services are launched successfully if you see this message.
+
+```bash
+ Server has been started. Serving DocService at http://127.0.0.1:8080/docs
+```
+
+## 5. Check DocService page
+
+Let's test and call our service operations, using Armeria's Documentation service.
+
+Click the URL http://127.0.0.1:8080/docs from the log message or open the URL on a web browser. If you see the Document service page, you've launched the <type://DocService> and server successfully. We're seeing no services on the
+page because we're to implement service methods.
+
+  ![](../../../../images/tutorial_blogservice_docservice_start.png)
+
+### Using DocService after adding service methods
+
+When you add service methods through later steps, you'll see a result similar to this.
+
+![](../../../../images/tutorial_blogservice_docservice_end.png)
+
+To test your service methods with the [Documentation service](/docs/server-docservice):
+
+1. Click the **createBlogPost()** method link in the left panel. You can make calls to the creation method from the page opened.
+
+  ![](../../../../images/tutorial_blogservice_reqex.png)
+
+  Note that in the **REQUEST BODY** section that the values specified for the <type://DocServiceBuilder> are automatically entered on the page.
+
+  ```java filename=Main.java highlight=5-8
+  static Server newServer(int port) {
+    ServerBuilder sb = Server.builder();
+    DocService docService =
+      DocService.builder()
+                .exampleRequests(
+                  BlogService.class,
+                  "createBlogPost",
+                  "{\"title\":\"My first blog\",\"content\":\"Hello Armeria!\"}")
+                .build();
+  ```
+
+2. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
+
+  ![](../../../../images/tutorial_blogservice_return.png)
+
+## What's next?
+
+In this step, we've added an empty blog service and the Documentation service to a server.
+
+Next, at [Step 4. Implement CREATE](/tutorials/rest/blog/implement-create), we'll finally implement a CREATE
+operation to create blog posts.
 
 <TutorialSteps current={3} />

--- a/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
+++ b/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
@@ -24,7 +24,7 @@ You can always [download](https://github.com/line/armeria-examples/blob/main/tut
 
 Create a service file, `BlogService.java`. You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/BlogService.java). We'll add on service methods in this class in later steps.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
 package example.armeria.server.blog;
 
 import java.util.Map;
@@ -40,7 +40,7 @@ public final class BlogService {
 In [Step 1. Create a server](/docs/tutorials/rest/create-server), we added a dummy service just to check that a server is launched. Now, let's remove the dummy service and add an empty blog service, instead.
 
 1. From `Main.java`, remove the dummy service at line 4.
-  ```java filename=Main.java highlight=4 showlineno=true
+  ```java title="Main.java" {4} showLineNumbers
   static Server newServer(int port) {
     ...
     return sb.http(port)
@@ -48,7 +48,7 @@ In [Step 1. Create a server](/docs/tutorials/rest/create-server), we added a dum
              .build();
   ```
 2. Add our service by adding line 4.
-  ```java filename=Main.java highlight=4 showlineno=true
+  ```java title="Main.java" {4} showLineNumbers
   static Server newServer(int port) {
     ...
     return sb.http(port)
@@ -64,7 +64,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server/docservice):
 1. In the `newServer()` method, add a [DocService](type) and a request example for [creating blog posts](/docs/tutorials/rest/implement-create),
    using [DocServiceBuilder#exampleRequests(Class,String,Iterable)](type). Feel free to add more examples for other service methods.
 
-  ```java filename=Main.java highlight=1,6-13
+  ```java title="Main.java" {1,6-13}
   import com.linecorp.armeria.server.docs.DocService;
 
   public final class Main {
@@ -80,7 +80,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server/docservice):
 
 2. Inside the `newServer()` method, add the [DocService](type) to our server builder.
 
-  ```java filename=Main.java highlight=5
+  ```java title="Main.java" {5}
   static Server newServer(int port) {
     ...
     return sb.http(port)
@@ -92,7 +92,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server/docservice):
 
 3. (Optional) To access the Documentation service result easily, edit the log message we added in [Step 1. Create a server](/docs/tutorials/rest/create-server) to the one specified below.
 
-  ```java filename=Main.java highlight=2
+  ```java title="Main.java" {2}
   public static void main(String[] args) throws Exception {
       logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
                   server.activeLocalPort());
@@ -132,7 +132,7 @@ To test your service methods with the [Documentation service](/docs/server/docse
 
   Note that in the **REQUEST BODY** section that the values specified for the [DocServiceBuilder](type) are automatically entered on the page.
 
-  ```java filename=Main.java highlight=5-8
+  ```java title="Main.java" {5-8}
   static Server newServer(int port) {
     ServerBuilder sb = Server.builder();
     DocService docService =

--- a/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
+++ b/site-new/docs/tutorials/rest/03-add-services-to-server.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Add services to a server"
-order: 3
+sidebar_label: "3. Add services to a server"
 type: step
 tags:
   - docservice
@@ -10,7 +9,7 @@ level: basic
 
 # Adding services to a server
 
-In this step, we'll add an empty blog service to the server we created in [Step 1. Create a server](/tutorials/rest/blog/create-server). Also, we'll add Armeria's [Documentation service](/docs/server-docservice) for testing our blog service.
+In this step, we'll add an empty blog service to the server we created in [Step 1. Create a server](/docs/tutorials/rest/create-server). Also, we'll add Armeria's [Documentation service](/docs/server/docservice) for testing our blog service.
 
 <TutorialSteps current={3} />
 
@@ -38,7 +37,7 @@ public final class BlogService {
 
 ## 2. Add a blog service to server
 
-In [Step 1. Create a server](/tutorials/rest/blog/create-server), we added a dummy service just to check that a server is launched. Now, let's remove the dummy service and add an empty blog service, instead.
+In [Step 1. Create a server](/docs/tutorials/rest/create-server), we added a dummy service just to check that a server is launched. Now, let's remove the dummy service and add an empty blog service, instead.
 
 1. From `Main.java`, remove the dummy service at line 4.
   ```java filename=Main.java highlight=4 showlineno=true
@@ -60,10 +59,10 @@ In [Step 1. Create a server](/tutorials/rest/blog/create-server), we added a dum
 
 ## 3. Add the Documentation service
 
-This time, we'll add Armeria's [Documentation service](/docs/server-docservice):
+This time, we'll add Armeria's [Documentation service](/docs/server/docservice):
 
-1. In the `newServer()` method, add a <type://DocService> and a request example for [creating blog posts](/tutorials/rest/blog/implement-create),
-   using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
+1. In the `newServer()` method, add a [DocService](type) and a request example for [creating blog posts](/docs/tutorials/rest/implement-create),
+   using [DocServiceBuilder#exampleRequests(Class,String,Iterable)](type). Feel free to add more examples for other service methods.
 
   ```java filename=Main.java highlight=1,6-13
   import com.linecorp.armeria.server.docs.DocService;
@@ -79,7 +78,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server-docservice):
                         .build();
   ```
 
-2. Inside the `newServer()` method, add the <type://DocService> to our server builder.
+2. Inside the `newServer()` method, add the [DocService](type) to our server builder.
 
   ```java filename=Main.java highlight=5
   static Server newServer(int port) {
@@ -91,7 +90,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server-docservice):
   }
   ```
 
-3. (Optional) To access the Documentation service result easily, edit the log message we added in [Step 1. Create a server](/tutorials/rest/blog/create-server) to the one specified below.
+3. (Optional) To access the Documentation service result easily, edit the log message we added in [Step 1. Create a server](/docs/tutorials/rest/create-server) to the one specified below.
 
   ```java filename=Main.java highlight=2
   public static void main(String[] args) throws Exception {
@@ -102,7 +101,7 @@ This time, we'll add Armeria's [Documentation service](/docs/server-docservice):
 
 ## 4. Run the server and services
 
-Like we did in _Step 1. Create a server_, [build and run](/tutorials/rest/blog/create-server#3-run-the-server-and-service) the service by running the `main()` method or using Gradle.
+Like we did in _Step 1. Create a server_, [build and run](/docs/tutorials/rest/create-server#3-run-the-server-and-service) the service by running the `main()` method or using Gradle.
 
 The server and services are launched successfully if you see this message.
 
@@ -114,24 +113,24 @@ The server and services are launched successfully if you see this message.
 
 Let's test and call our service operations, using Armeria's Documentation service.
 
-Click the URL http://127.0.0.1:8080/docs from the log message or open the URL on a web browser. If you see the Document service page, you've launched the <type://DocService> and server successfully. We're seeing no services on the
+Click the URL http://127.0.0.1:8080/docs from the log message or open the URL on a web browser. If you see the Document service page, you've launched the [DocService](type) and server successfully. We're seeing no services on the
 page because we're to implement service methods.
 
-  ![](../../../../images/tutorial_blogservice_docservice_start.png)
+  ![](/img/tutorial_blogservice_docservice_start.png)
 
 ### Using DocService after adding service methods
 
 When you add service methods through later steps, you'll see a result similar to this.
 
-![](../../../../images/tutorial_blogservice_docservice_end.png)
+![](/img/tutorial_blogservice_docservice_end.png)
 
-To test your service methods with the [Documentation service](/docs/server-docservice):
+To test your service methods with the [Documentation service](/docs/server/docservice):
 
 1. Click the **createBlogPost()** method link in the left panel. You can make calls to the creation method from the page opened.
 
-  ![](../../../../images/tutorial_blogservice_reqex.png)
+  ![](/img/tutorial_blogservice_reqex.png)
 
-  Note that in the **REQUEST BODY** section that the values specified for the <type://DocServiceBuilder> are automatically entered on the page.
+  Note that in the **REQUEST BODY** section that the values specified for the [DocServiceBuilder](type) are automatically entered on the page.
 
   ```java filename=Main.java highlight=5-8
   static Server newServer(int port) {
@@ -147,13 +146,13 @@ To test your service methods with the [Documentation service](/docs/server-docse
 
 2. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
 
-  ![](../../../../images/tutorial_blogservice_return.png)
+  ![](/img/tutorial_blogservice_return.png)
 
 ## What's next?
 
 In this step, we've added an empty blog service and the Documentation service to a server.
 
-Next, at [Step 4. Implement CREATE](/tutorials/rest/blog/implement-create), we'll finally implement a CREATE
+Next, at [Step 4. Implement CREATE](/docs/tutorials/rest/implement-create), we'll finally implement a CREATE
 operation to create blog posts.
 
 <TutorialSteps current={3} />

--- a/site-new/docs/tutorials/rest/04-implement-create.mdx
+++ b/site-new/docs/tutorials/rest/04-implement-create.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement CREATE"
-order: 4
+sidebar_label: "4. Implement CREATE"
 type: step
 tags:
   - rest
@@ -12,8 +11,8 @@ level: basic
 # Implementing CREATE operation
 
 In this step, you'll write a service method for creating a blog post and a test method to verify the service method.
-By completing this step, you'll learn to map your service with the HTTP POST (<type://@Post>) method,
-make your own request converter (<type://@RequestConverter>), and utilize a server extension for testing (<type://ServerExtension>).
+By completing this step, you'll learn to map your service with the HTTP POST ([@Post](type)) method,
+make your own request converter ([@RequestConverter](type)), and utilize a server extension for testing ([ServerExtension](type)).
 
 <TutorialSteps current={4} />
 
@@ -28,10 +27,10 @@ You can always [download](https://github.com/line/armeria-examples/blob/main/tut
 
 ## 1. Map HTTP method
 
-Let's start [mapping the HTTP POST method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+Let's start [mapping the HTTP POST method](/docs/server/annotated-service#mapping-http-service-methods) with our service method:
 
 1. Declare a service method, `createBlogPost()`, in the class `BlogService`.
-2. Map this service method with the HTTP POST method by adding the <type://@Post> annotation.
+2. Map this service method with the HTTP POST method by adding the [@Post](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
 ```java filename=BlogService.java highlight=6
@@ -47,17 +46,17 @@ public final class BlogService {
 
 ## 2. Handle parameters
 
-Let's receive blog post information through a request body. Armeria's [request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) converts request parameters in HTTP messages into Java objects for you. In the request converter, we define what keys of a JSON object to map with what properties of a Java object.
+Let's receive blog post information through a request body. Armeria's [request converter](/docs/server/annotated-service#converting-an-http-request-to-a-java-object) converts request parameters in HTTP messages into Java objects for you. In the request converter, we define what keys of a JSON object to map with what properties of a Java object.
 
 Let's first [write a request converter](#write-a-request-converter) and then [register the request converter](#register-a-request-converter) to the service method.
 
 ### Write a request converter
 
-Armeria's [request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) converts a request body from a client into a Java object for you.
+Armeria's [request converter](/docs/server/annotated-service#converting-an-http-request-to-a-java-object) converts a request body from a client into a Java object for you.
 
-We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but here let's give a go at customizing a request converter for our blog post requests. We want to convert blog post details into a Java object.
+We can use Armeria's default [JacksonRequestConverterFunction](type) as is, but here let's give a go at customizing a request converter for our blog post requests. We want to convert blog post details into a Java object.
 
-1. Create a `BlogPostRequestConverter.java` file and declare a class, implementing the <type://RequestConverterFunction> interface. For the sake of simplicity, generate impromptu IDs for this tutorial.
+1. Create a `BlogPostRequestConverter.java` file and declare a class, implementing the [RequestConverterFunction](type) interface. For the sake of simplicity, generate impromptu IDs for this tutorial.
 
   ```java filename=BlogRequestConverter.java
   package example.armeria.server.blog;
@@ -121,7 +120,7 @@ We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but
 
 ### Register a request converter
 
-In this step, assign the [request converter we customized](#write-a-request-converter) to our service method. Annotate the service method with <type://@RequestConverter> and specify the <type://RequestConverterFunction> class as `BlogPostRequestConverter.class`.
+In this step, assign the [request converter we customized](#write-a-request-converter) to our service method. Annotate the service method with [@RequestConverter](type) and specify the [RequestConverterFunction](type) class as `BlogPostRequestConverter.class`.
 
 ```java filename=BlogService.java highlight=7
 import com.linecorp.armeria.server.annotation.RequestConverter;
@@ -158,8 +157,8 @@ time.
 
 Let's return a response for blog post creation:
 
-1. Replace the return type of the `createBlogPost()` method from `void` to <type://HttpResponse>.
-2. Create and return an HTTP response using Armeria's <type://HttpResponse> with the information of the post created.
+1. Replace the return type of the `createBlogPost()` method from `void` to [HttpResponse](type).
+2. Create and return an HTTP response using Armeria's [HttpResponse](type) with the information of the post created.
 
   ```java filename=BlogService.java highlight=5,7
   import com.linecorp.armeria.common.HttpResponse;
@@ -193,10 +192,10 @@ class BlogServiceTest {
 
 ## 6. Register a ServerExtension
 
-Armeria's <type://ServerExtension> automatically handles set-up and tear-down of a server for testing.
+Armeria's [ServerExtension](type) automatically handles set-up and tear-down of a server for testing.
 This is convenient as it eliminates the need to execute the main method to set up a server before running our tests.
 
-In the `BlogServiceTest` class, register a <type://ServerExtension> as follows.
+In the `BlogServiceTest` class, register a [ServerExtension](type) as follows.
 Note that the service instance is added to the configuration.
 
 ```java filename=BlogServiceTest.java
@@ -264,14 +263,14 @@ Let's test if we can create a blog post.
 
   The service worked as expected if you see the test case passed.
 
-You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+You can test this also with Armeria's [Documentation service](/docs/server/docservice). See [Using DocService after adding service methods](/docs/tutorials/rest/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
 
 ## Next step
 
-In this step, we've written a method to implement a CREATE operation and used Armeria's annotations; <type://@Post> and <type://@RequestConverter>.
-We've also registered <type://ServerExtension> to our test and written a test method.
+In this step, we've written a method to implement a CREATE operation and used Armeria's annotations; [@Post](type) and [@RequestConverter](type).
+We've also registered [ServerExtension](type) to our test and written a test method.
 
-Next, at [Step 5. Implement READ](/tutorials/rest/blog/implement-read), we'll implement a READ operation to read a
+Next, at [Step 5. Implement READ](/docs/tutorials/rest/implement-read), we'll implement a READ operation to read a
 single post and also multiple posts.
 
 <TutorialSteps current={4} />

--- a/site-new/docs/tutorials/rest/04-implement-create.mdx
+++ b/site-new/docs/tutorials/rest/04-implement-create.mdx
@@ -33,7 +33,7 @@ Let's start [mapping the HTTP POST method](/docs/server/annotated-service#mappin
 2. Map this service method with the HTTP POST method by adding the [@Post](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
-```java filename=BlogService.java highlight=6
+```java title="BlogService.java" {6}
 import com.linecorp.armeria.server.annotation.Post;
 
 public final class BlogService {
@@ -58,7 +58,7 @@ We can use Armeria's default [JacksonRequestConverterFunction](type) as is, but 
 
 1. Create a `BlogPostRequestConverter.java` file and declare a class, implementing the [RequestConverterFunction](type) interface. For the sake of simplicity, generate impromptu IDs for this tutorial.
 
-  ```java filename=BlogRequestConverter.java
+  ```java title="BlogRequestConverter.java"
   package example.armeria.server.blog;
 
   import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,7 +73,7 @@ We can use Armeria's default [JacksonRequestConverterFunction](type) as is, but 
 
 2. Add a method retrieving a value of a given key in a JSON object:
 
-  ```java filename=BlogRequestConverter.java highlight=6-12
+  ```java title="BlogRequestConverter.java" {6-12}
   import com.fasterxml.jackson.databind.JsonNode;
 
   final class BlogPostRequestConverter implements RequestConverterFunction {
@@ -91,7 +91,7 @@ We can use Armeria's default [JacksonRequestConverterFunction](type) as is, but 
 
 3. Customize the default `convertRequest()` method as follows.
 
-  ```java filename=BlogRequestConverter.java highlight=10-22
+  ```java title="BlogRequestConverter.java" {10-22}
   import com.linecorp.armeria.server.ServiceRequestContext;
   import com.linecorp.armeria.common.AggregatedHttpRequest;
   import com.linecorp.armeria.common.annotation.Nullable;
@@ -122,7 +122,7 @@ We can use Armeria's default [JacksonRequestConverterFunction](type) as is, but 
 
 In this step, assign the [request converter we customized](#write-a-request-converter) to our service method. Annotate the service method with [@RequestConverter](type) and specify the [RequestConverterFunction](type) class as `BlogPostRequestConverter.class`.
 
-```java filename=BlogService.java highlight=7
+```java title="BlogService.java" {7}
 import com.linecorp.armeria.server.annotation.RequestConverter;
 
 public final class BlogService {
@@ -142,7 +142,7 @@ When the request for creation is received, our request converter creates an inst
 
 Let's store the blog post information in the map by adding line 4, in the `createBlogPost()` method.
 
-```java filename=BlogService.java highlight=4 showlineno=true
+```java title="BlogService.java" {4} showLineNumbers
 @Post("/blogs")
 @RequestConverter(BlogPostRequestConverter.class)
 public void createBlogPost(BlogPost blogPost) {
@@ -160,7 +160,7 @@ Let's return a response for blog post creation:
 1. Replace the return type of the `createBlogPost()` method from `void` to [HttpResponse](type).
 2. Create and return an HTTP response using Armeria's [HttpResponse](type) with the information of the post created.
 
-  ```java filename=BlogService.java highlight=5,7
+  ```java title="BlogService.java" {5,7}
   import com.linecorp.armeria.common.HttpResponse;
 
   public final class BlogService {
@@ -180,7 +180,7 @@ We'll use test code to verify what we implement along the way.
 Create the `BlogServiceTest.java` file as follows.
 You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/test/java/example/armeria/server/blog/BlogServiceTest.java).
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 package example.armeria.server.blog;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -198,7 +198,7 @@ This is convenient as it eliminates the need to execute the main method to set u
 In the `BlogServiceTest` class, register a [ServerExtension](type) as follows.
 Note that the service instance is added to the configuration.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -220,7 +220,7 @@ class BlogServiceTest {
 Let's test if we can create a blog post.
 
 1. In the `BlogServiceTest` class, add a private method as follows.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import java.util.Map;
   import com.fasterxml.jackson.core.JsonProcessingException;
   import com.linecorp.armeria.common.HttpRequest;
@@ -235,7 +235,7 @@ Let's test if we can create a blog post.
   }
   ```
 2. Add a test method as follows to test creating a blog post.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
   import org.junit.jupiter.api.Test;
   import com.linecorp.armeria.client.WebClient;

--- a/site-new/docs/tutorials/rest/04-implement-create.mdx
+++ b/site-new/docs/tutorials/rest/04-implement-create.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "4. Implement CREATE"
+menuTitle: "Implement CREATE"
+order: 4
 type: step
 tags:
   - rest
@@ -11,7 +12,266 @@ level: basic
 # Implementing CREATE operation
 
 In this step, you'll write a service method for creating a blog post and a test method to verify the service method.
-By completing this step, you'll learn to map your service with the HTTP POST ([@Post](type)) method,
-make your own request converter ([@RequestConverter](type)), and utilize a server extension for testing ([ServerExtension](type)).
+By completing this step, you'll learn to map your service with the HTTP POST (<type://@Post>) method,
+make your own request converter (<type://@RequestConverter>), and utilize a server extension for testing (<type://ServerExtension>).
+
+<TutorialSteps current={4} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/) the full version, instead of creating one yourself.
+
+- `Main.java`
+- `BlogPost.java`
+- `BlogService.java`
+
+## 1. Map HTTP method
+
+Let's start [mapping the HTTP POST method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+
+1. Declare a service method, `createBlogPost()`, in the class `BlogService`.
+2. Map this service method with the HTTP POST method by adding the <type://@Post> annotation.
+3. Bind the endpoint `/blogs` to the method.
+
+```java filename=BlogService.java highlight=6
+import com.linecorp.armeria.server.annotation.Post;
+
+public final class BlogService {
+  ...
+
+  @Post("/blogs")
+  public void createBlogPost(BlogPost blogPost) {}
+}
+```
+
+## 2. Handle parameters
+
+Let's receive blog post information through a request body. Armeria's [request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) converts request parameters in HTTP messages into Java objects for you. In the request converter, we define what keys of a JSON object to map with what properties of a Java object.
+
+Let's first [write a request converter](#write-a-request-converter) and then [register the request converter](#register-a-request-converter) to the service method.
+
+### Write a request converter
+
+Armeria's [request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) converts a request body from a client into a Java object for you.
+
+We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but here let's give a go at customizing a request converter for our blog post requests. We want to convert blog post details into a Java object.
+
+1. Create a `BlogPostRequestConverter.java` file and declare a class, implementing the <type://RequestConverterFunction> interface. For the sake of simplicity, generate impromptu IDs for this tutorial.
+
+  ```java filename=BlogRequestConverter.java
+  package example.armeria.server.blog;
+
+  import com.fasterxml.jackson.databind.ObjectMapper;
+  import com.linecorp.armeria.server.annotation.RequestConverterFunction;
+  import java.util.concurrent.atomic.AtomicInteger;
+
+  final class BlogPostRequestConverter implements RequestConverterFunction {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private AtomicInteger idGenerator = new AtomicInteger(); // Blog post ID
+  }
+  ```
+
+2. Add a method retrieving a value of a given key in a JSON object:
+
+  ```java filename=BlogRequestConverter.java highlight=6-12
+  import com.fasterxml.jackson.databind.JsonNode;
+
+  final class BlogPostRequestConverter implements RequestConverterFunction {
+    ...
+
+    static String stringValue(JsonNode jsonNode, String field) {
+      JsonNode value = jsonNode.get(field);
+      if (value == null) {
+        throw new IllegalArgumentException(field + " is missing!");
+      }
+      return value.textValue();
+    }
+  }
+  ```
+
+3. Customize the default `convertRequest()` method as follows.
+
+  ```java filename=BlogRequestConverter.java highlight=10-22
+  import com.linecorp.armeria.server.ServiceRequestContext;
+  import com.linecorp.armeria.common.AggregatedHttpRequest;
+  import com.linecorp.armeria.common.annotation.Nullable;
+  import java.lang.reflect.ParameterizedType;
+
+  final class BlogPostRequestConverter implements RequestConverterFunction {
+    ...
+
+    @Override
+    public Object convertRequest(ServiceRequestContext ctx,
+      AggregatedHttpRequest request, Class<?> expectedResultType,
+      @Nullable ParameterizedType expectedParameterizedResultType)
+        throws Exception {
+      if (expectedResultType == BlogPost.class) {
+        JsonNode jsonNode = mapper.readTree(request.contentUtf8());
+        int id = idGenerator.getAndIncrement();
+        String title = stringValue(jsonNode, "title");
+        String content = stringValue(jsonNode, "content");
+        return new BlogPost(id, title, content); // Create an instance of BlogPost object
+      }
+      return RequestConverterFunction.fallthrough();
+    }
+    ...
+  }
+  ```
+
+### Register a request converter
+
+In this step, assign the [request converter we customized](#write-a-request-converter) to our service method. Annotate the service method with <type://@RequestConverter> and specify the <type://RequestConverterFunction> class as `BlogPostRequestConverter.class`.
+
+```java filename=BlogService.java highlight=7
+import com.linecorp.armeria.server.annotation.RequestConverter;
+
+public final class BlogService {
+  ...
+
+  @Post("/blogs")
+  @RequestConverter(BlogPostRequestConverter.class)
+  public void createBlogPost(BlogPost blogPost) {
+    // Implement blog service
+  }
+}
+```
+
+## 3. Implement service code
+
+When the request for creation is received, our request converter creates an instance of a blog post object for us. We want to save the blog post object in the map (`blogPosts`) created in the `BlogService` class.
+
+Let's store the blog post information in the map by adding line 4, in the `createBlogPost()` method.
+
+```java filename=BlogService.java highlight=4 showlineno=true
+@Post("/blogs")
+@RequestConverter(BlogPostRequestConverter.class)
+public void createBlogPost(BlogPost blogPost) {
+  blogPosts.put(blogPost.getId(), blogPost);
+}
+```
+
+## 4. Return response
+
+Now, it's time to return a response to our client. As the response, return the information received, with additional information including the ID of the post, created time, plus the modified time which would be identical to the created 
+time.
+
+Let's return a response for blog post creation:
+
+1. Replace the return type of the `createBlogPost()` method from `void` to <type://HttpResponse>.
+2. Create and return an HTTP response using Armeria's <type://HttpResponse> with the information of the post created.
+
+  ```java filename=BlogService.java highlight=5,7
+  import com.linecorp.armeria.common.HttpResponse;
+
+  public final class BlogService {
+    ...
+    public HttpResponse createBlogPost(BlogPost blogPost) {
+      ...
+      return HttpResponse.ofJson(blogPost);
+    }
+  }
+  ```
+
+## 5. Create a test file
+
+Let's start writing test code.
+We'll use test code to verify what we implement along the way.
+
+Create the `BlogServiceTest.java` file as follows.
+You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/test/java/example/armeria/server/blog/BlogServiceTest.java).
+
+```java filename=BlogServiceTest.java
+package example.armeria.server.blog;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class BlogServiceTest {
+  private static final ObjectMapper mapper = new ObjectMapper();
+}
+```
+
+## 6. Register a ServerExtension
+
+Armeria's <type://ServerExtension> automatically handles set-up and tear-down of a server for testing.
+This is convenient as it eliminates the need to execute the main method to set up a server before running our tests.
+
+In the `BlogServiceTest` class, register a <type://ServerExtension> as follows.
+Note that the service instance is added to the configuration.
+
+```java filename=BlogServiceTest.java
+import org.junit.jupiter.api.extension.RegisterExtension;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class BlogServiceTest {
+...
+  @RegisterExtension
+  static final ServerExtension server = new ServerExtension() {
+    @Override
+    protected void configure(ServerBuilder sb) throws Exception {
+      sb.annotatedService(new BlogService());
+    }
+  };
+}
+```
+
+## 7. Test creating a blog post
+
+Let's test if we can create a blog post.
+
+1. In the `BlogServiceTest` class, add a private method as follows.
+  ```java filename=BlogServiceTest.java
+  import java.util.Map;
+  import com.fasterxml.jackson.core.JsonProcessingException;
+  import com.linecorp.armeria.common.HttpRequest;
+  import com.linecorp.armeria.common.MediaType;
+  ...
+  private static HttpRequest createBlogPostRequest(Map<String, String> content)
+        throws JsonProcessingException {
+    return HttpRequest.builder()
+                .post("/blogs")
+                .content(MediaType.JSON_UTF_8, mapper.writeValueAsString(content))
+                .build();
+  }
+  ```
+2. Add a test method as follows to test creating a blog post.
+  ```java filename=BlogServiceTest.java
+  import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+  import org.junit.jupiter.api.Test;
+  import com.linecorp.armeria.client.WebClient;
+  import com.linecorp.armeria.common.AggregatedHttpResponse;
+  ...
+  @Test
+  void createBlogPost() throws JsonProcessingException {
+      final WebClient client = WebClient.of(server.httpUri());
+      final HttpRequest request = createBlogPostRequest(Map.of("title", "My first blog",
+                "content", "Hello Armeria!"));
+      final AggregatedHttpResponse res = client.execute(request).aggregate().join();
+
+      final Map<String, Object> expected = Map.of("id", 0,
+                "title", "My first blog",
+                "content", "Hello Armeria!");
+
+      assertThatJson(res.contentUtf8()).whenIgnoringPaths("createdAt", "modifiedAt")
+                .isEqualTo(mapper.writeValueAsString(expected));
+  }
+  ```
+3. Run the test case on your IDE or using Gradle.
+  ```bash
+  ./gradlew test
+  ```
+
+  The service worked as expected if you see the test case passed.
+
+You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+
+## Next step
+
+In this step, we've written a method to implement a CREATE operation and used Armeria's annotations; <type://@Post> and <type://@RequestConverter>.
+We've also registered <type://ServerExtension> to our test and written a test method.
+
+Next, at [Step 5. Implement READ](/tutorials/rest/blog/implement-read), we'll implement a READ operation to read a
+single post and also multiple posts.
 
 <TutorialSteps current={4} />

--- a/site-new/docs/tutorials/rest/05-implement-read.mdx
+++ b/site-new/docs/tutorials/rest/05-implement-read.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement READ"
-order: 5
+sidebar_label: "5. Implement READ"
 type: step
 tags:
   - rest
@@ -11,7 +10,7 @@ level: basic
 # Implementing READ operation
 
 In this step, we'll implement two methods at once. One is for retrieving a single post and another for multiple blog 
-posts. By completing this step, you'll learn to map your service with the HTTP GET (<type://@Get>) method, use parameter injection (<type://@Param>), set default parameter value (<type://@Default>), and return a JSON object (<type://@ProducesJson>) as a response.
+posts. By completing this step, you'll learn to map your service with the HTTP GET ([@Get](type)) method, use parameter injection ([@Param](type)), set default parameter value ([@Default](type)), and return a JSON object ([@ProducesJson](type)) as a response.
 
 <TutorialSteps current={5} />
 
@@ -27,15 +26,15 @@ You can always [download](https://github.com/line/armeria-examples/blob/main/tut
 
 ## 1. Map HTTP method
 
-Let's start [mapping the HTTP GET method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+Let's start [mapping the HTTP GET method](/docs/server/annotated-service#mapping-http-service-methods) with our service method:
 
-<Tabs>
-<TabPane tab="Single post" key="1">
+<Tabs groupId="rest-read">
+<TabItem label="Single post" value="1">
 
 Map the HTTP GET method for retrieving a single post:
 
 1. Declare a service method `getBlogPost()` in the class `BlogService`.
-2. Map this service method with the HTTP GET method by adding the <type://@Get> annotation as follows.
+2. Map this service method with the HTTP GET method by adding the [@Get](type) annotation as follows.
 3. Bind the endpoint `/blogs` to the method.
 
   ```java filename=BlogService.java highlight=6
@@ -51,13 +50,13 @@ Map the HTTP GET method for retrieving a single post:
   }
   ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 Map the HTTP GET method for retrieving multiple posts:
 
 1. Declare a service method `getBlogPosts()` in the class `BlogService`.
-2. Map this service method with the HTTP GET method by adding the <type://@Get> annotation as follows.
+2. Map this service method with the HTTP GET method by adding the [@Get](type) annotation as follows.
 3. Bind the endpoint `/blogs` to the method.
 
   ```java filename=BlogService.java highlight=6
@@ -73,20 +72,20 @@ Map the HTTP GET method for retrieving multiple posts:
   }
   ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 2. Handle parameters
 
 Take in information through _path_ and _query_ parameters for retrieving blog posts. For retrieving a single post, we'll take a blog post ID as the path parameter. For multiple posts, we'll take the sorting order as a query parameter.
 
-<Tabs defaultActiveKey="1">
-<TabPane tab="Single post" key="1">
+<Tabs groupId="rest-read">
+<TabItem label="Single post" value="1">
 
 Let's handle parameters for retrieving a single post:
 
-1. To take in a path parameter, add `/:id` to the <type://@Get> annotation's parameter as in line 6.
-2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method, annotate the parameter with <type://@Param> as in line 7.
+1. To take in a path parameter, add `/:id` to the [@Get](type) annotation's parameter as in line 6.
+2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method, annotate the parameter with [@Param](type) as in line 7.
 
 ```java filename=BlogService.java showlineno=true
 import com.linecorp.armeria.server.annotation.Param;
@@ -101,14 +100,14 @@ public final class BlogService {
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 Let's handle parameters for retrieving multiple posts:
 
-1. Specify the endpoint for the service using the <type://@Get> annotation.
-2. [Inject the parameter](/docs/server-annotated-service#parameter-injection) by annotating the parameter `descending` with <type://@Param> as in line 8.
-3. Set the default sorting order to descending by annotating the parameter `descending` with <type://@Default>, with its parameter as `"true"`.
+1. Specify the endpoint for the service using the [@Get](type) annotation.
+2. [Inject the parameter](/docs/server/annotated-service#parameter-injection) by annotating the parameter `descending` with [@Param](type) as in line 8.
+3. Set the default sorting order to descending by annotating the parameter `descending` with [@Default](type), with its parameter as `"true"`.
 
   ```java filename=BlogService.java showlineno=true
   import com.linecorp.armeria.server.annotation.Param;
@@ -124,15 +123,15 @@ Let's handle parameters for retrieving multiple posts:
   }
   ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 3. Implement service code
 
 In this step, write the code required for service itself.
 
-<Tabs defaultActiveKey="1">
-<TabPane tab="Single post" key="1">
+<Tabs groupId="rest-read">
+<TabItem label="Single post" value="1">
 
 To retrieve a single blog post information, copy the following code inside the `getBlogPost()` method.
 
@@ -143,8 +142,8 @@ public void getBlogPost(@Param int id) {
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 To retrieve multiple blog posts, copy the following code inside the `getBlogPosts()` method. Note that the return type has been changed from `void` to `Iterable<BlogPost>`.
 
@@ -168,7 +167,7 @@ public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descendin
 }
 ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 
@@ -176,13 +175,13 @@ public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descendin
 
 Let's return a response for the service call.
 
-<Tabs defaultActiveKey="1">
-<TabPane tab="Single post" key="1">
+<Tabs groupId="rest-read">
+<TabItem label="Single post" value="1">
 
 To return a response for getting a single post:
 
-1. Replace the return type of the `getBlogPost()` method from `void` to <type://HttpResponse>.
-2. Return a response using Armeria's <type://HttpResponse> containing the content of the blog post retrieved.
+1. Replace the return type of the `getBlogPost()` method from `void` to [HttpResponse](type).
+2. Return a response using Armeria's [HttpResponse](type) containing the content of the blog post retrieved.
 
 ```java filename=BlogService.java highlight=5,8
 import com.linecorp.armeria.common.HttpResponse;
@@ -197,10 +196,10 @@ public final class BlogService {
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
-We've already implemented returning multiple blog posts in the previous step. Here, annotate the method `getBlogPosts()` with <type://@ProducesJson>. This converts a list of `BlogPost` objects into a JSON response.
+We've already implemented returning multiple blog posts in the previous step. Here, annotate the method `getBlogPosts()` with [@ProducesJson](type). This converts a list of `BlogPost` objects into a JSON response.
 
 ```java filename=BlogService.java highlight=4
 import com.linecorp.armeria.server.annotation.ProducesJson;
@@ -212,7 +211,7 @@ public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descendin
 }
 ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 5. Test retrieving a single post
@@ -292,12 +291,12 @@ void getBlogPosts() throws JsonProcessingException {
 Run all the test cases on your IDE or using Gradle.
 Check that you see the test is passed.
 
-You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+You can test this also with Armeria's [Documentation service](/docs/server/docservice). See [Using DocService after adding service methods](/docs/tutorials/rest/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
 
 ## Next step
 
-In this step, we've implemented methods for a READ operation and used Armeria's annotations; <type://@Get>, <type://@ProducesJson>, <type://@Param>, and <type://@Default>.
+In this step, we've implemented methods for a READ operation and used Armeria's annotations; [@Get](type), [@ProducesJson](type), [@Param](type), and [@Default](type).
 
-Next, at [Step 6. Implement UPDATE](/tutorials/rest/blog/implement-update), we'll implement an UPDATE operation to modify existing blog posts.
+Next, at [Step 6. Implement UPDATE](/docs/tutorials/rest/implement-update), we'll implement an UPDATE operation to modify existing blog posts.
 
 <TutorialSteps current={5} />

--- a/site-new/docs/tutorials/rest/05-implement-read.mdx
+++ b/site-new/docs/tutorials/rest/05-implement-read.mdx
@@ -37,7 +37,7 @@ Map the HTTP GET method for retrieving a single post:
 2. Map this service method with the HTTP GET method by adding the [@Get](type) annotation as follows.
 3. Bind the endpoint `/blogs` to the method.
 
-  ```java filename=BlogService.java highlight=6
+  ```java title="BlogService.java" {6}
   import com.linecorp.armeria.server.annotation.Get;
 
   public final class BlogService {
@@ -59,7 +59,7 @@ Map the HTTP GET method for retrieving multiple posts:
 2. Map this service method with the HTTP GET method by adding the [@Get](type) annotation as follows.
 3. Bind the endpoint `/blogs` to the method.
 
-  ```java filename=BlogService.java highlight=6
+  ```java title="BlogService.java" {6}
   import com.linecorp.armeria.server.annotation.Get;
 
   public final class BlogService {
@@ -87,7 +87,7 @@ Let's handle parameters for retrieving a single post:
 1. To take in a path parameter, add `/:id` to the [@Get](type) annotation's parameter as in line 6.
 2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method, annotate the parameter with [@Param](type) as in line 7.
 
-```java filename=BlogService.java showlineno=true
+```java title="BlogService.java" showLineNumbers
 import com.linecorp.armeria.server.annotation.Param;
 
 public final class BlogService {
@@ -109,7 +109,7 @@ Let's handle parameters for retrieving multiple posts:
 2. [Inject the parameter](/docs/server/annotated-service#parameter-injection) by annotating the parameter `descending` with [@Param](type) as in line 8.
 3. Set the default sorting order to descending by annotating the parameter `descending` with [@Default](type), with its parameter as `"true"`.
 
-  ```java filename=BlogService.java showlineno=true
+  ```java title="BlogService.java" showLineNumbers
   import com.linecorp.armeria.server.annotation.Param;
   import com.linecorp.armeria.server.annotation.Default;
 
@@ -135,7 +135,7 @@ In this step, write the code required for service itself.
 
 To retrieve a single blog post information, copy the following code inside the `getBlogPost()` method.
 
-```java filename=BlogService.java highlight=3
+```java title="BlogService.java" {3}
 @Get("/blogs")
 public void getBlogPost(@Param int id) {
   BlogPost blogPost = blogPosts.get(id);
@@ -147,7 +147,7 @@ public void getBlogPost(@Param int id) {
 
 To retrieve multiple blog posts, copy the following code inside the `getBlogPosts()` method. Note that the return type has been changed from `void` to `Iterable<BlogPost>`.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
 import java.util.Map.Entry;
 import java.util.Collections;
 import java.util.Comparator;
@@ -183,7 +183,7 @@ To return a response for getting a single post:
 1. Replace the return type of the `getBlogPost()` method from `void` to [HttpResponse](type).
 2. Return a response using Armeria's [HttpResponse](type) containing the content of the blog post retrieved.
 
-```java filename=BlogService.java highlight=5,8
+```java title="BlogService.java" {5,8}
 import com.linecorp.armeria.common.HttpResponse;
 
 public final class BlogService {
@@ -201,7 +201,7 @@ public final class BlogService {
 
 We've already implemented returning multiple blog posts in the previous step. Here, annotate the method `getBlogPosts()` with [@ProducesJson](type). This converts a list of `BlogPost` objects into a JSON response.
 
-```java filename=BlogService.java highlight=4
+```java title="BlogService.java" {4}
 import com.linecorp.armeria.server.annotation.ProducesJson;
 
 @Get("/blogs")
@@ -219,7 +219,7 @@ public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descendin
 Let's test if we can retrieve a blog post we created.
 
 1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @Test
   void getBlogPost() throws JsonProcessingException {
     final WebClient client = WebClient.of(server.httpUri());
@@ -234,7 +234,7 @@ Let's test if we can retrieve a blog post we created.
   ```
 2. Add annotations to configure the order our test methods will be executed.
   The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
   import org.junit.jupiter.api.Order;
   import org.junit.jupiter.api.TestMethodOrder;
@@ -265,7 +265,7 @@ Let's test if we can retrieve a blog post we created.
 Finally, let's test if we can retrieve multiple posts.
 Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import java.util.List;
 
 @Test

--- a/site-new/docs/tutorials/rest/05-implement-read.mdx
+++ b/site-new/docs/tutorials/rest/05-implement-read.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "5. Implement READ"
+menuTitle: "Implement READ"
+order: 5
 type: step
 tags:
   - rest
@@ -8,5 +9,295 @@ level: basic
 ---
 
 # Implementing READ operation
+
+In this step, we'll implement two methods at once. One is for retrieving a single post and another for multiple blog 
+posts. By completing this step, you'll learn to map your service with the HTTP GET (<type://@Get>) method, use parameter injection (<type://@Param>), set default parameter value (<type://@Default>), and return a JSON object (<type://@ProducesJson>) as a response.
+
+<TutorialSteps current={5} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/) the full version, instead of creating one yourself.
+
+- `Main.java`
+- `BlogPost.java`
+- `BlogService.java`
+- `BlogServiceTest.java`
+
+## 1. Map HTTP method
+
+Let's start [mapping the HTTP GET method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+
+<Tabs>
+<TabPane tab="Single post" key="1">
+
+Map the HTTP GET method for retrieving a single post:
+
+1. Declare a service method `getBlogPost()` in the class `BlogService`.
+2. Map this service method with the HTTP GET method by adding the <type://@Get> annotation as follows.
+3. Bind the endpoint `/blogs` to the method.
+
+  ```java filename=BlogService.java highlight=6
+  import com.linecorp.armeria.server.annotation.Get;
+
+  public final class BlogService {
+    ...
+
+    @Get("/blogs")
+    public void getBlogPost(int id) {
+      // Retrieve a single post
+    }
+  }
+  ```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+Map the HTTP GET method for retrieving multiple posts:
+
+1. Declare a service method `getBlogPosts()` in the class `BlogService`.
+2. Map this service method with the HTTP GET method by adding the <type://@Get> annotation as follows.
+3. Bind the endpoint `/blogs` to the method.
+
+  ```java filename=BlogService.java highlight=6
+  import com.linecorp.armeria.server.annotation.Get;
+
+  public final class BlogService {
+    ...
+
+    @Get("/blogs")
+    public void getBlogPosts(boolean descending) {
+      // Retrieve multiple posts
+    }
+  }
+  ```
+
+</TabPane>
+</Tabs>
+
+## 2. Handle parameters
+
+Take in information through _path_ and _query_ parameters for retrieving blog posts. For retrieving a single post, we'll take a blog post ID as the path parameter. For multiple posts, we'll take the sorting order as a query parameter.
+
+<Tabs defaultActiveKey="1">
+<TabPane tab="Single post" key="1">
+
+Let's handle parameters for retrieving a single post:
+
+1. To take in a path parameter, add `/:id` to the <type://@Get> annotation's parameter as in line 6.
+2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method, annotate the parameter with <type://@Param> as in line 7.
+
+```java filename=BlogService.java showlineno=true
+import com.linecorp.armeria.server.annotation.Param;
+
+public final class BlogService {
+ ...
+
+ @Get("/blogs/:id")
+ public void getBlogPost(@Param int id) {
+   // Retrieve a single post
+ }
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+Let's handle parameters for retrieving multiple posts:
+
+1. Specify the endpoint for the service using the <type://@Get> annotation.
+2. [Inject the parameter](/docs/server-annotated-service#parameter-injection) by annotating the parameter `descending` with <type://@Param> as in line 8.
+3. Set the default sorting order to descending by annotating the parameter `descending` with <type://@Default>, with its parameter as `"true"`.
+
+  ```java filename=BlogService.java showlineno=true
+  import com.linecorp.armeria.server.annotation.Param;
+  import com.linecorp.armeria.server.annotation.Default;
+
+  public final class BlogService {
+    ...
+
+    @Get("/blogs")
+    public void getBlogPosts(@Param @Default("true") boolean descending) {
+      // Retrieve multiple posts
+    }
+  }
+  ```
+
+</TabPane>
+</Tabs>
+
+## 3. Implement service code
+
+In this step, write the code required for service itself.
+
+<Tabs defaultActiveKey="1">
+<TabPane tab="Single post" key="1">
+
+To retrieve a single blog post information, copy the following code inside the `getBlogPost()` method.
+
+```java filename=BlogService.java highlight=3
+@Get("/blogs")
+public void getBlogPost(@Param int id) {
+  BlogPost blogPost = blogPosts.get(id);
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+To retrieve multiple blog posts, copy the following code inside the `getBlogPosts()` method. Note that the return type has been changed from `void` to `Iterable<BlogPost>`.
+
+```java filename=BlogService.java
+import java.util.Map.Entry;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+@Get("/blogs")
+public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descending) {
+  // Descending
+  if (descending) {
+      return blogPosts.entrySet()
+                      .stream()
+                      .sorted(Collections.reverseOrder(Comparator.comparingInt(Entry::getKey)))
+                      .map(Entry::getValue).collect(Collectors.toList());
+  }
+  // Ascending
+  return blogPosts.values().stream().collect(Collectors.toList());
+}
+```
+
+</TabPane>
+</Tabs>
+
+
+## 4. Return response
+
+Let's return a response for the service call.
+
+<Tabs defaultActiveKey="1">
+<TabPane tab="Single post" key="1">
+
+To return a response for getting a single post:
+
+1. Replace the return type of the `getBlogPost()` method from `void` to <type://HttpResponse>.
+2. Return a response using Armeria's <type://HttpResponse> containing the content of the blog post retrieved.
+
+```java filename=BlogService.java highlight=5,8
+import com.linecorp.armeria.common.HttpResponse;
+
+public final class BlogService {
+  @Get("/blogs/:id")
+  public HttpResponse getBlogPost(@Param int id) {
+    ...
+
+    return HttpResponse.ofJson(blogPost);
+  }
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+We've already implemented returning multiple blog posts in the previous step. Here, annotate the method `getBlogPosts()` with <type://@ProducesJson>. This converts a list of `BlogPost` objects into a JSON response.
+
+```java filename=BlogService.java highlight=4
+import com.linecorp.armeria.server.annotation.ProducesJson;
+
+@Get("/blogs")
+@ProducesJson
+public Iterable<BlogPost> getBlogPosts(@Param @Default("true") boolean descending) {
+  // Retrieve multiple blog posts
+}
+```
+
+</TabPane>
+</Tabs>
+
+## 5. Test retrieving a single post
+
+Let's test if we can retrieve a blog post we created.
+
+1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
+  ```java filename=BlogServiceTest.java
+  @Test
+  void getBlogPost() throws JsonProcessingException {
+    final WebClient client = WebClient.of(server.httpUri());
+    final AggregatedHttpResponse res = client.get("/blogs/0").aggregate().join();
+    final Map<String, Object> expected = Map.of("id", 0,
+                "title", "My first blog",
+                "content", "Hello Armeria!");
+
+    assertThatJson(res.contentUtf8()).whenIgnoringPaths("createdAt", "modifiedAt")
+                .isEqualTo(mapper.writeValueAsString(expected));
+  }
+  ```
+2. Add annotations to configure the order our test methods will be executed.
+  The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
+  ```java filename=BlogServiceTest.java
+  import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+  import org.junit.jupiter.api.Order;
+  import org.junit.jupiter.api.TestMethodOrder;
+
+  @TestMethodOrder(OrderAnnotation.class) // Add this
+  class BlogServiceTest {
+    ...
+
+    @Test
+    @Order(1) // Add this
+    void createBlogPost() throws JsonProcessingException {
+      ...
+    }
+
+    @Test
+    @Order(2) // Add this
+    void getBlogPost() throws JsonProcessingException {
+      ...
+    }
+  }
+  ```
+3. Run all the test cases on your IDE or using Gradle.
+
+  Your client retrieved a blog post from the server successfully if the test is passed.
+
+## 6. Test retrieving multiple posts
+
+Finally, let's test if we can retrieve multiple posts.
+Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
+
+```java filename=BlogServiceTest.java
+import java.util.List;
+
+@Test
+@Order(3)
+void getBlogPosts() throws JsonProcessingException {
+  final WebClient client = WebClient.of(server.httpUri());
+  final HttpRequest request = createBlogPostRequest(Map.of("title", "My second blog",
+                "content", "Armeria is awesome!"));
+  client.execute(request).aggregate().join();
+  final AggregatedHttpResponse res = client.get("/blogs").aggregate().join();
+  final List<Map<String, Object>> expected = List.of(
+          Map.of("id", 1,
+                 "title", "My second blog",
+                 "content", "Armeria is awesome!"),
+          Map.of("id", 0,
+                 "title", "My first blog",
+                 "content", "Hello Armeria!"));
+  assertThatJson(res.contentUtf8()).whenIgnoringPaths("[*].createdAt", "[*].modifiedAt")
+                .isEqualTo(mapper.writeValueAsString(expected));
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+
+## Next step
+
+In this step, we've implemented methods for a READ operation and used Armeria's annotations; <type://@Get>, <type://@ProducesJson>, <type://@Param>, and <type://@Default>.
+
+Next, at [Step 6. Implement UPDATE](/tutorials/rest/blog/implement-update), we'll implement an UPDATE operation to modify existing blog posts.
 
 <TutorialSteps current={5} />

--- a/site-new/docs/tutorials/rest/06-implement-update.mdx
+++ b/site-new/docs/tutorials/rest/06-implement-update.mdx
@@ -32,7 +32,7 @@ Let's start [mapping the HTTP PUT method](/docs/server/annotated-service#mapping
 2. Map this service method with the HTTP PUT method by adding the [@Put](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
-```java filename=BlogService.java highlight=6
+```java title="BlogService.java" {6}
 import com.linecorp.armeria.server.annotation.Put;
 
 public final class BlogService {
@@ -53,7 +53,7 @@ For updating a blog post, let's take a blog post ID (`id`) and new blog post inf
 2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method by annotating the parameter with [@Param](type).
 3. [Convert request body](/docs/server/annotated-service#converting-an-http-request-to-a-java-object) into a Java object by annotating the `BlogPost` parameter with [@RequestObject](type).
 
-  ```java filename=BlogService.java
+  ```java title="BlogService.java"
   import com.linecorp.armeria.server.annotation.Param;
   import com.linecorp.armeria.server.annotation.RequestObject;
 
@@ -69,7 +69,7 @@ For updating a blog post, let's take a blog post ID (`id`) and new blog post inf
   ```
 4. For conversion, annotate blog post constructor to map JSON object keys to blog post object members. You can find more information on `@JsonCreator` [here](https://www.baeldung.com/jackson-annotations#1-jsoncreator).
 
-  ```java filename=BlogPost.java highlight=7-9
+  ```java title="BlogPost.java" {7-9}
   import com.fasterxml.jackson.annotation.JsonCreator;
   import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -90,7 +90,7 @@ In this step, write the code required for service itself. You need to update the
 
 To update a blog post, copy the following code inside the `updateBlogPost()` method.
 
-```java filename=BlogService.java
+```java title="BlogService.java"
   @Put("/blogs/:id")
   public void updateBlogPost(@Param int id, @RequestObject BlogPost blogPost) {
     BlogPost oldBlogPost = blogPosts.get(id);
@@ -118,7 +118,7 @@ Let's return an error for the request to update a blog post that doesn't exist.
 1. Replace the return type of the `updateBlogPost()` method from `void` to [HttpResponse](type).
 2. Return a response using Armeria's [HttpResponse](type) containing [HttpStatus#NOT_FOUND](type).
 
-```java filename=BlogService.java highlight=8,11
+```java title="BlogService.java" {8,11}
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 
@@ -143,7 +143,7 @@ Let's return the information updated when the target blog post exists:
 1. Replace the return type of the `updateBlogPost()` method from `void` to [HttpResponse](type).
 2. Return a response using Armeria's [HttpResponse](type) containing the updated information of the post.
 
-```java filename=BlogService.java highlight=7,9
+```java title="BlogService.java" {7,9}
 import com.linecorp.armeria.common.HttpResponse;
 
 public final class BlogService {
@@ -162,7 +162,7 @@ public final class BlogService {
 Let's try updating the content of the first blog post.
 Add a method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(4)
 void updateBlogPosts() throws JsonProcessingException {

--- a/site-new/docs/tutorials/rest/06-implement-update.mdx
+++ b/site-new/docs/tutorials/rest/06-implement-update.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "6. Implement UPDATE"
+menuTitle: "Implement UPDATE"
+order: 6
 type: step
 tags:
   - rest
@@ -10,5 +11,192 @@ level: basic
 
 # Implementing UPDATE operation
 
+In this step, you'll write a method for updating a blog post. By completing this step, you'll learn to map your service with the HTTP PUT (<type://@Put>) method, use parameter injection, and convert request body into a Java object using a request object (<type://@RequestObject>).
+
+<TutorialSteps current={6} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/) the full version, instead of creating one yourself.
+
+- `Main.java`
+- `BlogPost.java`
+- `BlogService.java`
+- `BlogServiceTest.java`
+
+## 1. Map HTTP method
+
+Let's start [mapping the HTTP PUT method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+
+1. Declare a service method, `updateBlogPost()`, in the class `BlogService`.
+2. Map this service method with the HTTP PUT method by adding the <type://@Put> annotation.
+3. Bind the endpoint `/blogs` to the method.
+
+```java filename=BlogService.java highlight=6
+import com.linecorp.armeria.server.annotation.Put;
+
+public final class BlogService {
+  ...
+
+  @Put("/blogs")
+  public void updateBlogPost(int id, BlogPost blogPost) {
+    // Update a blog post
+  }
+}
+```
+
+## 2. Handle parameters
+
+For updating a blog post, let's take a blog post ID (`id`) and new blog post information to update with. For [creating a blog post](/tutorials/rest/blog/implement-create), we've used Armeria's <type://RequestConverter> to convert a request body into a Java object. For a change, let's try using <type://@RequestObject> to convert a request body.
+
+1. Take in the ID value as a path parameter by adding `/blogs/:id` to the <type://@Put> annotation.
+2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method by annotating the parameter with <type://@Param>.
+3. [Convert request body](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) into a Java object by annotating the `BlogPost` parameter with <type://@RequestObject>.
+
+  ```java filename=BlogService.java
+  import com.linecorp.armeria.server.annotation.Param;
+  import com.linecorp.armeria.server.annotation.RequestObject;
+
+  public final class BlogService {
+    ...
+
+    // Instructions 1 to 3
+    @Put("/blogs/:id")
+    public void updateBlogPost(@Param int id, @RequestObject BlogPost blogPost) {
+      // Update a blog post
+    }
+  }
+  ```
+4. For conversion, annotate blog post constructor to map JSON object keys to blog post object members. You can find more information on `@JsonCreator` [here](https://www.baeldung.com/jackson-annotations#1-jsoncreator).
+
+  ```java filename=BlogPost.java highlight=7-9
+  import com.fasterxml.jackson.annotation.JsonCreator;
+  import com.fasterxml.jackson.annotation.JsonProperty;
+
+  public final class BlogPost {
+    ...
+
+    @JsonCreator
+    BlogPost(@JsonProperty("id") int id, @JsonProperty("title") String title,
+             @JsonProperty("content") String content) {
+      ...
+    }
+  }
+  ```
+
+## 3. Implement service code
+
+In this step, write the code required for service itself. You need to update the information contained in the `blogPosts` map. In real services, you'll be retrieving and updating the blog post information from and to a database.
+
+To update a blog post, copy the following code inside the `updateBlogPost()` method.
+
+```java filename=BlogService.java
+  @Put("/blogs/:id")
+  public void updateBlogPost(@Param int id, @RequestObject BlogPost blogPost) {
+    BlogPost oldBlogPost = blogPosts.get(id);
+    // Check if the given blog post exists
+    if (oldBlogPost == null) {
+      // Return a Not Found error. See the next section for instructions
+    }
+    BlogPost newBlogPost = new BlogPost(id, blogPost.getTitle(),
+                                        blogPost.getContent(),
+                                        oldBlogPost.getCreatedAt(),
+                                        blogPost.getCreatedAt());
+    blogPosts.put(id, newBlogPost); // Update the info in the map
+    ...
+  }
+```
+
+## 4. Return response
+
+Two possibilities are available for the response. If the blog post to update exists, we respond to the client that the update has been successful. The other response informs the client that the blog post doesn't exist.
+
+### Return error
+
+Let's return an error for the request to update a blog post that doesn't exist.
+
+1. Replace the return type of the `updateBlogPost()` method from `void` to <type://HttpResponse>.
+2. Return a response using Armeria's <type://HttpResponse> containing <type://HttpStatus#NOT_FOUND>.
+
+```java filename=BlogService.java highlight=8,11
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+public final class BlogService {
+  ...
+
+  @Put("/blogs/:id")
+  public HttpResponse updateBlogPost(@Param int id, @RequestObject BlogPost blogPost) {
+    ...
+    if (oldBlogPost == null) {
+      return HttpResponse.of(HttpStatus.NOT_FOUND);
+    }
+    ...
+  }
+}
+```
+
+### Return success
+
+Let's return the information updated when the target blog post exists:
+
+1. Replace the return type of the `updateBlogPost()` method from `void` to <type://HttpResponse>.
+2. Return a response using Armeria's <type://HttpResponse> containing the updated information of the post.
+
+```java filename=BlogService.java highlight=7,9
+import com.linecorp.armeria.common.HttpResponse;
+
+public final class BlogService {
+  ...
+
+  @Put("/blogs/:id")
+  public HttpResponse updateBlogPost(@Param int id, @RequestObject BlogPost blogPost) {
+    ...
+    return HttpResponse.ofJson(newBlogPost);
+  }
+}
+```
+
+## 5. Test updating a blog post
+
+Let's try updating the content of the first blog post.
+Add a method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(4)
+void updateBlogPosts() throws JsonProcessingException {
+  final WebClient client = WebClient.of(server.httpUri());
+  final Map<String, Object> updatedContent = Map.of("id", 0,
+                "title", "My first blog",
+                "content", "Hello awesome Armeria!");
+  final HttpRequest updateBlogPostRequest =
+          HttpRequest.builder()
+                .put("/blogs/0")
+                .content(MediaType.JSON_UTF_8, mapper.writeValueAsString(updatedContent))
+                .build();
+  client.execute(updateBlogPostRequest).aggregate().join();
+  final AggregatedHttpResponse res = client.get("/blogs/0").aggregate().join();
+  final Map<String, Object> expected = Map.of("id", 0,
+                "title", "My first blog",
+                "content", "Hello awesome Armeria!");
+
+  assertThatJson(res.contentUtf8()).whenIgnoringPaths("createdAt", "modifiedAt")
+                .isEqualTo(mapper.writeValueAsString(expected));
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+
+## Next step
+
+In this step, we've implemented a method for an UPDATE operation and used Armeria's annotations; <type://@Put>, <type://@Param>, and <type://@RequestObject>.
+
+Next, at [Step 7. Implement DELETE](/tutorials/rest/blog/implement-delete), we'll implement a DELETE operation to delete
+blog posts.
 
 <TutorialSteps current={6} />

--- a/site-new/docs/tutorials/rest/06-implement-update.mdx
+++ b/site-new/docs/tutorials/rest/06-implement-update.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement UPDATE"
-order: 6
+sidebar_label: "6. Implement UPDATE"
 type: step
 tags:
   - rest
@@ -11,7 +10,7 @@ level: basic
 
 # Implementing UPDATE operation
 
-In this step, you'll write a method for updating a blog post. By completing this step, you'll learn to map your service with the HTTP PUT (<type://@Put>) method, use parameter injection, and convert request body into a Java object using a request object (<type://@RequestObject>).
+In this step, you'll write a method for updating a blog post. By completing this step, you'll learn to map your service with the HTTP PUT ([@Put](type)) method, use parameter injection, and convert request body into a Java object using a request object ([@RequestObject](type)).
 
 <TutorialSteps current={6} />
 
@@ -27,10 +26,10 @@ You can always [download](https://github.com/line/armeria-examples/blob/main/tut
 
 ## 1. Map HTTP method
 
-Let's start [mapping the HTTP PUT method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+Let's start [mapping the HTTP PUT method](/docs/server/annotated-service#mapping-http-service-methods) with our service method:
 
 1. Declare a service method, `updateBlogPost()`, in the class `BlogService`.
-2. Map this service method with the HTTP PUT method by adding the <type://@Put> annotation.
+2. Map this service method with the HTTP PUT method by adding the [@Put](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
 ```java filename=BlogService.java highlight=6
@@ -48,11 +47,11 @@ public final class BlogService {
 
 ## 2. Handle parameters
 
-For updating a blog post, let's take a blog post ID (`id`) and new blog post information to update with. For [creating a blog post](/tutorials/rest/blog/implement-create), we've used Armeria's <type://RequestConverter> to convert a request body into a Java object. For a change, let's try using <type://@RequestObject> to convert a request body.
+For updating a blog post, let's take a blog post ID (`id`) and new blog post information to update with. For [creating a blog post](/docs/tutorials/rest/implement-create), we've used Armeria's [RequestConverter](type) to convert a request body into a Java object. For a change, let's try using [@RequestObject](type) to convert a request body.
 
-1. Take in the ID value as a path parameter by adding `/blogs/:id` to the <type://@Put> annotation.
-2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method by annotating the parameter with <type://@Param>.
-3. [Convert request body](/docs/server-annotated-service#converting-an-http-request-to-a-java-object) into a Java object by annotating the `BlogPost` parameter with <type://@RequestObject>.
+1. Take in the ID value as a path parameter by adding `/blogs/:id` to the [@Put](type) annotation.
+2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method by annotating the parameter with [@Param](type).
+3. [Convert request body](/docs/server/annotated-service#converting-an-http-request-to-a-java-object) into a Java object by annotating the `BlogPost` parameter with [@RequestObject](type).
 
   ```java filename=BlogService.java
   import com.linecorp.armeria.server.annotation.Param;
@@ -116,8 +115,8 @@ Two possibilities are available for the response. If the blog post to update exi
 
 Let's return an error for the request to update a blog post that doesn't exist.
 
-1. Replace the return type of the `updateBlogPost()` method from `void` to <type://HttpResponse>.
-2. Return a response using Armeria's <type://HttpResponse> containing <type://HttpStatus#NOT_FOUND>.
+1. Replace the return type of the `updateBlogPost()` method from `void` to [HttpResponse](type).
+2. Return a response using Armeria's [HttpResponse](type) containing [HttpStatus#NOT_FOUND](type).
 
 ```java filename=BlogService.java highlight=8,11
 import com.linecorp.armeria.common.HttpResponse;
@@ -141,8 +140,8 @@ public final class BlogService {
 
 Let's return the information updated when the target blog post exists:
 
-1. Replace the return type of the `updateBlogPost()` method from `void` to <type://HttpResponse>.
-2. Return a response using Armeria's <type://HttpResponse> containing the updated information of the post.
+1. Replace the return type of the `updateBlogPost()` method from `void` to [HttpResponse](type).
+2. Return a response using Armeria's [HttpResponse](type) containing the updated information of the post.
 
 ```java filename=BlogService.java highlight=7,9
 import com.linecorp.armeria.common.HttpResponse;
@@ -190,13 +189,13 @@ void updateBlogPosts() throws JsonProcessingException {
 Run all the test cases on your IDE or using Gradle.
 Check that you see the test is passed.
 
-You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+You can test this also with Armeria's [Documentation service](/docs/server/docservice). See [Using DocService after adding service methods](/docs/tutorials/rest/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
 
 ## Next step
 
-In this step, we've implemented a method for an UPDATE operation and used Armeria's annotations; <type://@Put>, <type://@Param>, and <type://@RequestObject>.
+In this step, we've implemented a method for an UPDATE operation and used Armeria's annotations; [@Put](type), [@Param](type), and [@RequestObject](type).
 
-Next, at [Step 7. Implement DELETE](/tutorials/rest/blog/implement-delete), we'll implement a DELETE operation to delete
+Next, at [Step 7. Implement DELETE](/docs/tutorials/rest/implement-delete), we'll implement a DELETE operation to delete
 blog posts.
 
 <TutorialSteps current={6} />

--- a/site-new/docs/tutorials/rest/07-implement-delete.mdx
+++ b/site-new/docs/tutorials/rest/07-implement-delete.mdx
@@ -1,5 +1,6 @@
 ---
-sidebar_label: "7. Implement DELETE"
+menuTitle: "Implement DELETE"
+order: 7
 type: step
 tags:
   - rest
@@ -13,6 +14,214 @@ level: basic
 
 # Implementing DELETE operation
 
-In this step, we'll write a method for deleting a blog post. By completing this step, you'll learn to map your service with the HTTP DELETE ([@Delete](type)) method, customize an exception handler, and use a blocking task executor.
+In this step, we'll write a method for deleting a blog post. By completing this step, you'll learn to map your service with the HTTP DELETE (<type://@Delete>) method, customize an exception handler, and use a blocking task executor.
+
+<TutorialSteps current={7} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/blog/) the full version, instead of creating one yourself.
+
+- `Main.java`
+- `BlogPost.java`
+- `BlogService.java`
+- `BlogServiceTest.java`
+
+## 1. Map HTTP method
+
+Let's start [mapping the HTTP DELETE method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+
+1. Declare a service method, `deleteBlogPost()` in the class `BlogService`.
+2. Map this service method with the HTTP DELETE method by adding the <type://@Delete> annotation.
+3. Bind the endpoint `/blogs` to the method.
+
+```java filename=BlogService.java highlight=6
+import com.linecorp.armeria.server.annotation.Delete;
+
+public final class BlogService {
+  ...
+
+  @Delete("/blogs")
+  public void deleteBlogPost(int id) {
+    // Delete a blog post
+  }
+}
+```
+
+## 2. Handle parameters
+
+Let's take the blog post ID (`id`) as a path parameter for identifying the post to delete.
+
+1. Take in the ID value as a path parameter by adding `/blogs/:id` to the <type://@Delete> annotation.
+2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method by annotating the parameter with <type://@Param>.
+
+  ```java filename=BlogService.java highlight=6-7
+  import com.linecorp.armeria.server.annotation.Param;
+
+  public final class BlogService {
+    ...
+
+    @Delete("/blogs/:id")
+    public void deleteBlogPost(@Param int id) {
+      // Delete a blog post
+    }
+  }
+  ```
+
+## 3. Implement service code
+
+In this step, write the code to delete a blog post, handle an exception, and block the operation.
+
+- [Delete a blog post](#delete-a-blog-post)
+- [Handle exceptions](#handle-exceptions)
+- [Add blocking](#add-blocking)
+
+### Delete a blog post
+
+Deleting a given blog post in this tutorial means removing a blog post from the map, `blogPosts`. However, in real services you would be performing this action on a database.
+
+To delete a blog post, copy line 3 into the `deleteBlogPost()` method.
+
+```java filename=BlogService.Java highlight=3 showlineno=true
+@Delete("/blogs/:id")
+public void deleteBlogPost(@Param int id) {
+  BlogPost removed = blogPosts.remove(id);
+}
+```
+
+### Handle exceptions
+
+What if there is no such post to delete? We can check if the blog exists before attempting to remove the blog post. Here, let's handle it after the attempt.
+
+1. Throw an `IllegalArgumentException` if no blog post exists with a given ID.
+
+  ```java filename=BlogService.java
+  @Delete("/blogs/:id")
+  public void deleteBlogPost(@Param int id) {
+    ...
+
+    if (removed == null) {
+      throw new IllegalArgumentException("The blog post does not exist. ID: " + id);
+    }
+  }
+  ```
+
+2. Create an exception handler for the blog service:
+   1. Create a file, `BadRequestExceptionHandler.java`.
+   2. In the file, declare a custom exception handler implementing Armeria's <type://ExceptionHandlerFunction> interface.
+
+   ```java filename=BadRequestExceptionHandler.java
+   package example.armeria.server.blog;
+   
+   import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
+   import com.fasterxml.jackson.databind.ObjectMapper;
+   
+   public class BadRequestExceptionHandler implements ExceptionHandlerFunction {
+     private static final ObjectMapper mapper = new ObjectMapper();
+   }
+   ```
+
+3. Implement your own exception handler by overriding the default `handleException()` method. Add a code block for handling the `IllegalArgumentException` thrown. For this tutorial, return a BAD REQUEST as the response.
+
+  ```java filename=BadRequesExceptionHandler.java highlight=11,15,17
+  import com.fasterxml.jackson.databind.node.ObjectNode;
+  import com.linecorp.armeria.common.HttpResponse;
+  import com.linecorp.armeria.common.HttpStatus;
+  import com.linecorp.armeria.server.ServiceRequestContext;
+
+  public class BadRequestExceptionHandler implements ExceptionHandlerFunction {
+    ...
+
+    @Override
+    public HttpResponse handleException(ServiceRequestContext ctx, HttpRequest req, Throwable cause) {
+      if (cause instanceof IllegalArgumentException) {
+          String message = cause.getMessage();
+          ObjectNode objectNode = mapper.createObjectNode();
+          objectNode.put("error", message);
+          return HttpResponse.ofJson(HttpStatus.BAD_REQUEST, objectNode);
+      }
+      return ExceptionHandlerFunction.fallthrough();
+    }
+  }
+  ```
+
+4. Assign the exception handler to the `deleteBlogPost()` method by annotating the `deletePost()` method with the <type://@ExceptionHandler> as follows.
+
+  ```java filename=BlogService.java highlight=2
+  import com.linecorp.armeria.server.annotation.ExceptionHandler;
+
+  @Delete("/blogs/:id")
+  @ExceptionHandler(BadRequestExceptionHandler.class)
+  public void deleteBlogPost(@Param int id) { ... }
+  ```
+
+### Add blocking
+
+With real services, accessing and operating on a database takes time. We need to hand over such blocking tasks to [blocking task executor](/docs/server-annotated-service#specifying-a-blocking-task-executor) so that the EventLoop isn't blocked. There are a few options to implement this; we'll annotate our service method with the <type://@Blocking>.
+
+```java filename=BlogService.java highlight=6
+import com.linecorp.armeria.server.annotation.Blocking;
+
+public final class BlogService {
+  ...
+
+  @Blocking
+  @Delete("/blogs/:id")
+  @ExceptionHandler(BadRequestExceptionHandler.class)
+  public void deleteBlogPost(@Param int id) { ... }
+}
+```
+
+## 4. Return response
+
+We've already handled returning the not found error in the [exception handling section](#handle-exceptions). Here, we'll return a response for successful deletion.
+
+1. Replace the return type of the `deleteBlogPost()` method from `void` to <type://HttpResponse>.
+2. Return a response using Armeria's <type://HttpResponse>, containing <type://HttpStatus#NO_CONTENT>.
+
+```java filename=BlogService.java highlight=9,11
+import com.linecorp.armeria.common.HttpResponse;
+
+public final class BlogService {
+  ...
+
+  @Blocking
+  @Delete("/blogs/:id")
+  @ExceptionHandler(BadRequestExceptionHandler.class)
+  public HttpResponse deleteBlogPost(@Param int id) {
+    ...
+    return HttpResponse.of(HttpStatus.NO_CONTENT);
+  }
+}
+```
+
+## 5. Test an error case
+
+Add a test method as follows to test if our exception handler is working properly.
+
+```java filename=BlogServiceTest.java
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test
+@Order(5)
+void badRequestExceptionHandlerWhenTryingDeleteMissingBlogPost() throws JsonProcessingException {
+    final WebClient client = WebClient.of(server.httpUri());
+    final AggregatedHttpResponse res = client.delete("/blogs/100").aggregate().join();
+    assertThat(res.status()).isSameAs(HttpStatus.BAD_REQUEST);
+    assertThatJson(res.contentUtf8()).isEqualTo("{\"error\":\"The blog post does not exist. ID: 100\"}");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+
+## Next step
+
+In this step, we've written a method for a DELETE operation and used Armeria's annotations; <type://@Delete>, <type://@Param>, <type://@ExceptionHandler> and <type://@Blocking>.
+
+We've come to the end of this tutorial. Next, try adding more service methods to the tutorial or have a go at developing a service of your own.
 
 <TutorialSteps current={7} />

--- a/site-new/docs/tutorials/rest/07-implement-delete.mdx
+++ b/site-new/docs/tutorials/rest/07-implement-delete.mdx
@@ -35,7 +35,7 @@ Let's start [mapping the HTTP DELETE method](/docs/server/annotated-service#mapp
 2. Map this service method with the HTTP DELETE method by adding the [@Delete](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
-```java filename=BlogService.java highlight=6
+```java title="BlogService.java" {6}
 import com.linecorp.armeria.server.annotation.Delete;
 
 public final class BlogService {
@@ -55,7 +55,7 @@ Let's take the blog post ID (`id`) as a path parameter for identifying the post 
 1. Take in the ID value as a path parameter by adding `/blogs/:id` to the [@Delete](type) annotation.
 2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method by annotating the parameter with [@Param](type).
 
-  ```java filename=BlogService.java highlight=6-7
+  ```java title="BlogService.java" {6}-7
   import com.linecorp.armeria.server.annotation.Param;
 
   public final class BlogService {
@@ -82,7 +82,7 @@ Deleting a given blog post in this tutorial means removing a blog post from the 
 
 To delete a blog post, copy line 3 into the `deleteBlogPost()` method.
 
-```java filename=BlogService.Java highlight=3 showlineno=true
+```java title="BlogService.Java" {3} showLineNumbers
 @Delete("/blogs/:id")
 public void deleteBlogPost(@Param int id) {
   BlogPost removed = blogPosts.remove(id);
@@ -95,7 +95,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 1. Throw an `IllegalArgumentException` if no blog post exists with a given ID.
 
-  ```java filename=BlogService.java
+  ```java title="BlogService.java"
   @Delete("/blogs/:id")
   public void deleteBlogPost(@Param int id) {
     ...
@@ -110,7 +110,7 @@ What if there is no such post to delete? We can check if the blog exists before 
    1. Create a file, `BadRequestExceptionHandler.java`.
    2. In the file, declare a custom exception handler implementing Armeria's [ExceptionHandlerFunction](type) interface.
 
-   ```java filename=BadRequestExceptionHandler.java
+   ```java title="BadRequestExceptionHandler.java"
    package example.armeria.server.blog;
    
    import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
@@ -123,7 +123,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 3. Implement your own exception handler by overriding the default `handleException()` method. Add a code block for handling the `IllegalArgumentException` thrown. For this tutorial, return a BAD REQUEST as the response.
 
-  ```java filename=BadRequesExceptionHandler.java highlight=11,15,17
+  ```java title="BadRequesExceptionHandler.java" {11,15,17}
   import com.fasterxml.jackson.databind.node.ObjectNode;
   import com.linecorp.armeria.common.HttpResponse;
   import com.linecorp.armeria.common.HttpStatus;
@@ -147,7 +147,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 4. Assign the exception handler to the `deleteBlogPost()` method by annotating the `deletePost()` method with the [@ExceptionHandler](type) as follows.
 
-  ```java filename=BlogService.java highlight=2
+  ```java title="BlogService.java" {2}
   import com.linecorp.armeria.server.annotation.ExceptionHandler;
 
   @Delete("/blogs/:id")
@@ -159,7 +159,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 With real services, accessing and operating on a database takes time. We need to hand over such blocking tasks to [blocking task executor](/docs/server/annotated-service#specifying-a-blocking-task-executor) so that the EventLoop isn't blocked. There are a few options to implement this; we'll annotate our service method with the [@Blocking](type).
 
-```java filename=BlogService.java highlight=6
+```java title="BlogService.java" {6}
 import com.linecorp.armeria.server.annotation.Blocking;
 
 public final class BlogService {
@@ -179,7 +179,7 @@ We've already handled returning the not found error in the [exception handling s
 1. Replace the return type of the `deleteBlogPost()` method from `void` to [HttpResponse](type).
 2. Return a response using Armeria's [HttpResponse](type), containing [HttpStatus#NO_CONTENT](type).
 
-```java filename=BlogService.java highlight=9,11
+```java title="BlogService.java" {9,11}
 import com.linecorp.armeria.common.HttpResponse;
 
 public final class BlogService {
@@ -199,7 +199,7 @@ public final class BlogService {
 
 Add a test method as follows to test if our exception handler is working properly.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Test

--- a/site-new/docs/tutorials/rest/07-implement-delete.mdx
+++ b/site-new/docs/tutorials/rest/07-implement-delete.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement DELETE"
-order: 7
+sidebar_label: "7. Implement DELETE"
 type: step
 tags:
   - rest
@@ -14,7 +13,7 @@ level: basic
 
 # Implementing DELETE operation
 
-In this step, we'll write a method for deleting a blog post. By completing this step, you'll learn to map your service with the HTTP DELETE (<type://@Delete>) method, customize an exception handler, and use a blocking task executor.
+In this step, we'll write a method for deleting a blog post. By completing this step, you'll learn to map your service with the HTTP DELETE ([@Delete](type)) method, customize an exception handler, and use a blocking task executor.
 
 <TutorialSteps current={7} />
 
@@ -30,10 +29,10 @@ You can always [download](https://github.com/line/armeria-examples/blob/main/tut
 
 ## 1. Map HTTP method
 
-Let's start [mapping the HTTP DELETE method](/docs/server-annotated-service#mapping-http-service-methods) with our service method:
+Let's start [mapping the HTTP DELETE method](/docs/server/annotated-service#mapping-http-service-methods) with our service method:
 
 1. Declare a service method, `deleteBlogPost()` in the class `BlogService`.
-2. Map this service method with the HTTP DELETE method by adding the <type://@Delete> annotation.
+2. Map this service method with the HTTP DELETE method by adding the [@Delete](type) annotation.
 3. Bind the endpoint `/blogs` to the method.
 
 ```java filename=BlogService.java highlight=6
@@ -53,8 +52,8 @@ public final class BlogService {
 
 Let's take the blog post ID (`id`) as a path parameter for identifying the post to delete.
 
-1. Take in the ID value as a path parameter by adding `/blogs/:id` to the <type://@Delete> annotation.
-2. [Inject the path parameter](/docs/server-annotated-service#parameter-injection) to the service method by annotating the parameter with <type://@Param>.
+1. Take in the ID value as a path parameter by adding `/blogs/:id` to the [@Delete](type) annotation.
+2. [Inject the path parameter](/docs/server/annotated-service#parameter-injection) to the service method by annotating the parameter with [@Param](type).
 
   ```java filename=BlogService.java highlight=6-7
   import com.linecorp.armeria.server.annotation.Param;
@@ -109,7 +108,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 2. Create an exception handler for the blog service:
    1. Create a file, `BadRequestExceptionHandler.java`.
-   2. In the file, declare a custom exception handler implementing Armeria's <type://ExceptionHandlerFunction> interface.
+   2. In the file, declare a custom exception handler implementing Armeria's [ExceptionHandlerFunction](type) interface.
 
    ```java filename=BadRequestExceptionHandler.java
    package example.armeria.server.blog;
@@ -146,7 +145,7 @@ What if there is no such post to delete? We can check if the blog exists before 
   }
   ```
 
-4. Assign the exception handler to the `deleteBlogPost()` method by annotating the `deletePost()` method with the <type://@ExceptionHandler> as follows.
+4. Assign the exception handler to the `deleteBlogPost()` method by annotating the `deletePost()` method with the [@ExceptionHandler](type) as follows.
 
   ```java filename=BlogService.java highlight=2
   import com.linecorp.armeria.server.annotation.ExceptionHandler;
@@ -158,7 +157,7 @@ What if there is no such post to delete? We can check if the blog exists before 
 
 ### Add blocking
 
-With real services, accessing and operating on a database takes time. We need to hand over such blocking tasks to [blocking task executor](/docs/server-annotated-service#specifying-a-blocking-task-executor) so that the EventLoop isn't blocked. There are a few options to implement this; we'll annotate our service method with the <type://@Blocking>.
+With real services, accessing and operating on a database takes time. We need to hand over such blocking tasks to [blocking task executor](/docs/server/annotated-service#specifying-a-blocking-task-executor) so that the EventLoop isn't blocked. There are a few options to implement this; we'll annotate our service method with the [@Blocking](type).
 
 ```java filename=BlogService.java highlight=6
 import com.linecorp.armeria.server.annotation.Blocking;
@@ -177,8 +176,8 @@ public final class BlogService {
 
 We've already handled returning the not found error in the [exception handling section](#handle-exceptions). Here, we'll return a response for successful deletion.
 
-1. Replace the return type of the `deleteBlogPost()` method from `void` to <type://HttpResponse>.
-2. Return a response using Armeria's <type://HttpResponse>, containing <type://HttpStatus#NO_CONTENT>.
+1. Replace the return type of the `deleteBlogPost()` method from `void` to [HttpResponse](type).
+2. Return a response using Armeria's [HttpResponse](type), containing [HttpStatus#NO_CONTENT](type).
 
 ```java filename=BlogService.java highlight=9,11
 import com.linecorp.armeria.common.HttpResponse;
@@ -216,11 +215,11 @@ void badRequestExceptionHandlerWhenTryingDeleteMissingBlogPost() throws JsonProc
 Run all the test cases on your IDE or using Gradle.
 Check that you see the test is passed.
 
-You can test this also with Armeria's [Documentation service](/docs/server-docservice). See [Using DocService after adding service methods](/tutorials/rest/blog/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
+You can test this also with Armeria's [Documentation service](/docs/server/docservice). See [Using DocService after adding service methods](/docs/tutorials/rest/add-services-to-server#using-docservice-after-adding-service-methods) for instructions.
 
 ## Next step
 
-In this step, we've written a method for a DELETE operation and used Armeria's annotations; <type://@Delete>, <type://@Param>, <type://@ExceptionHandler> and <type://@Blocking>.
+In this step, we've written a method for a DELETE operation and used Armeria's annotations; [@Delete](type), [@Param](type), [@ExceptionHandler](type) and [@Blocking](type).
 
 We've come to the end of this tutorial. Next, try adding more service methods to the tutorial or have a go at developing a service of your own.
 

--- a/site-new/docs/tutorials/rest/index.mdx
+++ b/site-new/docs/tutorials/rest/index.mdx
@@ -1,1 +1,130 @@
+---
+type: tutorial
+tags:
+  - rest
+  - request
+  - request-converter
+  - exceptions
+  - exception-handling
+  - blocking
+level: basic
+---
+
+import versions from '/gen-src/versions.json';
+
 # REST tutorial introduction
+
+Using Armeria's annotations, you can build RESTful services on the go.
+Through this tutorial, you'll learn to build a RESTful service with Armeria.
+In particular, you'll be using these Armeria features:
+
+- [Service annotations](/docs/server-annotated-service)
+- [Request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object)
+- [Parameter injection](/docs/server-annotated-service#injecting-value-of-parameters-and-http-headers-into-a-java-object)
+- [Exception handler](/docs/server-annotated-service#handling-exceptions)
+- [Blocking task executor](/docs/server-annotated-service/#specifying-a-blocking-task-executor)
+
+This tutorial is based on a [sample service](#sample-service), a minimal blog service, with which you can create, read, update, and delete blog posts.
+
+Follow this tutorial to write a service yourself or try [running the sample service](#build-and-run-sample-service) right away.
+
+## Assumptions
+
+This tutorial assumes that you have:
+
+- Experience in building services in Java
+- Experience in Java frameworks for server-side programming
+- Understanding of RESTful APIs and how to implement them
+
+## Prerequisites
+
+To run and develop the sample service, set your computer with the requirements:
+
+- JDK 11 or higher
+- Gradle: Set your Gradle to compile Java with the [-parameters](/docs/setup/#configure--parameters-javac-option) option
+
+## Sample service
+
+The [sample service](https://github.com/line/armeria-examples/tree/main/tutorials/rest-api-annotated-service) provides you implementations of CRUD operations as specified below.
+
+| Operation | Method | Annotation |
+| -- | -- | -- |
+| Create | `createBlogPost()` | <type://@Post> |
+| Read | `getBlogPost()`, `getBlogPosts()` | <type://@Get> |
+| Update | `updateBlogPost()` | <type://@Put> |
+| Delete | `deleteBlogPost()` | <type://@Delete> |
+
+The sample service code consists of the following folders and files.
+
+```
+rest-api-annotated-service/
+├─ src/
+│  ├─ main/
+│  │  ├─ java/
+│  │  │  ├─ example.armeria.server.blog/
+│  │  │  │  ├─ BadRequestExceptionHandler.java
+│  │  │  │  ├─ BlogPost.java
+│  │  │  │  ├─ BlogPostRequestConverter.java
+│  │  │  │  ├─ BlogService.java
+│  │  │  │  └─ Main.java
+│  └─ test/
+│     └─ java/
+│        └─ example.armeria.server.blog/
+│           └─ BlogServiceTest.java
+└─ build.gradle
+```
+
+<Tip>
+
+  To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
+
+</Tip>
+
+## Build and run sample service
+
+Have a go at running the sample service and experience the outcome of this tutorial.
+Using Armeria's [Documentation Service](/docs/server-docservice), you can see a server running, receiving requests and sending responses.
+
+1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/rest-api-annotated-service).
+2. Build the sample service using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew build
+  ```
+3. Run the sample service again, using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew run
+  ```
+4. Open the Documentation service page on your web browser at http://127.0.0.1:8080/docs.
+
+## Try writing blog service yourself
+
+Use the sample service's [build.gradle](https://github.com/line/armeria-examples/blob/main/tutorials/rest-api-annotated-service/build.gradle) file to start building the service from scratch.
+Below is a part of the `build.gradle` file for the sample service.
+
+<CodeBlock language="groovy" filename="build.gradle">{`
+  apply plugin: 'java'
+  apply plugin: 'idea'
+  apply plugin: 'eclipse'\n
+  repositories {
+    mavenCentral()
+  }\n
+  dependencies {
+    implementation "com.linecorp.armeria:armeria:${versions['com.linecorp.armeria:armeria-bom']}"\n
+    // Logging
+    runtimeOnly 'ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}'\n
+    runtimeOnly 'org.slf4j:log4j-over-slf4j:${versions['org.slf4j:log4j-over-slf4j']}'\n
+    testImplementation "org.junit.jupiter:junit-jupiter:${versions['org.junit:junit-bom']}"\n
+    testImplementation "com.linecorp.armeria:armeria-junit5:${versions['com.linecorp.armeria:armeria-bom']}"\n
+    testImplementation "org.assertj:assertj-core:${versions['org.assertj:assertj-core']}"
+  }
+`}</CodeBlock>
+
+Start writing the blog service yourself by following the tutorial step by step:
+
+1. [Creating a server](/tutorials/rest/blog/create-server)
+2. [Preparing a data object](/tutorials/rest/blog/prepare-data-object)
+3. [Adding services to server](/tutorials/rest/blog/add-services-to-server)
+4. [Implementing CREATE operation](/tutorials/rest/blog/implement-create)
+5. [Implementing READ operation](/tutorials/rest/blog/implement-read)
+6. [Implementing UPDATE operation](/tutorials/rest/blog/implement-update)
+7. [Implementing DELETE operation](/tutorials/rest/blog/implement-delete)

--- a/site-new/docs/tutorials/rest/index.mdx
+++ b/site-new/docs/tutorials/rest/index.mdx
@@ -10,7 +10,7 @@ tags:
 level: basic
 ---
 
-import versions from '/gen-src/versions.json';
+import versions from '../../../gen-src-temp/versions.json';
 
 # REST tutorial introduction
 
@@ -18,11 +18,11 @@ Using Armeria's annotations, you can build RESTful services on the go.
 Through this tutorial, you'll learn to build a RESTful service with Armeria.
 In particular, you'll be using these Armeria features:
 
-- [Service annotations](/docs/server-annotated-service)
-- [Request converter](/docs/server-annotated-service#converting-an-http-request-to-a-java-object)
-- [Parameter injection](/docs/server-annotated-service#injecting-value-of-parameters-and-http-headers-into-a-java-object)
-- [Exception handler](/docs/server-annotated-service#handling-exceptions)
-- [Blocking task executor](/docs/server-annotated-service/#specifying-a-blocking-task-executor)
+- [Service annotations](/docs/server/annotated-service)
+- [Request converter](/docs/server/annotated-service#converting-an-http-request-to-a-java-object)
+- [Parameter injection](/docs/server/annotated-service#injecting-value-of-parameters-and-http-headers-into-a-java-object)
+- [Exception handler](/docs/server/annotated-service#handling-exceptions)
+- [Blocking task executor](/docs/server/annotated-service/#specifying-a-blocking-task-executor)
 
 This tutorial is based on a [sample service](#sample-service), a minimal blog service, with which you can create, read, update, and delete blog posts.
 
@@ -49,10 +49,10 @@ The [sample service](https://github.com/line/armeria-examples/tree/main/tutorial
 
 | Operation | Method | Annotation |
 | -- | -- | -- |
-| Create | `createBlogPost()` | <type://@Post> |
-| Read | `getBlogPost()`, `getBlogPosts()` | <type://@Get> |
-| Update | `updateBlogPost()` | <type://@Put> |
-| Delete | `deleteBlogPost()` | <type://@Delete> |
+| Create | `createBlogPost()` | [@Post](type) |
+| Read | `getBlogPost()`, `getBlogPosts()` | [@Get](type) |
+| Update | `updateBlogPost()` | [@Put](type) |
+| Delete | `deleteBlogPost()` | [@Delete](type) |
 
 The sample service code consists of the following folders and files.
 
@@ -74,16 +74,16 @@ rest-api-annotated-service/
 └─ build.gradle
 ```
 
-<Tip>
+:::tip
 
   To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
 
-</Tip>
+:::
 
 ## Build and run sample service
 
 Have a go at running the sample service and experience the outcome of this tutorial.
-Using Armeria's [Documentation Service](/docs/server-docservice), you can see a server running, receiving requests and sending responses.
+Using Armeria's [Documentation Service](/docs/server/docservice), you can see a server running, receiving requests and sending responses.
 
 1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/rest-api-annotated-service).
 2. Build the sample service using the Gradle Wrapper.
@@ -121,10 +121,10 @@ Below is a part of the `build.gradle` file for the sample service.
 
 Start writing the blog service yourself by following the tutorial step by step:
 
-1. [Creating a server](/tutorials/rest/blog/create-server)
-2. [Preparing a data object](/tutorials/rest/blog/prepare-data-object)
-3. [Adding services to server](/tutorials/rest/blog/add-services-to-server)
-4. [Implementing CREATE operation](/tutorials/rest/blog/implement-create)
-5. [Implementing READ operation](/tutorials/rest/blog/implement-read)
-6. [Implementing UPDATE operation](/tutorials/rest/blog/implement-update)
-7. [Implementing DELETE operation](/tutorials/rest/blog/implement-delete)
+1. [Creating a server](/docs/tutorials/rest/create-server)
+2. [Preparing a data object](/docs/tutorials/rest/prepare-data-object)
+3. [Adding services to server](/docs/tutorials/rest/add-services-to-server)
+4. [Implementing CREATE operation](/docs/tutorials/rest/implement-create)
+5. [Implementing READ operation](/docs/tutorials/rest/implement-read)
+6. [Implementing UPDATE operation](/docs/tutorials/rest/implement-update)
+7. [Implementing DELETE operation](/docs/tutorials/rest/implement-delete)

--- a/site-new/docs/tutorials/thrift/01-define-a-service.mdx
+++ b/site-new/docs/tutorials/thrift/01-define-a-service.mdx
@@ -1,1 +1,0 @@
-# 1. Define a service

--- a/site-new/docs/tutorials/thrift/01-define-service.mdx
+++ b/site-new/docs/tutorials/thrift/01-define-service.mdx
@@ -1,0 +1,114 @@
+---
+menuTitle: "Define a service"
+order: 1
+category: thrift
+type: step
+targetLang: java
+---
+
+# Defining a blog service
+
+Let's begin by defining our blog service in a Thrift file.
+
+<TutorialSteps current={1} />
+
+## What you need
+
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/thrift/blog/#prerequisites).
+
+## 1. Create a Thrift file
+
+Create a Thrift file, `blog.thrift` in the `{project_root}/src/main/thrift` folder as follows.
+You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/main/thrift/blog.thrift).
+
+```cpp filename=blog.thrift
+namespace java example.armeria.blog.thrift
+```
+
+<Tip>
+
+  See [Sample service structure](/tutorials/thrift/blog#sample-service) for the overall folder structure.
+
+</Tip>
+
+## 2. Define a service
+
+Let's define our blog service in the `blog.thrift` file.
+We'll add structs, an exception, and service methods.
+
+1. Add the `BlogPost` struct.
+  ```cpp filename=blog.thrift
+  struct BlogPost {
+    1: i32 id;
+    2: string title;
+    3: string content;
+    4: i64 createdAt;
+    5: i64 modifiedAt;
+  }
+  ```
+2. Add structs for request and response objects as follows.
+  ```cpp filename=blog.thrift
+  struct CreateBlogPostRequest {
+    1: string title;
+    2: string content;
+  }
+
+  struct GetBlogPostRequest {
+    1: i32 id;
+  }
+
+  struct ListBlogPostsRequest {
+    1: bool descending;
+  }
+
+  struct ListBlogPostsResponse {
+    1: list<BlogPost> blogs;
+  }
+
+  struct UpdateBlogPostRequest {
+    1: i32 id;
+    2: string title;
+    3: string content;
+  }
+
+  struct DeleteBlogPostRequest {
+    1: i32 id;
+  }
+  ```
+3. Add the `BlogNotFoundException`.
+  ```cpp filename=blog.thrift
+  exception BlogNotFoundException {
+    1: string reason
+  }
+  ```
+4. Add a service with methods for create, read, update, and delete operations.
+  ```cpp filename=blog.thrift
+  service BlogService {
+    BlogPost createBlogPost(1:CreateBlogPostRequest request),
+
+    BlogPost getBlogPost(1:GetBlogPostRequest request) throws (1:BlogNotFoundException e),
+
+    ListBlogPostsResponse listBlogPosts(1:ListBlogPostsRequest request),
+
+    BlogPost updateBlogPost(1:UpdateBlogPostRequest request) throws (1:BlogNotFoundException e),
+
+    void deleteBlogPost(1:DeleteBlogPostRequest request) throws (1:BlogNotFoundException e),
+  }
+  ```
+
+## 3. Compile the Thrift file
+
+Compile the `blog.thrift` file to generate Java code.
+You can refer to the full [build.gradle](https://github.com/line/armeria-examples/tree/main/tutorials/thrift/build.gradle) file for generating code with [Gradle Thrift Plugin](https://github.com/jruyi/thrift-gradle-plugin).
+
+```bash
+./gradlew compileThrift
+```
+You'll see the generated Java code in the `{project_root}/build/generated-sources/thrift/gen-java/example/armeria/blog/thrift/` folder.
+
+## Next step
+
+In this step, we've defined a Thrift file for our service and generated Java code.
+Next, we'll [run a service](/tutorials/thrift/blog/run-service) and test the connection.
+
+<TutorialSteps current={1} />

--- a/site-new/docs/tutorials/thrift/01-define-service.mdx
+++ b/site-new/docs/tutorials/thrift/01-define-service.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Define a service"
-order: 1
+sidebar_label: "1. Define a service"
 category: thrift
 type: step
 targetLang: java
@@ -14,22 +13,22 @@ Let's begin by defining our blog service in a Thrift file.
 
 ## What you need
 
-No preparation is required for this step. Do check that you've prepared the [prerequisites](/tutorials/thrift/blog/#prerequisites).
+No preparation is required for this step. Do check that you've prepared the [prerequisites](/docs/tutorials/thrift/#prerequisites).
 
 ## 1. Create a Thrift file
 
 Create a Thrift file, `blog.thrift` in the `{project_root}/src/main/thrift` folder as follows.
 You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/main/thrift/blog.thrift).
 
-```cpp filename=blog.thrift
+```cpp title="blog.thrift"
 namespace java example.armeria.blog.thrift
 ```
 
-<Tip>
+:::tip
 
-  See [Sample service structure](/tutorials/thrift/blog#sample-service) for the overall folder structure.
+  See [Sample service structure](/docs/tutorials/thrift#sample-service) for the overall folder structure.
 
-</Tip>
+:::
 
 ## 2. Define a service
 
@@ -37,7 +36,7 @@ Let's define our blog service in the `blog.thrift` file.
 We'll add structs, an exception, and service methods.
 
 1. Add the `BlogPost` struct.
-  ```cpp filename=blog.thrift
+  ```cpp title="blog.thrift"
   struct BlogPost {
     1: i32 id;
     2: string title;
@@ -47,7 +46,7 @@ We'll add structs, an exception, and service methods.
   }
   ```
 2. Add structs for request and response objects as follows.
-  ```cpp filename=blog.thrift
+  ```cpp title="blog.thrift"
   struct CreateBlogPostRequest {
     1: string title;
     2: string content;
@@ -76,13 +75,13 @@ We'll add structs, an exception, and service methods.
   }
   ```
 3. Add the `BlogNotFoundException`.
-  ```cpp filename=blog.thrift
+  ```cpp title="blog.thrift"
   exception BlogNotFoundException {
     1: string reason
   }
   ```
 4. Add a service with methods for create, read, update, and delete operations.
-  ```cpp filename=blog.thrift
+  ```cpp title="blog.thrift"
   service BlogService {
     BlogPost createBlogPost(1:CreateBlogPostRequest request),
 
@@ -109,6 +108,6 @@ You'll see the generated Java code in the `{project_root}/build/generated-source
 ## Next step
 
 In this step, we've defined a Thrift file for our service and generated Java code.
-Next, we'll [run a service](/tutorials/thrift/blog/run-service) and test the connection.
+Next, we'll [run a service](/docs/tutorials/thrift/run-service) and test the connection.
 
 <TutorialSteps current={1} />

--- a/site-new/docs/tutorials/thrift/02-run-service.mdx
+++ b/site-new/docs/tutorials/thrift/02-run-service.mdx
@@ -1,0 +1,144 @@
+---
+menuTitle: "Run a service"
+order: 2
+category: thrift
+type: step
+targetLang: java
+---
+
+# Running a service
+
+In this step, we'll do three things with the code we obtained from our Thrift file; define the blog service in Java, create a server instance, and run the service.
+
+<TutorialSteps current={2} />
+
+## What you need
+
+You need to have the [generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file) obtained from the previous step.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
+
+## 1. Implement the service
+
+Create a file, `BlogServiceImpl.java`, and declare the `BlogServiceImpl` class implementing the `BlogService` service we defined earlier in [Step 1. Define a service](/tutorials/thrift/blog/define-service).
+
+```java filename=BlogServiceImpl.java
+package example.armeria.server.blog.thrift;
+
+import example.armeria.blog.thrift.BlogService;
+
+public class BlogServiceImpl implements BlogService.AsyncIface {}
+```
+
+## 2. Override service methods
+
+Add empty service methods as follows to override the service methods.
+We'll implement the service methods one by one in this tutorial.
+Let's leave them empty for now.
+
+```java filename=BlogServiceImpl.java
+import example.armeria.blog.thrift.BlogPost;
+import example.armeria.blog.thrift.CreateBlogPostRequest;
+import example.armeria.blog.thrift.GetBlogPostRequest;
+import example.armeria.blog.thrift.ListBlogPostsRequest;
+import example.armeria.blog.thrift.ListBlogPostsResponse;
+import example.armeria.blog.thrift.UpdateBlogPostRequest;
+import example.armeria.blog.thrift.DeleteBlogPostRequest;
+import org.apache.thrift.TException;
+import org.apache.thrift.async.AsyncMethodCallback;
+
+public class BlogServiceImpl implements BlogService.AsyncIface {
+
+  @Override
+  public void createBlogPost(CreateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+          throws TException {}
+
+  @Override
+  public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+          throws TException {}
+
+  @Override
+  public void listBlogPosts(ListBlogPostsRequest request, AsyncMethodCallback<ListBlogPostsResponse> resultHandler)
+          throws TException {}
+
+  @Override
+  public void updateBlogPost(UpdateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+          throws TException {}
+
+  @Override
+  public void deleteBlogPost(DeleteBlogPostRequest request, AsyncMethodCallback<Void> resultHandler)
+          throws TException {}
+}
+```
+
+## 3. Create a server
+
+Let's create a server to serve our service.
+
+1. Create the `Main` class for the server.
+You can see the full version of the file [here](https://github.com/line/armeria-examples/tree/main/tutorials/thrift/src/main/java/example/armeria/server/blog/thrift/Main.java).
+  ```java filename=Main.java
+  package example.armeria.server.blog.thrift;
+
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+  public final class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+  }
+  ```
+2. Add the `newServer()` method in the `Main` class as follows.
+We are using Armeria's <type://THttpService> to handle Thrift calls.
+  ```java filename=Main.java
+  import com.linecorp.armeria.server.Server;
+  import com.linecorp.armeria.server.thrift.THttpService;
+  ...
+  private static Server newServer(int port) throws Exception {
+    final THttpService tHttpService =
+              THttpService.builder()
+                          .addService(new BlogServiceImpl())
+                          .build();
+  }
+  ```
+3. Create and return a server instance using Armeria's <type://ServerBuilder>.
+Note that the service instance, `tHttpService`, is added to the server instance.
+  ```java filename=Main.java
+  private static Server newServer(int port) throws Exception {
+    ...
+    return Server.builder()
+                 .http(port)
+                 .service("/thrift", tHttpService) // Add the service to server
+                 .build();
+  }
+  ```
+4. Add the `main()` method in the `Main` class as follows.
+  ```java filename=Main.java
+  public static void main(String[] args) throws Exception {
+    final Server server = newServer(8080);
+
+    server.closeOnJvmShutdown().thenRun(() -> {
+      logger.info("Server has been stopped.");
+    });
+
+    server.start().join();
+  }
+  ```
+
+## 4. Run the server
+
+Run the `Main.main()` method on your IDE or using Gradle.
+```bash
+./gradlew run
+```
+
+Your server is running if you see the following message.
+```bash
+[armeria-boss-http-*:8080] INFO com.linecorp.armeria.server.Server - Serving HTTP at /[0:0:0:0:0:0:0:0]:8080 - http://127.0.0.1:8080/
+```
+
+## What's next
+
+In this step, we've created and added an empty Thrift service to a server.
+
+Next, we'll get on with implementing a service method for [creating blog posts](/tutorials/thrift/blog/implement-create).
+
+<TutorialSteps current={2} />

--- a/site-new/docs/tutorials/thrift/02-run-service.mdx
+++ b/site-new/docs/tutorials/thrift/02-run-service.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Run a service"
-order: 2
+sidebar_label: "2. Run a service"
 category: thrift
 type: step
 targetLang: java
@@ -14,14 +13,14 @@ In this step, we'll do three things with the code we obtained from our Thrift fi
 
 ## What you need
 
-You need to have the [generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file) obtained from the previous step.
+You need to have the [generated Java code](/docs/tutorials/thrift/define-service#3-compile-the-thrift-file) obtained from the previous step.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
 
 ## 1. Implement the service
 
-Create a file, `BlogServiceImpl.java`, and declare the `BlogServiceImpl` class implementing the `BlogService` service we defined earlier in [Step 1. Define a service](/tutorials/thrift/blog/define-service).
+Create a file, `BlogServiceImpl.java`, and declare the `BlogServiceImpl` class implementing the `BlogService` service we defined earlier in [Step 1. Define a service](/docs/tutorials/thrift/define-service).
 
-```java filename=BlogServiceImpl.java
+```java title="BlogServiceImpl.java"
 package example.armeria.server.blog.thrift;
 
 import example.armeria.blog.thrift.BlogService;
@@ -35,7 +34,7 @@ Add empty service methods as follows to override the service methods.
 We'll implement the service methods one by one in this tutorial.
 Let's leave them empty for now.
 
-```java filename=BlogServiceImpl.java
+```java title="BlogServiceImpl.java"
 import example.armeria.blog.thrift.BlogPost;
 import example.armeria.blog.thrift.CreateBlogPostRequest;
 import example.armeria.blog.thrift.GetBlogPostRequest;
@@ -76,7 +75,7 @@ Let's create a server to serve our service.
 
 1. Create the `Main` class for the server.
 You can see the full version of the file [here](https://github.com/line/armeria-examples/tree/main/tutorials/thrift/src/main/java/example/armeria/server/blog/thrift/Main.java).
-  ```java filename=Main.java
+  ```java title="Main.java"
   package example.armeria.server.blog.thrift;
 
   import org.slf4j.Logger;
@@ -87,8 +86,8 @@ You can see the full version of the file [here](https://github.com/line/armeria-
   }
   ```
 2. Add the `newServer()` method in the `Main` class as follows.
-We are using Armeria's <type://THttpService> to handle Thrift calls.
-  ```java filename=Main.java
+We are using Armeria's [THttpService](type) to handle Thrift calls.
+  ```java title="Main.java"
   import com.linecorp.armeria.server.Server;
   import com.linecorp.armeria.server.thrift.THttpService;
   ...
@@ -99,9 +98,9 @@ We are using Armeria's <type://THttpService> to handle Thrift calls.
                           .build();
   }
   ```
-3. Create and return a server instance using Armeria's <type://ServerBuilder>.
+3. Create and return a server instance using Armeria's [ServerBuilder](type).
 Note that the service instance, `tHttpService`, is added to the server instance.
-  ```java filename=Main.java
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
     ...
     return Server.builder()
@@ -111,7 +110,7 @@ Note that the service instance, `tHttpService`, is added to the server instance.
   }
   ```
 4. Add the `main()` method in the `Main` class as follows.
-  ```java filename=Main.java
+  ```java title="Main.java"
   public static void main(String[] args) throws Exception {
     final Server server = newServer(8080);
 
@@ -139,6 +138,6 @@ Your server is running if you see the following message.
 
 In this step, we've created and added an empty Thrift service to a server.
 
-Next, we'll get on with implementing a service method for [creating blog posts](/tutorials/thrift/blog/implement-create).
+Next, we'll get on with implementing a service method for [creating blog posts](/docs/tutorials/thrift/implement-create).
 
 <TutorialSteps current={2} />

--- a/site-new/docs/tutorials/thrift/03-implement-create.mdx
+++ b/site-new/docs/tutorials/thrift/03-implement-create.mdx
@@ -1,0 +1,199 @@
+---
+menuTitle: "Implement CREATE"
+order: 3
+category: thrift
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing CREATE operation
+
+In the previous step, we defined empty service methods.
+In this step, we'll fill in one of the service methods to create a blog post and implement a corresponding client method.
+Also, we'll try making a call to the service method with test code using Armeria's <type://ServerExtension>.
+
+<TutorialSteps current={3} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- `Main.java`
+- `BlogServiceImpl.java`
+
+## 1. Implement server-side
+
+Let's implement a service method to create a blog post.
+
+1. In the `BlogServiceImpl` class, create an ID generator to issue temporary blog post IDs and a map to contain blog posts.
+  ```java filename=BlogServiceImpl.java
+  import java.util.Map;
+  import java.util.concurrent.ConcurrentHashMap;
+  import java.util.concurrent.atomic.AtomicInteger;
+
+  public class BlogServiceImpl implements BlogService.AsyncIface {
+    private final AtomicInteger idGenerator = new AtomicInteger();
+    private final Map<Integer, BlogPost> blogPosts = new ConcurrentHashMap<>();
+    ...
+  }
+  ```
+2. In the `createBlogPost()` method, create a `BlogPost` object with a generated ID and request parameters.
+  ```java filename=BlogServiceImpl.java
+  import java.time.Instant;
+  ...
+  @Override
+  public void createBlogPost(CreateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+          throws TException {
+    final int id = idGenerator.getAndIncrement();
+    final Instant now = Instant.now();
+    final BlogPost blogPost = new BlogPost()
+            .setId(id)
+            .setTitle(request.getTitle())
+            .setContent(request.getContent())
+            .setModifiedAt(now.toEpochMilli())
+            .setCreatedAt(now.toEpochMilli());
+  }
+  ```
+2. In the `createBlogPost()` method, save the post information in the `blogPosts` map and return the information of the created blog post to the `resultHandler`.
+  ```java filename=BlogServiceImpl.java
+  @Override
+  public void createBlogPost(CreateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+          throws TException {
+    ...
+    blogPosts.put(id, blogPost);
+    final BlogPost stored = blogPost;
+    resultHandler.onComplete(stored);
+  }
+  ```
+
+## 2. Create a client
+
+Let's create a client to send a request to the service.
+You can refer to the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/main/java/example/armeria/server/blog/thrift/BlogClient.java) of the file.
+
+1. Create a class for our client. We'll name the class `BlogClient`.
+  ```java filename=BlogClient.java
+  package example.armeria.server.blog.thrift;
+
+  import org.slf4j.Logger;
+  import org.slf4j.LoggerFactory;
+
+  public class BlogClient {
+    private static final Logger logger = LoggerFactory.getLogger(BlogClient.class);
+  }
+  ```
+2. In the `BlogClient` class, add a constructor and create a Thrift client instance using Armeria's <type://ThriftClients>.
+  ```java filename=BlogClient.java
+  import java.net.URI;
+  import com.linecorp.armeria.client.thrift.ThriftClients;
+  import example.armeria.blog.thrift.BlogService;
+
+  public class BlogClient {
+    ...
+    private final BlogService.Iface blogService;
+
+    BlogClient(URI uri, String path) {
+      blogService =
+        ThriftClients.builder(uri)
+          .path(path)
+          .build(BlogService.Iface.class);
+    }
+  }
+  ```
+
+## 3. Implement client-side
+
+In the `BlogClient` class, add a method to send a request to create a blog post.
+
+```java filename=BlogClient.java
+import org.apache.thrift.TException;
+import example.armeria.blog.thrift.BlogPost;
+import example.armeria.blog.thrift.CreateBlogPostRequest;
+...
+BlogPost createBlogPost(String title, String content) throws TException {
+  final CreateBlogPostRequest request =
+          new CreateBlogPostRequest().setTitle(title)
+                                     .setContent(content);
+  return blogService.createBlogPost(request);
+}
+```
+
+## 4. Create a test file
+
+Let's start writing test code.
+We'll use test code to verify what we implement along the way.
+
+Create a file, `BlogServiceTest.java`, under `{project_root}/src/test/java/example/armeria/server/blog/thrift` as follows.
+You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/test/java/example/armeria/server/blog/thrift/BlogServiceTest.java).
+```java filename=BlogServiceTest.java
+package example.armeria.server.blog.thrift;
+
+class BlogServiceTest {}
+```
+
+## 5. Register a ServerExtension
+
+Armeria's <type://ServerExtension> automatically handles set-up and tear-down of a server for testing.
+This is convenient as it eliminates the need to execute the main method to set up a server before running our tests.
+
+In the `BlogServiceTest` class, register a <type://ServerExtension> as follows.
+Note that the service instance is added to the configuration.
+
+```java filename=BlogServiceTest.java
+import org.junit.jupiter.api.extension.RegisterExtension;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.thrift.THttpService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+...
+@RegisterExtension
+static final ServerExtension server = new ServerExtension() {
+  @Override
+  protected void configure(ServerBuilder sb) throws Exception {
+    sb.service("/thrift",
+               THttpService.builder()
+                           // Add the service to the configuration
+                           .addService(new BlogServiceImpl())
+                           .build());
+  }
+};
+```
+
+## 6. Test creating a blog post
+
+Let's test if we can create a blog post.
+
+1. In the `BlogServiceTest` class, add a test method as follows.
+  ```java filename=BlogServiceTest.java
+  import static org.assertj.core.api.Assertions.assertThat;
+  import org.apache.thrift.TException;
+  import org.junit.jupiter.api.Test;
+  import example.armeria.blog.thrift.BlogPost;
+  ...
+  @Test
+  void createBlogPost() throws TException {
+    final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+    final BlogPost response = client.createBlogPost("My first blog", "Hello Armeria!");
+    assertThat(response.getId()).isGreaterThanOrEqualTo(0);
+    assertThat(response.getTitle()).isEqualTo("My first blog");
+    assertThat(response.getContent()).isEqualTo("Hello Armeria!");
+  }
+  ```
+2. Run the test case on your IDE or using Gradle.
+  ```bash
+  ./gradlew test
+  ```
+
+  The service worked as expected if you see the test case passed.
+
+## What's next
+
+In this step, we've implemented a method for creating a blog post.
+We've also written test code and registered <type://ServerExtension> to our test.
+
+Next, at [Step 4. Implement READ](/tutorials/thrift/blog/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
+
+<TutorialSteps current={3} />

--- a/site-new/docs/tutorials/thrift/03-implement-create.mdx
+++ b/site-new/docs/tutorials/thrift/03-implement-create.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement CREATE"
-order: 3
+sidebar_label: "3. Implement CREATE"
 category: thrift
 tags:
   - server
@@ -12,7 +11,7 @@ type: step
 
 In the previous step, we defined empty service methods.
 In this step, we'll fill in one of the service methods to create a blog post and implement a corresponding client method.
-Also, we'll try making a call to the service method with test code using Armeria's <type://ServerExtension>.
+Also, we'll try making a call to the service method with test code using Armeria's [ServerExtension](type).
 
 <TutorialSteps current={3} />
 
@@ -21,7 +20,7 @@ Also, we'll try making a call to the service method with test code using Armeria
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- [Generated Java code](/docs/tutorials/thrift/define-service#3-compile-the-thrift-file)
 - `Main.java`
 - `BlogServiceImpl.java`
 
@@ -30,7 +29,7 @@ You can always [download](https://github.com/line/armeria-examples/tree/main/tut
 Let's implement a service method to create a blog post.
 
 1. In the `BlogServiceImpl` class, create an ID generator to issue temporary blog post IDs and a map to contain blog posts.
-  ```java filename=BlogServiceImpl.java
+  ```java title="BlogServiceImpl.java"
   import java.util.Map;
   import java.util.concurrent.ConcurrentHashMap;
   import java.util.concurrent.atomic.AtomicInteger;
@@ -42,7 +41,7 @@ Let's implement a service method to create a blog post.
   }
   ```
 2. In the `createBlogPost()` method, create a `BlogPost` object with a generated ID and request parameters.
-  ```java filename=BlogServiceImpl.java
+  ```java title="BlogServiceImpl.java"
   import java.time.Instant;
   ...
   @Override
@@ -59,7 +58,7 @@ Let's implement a service method to create a blog post.
   }
   ```
 2. In the `createBlogPost()` method, save the post information in the `blogPosts` map and return the information of the created blog post to the `resultHandler`.
-  ```java filename=BlogServiceImpl.java
+  ```java title="BlogServiceImpl.java"
   @Override
   public void createBlogPost(CreateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
           throws TException {
@@ -76,7 +75,7 @@ Let's create a client to send a request to the service.
 You can refer to the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/main/java/example/armeria/server/blog/thrift/BlogClient.java) of the file.
 
 1. Create a class for our client. We'll name the class `BlogClient`.
-  ```java filename=BlogClient.java
+  ```java title="BlogClient.java"
   package example.armeria.server.blog.thrift;
 
   import org.slf4j.Logger;
@@ -86,8 +85,8 @@ You can refer to the full version of the file [here](https://github.com/line/arm
     private static final Logger logger = LoggerFactory.getLogger(BlogClient.class);
   }
   ```
-2. In the `BlogClient` class, add a constructor and create a Thrift client instance using Armeria's <type://ThriftClients>.
-  ```java filename=BlogClient.java
+2. In the `BlogClient` class, add a constructor and create a Thrift client instance using Armeria's [ThriftClients](type).
+  ```java title="BlogClient.java"
   import java.net.URI;
   import com.linecorp.armeria.client.thrift.ThriftClients;
   import example.armeria.blog.thrift.BlogService;
@@ -109,7 +108,7 @@ You can refer to the full version of the file [here](https://github.com/line/arm
 
 In the `BlogClient` class, add a method to send a request to create a blog post.
 
-```java filename=BlogClient.java
+```java title="BlogClient.java"
 import org.apache.thrift.TException;
 import example.armeria.blog.thrift.BlogPost;
 import example.armeria.blog.thrift.CreateBlogPostRequest;
@@ -129,7 +128,7 @@ We'll use test code to verify what we implement along the way.
 
 Create a file, `BlogServiceTest.java`, under `{project_root}/src/test/java/example/armeria/server/blog/thrift` as follows.
 You can see the full version of the file [here](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/src/test/java/example/armeria/server/blog/thrift/BlogServiceTest.java).
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 package example.armeria.server.blog.thrift;
 
 class BlogServiceTest {}
@@ -137,13 +136,13 @@ class BlogServiceTest {}
 
 ## 5. Register a ServerExtension
 
-Armeria's <type://ServerExtension> automatically handles set-up and tear-down of a server for testing.
+Armeria's [ServerExtension](type) automatically handles set-up and tear-down of a server for testing.
 This is convenient as it eliminates the need to execute the main method to set up a server before running our tests.
 
-In the `BlogServiceTest` class, register a <type://ServerExtension> as follows.
+In the `BlogServiceTest` class, register a [ServerExtension](type) as follows.
 Note that the service instance is added to the configuration.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.thrift.THttpService;
@@ -167,7 +166,7 @@ static final ServerExtension server = new ServerExtension() {
 Let's test if we can create a blog post.
 
 1. In the `BlogServiceTest` class, add a test method as follows.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import static org.assertj.core.api.Assertions.assertThat;
   import org.apache.thrift.TException;
   import org.junit.jupiter.api.Test;
@@ -192,8 +191,8 @@ Let's test if we can create a blog post.
 ## What's next
 
 In this step, we've implemented a method for creating a blog post.
-We've also written test code and registered <type://ServerExtension> to our test.
+We've also written test code and registered [ServerExtension](type) to our test.
 
-Next, at [Step 4. Implement READ](/tutorials/thrift/blog/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
+Next, at [Step 4. Implement READ](/docs/tutorials/thrift/implement-read), we'll implement a READ operation to read a single post and also multiple posts.
 
 <TutorialSteps current={3} />

--- a/site-new/docs/tutorials/thrift/04-implement-read.mdx
+++ b/site-new/docs/tutorials/thrift/04-implement-read.mdx
@@ -1,0 +1,241 @@
+---
+menuTitle: "Implement READ"
+order: 4
+type: step
+category: thrift
+tags:
+  - server
+level: basic
+---
+
+# Implementing READ operation
+
+In the earlier step, we created blog posts.
+In this step, we'll implement a read operation and make a call to read blog posts.
+We'll write two service methods, one for reading a single post and another for multiple posts.
+
+<TutorialSteps current={4} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- `BlogServiceImpl.java`
+- `Main.java`
+- `BlogClient.java`
+- `BlogServiceTest.java`
+
+## 1. Implement server-side
+
+Let's write two methods for retrieving blog posts; one for a single post and another for multiple posts.
+
+<Tabs>
+<TabPane tab="Single post" key="1">
+
+In the `BlogServiceImpl` class, implement the `getBlogPost()` method to retrieve a single post.
+Let's throw an exception in case there is no blog post for the given ID.
+
+```java filename=BlogServiceImpl.java
+import example.armeria.blog.thrift.BlogNotFoundException;
+...
+@Override
+public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+        throws TException {
+  final BlogPost blogPost = blogPosts.get(request.getId());
+  if (blogPost == null) {
+    // throwing an exception will also have the same effect
+    // throw new BlogNotFoundException("The blog post does not exist. ID: " + request.getId());
+    resultHandler.onError(
+            new BlogNotFoundException("The blog post does not exist. ID: " + request.getId()));
+  } else {
+    resultHandler.onComplete(blogPost);
+  }
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+1. Implement the `listBlogPosts()` method in the `BlogServiceImpl` class to retrieve multiple posts.
+  ```java filename=BlogServiceImpl.java
+  import java.util.List;
+  import java.util.stream.Collectors;
+  ...
+  @Override
+  public void listBlogPosts(ListBlogPostsRequest request,
+                            AsyncMethodCallback<ListBlogPostsResponse> resultHandler) throws TException {
+    final List<BlogPost> blogPosts = this.blogPosts.values().stream().collect(Collectors.toList());
+    resultHandler.onComplete(new ListBlogPostsResponse().setBlogs(blogPosts));
+  }
+  ```
+2. Add an if-else statement by adding line 9-16, to sort the blog posts based on the value of the `descending` parameter.
+  ```java filename=BlogServiceImpl.java showlineno=true
+  import java.util.Collections;
+  import java.util.Comparator;
+  import java.util.Map.Entry;
+  ...
+  @Override
+  public void listBlogPosts(ListBlogPostsRequest request,
+                            AsyncMethodCallback<ListBlogPostsResponse> resultHandler) throws TException {
+    final List<BlogPost> blogPosts;
+    if (request.isDescending()) {
+      blogPosts = this.blogPosts.entrySet()
+                                .stream()
+                                .sorted(Collections.reverseOrder(Comparator.comparingInt(Entry::getKey)))
+                                .map(Entry::getValue).collect(Collectors.toList());
+    } else {
+      blogPosts = this.blogPosts.values().stream().collect(Collectors.toList());
+    }
+    resultHandler.onComplete(new ListBlogPostsResponse().setBlogs(blogPosts));
+  }
+  ```
+
+</TabPane>
+</Tabs>
+
+## 2. Implement client-side
+
+This time, we'll implement the client-side for reading blog posts.
+Let's implement client methods for each corresponding server method.
+
+<Tabs>
+<TabPane tab="Single post" key="1">
+
+In the `BlogClient` class, add a method to retrieve a single post.
+
+```java filename=BlogClient.java
+import example.armeria.blog.thrift.GetBlogPostRequest;
+...
+BlogPost getBlogPost(int id) throws TException {
+  final GetBlogPostRequest request =
+              new GetBlogPostRequest().setId(id);
+  return blogService.getBlogPost(request);
+}
+```
+
+</TabPane>
+<TabPane tab="Multiple posts" key="2">
+
+In the `BlogClient` class, add a method to retrieve a list of posts.
+
+```java filename=BlogClient.java
+import example.armeria.blog.thrift.ListBlogPostsRequest;
+import example.armeria.blog.thrift.ListBlogPostsResponse;
+...
+List<BlogPost> listBlogPosts(boolean descending) throws TException {
+  return blogService.listBlogPosts(new ListBlogPostsRequest().setDescending(descending))
+                    .getBlogs();
+}
+```
+
+</TabPane>
+</Tabs>
+
+## 3. Test retrieving a single post
+
+Let's test if we can retrieve a blog post we created.
+
+1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
+  ```java filename=BlogServiceTest.java
+  @Test
+  void getBlogPost() throws TException {
+    final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+    final BlogPost blogPost = client.getBlogPost(0);
+
+    assertThat(blogPost.getTitle()).isEqualTo("My first blog");
+    assertThat(blogPost.getContent()).isEqualTo("Hello Armeria!");
+  }
+  ```
+2. Add annotations to configure the order our test methods will be executed.
+  The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
+  ```java filename=BlogServiceTest.java
+  import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+  import org.junit.jupiter.api.Order;
+  import org.junit.jupiter.api.TestMethodOrder;
+
+  @TestMethodOrder(OrderAnnotation.class) // Add this
+  class BlogServiceTest {
+    ...
+
+    @Test
+    @Order(1) // Add this
+    void createBlogPost() throws TException {
+      ...
+    }
+
+    @Test
+    @Order(2) // Add this
+    void getBlogPost() throws TException {
+      ...
+    }
+  }
+  ```
+3. Run all the test cases on your IDE or using Gradle.
+
+  Your client retrieved a blog post from the server successfully if the test is passed.
+
+## 4. Test an error case
+
+Let's try retrieving a blog post that does not exist.
+Add a test method to retrieve a blog post with an invalid ID, asserting an exception is thrown.
+
+```java filename=BlogServiceTest.java
+import static org.assertj.core.api.Assertions.catchThrowable;
+import example.armeria.blog.thrift.BlogNotFoundException;
+...
+@Test
+@Order(3)
+void getInvalidBlogPost() {
+  final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+  final Throwable exception = catchThrowable(() -> {
+    client.getBlogPost(Integer.MAX_VALUE);
+  });
+  assertThat(exception)
+    .isInstanceOf(BlogNotFoundException.class)
+    .extracting("reason")
+    .asString()
+    .isEqualTo("The blog post does not exist. ID: " + Integer.MAX_VALUE);
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 5. Test retrieving multiple posts
+
+Finally, let's test if we can retrieve multiple posts.
+Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
+
+```java filename=BlogServiceTest.java
+import java.util.List;
+...
+@Test
+@Order(4)
+void listBlogPosts() throws TException {
+  final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+  client.createBlogPost("My second blog", "Armeria is awesome!");
+
+  final List<BlogPost> blogs = client.listBlogPosts(false);
+  assertThat(blogs).hasSize(2);
+  final BlogPost firstBlog = blogs.get(0);
+  assertThat(firstBlog.getTitle()).isEqualTo("My first blog");
+  assertThat(firstBlog.getContent()).isEqualTo("Hello Armeria!");
+
+  final BlogPost secondBlog = blogs.get(1);
+  assertThat(secondBlog.getTitle()).isEqualTo("My second blog");
+  assertThat(secondBlog.getContent()).isEqualTo("Armeria is awesome!");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## What's next
+
+In this step, we've implemented service methods and client methods to retrieve blog posts.
+
+Next, at [Step 5. Implement UPDATE](/tutorials/thrift/blog/implement-update), we'll implement an UPDATE operation to update a blog post.
+
+<TutorialSteps current={4} />

--- a/site-new/docs/tutorials/thrift/04-implement-read.mdx
+++ b/site-new/docs/tutorials/thrift/04-implement-read.mdx
@@ -70,7 +70,7 @@ public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost
   }
   ```
 2. Add an if-else statement by adding line 9-16, to sort the blog posts based on the value of the `descending` parameter.
-  ```java title="BlogServiceImpl.java" showlineno=true
+  ```java title="BlogServiceImpl.java" showLineNumbers
   import java.util.Collections;
   import java.util.Comparator;
   import java.util.Map.Entry;

--- a/site-new/docs/tutorials/thrift/04-implement-read.mdx
+++ b/site-new/docs/tutorials/thrift/04-implement-read.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement READ"
-order: 4
+sidebar_label: "4. Implement READ"
 type: step
 category: thrift
 tags:
@@ -21,7 +20,7 @@ We'll write two service methods, one for reading a single post and another for m
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- [Generated Java code](/docs/tutorials/thrift/define-service#3-compile-the-thrift-file)
 - `BlogServiceImpl.java`
 - `Main.java`
 - `BlogClient.java`
@@ -31,13 +30,13 @@ You can always [download](https://github.com/line/armeria-examples/tree/main/tut
 
 Let's write two methods for retrieving blog posts; one for a single post and another for multiple posts.
 
-<Tabs>
-<TabPane tab="Single post" key="1">
+<Tabs groupId="thrift-read">
+<TabItem label="Single post" value="1">
 
 In the `BlogServiceImpl` class, implement the `getBlogPost()` method to retrieve a single post.
 Let's throw an exception in case there is no blog post for the given ID.
 
-```java filename=BlogServiceImpl.java
+```java title="BlogServiceImpl.java"
 import example.armeria.blog.thrift.BlogNotFoundException;
 ...
 @Override
@@ -55,11 +54,11 @@ public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 1. Implement the `listBlogPosts()` method in the `BlogServiceImpl` class to retrieve multiple posts.
-  ```java filename=BlogServiceImpl.java
+  ```java title="BlogServiceImpl.java"
   import java.util.List;
   import java.util.stream.Collectors;
   ...
@@ -71,7 +70,7 @@ public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost
   }
   ```
 2. Add an if-else statement by adding line 9-16, to sort the blog posts based on the value of the `descending` parameter.
-  ```java filename=BlogServiceImpl.java showlineno=true
+  ```java title="BlogServiceImpl.java" showlineno=true
   import java.util.Collections;
   import java.util.Comparator;
   import java.util.Map.Entry;
@@ -92,7 +91,7 @@ public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost
   }
   ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 2. Implement client-side
@@ -100,12 +99,12 @@ public void getBlogPost(GetBlogPostRequest request, AsyncMethodCallback<BlogPost
 This time, we'll implement the client-side for reading blog posts.
 Let's implement client methods for each corresponding server method.
 
-<Tabs>
-<TabPane tab="Single post" key="1">
+<Tabs groupId="thrift-read">
+<TabItem label="Single post" value="1">
 
 In the `BlogClient` class, add a method to retrieve a single post.
 
-```java filename=BlogClient.java
+```java title="BlogClient.java"
 import example.armeria.blog.thrift.GetBlogPostRequest;
 ...
 BlogPost getBlogPost(int id) throws TException {
@@ -115,12 +114,12 @@ BlogPost getBlogPost(int id) throws TException {
 }
 ```
 
-</TabPane>
-<TabPane tab="Multiple posts" key="2">
+</TabItem>
+<TabItem label="Multiple posts" value="2">
 
 In the `BlogClient` class, add a method to retrieve a list of posts.
 
-```java filename=BlogClient.java
+```java title="BlogClient.java"
 import example.armeria.blog.thrift.ListBlogPostsRequest;
 import example.armeria.blog.thrift.ListBlogPostsResponse;
 ...
@@ -130,7 +129,7 @@ List<BlogPost> listBlogPosts(boolean descending) throws TException {
 }
 ```
 
-</TabPane>
+</TabItem>
 </Tabs>
 
 ## 3. Test retrieving a single post
@@ -138,7 +137,7 @@ List<BlogPost> listBlogPosts(boolean descending) throws TException {
 Let's test if we can retrieve a blog post we created.
 
 1. In the `BlogServiceTest` class, add a test method to retrieve the first blog post with ID `0`.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @Test
   void getBlogPost() throws TException {
     final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
@@ -150,7 +149,7 @@ Let's test if we can retrieve a blog post we created.
   ```
 2. Add annotations to configure the order our test methods will be executed.
   The annotations guarantee that the first blog post will be created in the `createBlogPost()` method before we try to retrieve it in the `getBlogPost()` method.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
   import org.junit.jupiter.api.Order;
   import org.junit.jupiter.api.TestMethodOrder;
@@ -181,7 +180,7 @@ Let's test if we can retrieve a blog post we created.
 Let's try retrieving a blog post that does not exist.
 Add a test method to retrieve a blog post with an invalid ID, asserting an exception is thrown.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import static org.assertj.core.api.Assertions.catchThrowable;
 import example.armeria.blog.thrift.BlogNotFoundException;
 ...
@@ -208,7 +207,7 @@ Check that you see the test is passed.
 Finally, let's test if we can retrieve multiple posts.
 Add a test method like the following to create the second blog post and test retrieving the list of blog posts.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 import java.util.List;
 ...
 @Test
@@ -236,6 +235,6 @@ Check that you see the test is passed.
 
 In this step, we've implemented service methods and client methods to retrieve blog posts.
 
-Next, at [Step 5. Implement UPDATE](/tutorials/thrift/blog/implement-update), we'll implement an UPDATE operation to update a blog post.
+Next, at [Step 5. Implement UPDATE](/docs/tutorials/thrift/implement-update), we'll implement an UPDATE operation to update a blog post.
 
 <TutorialSteps current={4} />

--- a/site-new/docs/tutorials/thrift/05-implement-update.mdx
+++ b/site-new/docs/tutorials/thrift/05-implement-update.mdx
@@ -1,0 +1,176 @@
+---
+menuTitle: "Implement UPDATE"
+order: 5
+category: thrift
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing UPDATE operation
+
+Previously, we created and read blog posts.
+Now, let's implement and make a call to update a blog post.
+We'll also learn how to handle an exception with a custom exception handler.
+
+<TutorialSteps current={5} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- `BlogServiceImpl.java`
+- `Main.java`
+- `BlogClient.java`
+- `BlogServiceTest.java`
+
+## 1. Implement server-side
+
+Let's implement the server-side for updating blog posts.
+This time, we'll use a custom exception handler.
+
+### Add an exception handler
+
+First, add a custom exception handler for the blog service.
+
+1. Add an exception handler class to convert an `IllegalArgumentException` into a `BlogNotFoundException`.
+  ```java filename=BlogServiceExceptionHandler.java
+  package example.armeria.server.blog.thrift;
+
+  import java.util.function.BiFunction;
+
+  import com.linecorp.armeria.common.RpcResponse;
+  import com.linecorp.armeria.server.ServiceRequestContext;
+
+  import example.armeria.blog.thrift.BlogNotFoundException;
+
+  public class BlogServiceExceptionHandler implements BiFunction<ServiceRequestContext, Throwable, RpcResponse> {
+
+    @Override
+    public RpcResponse apply(ServiceRequestContext serviceRequestContext, Throwable cause) {
+      if (cause instanceof IllegalArgumentException) {
+        return RpcResponse.ofFailure(new BlogNotFoundException(cause.getMessage()));
+      }
+      return RpcResponse.ofFailure(cause);
+    }
+  }
+  ```
+2. In the `Main` class, bind the `BlogServiceExceptionHandler` to our service.
+  ```java filename=Main.java
+  ...
+  private static Server newServer(int port) throws Exception {
+    final THttpService tHttpService =
+      THttpService.builder()
+                  .addService(new BlogServiceImpl())
+                  .exceptionHandler(new BlogServiceExceptionHandler()) // Add this
+                  .build();
+    ...
+  }
+  ```
+
+### Implement the service method
+
+In the `BlogServiceImpl` class, implement the `updateBlogPost()` method to update a blog post.
+This time, let's use the `IllegalArgumentException` instead of the `BlogNotFoundException`.
+
+```java filename=BlogServiceImpl.java
+@Override
+public void updateBlogPost(UpdateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
+        throws TException {
+  final BlogPost oldBlogPost = blogPosts.get(request.getId());
+  if (oldBlogPost == null) {
+    resultHandler.onError(
+            new IllegalArgumentException("The blog post does not exist. ID: " + request.getId()));
+  } else {
+    final BlogPost newBlogPost = oldBlogPost
+            .deepCopy()
+            .setTitle(request.getTitle())
+            .setContent(request.getContent())
+            .setModifiedAt(Instant.now().toEpochMilli());
+    blogPosts.put(request.getId(), newBlogPost);
+    resultHandler.onComplete(newBlogPost);
+  }
+}
+```
+
+## 2. Implement client-side
+
+Add a method `updateBlogPost()` to send a request to update a blog post.
+
+```java filename=BlogClient.java
+import example.armeria.blog.thrift.UpdateBlogPostRequest;
+...
+BlogPost updateBlogPost(int id, String newTitle, String newContent) throws TException {
+  final UpdateBlogPostRequest request = new UpdateBlogPostRequest().setId(id).setTitle(newTitle).setContent(newContent);
+  return blogService.updateBlogPost(request);
+}
+```
+
+## 3. Test updating a blog post
+
+Let's try updating the content of the first blog post.
+Add a method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(5)
+void updateBlogPosts() throws TException {
+  final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+  final BlogPost updated = client.updateBlogPost(0, "My first blog", "Hello awesome Armeria!");
+  assertThat(updated.getId()).isZero();
+  assertThat(updated.getTitle()).isEqualTo("My first blog");
+  assertThat(updated.getContent()).isEqualTo("Hello awesome Armeria!");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 4. Test an error case
+
+To check that our exception handler is working, let's try updating a post which does not exist.
+
+1. Bind the exception handler to the service for the test server.
+  ```java filename=BlogServiceTest.java
+  @RegisterExtension
+  static final ServerExtension server = new ServerExtension() {
+    @Override
+    protected void configure(ServerBuilder sb) throws Exception {
+      sb.service("/thrift", THttpService.builder()
+          .exceptionHandler(new BlogServiceExceptionHandler()) // Add this
+          .addService(new BlogServiceImpl())
+          .build());
+    }
+  };
+  ```
+2. Add a test method to update a blog post with an invalid ID, asserting a `BlogNotFoundException` is thrown.
+  ```java filename=BlogServiceTest.java
+  @Test
+  @Order(6)
+  void updateInvalidBlogPost() {
+    final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+    final Throwable exception = catchThrowable(() -> {
+      final BlogPost updated = client.updateBlogPost(Integer.MAX_VALUE, "My first blog", "Hello awesome Armeria!");
+    });
+    assertThat(exception)
+      .isInstanceOf(BlogNotFoundException.class)
+      .extracting("reason")
+      .asString()
+      .isEqualTo("The blog post does not exist. ID: " + Integer.MAX_VALUE);
+  }
+  ```
+3. Run all the test cases on your IDE or using Gradle.
+  Check that you see the test is passed.
+
+## What's next
+
+In this step, we've implemented a service method and client method for updating a blog post.
+We've also added an exception handler.
+
+Next, at [Step 6. Implement DELETE](/tutorials/thrift/blog/implement-delete), we'll implement a method
+for deleting a blog post and add a [Documentation Service](/docs/server-docservice) to our service.
+
+<TutorialSteps current={5} />

--- a/site-new/docs/tutorials/thrift/05-implement-update.mdx
+++ b/site-new/docs/tutorials/thrift/05-implement-update.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement UPDATE"
-order: 5
+sidebar_label: "5. Implement UPDATE"
 category: thrift
 tags:
   - server
@@ -21,7 +20,7 @@ We'll also learn how to handle an exception with a custom exception handler.
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- [Generated Java code](/docs/tutorials/thrift/define-service#3-compile-the-thrift-file)
 - `BlogServiceImpl.java`
 - `Main.java`
 - `BlogClient.java`
@@ -37,7 +36,7 @@ This time, we'll use a custom exception handler.
 First, add a custom exception handler for the blog service.
 
 1. Add an exception handler class to convert an `IllegalArgumentException` into a `BlogNotFoundException`.
-  ```java filename=BlogServiceExceptionHandler.java
+  ```java title="BlogServiceExceptionHandler.java"
   package example.armeria.server.blog.thrift;
 
   import java.util.function.BiFunction;
@@ -59,7 +58,7 @@ First, add a custom exception handler for the blog service.
   }
   ```
 2. In the `Main` class, bind the `BlogServiceExceptionHandler` to our service.
-  ```java filename=Main.java
+  ```java title="Main.java"
   ...
   private static Server newServer(int port) throws Exception {
     final THttpService tHttpService =
@@ -76,7 +75,7 @@ First, add a custom exception handler for the blog service.
 In the `BlogServiceImpl` class, implement the `updateBlogPost()` method to update a blog post.
 This time, let's use the `IllegalArgumentException` instead of the `BlogNotFoundException`.
 
-```java filename=BlogServiceImpl.java
+```java title="BlogServiceImpl.java"
 @Override
 public void updateBlogPost(UpdateBlogPostRequest request, AsyncMethodCallback<BlogPost> resultHandler)
         throws TException {
@@ -100,7 +99,7 @@ public void updateBlogPost(UpdateBlogPostRequest request, AsyncMethodCallback<Bl
 
 Add a method `updateBlogPost()` to send a request to update a blog post.
 
-```java filename=BlogClient.java
+```java title="BlogClient.java"
 import example.armeria.blog.thrift.UpdateBlogPostRequest;
 ...
 BlogPost updateBlogPost(int id, String newTitle, String newContent) throws TException {
@@ -114,7 +113,7 @@ BlogPost updateBlogPost(int id, String newTitle, String newContent) throws TExce
 Let's try updating the content of the first blog post.
 Add a method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(5)
 void updateBlogPosts() throws TException {
@@ -134,7 +133,7 @@ Check that you see the test is passed.
 To check that our exception handler is working, let's try updating a post which does not exist.
 
 1. Bind the exception handler to the service for the test server.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @RegisterExtension
   static final ServerExtension server = new ServerExtension() {
     @Override
@@ -147,7 +146,7 @@ To check that our exception handler is working, let's try updating a post which 
   };
   ```
 2. Add a test method to update a blog post with an invalid ID, asserting a `BlogNotFoundException` is thrown.
-  ```java filename=BlogServiceTest.java
+  ```java title="BlogServiceTest.java"
   @Test
   @Order(6)
   void updateInvalidBlogPost() {
@@ -170,7 +169,7 @@ To check that our exception handler is working, let's try updating a post which 
 In this step, we've implemented a service method and client method for updating a blog post.
 We've also added an exception handler.
 
-Next, at [Step 6. Implement DELETE](/tutorials/thrift/blog/implement-delete), we'll implement a method
-for deleting a blog post and add a [Documentation Service](/docs/server-docservice) to our service.
+Next, at [Step 6. Implement DELETE](/docs/tutorials/thrift/implement-delete), we'll implement a method
+for deleting a blog post and add a [Documentation Service](/docs/server/docservice) to our service.
 
 <TutorialSteps current={5} />

--- a/site-new/docs/tutorials/thrift/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/thrift/06-implement-delete.mdx
@@ -1,0 +1,199 @@
+---
+menuTitle: "Implement DELETE"
+order: 6
+category: thrift
+tags:
+  - server
+level: basic
+type: step
+---
+
+# Implementing DELETE operation
+
+So far, we created, read, and updated a blog post.
+Now, let's implement and make a call to delete a blog post.
+Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for testing our blog service.
+
+<TutorialSteps current={6} />
+
+## What you need
+
+You need to have the following files obtained from previous steps.
+You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
+
+- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- `BlogServiceImpl.java`
+- `Main.java`
+- `BlogClient.java`
+- `BlogServiceTest.java`
+- `BlogServiceExceptionHandler.java`
+
+## 1. Implement server-side
+
+In the `BlogServiceImpl` class, implement the `deleteBlogPost()` method to delete a blog post.
+Let's throw an exception in case there is no blog post for the given ID.
+
+```java filename=BlogServiceImpl.java
+@Override
+public void deleteBlogPost(DeleteBlogPostRequest request, AsyncMethodCallback<Void> resultHandler)
+      throws TException {
+  final BlogPost removed = blogPosts.remove(request.getId());
+  if (removed == null) {
+    resultHandler.onError(
+            new IllegalArgumentException("The blog post does not exist. ID: " + request.getId()));
+  } else {
+    resultHandler.onComplete(null);
+  }
+}
+```
+
+## 2. Implement client-side
+
+In the `BlogClient` class, add the `deleteBlogPost()` method to send a request deleting a blog post.
+
+```java filename=BlogClient.java
+import example.armeria.blog.thrift.DeleteBlogPostRequest;
+...
+void deleteBlogPost(int id) throws TException {
+  final DeleteBlogPostRequest request = new DeleteBlogPostRequest().setId(id);
+  blogService.deleteBlogPost(request);
+}
+```
+
+## 3. Test deleting a blog post
+
+Let's test deleting a blog post.
+We'll delete the blog post with ID `1`, and try retrieving with the same ID to verify it is indeed deleted.
+Add a test method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(7)
+void deleteBlogPost() throws TException {
+  final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+  client.deleteBlogPost(1);
+  final Throwable exception = catchThrowable(() -> {
+    client.getBlogPost(1);
+  });
+  assertThat(exception)
+    .isInstanceOf(BlogNotFoundException.class)
+    .extracting("reason")
+    .asString()
+    .isEqualTo("The blog post does not exist. ID: 1");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 4. Test an error case
+
+Let's test deleting a blog post that does not exist.
+Add a test method like the following.
+
+```java filename=BlogServiceTest.java
+@Test
+@Order(8)
+void deleteInvalidBlogPost() {
+  final BlogClient client = new BlogClient(server.httpUri(), "/thrift");
+  final Throwable exception = catchThrowable(() -> {
+    client.deleteBlogPost(100);
+  });
+  assertThat(exception)
+    .isInstanceOf(BlogNotFoundException.class)
+    .extracting("reason")
+    .asString()
+    .isEqualTo("The blog post does not exist. ID: 100");
+}
+```
+
+Run all the test cases on your IDE or using Gradle.
+Check that you see the test is passed.
+
+## 5. Add the Documentation service
+
+This time, we'll add Armeria's [Documentation service](/docs/server-docservice).
+The Documentation service automatically creates documentation of your service methods, as well as providing means to test out the methods.
+
+1. In the `newServer()` method, add a <type://DocService> and a request example for [creating blog posts](/tutorials/thrift/blog/implement-create),
+  using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
+  ```java filename=Main.java
+  import com.linecorp.armeria.server.docs.DocService;
+  import example.armeria.blog.thrift.CreateBlogPostRequest;
+  ...
+  private static Server newServer(int port) throws Exception {
+    ...
+    final CreateBlogPostRequest exampleRequest = new CreateBlogPostRequest()
+            .setTitle("Example title")
+            .setContent("Example content");
+    final DocService docService = DocService
+            .builder()
+            .exampleRequests(List.of(new BlogService.createBlogPost_args(exampleRequest)))
+            .build();
+    ...
+  }
+  ```
+2. In the `newServer()` method, add the <type://DocService> to our server builder.
+  ```java filename=Main.java highlight=5
+  private static Server newServer(int port) throws Exception {
+    ...
+    return Server.builder()
+             .http(port)
+             .service("/thrift", tHttpService)
+             // You can access the documentation service at http://127.0.0.1:8080/docs.
+             // See https://armeria.dev/docs/server-docservice for more information.
+             .serviceUnder("/docs", docService)
+             .build();
+  }
+  ```
+
+3. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
+  ```java filename=Main.java highlight=2
+  public static void main(String[] args) throws Exception {
+    ...
+    logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
+                server.activeLocalPort());
+  }
+  ```
+4. Now, [re-run the server](/tutorials/thrift/blog/run-service#4-run-the-server).
+
+  The server and services are launched successfully if you see this message.
+  ```bash
+   Server has been started. Serving DocService at http://127.0.0.1:8080/docs
+  ```
+
+## 6. Check the DocService page
+
+Let's test and call our service operations using Armeria's Documentation service.
+
+1. Click the URL http://127.0.0.1:8080/docs from the log message or open up the URL on a web browser.
+
+  If you see the Document service page, you've successfully launched the <type://DocService> and server.
+
+  ![](../../../../images/tutorial_blogservice_thrift_docservice_start.png)
+
+2. Click the **createBlogPost()** method link in the left panel. You can make calls to the method by clicking on the `Debug` button on the top right.
+
+  ![](../../../../images/tutorial_blogservice_thrift_reqex.png)
+
+  Note that in the **REQUEST BODY** section the values specified in the `exampleRequest` are automatically displayed on the page.
+
+  ```java filename=Main.java
+  final CreateBlogPostRequest exampleRequest = new CreateBlogPostRequest()
+          .setTitle("Example title")
+          .setContent("Example content");
+  ```
+
+3. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
+
+  ![](../../../../images/tutorial_blogservice_thrift_return.png)
+
+## What's next
+
+In this step, we've implemented a service method and client method for deleting a blog post.
+We've also added [Documentation service](/docs/server-docservice) to our server.
+
+We've finally come to the end of this tutorial.
+Next, try adding more service methods to the tutorial or have a go at developing a service of your own.
+
+<TutorialSteps current={6} />

--- a/site-new/docs/tutorials/thrift/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/thrift/06-implement-delete.mdx
@@ -133,7 +133,7 @@ The Documentation service automatically creates documentation of your service me
   }
   ```
 2. In the `newServer()` method, add the [DocService](type) to our server builder.
-  ```java title="Main.java" highlight=5
+  ```java title="Main.java"
   private static Server newServer(int port) throws Exception {
     ...
     return Server.builder()
@@ -147,7 +147,7 @@ The Documentation service automatically creates documentation of your service me
   ```
 
 3. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
-  ```java title="Main.java" highlight=2
+  ```java title="Main.java"
   public static void main(String[] args) throws Exception {
     ...
     logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",

--- a/site-new/docs/tutorials/thrift/06-implement-delete.mdx
+++ b/site-new/docs/tutorials/thrift/06-implement-delete.mdx
@@ -1,6 +1,5 @@
 ---
-menuTitle: "Implement DELETE"
-order: 6
+sidebar_label: "6. Implement DELETE"
 category: thrift
 tags:
   - server
@@ -12,7 +11,7 @@ type: step
 
 So far, we created, read, and updated a blog post.
 Now, let's implement and make a call to delete a blog post.
-Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for testing our blog service.
+Also, we'll add Armeria's [Documentation Service](/docs/server/docservice) for testing our blog service.
 
 <TutorialSteps current={6} />
 
@@ -21,7 +20,7 @@ Also, we'll add Armeria's [Documentation Service](/docs/server-docservice) for t
 You need to have the following files obtained from previous steps.
 You can always [download](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) the full version, instead of creating one yourself.
 
-- [Generated Java code](/tutorials/thrift/blog/define-service#3-compile-the-thrift-file)
+- [Generated Java code](/docs/tutorials/thrift/define-service#3-compile-the-thrift-file)
 - `BlogServiceImpl.java`
 - `Main.java`
 - `BlogClient.java`
@@ -33,7 +32,7 @@ You can always [download](https://github.com/line/armeria-examples/tree/main/tut
 In the `BlogServiceImpl` class, implement the `deleteBlogPost()` method to delete a blog post.
 Let's throw an exception in case there is no blog post for the given ID.
 
-```java filename=BlogServiceImpl.java
+```java title="BlogServiceImpl.java"
 @Override
 public void deleteBlogPost(DeleteBlogPostRequest request, AsyncMethodCallback<Void> resultHandler)
       throws TException {
@@ -51,7 +50,7 @@ public void deleteBlogPost(DeleteBlogPostRequest request, AsyncMethodCallback<Vo
 
 In the `BlogClient` class, add the `deleteBlogPost()` method to send a request deleting a blog post.
 
-```java filename=BlogClient.java
+```java title="BlogClient.java"
 import example.armeria.blog.thrift.DeleteBlogPostRequest;
 ...
 void deleteBlogPost(int id) throws TException {
@@ -66,7 +65,7 @@ Let's test deleting a blog post.
 We'll delete the blog post with ID `1`, and try retrieving with the same ID to verify it is indeed deleted.
 Add a test method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(7)
 void deleteBlogPost() throws TException {
@@ -91,7 +90,7 @@ Check that you see the test is passed.
 Let's test deleting a blog post that does not exist.
 Add a test method like the following.
 
-```java filename=BlogServiceTest.java
+```java title="BlogServiceTest.java"
 @Test
 @Order(8)
 void deleteInvalidBlogPost() {
@@ -112,12 +111,12 @@ Check that you see the test is passed.
 
 ## 5. Add the Documentation service
 
-This time, we'll add Armeria's [Documentation service](/docs/server-docservice).
+This time, we'll add Armeria's [Documentation service](/docs/server/docservice).
 The Documentation service automatically creates documentation of your service methods, as well as providing means to test out the methods.
 
-1. In the `newServer()` method, add a <type://DocService> and a request example for [creating blog posts](/tutorials/thrift/blog/implement-create),
-  using <type://DocServiceBuilder#exampleRequests(Class,String,Iterable)>. Feel free to add more examples for other service methods.
-  ```java filename=Main.java
+1. In the `newServer()` method, add a [DocService](type) and a request example for [creating blog posts](/docs/tutorials/thrift/implement-create),
+  using [DocServiceBuilder#exampleRequests(Class,String,Iterable)](type). Feel free to add more examples for other service methods.
+  ```java title="Main.java"
   import com.linecorp.armeria.server.docs.DocService;
   import example.armeria.blog.thrift.CreateBlogPostRequest;
   ...
@@ -133,29 +132,29 @@ The Documentation service automatically creates documentation of your service me
     ...
   }
   ```
-2. In the `newServer()` method, add the <type://DocService> to our server builder.
-  ```java filename=Main.java highlight=5
+2. In the `newServer()` method, add the [DocService](type) to our server builder.
+  ```java title="Main.java" highlight=5
   private static Server newServer(int port) throws Exception {
     ...
     return Server.builder()
              .http(port)
              .service("/thrift", tHttpService)
              // You can access the documentation service at http://127.0.0.1:8080/docs.
-             // See https://armeria.dev/docs/server-docservice for more information.
+             // See https://armeria.dev/docs/server/docservice for more information.
              .serviceUnder("/docs", docService)
              .build();
   }
   ```
 
 3. (Optional) To access the Documentation service result easily, edit the log message in the `main()` method.
-  ```java filename=Main.java highlight=2
+  ```java title="Main.java" highlight=2
   public static void main(String[] args) throws Exception {
     ...
     logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
                 server.activeLocalPort());
   }
   ```
-4. Now, [re-run the server](/tutorials/thrift/blog/run-service#4-run-the-server).
+4. Now, [re-run the server](/docs/tutorials/thrift/run-service#4-run-the-server).
 
   The server and services are launched successfully if you see this message.
   ```bash
@@ -168,17 +167,17 @@ Let's test and call our service operations using Armeria's Documentation service
 
 1. Click the URL http://127.0.0.1:8080/docs from the log message or open up the URL on a web browser.
 
-  If you see the Document service page, you've successfully launched the <type://DocService> and server.
+  If you see the Document service page, you've successfully launched the [DocService](type) and server.
 
-  ![](../../../../images/tutorial_blogservice_thrift_docservice_start.png)
+  ![](/img/tutorial_blogservice_thrift_docservice_start.png)
 
 2. Click the **createBlogPost()** method link in the left panel. You can make calls to the method by clicking on the `Debug` button on the top right.
 
-  ![](../../../../images/tutorial_blogservice_thrift_reqex.png)
+  ![](/img/tutorial_blogservice_thrift_reqex.png)
 
   Note that in the **REQUEST BODY** section the values specified in the `exampleRequest` are automatically displayed on the page.
 
-  ```java filename=Main.java
+  ```java title="Main.java"
   final CreateBlogPostRequest exampleRequest = new CreateBlogPostRequest()
           .setTitle("Example title")
           .setContent("Example content");
@@ -186,12 +185,12 @@ Let's test and call our service operations using Armeria's Documentation service
 
 3. Click the **SUBMIT** button, and you'll see the blog post information returned in the right panel.
 
-  ![](../../../../images/tutorial_blogservice_thrift_return.png)
+  ![](/img/tutorial_blogservice_thrift_return.png)
 
 ## What's next
 
 In this step, we've implemented a service method and client method for deleting a blog post.
-We've also added [Documentation service](/docs/server-docservice) to our server.
+We've also added [Documentation service](/docs/server/docservice) to our server.
 
 We've finally come to the end of this tutorial.
 Next, try adding more service methods to the tutorial or have a go at developing a service of your own.

--- a/site-new/docs/tutorials/thrift/index.mdx
+++ b/site-new/docs/tutorials/thrift/index.mdx
@@ -1,1 +1,135 @@
+---
+type: tutorial
+level: basic
+---
+
+import versions from '/gen-src/versions.json';
+
 # Thrift tutorial introduction
+
+In this tutorial, you'll learn how to build an [Apache Thrift](https://thrift.apache.org/) service with Armeria.
+This tutorial is based on a [sample service](#sample-service), a minimal blog service, with which you can create, read, update, and delete blog posts.
+
+Follow this tutorial to write a service yourself or try [running the sample service](#build-and-run-sample-service) right away.
+
+## Background
+
+Before we start, let's swiftly go over Armeria's Thrift features:
+
+- Transport over HTTP/1.1 or HTTP/2.
+- Support for `TBINARY`, `TCOMPACT`, `TJSON` and `TTEXT` [serialization formats](/docs/server-thrift#serialization-formats).
+- RPC level decorator support for both [client](/docs/client-decorator#implementing-decoratinghttpclientfunction-and-decoratingrpcclientfunction)
+and [server](/docs/server-decorator#implementing-decoratinghttpservicefunction-and-decoratingrpcservicefunction).
+  - Out of the box support for circuit breaker, retries, metric collection and more.
+- Full-fledged [Thrift documentation service](/docs/server-docservice).
+
+## Assumptions
+
+This tutorial assumes that you have:
+
+- Experience in building services in Java
+- Experience in Java frameworks for server-side programming
+- Understanding of Apache Thrift and experience in implementing Thrift services
+
+## Prerequisites
+
+To run and develop the sample service, set your computer with the following requirements:
+
+* JDK 11 or higher
+* Thrift compiler: Install a Thrift compiler by either [building from source](https://thrift.apache.org/docs/install/) or using a package manager like `brew` or `apt` depending on your environment.
+
+## Sample service
+
+The [sample service](https://github.com/line/armeria-examples/tree/main/tutorials/thrift) provides you implementations of CRUD operations as specified below.
+
+| Operation | Method |
+| -- | -- |
+| Create | `createBlogPost()` |
+| Read | `getBlogPost()`, `listBlogPosts()` |
+| Update | `updateBlogPost()` |
+| Delete | `deleteBlogPost()` |
+
+The sample service code consists of the following folders and files.
+
+```
+thrift/
+├─ src/
+│  ├─ main/
+│  │  ├─ java/
+│  │  │  ├─ example.armeria.server.blog.thrift/
+│  │  │  │  ├─ BlogClient.java
+│  │  │  │  ├─ BlogServiceExceptionHandler.java
+│  │  │  │  ├─ BlogServiceImpl.java
+│  │  │  │  └─ Main.java
+│  │  ├─ thrift/
+│  │  │  └─ blog.thrift
+│  └─ test/
+│     └─ java/
+│        └─ example.armeria.server.blog.thrift/
+│           └─ BlogServiceTest.java
+└─ build.gradle
+```
+
+<Tip>
+
+  To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
+
+</Tip>
+
+## Build and run sample service
+
+Try running the sample service and see the outcome of this tutorial.
+Using Armeria's [Documentation Service](/docs/server-docservice), you can easily verify a server is running, receiving requests and sending responses.
+
+1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/thrift).
+2. Build the sample service using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew build
+  ```
+3. Run the sample service again, using the Gradle Wrapper.
+  ```bash
+  $ ./gradlew run
+  ```
+4. Open the Documentation service page on your web browser at http://127.0.0.1:8080/docs.
+
+## Try writing blog service yourself
+
+Use the sample service's [build.gradle](https://github.com/line/armeria-examples/blob/main/tutorials/thrift/build.gradle) file to start building the service from scratch.
+Below is a part of the `build.gradle` file for the sample service.
+This tutorial uses [thrift-gradle-plugin](https://plugins.gradle.org/plugin/org.jruyi.thrift) to compile Thrift IDL files and generate stubs.
+
+<CodeBlock language="groovy" filename="build.gradle">{`
+plugins {
+  id "org.jruyi.thrift" version "0.4.2"
+  id "application"
+  id "idea"
+  id "eclipse"
+}\n
+repositories {
+  mavenCentral()
+}\n
+dependencies {
+  implementation "com.linecorp.armeria:armeria:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  implementation "com.linecorp.armeria:armeria-thrift0.17:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  // Logging
+  runtimeOnly "ch.qos.logback:logback-classic:${versions['ch.qos.logback:logback-classic']}"\n
+  testImplementation "org.junit.jupiter:junit-jupiter:${versions['org.junit:junit-bom']}"\n
+  testImplementation "com.linecorp.armeria:armeria-junit5:${versions['com.linecorp.armeria:armeria-bom']}"\n
+  testImplementation "org.assertj:assertj-core:${versions['org.assertj:assertj-core']}"
+}\n
+application {
+  mainClass.set('example.armeria.server.blog.thrift.Main')
+}\n
+tasks.withType(Test) {
+  useJUnitPlatform()
+}
+`}</CodeBlock>
+
+Start writing the blog service yourself by following the tutorial step by step:
+
+1. [Define a service](/tutorials/thrift/blog/define-service)
+2. [Run a service](/tutorials/thrift/blog/run-service)
+3. [Implement CREATE](/tutorials/thrift/blog/implement-create)
+4. [Implement READ](/tutorials/thrift/blog/implement-read)
+5. [Implement UPDATE](/tutorials/thrift/blog/implement-update)
+6. [Implement DELETE](/tutorials/thrift/blog/implement-delete)

--- a/site-new/docs/tutorials/thrift/index.mdx
+++ b/site-new/docs/tutorials/thrift/index.mdx
@@ -3,7 +3,7 @@ type: tutorial
 level: basic
 ---
 
-import versions from '/gen-src/versions.json';
+import versions from '../../../gen-src-temp/versions.json';
 
 # Thrift tutorial introduction
 
@@ -17,11 +17,11 @@ Follow this tutorial to write a service yourself or try [running the sample serv
 Before we start, let's swiftly go over Armeria's Thrift features:
 
 - Transport over HTTP/1.1 or HTTP/2.
-- Support for `TBINARY`, `TCOMPACT`, `TJSON` and `TTEXT` [serialization formats](/docs/server-thrift#serialization-formats).
-- RPC level decorator support for both [client](/docs/client-decorator#implementing-decoratinghttpclientfunction-and-decoratingrpcclientfunction)
-and [server](/docs/server-decorator#implementing-decoratinghttpservicefunction-and-decoratingrpcservicefunction).
+- Support for `TBINARY`, `TCOMPACT`, `TJSON` and `TTEXT` [serialization formats](/docs/server/thrift#serialization-formats).
+- RPC level decorator support for both [client](/docs/client/decorator#implementing-decoratinghttpclientfunction-and-decoratingrpcclientfunction)
+and [server](/docs/server/decorator#implementing-decoratinghttpservicefunction-and-decoratingrpcservicefunction).
   - Out of the box support for circuit breaker, retries, metric collection and more.
-- Full-fledged [Thrift documentation service](/docs/server-docservice).
+- Full-fledged [Thrift documentation service](/docs/server/docservice).
 
 ## Assumptions
 
@@ -70,16 +70,16 @@ thrift/
 └─ build.gradle
 ```
 
-<Tip>
+:::tip
 
   To keep our focus on Armeria, this tutorial and the sample service implement memory-based operations instead of using a database.
 
-</Tip>
+:::
 
 ## Build and run sample service
 
 Try running the sample service and see the outcome of this tutorial.
-Using Armeria's [Documentation Service](/docs/server-docservice), you can easily verify a server is running, receiving requests and sending responses.
+Using Armeria's [Documentation Service](/docs/server/docservice), you can easily verify a server is running, receiving requests and sending responses.
 
 1. Download the code from [here](https://github.com/line/armeria-examples/tree/main/tutorials/thrift).
 2. Build the sample service using the Gradle Wrapper.
@@ -127,9 +127,9 @@ tasks.withType(Test) {
 
 Start writing the blog service yourself by following the tutorial step by step:
 
-1. [Define a service](/tutorials/thrift/blog/define-service)
-2. [Run a service](/tutorials/thrift/blog/run-service)
-3. [Implement CREATE](/tutorials/thrift/blog/implement-create)
-4. [Implement READ](/tutorials/thrift/blog/implement-read)
-5. [Implement UPDATE](/tutorials/thrift/blog/implement-update)
-6. [Implement DELETE](/tutorials/thrift/blog/implement-delete)
+1. [Define a service](/docs/tutorials/thrift/define-service)
+2. [Run a service](/docs/tutorials/thrift/run-service)
+3. [Implement CREATE](/docs/tutorials/thrift/implement-create)
+4. [Implement READ](/docs/tutorials/thrift/implement-read)
+5. [Implement UPDATE](/docs/tutorials/thrift/implement-update)
+6. [Implement DELETE](/docs/tutorials/thrift/implement-delete)

--- a/site-new/docusaurus.config.ts
+++ b/site-new/docusaurus.config.ts
@@ -158,6 +158,12 @@ const config: Config = {
         'shell-session',
       ],
     },
+    docs: {
+      sidebar: {
+        hideable: true,
+        autoCollapseCategories: true,
+      },
+    },
   } satisfies Preset.ThemeConfig,
 
   plugins: [

--- a/site-new/sidebars.ts
+++ b/site-new/sidebars.ts
@@ -137,7 +137,14 @@ const sidebars: SidebarsConfig = {
         type: 'doc',
         id: 'tutorials/grpc/index',
       },
-      items: ['tutorials/grpc/define-a-service'],
+      items: [
+        'tutorials/grpc/define-service',
+        'tutorials/grpc/run-service',
+        'tutorials/grpc/implement-create',
+        'tutorials/grpc/implement-read',
+        'tutorials/grpc/implement-update',
+        'tutorials/grpc/implement-delete',
+      ],
     },
     {
       type: 'category',
@@ -146,7 +153,14 @@ const sidebars: SidebarsConfig = {
         type: 'doc',
         id: 'tutorials/thrift/index',
       },
-      items: ['tutorials/thrift/define-a-service'],
+      items: [
+        'tutorials/thrift/define-service',
+        'tutorials/thrift/run-service',
+        'tutorials/thrift/implement-create',
+        'tutorials/thrift/implement-read',
+        'tutorials/thrift/implement-update',
+        'tutorials/thrift/implement-delete',
+      ],
     },
     {
       type: 'html',

--- a/site-new/src/css/antd.css
+++ b/site-new/src/css/antd.css
@@ -2,7 +2,7 @@
 
   &.ant-steps-small {
     .ant-steps-item-content {
-      max-width: 105px;
+      max-width: 85px;
     }
 
     .ant-steps-item-title,
@@ -12,11 +12,11 @@
 
     &.ant-steps-dot {
       .ant-steps-item-icon {
-        margin-left: 50px;
-        margin-inline-start: 50px !important;
+        margin-left: 40px;
+        margin-inline-start: 40px !important;
       }
       .ant-steps-item-tail {
-        margin-left: 52.5px;
+        margin-left: 42.5px;
       }
     .ant-steps-item-tail:after {
       width: calc(100% - 20px);

--- a/site-new/src/css/custom.css
+++ b/site-new/src/css/custom.css
@@ -41,3 +41,15 @@ li {
     background-color: var(--ifm-color-gray-300);
   }
 }
+
+.doc-card-list-expanded {
+  h2, p {
+    overflow: visible;
+    white-space: normal;
+    text-overflow: initial;
+  }
+}
+
+.doc-card-list-no-description p {
+  display: none;
+}

--- a/site-new/src/theme/MDXComponents.ts
+++ b/site-new/src/theme/MDXComponents.ts
@@ -9,6 +9,7 @@ import TutorialSteps from '@site/src/components/steps';
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import DocCardList from '@theme/DocCardList';
 
 export default {
   // Re-use the default mapping
@@ -22,4 +23,5 @@ export default {
   CodeBlock,
   Tabs,
   TabItem,
+  DocCardList,
 };


### PR DESCRIPTION
Motivation:

Several formats used in MDX are changed during the migration.

Modifications:

- Migrate **Documentation > Tutorials** MDX content. Included changes on MDX files are basically the same as those listed in the PR #6240 (API link format, Image path, and so on).
- Reflect the changes to the syntax for the file name and highlighting in the code block (which I had missed in the previous PR). 
  - Before: ` ```java filename=BlogService.java highlight=3`
  - After: ` ```java title="BlogService.java" {3}`
- Adjust style for TutorialSteps to make it fit into the main content space
- Enable sidebar category auto-collapse option, hideable option
- Use the DocCardList component for the tutorials list in the tutorials intro page


