### PR TITLE
Ensure HTTP/2 flow control to work at the stream level

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AbstractHttpRequestHandler.java
@@ -187,6 +187,7 @@ abstract class AbstractHttpRequestHandler implements ChannelFutureListener {
         }
 
         this.session = session;
+        originalRes.setId(id);
         responseWrapper = responseDecoder.addResponse(this, id, originalRes, ctx, ch.eventLoop());
 
         if (timeoutMillis > 0) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -76,6 +76,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -631,6 +632,24 @@ public final class ClientFactoryBuilder implements TlsSetters {
                       "http2InitialStreamWindowSize: %s (expected: > 0 and <= %s)",
                       http2InitialStreamWindowSize, MAX_INITIAL_WINDOW_SIZE);
         option(ClientFactoryOptions.HTTP2_INITIAL_STREAM_WINDOW_SIZE, http2InitialStreamWindowSize);
+        return this;
+    }
+
+    /**
+     * Sets the threshold ratio of the HTTP/2 stream flow-control window at which a
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9">WINDOW_UPDATE</a> frame will be sent.
+     * When the size of the flow-control window drops below the specified ratio (relative to the initial window
+     * size), a {@code WINDOW_UPDATE} frame is triggered to replenish the window.
+     *
+     * <p>The default value is {@value DefaultHttp2LocalFlowController#DEFAULT_WINDOW_UPDATE_RATIO}.
+     * The value must be greater than 0 and less than 1.0.
+     */
+    @UnstableApi
+    public ClientFactoryBuilder http2StreamWindowUpdateRatio(float http2StreamWindowUpdateRatio) {
+        checkArgument(http2StreamWindowUpdateRatio > 0 && http2StreamWindowUpdateRatio < 1.0f,
+                      "http2StreamWindowUpdateRatio: %s (expected: > 0 and < 1.0)",
+                      http2StreamWindowUpdateRatio);
+        option(ClientFactoryOptions.HTTP2_STREAM_WINDOW_UPDATE_RATIO, http2StreamWindowUpdateRatio);
         return this;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -643,6 +643,8 @@ public final class ClientFactoryBuilder implements TlsSetters {
      *
      * <p>The default value is {@value DefaultHttp2LocalFlowController#DEFAULT_WINDOW_UPDATE_RATIO}.
      * The value must be greater than 0 and less than 1.0.
+     *
+     * <p>Note: Do not change this value unless you know what you are doing.
      */
     @UnstableApi
     public ClientFactoryBuilder http2StreamWindowUpdateRatio(float http2StreamWindowUpdateRatio) {

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -161,6 +161,17 @@ public final class ClientFactoryOptions
                                        Flags.defaultHttp2InitialStreamWindowSize());
 
     /**
+     * The threshold ratio of the HTTP/2 stream flow-control window at which a
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9">WINDOW_UPDATE</a> frame will be sent.
+     * When the size of the flow-control window drops below the specified ratio (relative to the initial window
+     * size), a {@code WINDOW_UPDATE} frame is triggered to replenish the window.
+     */
+    @UnstableApi
+    public static final ClientFactoryOption<Float> HTTP2_STREAM_WINDOW_UPDATE_RATIO =
+            ClientFactoryOption.define("HTTP2_STREAM_WINDOW_UPDATE_RATIO",
+                                       Flags.defaultHttp2StreamWindowUpdateRatio());
+
+    /**
      * The <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.5.2">SETTINGS_MAX_FRAME_SIZE</a>
      * that indicates the size of the largest frame payload that this client is willing to receive.
      */
@@ -502,6 +513,17 @@ public final class ClientFactoryOptions
      */
     public int http2InitialStreamWindowSize() {
         return get(HTTP2_INITIAL_STREAM_WINDOW_SIZE);
+    }
+
+    /**
+     * Returns the threshold ratio of the HTTP/2 stream flow-control window at which a
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9">WINDOW_UPDATE</a> frame will be sent.
+     * When the size of the flow-control window drops below the specified ratio (relative to the initial window
+     * size), a {@code WINDOW_UPDATE} frame is triggered to replenish the window.
+     */
+    @UnstableApi
+    public float http2StreamWindowUpdateRatio() {
+        return get(HTTP2_STREAM_WINDOW_UPDATE_RATIO);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -45,9 +45,10 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
         super(decoder, encoder, initialSettings,
               newKeepAliveHandler(encoder, channel, clientFactory, protocol));
 
-        responseDecoder = new Http2ResponseDecoder(channel, encoder(), clientFactory, keepAliveHandler());
+        responseDecoder = new Http2ResponseDecoder(channel, encoder(), decoder, clientFactory,
+                                                   keepAliveHandler());
         connection().addListener(responseDecoder);
-        decoder().frameListener(responseDecoder);
+        decoder.frameListener(responseDecoder);
     }
 
     private static KeepAliveHandler newKeepAliveHandler(

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -44,6 +44,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Exception;
@@ -63,10 +64,12 @@ final class Http2ResponseDecoder extends AbstractHttpResponseDecoder implements 
     private final Http2GoAwayHandler goAwayHandler;
     private final KeepAliveHandler keepAliveHandler;
 
-    Http2ResponseDecoder(Channel channel, Http2ConnectionEncoder encoder, HttpClientFactory clientFactory,
+    Http2ResponseDecoder(Channel channel, Http2ConnectionEncoder encoder, Http2ConnectionDecoder decoder,
+                         HttpClientFactory clientFactory,
                          KeepAliveHandler keepAliveHandler) {
         super(channel,
-              InboundTrafficController.ofHttp2(channel, clientFactory.http2InitialConnectionWindowSize()));
+              InboundTrafficController.ofHttp2(channel, decoder,
+                                               clientFactory.http2InitialConnectionWindowSize()));
         conn = encoder.connection();
         this.encoder = encoder;
         assert keepAliveHandler instanceof Http2ClientKeepAliveHandler ||
@@ -284,8 +287,8 @@ final class Http2ResponseDecoder extends AbstractHttpResponseDecoder implements 
             res.close();
         }
 
-        // All bytes have been processed.
-        return dataLength + padding;
+        // The data length will be reported to InboundTrafficController upon consumption for flow control.
+        return padding;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -111,6 +111,7 @@ final class HttpClientFactory implements ClientFactory {
     private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
+    private final float http2StreamWindowUpdateRatio;
     private final int http2MaxFrameSize;
     private final long http2MaxHeaderListSize;
     private final int http1MaxInitialLineLength;
@@ -208,6 +209,7 @@ final class HttpClientFactory implements ClientFactory {
 
         http2InitialConnectionWindowSize = options.http2InitialConnectionWindowSize();
         http2InitialStreamWindowSize = options.http2InitialStreamWindowSize();
+        http2StreamWindowUpdateRatio = options.http2StreamWindowUpdateRatio();
         http2MaxFrameSize = options.http2MaxFrameSize();
         http2MaxHeaderListSize = options.http2MaxHeaderListSize();
         pingIntervalMillis = options.pingIntervalMillis();
@@ -263,6 +265,10 @@ final class HttpClientFactory implements ClientFactory {
 
     int http2InitialStreamWindowSize() {
         return http2InitialStreamWindowSize;
+    }
+
+    float http2StreamWindowUpdateRatio() {
+        return http2StreamWindowUpdateRatio;
     }
 
     int http2MaxFrameSize() {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -540,7 +540,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             final Http2ResponseDecoder responseDecoder = this.responseDecoder;
             final DecodedHttpResponse res = new DecodedHttpResponse(ctx.channel().eventLoop());
 
+            final int id = 0;
             res.init(responseDecoder.inboundTrafficController());
+            res.setId(0);
             res.subscribe(new Subscriber<HttpObject>() {
 
                 private boolean notified;
@@ -581,7 +583,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                     System.nanoTime(), SystemInfo.currentTimeMicros());
 
             // NB: No need to set the response timeout because we have session creation timeout.
-            responseDecoder.addResponse(null, 0, res, reqCtx, ctx.channel().eventLoop());
+            responseDecoder.addResponse(null, id, res, reqCtx, ctx.channel().eventLoop());
             ctx.fireChannelActive();
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -95,6 +95,7 @@ import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
 import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
 import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
+import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
@@ -781,6 +782,10 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 /* validateHeaders */ false, clientFactory.http2MaxHeaderListSize());
         Http2FrameReader reader = new DefaultHttp2FrameReader(headersDecoder);
         reader = new Http2InboundFrameLogger(reader, frameLogger);
+        final DefaultHttp2LocalFlowController flowController =
+                new DefaultHttp2LocalFlowController(connection, clientFactory.http2StreamWindowUpdateRatio(),
+                                                    false);
+        connection.local().flowController(flowController);
         return new DefaultHttp2ConnectionDecoder(connection, encoder, reader);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -542,7 +542,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
             final int id = 0;
             res.init(responseDecoder.inboundTrafficController());
-            res.setId(0);
+            res.setId(id);
             res.subscribe(new Subscriber<HttpObject>() {
 
                 private boolean notified;

--- a/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DefaultFlagsProvider.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.server.TransientServiceOption;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 
 /**
  * Implementation of {@link FlagsProvider} which provides default values to {@link Flags}.
@@ -81,6 +82,8 @@ final class DefaultFlagsProvider implements FlagsProvider {
     static final long DEFAULT_CLIENT_HTTP2_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS = 1000;
     static final int DEFAULT_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE = 1024 * 1024; // 1MiB
     static final int DEFAULT_HTTP2_INITIAL_STREAM_WINDOW_SIZE = 1024 * 1024; // 1MiB
+    static final float DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO =
+            DefaultHttp2LocalFlowController.DEFAULT_WINDOW_UPDATE_RATIO; // 0.5f
     static final int DEFAULT_HTTP2_MAX_FRAME_SIZE = 16384; // From HTTP/2 specification
 
     // Can't use 0xFFFFFFFFL because some implementations use a signed 32-bit integer to store HTTP/2 SETTINGS
@@ -328,6 +331,11 @@ final class DefaultFlagsProvider implements FlagsProvider {
     @Override
     public Integer defaultHttp2InitialStreamWindowSize() {
         return DEFAULT_HTTP2_INITIAL_STREAM_WINDOW_SIZE;
+    }
+
+    @Override
+    public Float defaultHttp2StreamWindowUpdateRatio() {
+        return DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -297,6 +297,10 @@ public final class Flags {
             getValue(FlagsProvider::defaultHttp2InitialStreamWindowSize,
                      "defaultHttp2InitialStreamWindowSize", value -> value > 0);
 
+    private static final float DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO =
+            getValue(FlagsProvider::defaultHttp2StreamWindowUpdateRatio,
+                     "defaultHttp2InitialStreamWindowSize", value -> value > 0 && value <= 1.0f);
+
     private static final int DEFAULT_HTTP2_MAX_FRAME_SIZE =
             getValue(FlagsProvider::defaultHttp2MaxFrameSize, "defaultHttp2MaxFrameSize",
                      value -> value >= Http2CodecUtil.MAX_FRAME_SIZE_LOWER_BOUND &&
@@ -1110,6 +1114,23 @@ public final class Flags {
      */
     public static int defaultHttp2InitialStreamWindowSize() {
         return DEFAULT_HTTP2_INITIAL_STREAM_WINDOW_SIZE;
+    }
+
+    /**
+     * Returns the default value of the {@link ServerBuilder#http2StreamWindowUpdateRatio(float)} and
+     * {@link ClientFactoryBuilder#http2StreamWindowUpdateRatio(float)}.
+     * Note that this flag has no effect if a user specified the value explicitly via
+     * {@link ServerBuilder#http2StreamWindowUpdateRatio(float)} or
+     * {@link ClientFactoryBuilder#http2StreamWindowUpdateRatio(float)}.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2StreamWindowUpdateRatio=<float>} JVM option
+     * to override the default value.
+     */
+    @UnstableApi
+    public static Float defaultHttp2StreamWindowUpdateRatio() {
+        return DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -703,6 +703,23 @@ public interface FlagsProvider {
     }
 
     /**
+     * Returns the default value of the {@link ServerBuilder#http2StreamWindowUpdateRatio(float)} and
+     * {@link ClientFactoryBuilder#http2StreamWindowUpdateRatio(float)}.
+     * Note that this flag has no effect if a user specified the value explicitly via
+     * {@link ServerBuilder#http2StreamWindowUpdateRatio(float)} or
+     * {@link ClientFactoryBuilder#http2StreamWindowUpdateRatio(float)}.
+     *
+     * <p>The default value of this flag is
+     * {@value DefaultFlagsProvider#DEFAULT_HTTP2_STREAM_WINDOW_UPDATE_RATIO}.
+     * Specify the {@code -Dcom.linecorp.armeria.defaultHttp2StreamWindowUpdateRatio=<float>} JVM option
+     * to override the default value.
+     */
+    @Nullable
+    default Float defaultHttp2StreamWindowUpdateRatio() {
+        return null;
+    }
+
+    /**
      * Returns the default value of the {@link ServerBuilder#http2MaxFrameSize(int)} and
      * {@link ClientFactoryBuilder#http2MaxFrameSize(int)} option.
      * Note that this flag has no effect if a user specified the value explicitly via

--- a/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/SystemPropertyFlagsProvider.java
@@ -348,6 +348,11 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
         return getInt("defaultHttp2InitialStreamWindowSize");
     }
 
+    @Override
+    public @Nullable Float defaultHttp2StreamWindowUpdateRatio() {
+        return getFloat("defaultHttp2StreamWindowUpdateRatio");
+    }
+
     @Nullable
     @Override
     public Integer defaultHttp2MaxFrameSize() {
@@ -623,6 +628,11 @@ final class SystemPropertyFlagsProvider implements FlagsProvider {
     @Nullable
     private static Integer getInt(String name) {
         return getAndParse(name, Integer::parseInt);
+    }
+
+    @Nullable
+    private static Float getFloat(String name) {
+        return getAndParse(name, Float::parseFloat);
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DecodedHttpResponse.java
@@ -79,7 +79,7 @@ public final class DecodedHttpResponse extends DefaultHttpResponse {
         if (obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
             assert inboundTrafficController != null;
-            assert id > 0 : "id must be set before consuming HttpData";
+            assert id > -1 : "id must be set before consuming HttpData";
             inboundTrafficController.dec(id, length);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DecodedHttpResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DecodedHttpResponse.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.internal.client;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -31,6 +33,7 @@ public final class DecodedHttpResponse extends DefaultHttpResponse {
     @Nullable
     private InboundTrafficController inboundTrafficController;
     private long writtenBytes;
+    private int id = -1;
 
     public DecodedHttpResponse(EventLoop eventLoop) {
         this.eventLoop = eventLoop;
@@ -40,6 +43,10 @@ public final class DecodedHttpResponse extends DefaultHttpResponse {
         this.inboundTrafficController = inboundTrafficController;
     }
 
+    public void setId(int id) {
+        this.id = id;
+    }
+
     public long writtenBytes() {
         return writtenBytes;
     }
@@ -47,6 +54,12 @@ public final class DecodedHttpResponse extends DefaultHttpResponse {
     @Override
     public EventExecutor defaultSubscriberExecutor() {
         return eventLoop;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public InboundTrafficController inboundTrafficController() {
+        return inboundTrafficController;
     }
 
     @Override
@@ -66,7 +79,8 @@ public final class DecodedHttpResponse extends DefaultHttpResponse {
         if (obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
             assert inboundTrafficController != null;
-            inboundTrafficController.dec(length);
+            assert id > 0 : "id must be set before consuming HttpData";
+            inboundTrafficController.dec(id, length);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
@@ -131,7 +131,7 @@ public final class InboundTrafficController extends AtomicInteger {
             } catch (Http2Exception e) {
                 logger.warn("{} Failed to consume bytes from stream {}", channel, streamId, e);
             }
-        } else if (!decoder.connection().streamMayHaveExisted(streamId)){
+        } else if (!decoder.connection().streamMayHaveExisted(streamId)) {
             logger.warn("{} Stream {} not found when consuming bytes", channel, streamId);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
@@ -131,7 +131,7 @@ public final class InboundTrafficController extends AtomicInteger {
             } catch (Http2Exception e) {
                 logger.warn("{} Failed to consume bytes from stream {}", channel, streamId, e);
             }
-        } else {
+        } else if (!decoder.connection().streamMayHaveExisted(streamId)){
             logger.warn("{} Stream {} not found when consuming bytes", channel, streamId);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/InboundTrafficController.java
@@ -18,6 +18,10 @@ package com.linecorp.armeria.internal.common;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.math.IntMath;
 
@@ -25,12 +29,18 @@ import com.linecorp.armeria.common.annotation.Nullable;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2Stream;
 
 public final class InboundTrafficController extends AtomicInteger {
 
+    private static final Logger logger = LoggerFactory.getLogger(InboundTrafficController.class);
+
     private static final long serialVersionUID = 420503276551000218L;
 
-    private static final InboundTrafficController DISABLED = new InboundTrafficController(null, 0, 0);
+    private static final InboundTrafficController DISABLED = new InboundTrafficController(null, null,
+                                                                                          0, 0);
     private static int numDeferredReads;
 
     public static int numDeferredReads() {
@@ -38,17 +48,20 @@ public final class InboundTrafficController extends AtomicInteger {
     }
 
     public static InboundTrafficController ofHttp1(Channel channel) {
-        return new InboundTrafficController(channel, 128 * 1024, 64 * 1024);
+        return new InboundTrafficController(channel, null, 128 * 1024, 64 * 1024);
     }
 
-    public static InboundTrafficController ofHttp2(Channel channel, int connectionWindowSize) {
+    // TODO(ikhoon): Add OutboundTrafficController.ofHttp2() method to apply backpressure to outbound traffic
+    //               using HTTP/2 flow control.
+    public static InboundTrafficController ofHttp2(Channel channel, Http2ConnectionDecoder decoder,
+                                                   int connectionWindowSize) {
         // Compensate for protocol overhead traffic incurred by frame headers, etc.
         // This is a very rough estimate, but it should not hurt.
         connectionWindowSize = IntMath.saturatedAdd(connectionWindowSize, 1024);
 
-        final int highWatermark = Math.max(connectionWindowSize, 128 * 1024);
+        final int highWatermark = connectionWindowSize;
         final int lowWatermark = highWatermark >>> 1;
-        return new InboundTrafficController(channel, highWatermark, lowWatermark);
+        return new InboundTrafficController(channel, decoder, highWatermark, lowWatermark);
     }
 
     public static InboundTrafficController disabled() {
@@ -56,13 +69,21 @@ public final class InboundTrafficController extends AtomicInteger {
     }
 
     @Nullable
+    private final Channel channel;
+    @Nullable
     private final ChannelConfig cfg;
+    @Nullable
+    private final Http2ConnectionDecoder decoder;
     private final int highWatermark;
     private final int lowWatermark;
     private volatile boolean suspended;
 
-    private InboundTrafficController(@Nullable Channel channel, int highWatermark, int lowWatermark) {
+    private InboundTrafficController(@Nullable Channel channel,
+                                     @Nullable Http2ConnectionDecoder decoder,
+                                     int highWatermark, int lowWatermark) {
+        this.channel = channel;
         cfg = channel != null ? channel.config() : null;
+        this.decoder = decoder;
         this.highWatermark = highWatermark;
         this.lowWatermark = lowWatermark;
     }
@@ -79,7 +100,15 @@ public final class InboundTrafficController extends AtomicInteger {
         }
     }
 
-    public void dec(int numConsumedBytes) {
+    public void dec(int id, int numConsumedBytes) {
+        if (decoder != null) {
+            assert channel != null;
+            if (channel.eventLoop().inEventLoop()) {
+                consumeHttp2Bytes(id, numConsumedBytes);
+            } else {
+                channel.eventLoop().execute(() -> consumeHttp2Bytes(id, numConsumedBytes));
+            }
+        }
         final int oldValue = getAndAdd(-numConsumedBytes);
         if (oldValue > lowWatermark && oldValue - numConsumedBytes <= lowWatermark) {
             // Just went below low watermark
@@ -88,6 +117,38 @@ public final class InboundTrafficController extends AtomicInteger {
                 suspended = false;
             }
         }
+    }
+
+    private void consumeHttp2Bytes(int id, int numConsumedBytes) {
+        final int streamId = streamId(id);
+        assert decoder != null && channel != null;
+        final Http2Stream stream = decoder.connection().stream(streamId);
+        if (stream != null) {
+            try {
+                if (decoder.flowController().consumeBytes(stream, numConsumedBytes)) {
+                    channel.flush();
+                }
+            } catch (Http2Exception e) {
+                logger.warn("{} Failed to consume bytes from stream {}", channel, streamId, e);
+            }
+        } else {
+            logger.warn("{} Stream {} not found when consuming bytes", channel, streamId);
+        }
+    }
+
+    @Nullable
+    @VisibleForTesting
+    public Http2ConnectionDecoder decoder() {
+        return decoder;
+    }
+
+    @VisibleForTesting
+    public boolean isSuspended() {
+        return suspended;
+    }
+
+    private static int streamId(int id) {
+        return (id << 1) + 1;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecodedHttpRequest.java
@@ -54,7 +54,7 @@ interface DecodedHttpRequest extends HttpRequest {
                     return new StreamingDecodedHttpRequest(
                             eventLoop, id, streamId, headers, keepAlive, inboundTrafficController,
                             config.maxRequestLength(), routingCtx, exchangeType,
-                            requestStartTimeNanos, requestStartTimeMicros, false, false);
+                            requestStartTimeNanos, requestStartTimeMicros, false);
                 } else {
                     return new AggregatingDecodedHttpRequest(
                             eventLoop, id, streamId, headers, keepAlive, config.maxRequestLength(), routingCtx,

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -82,6 +82,7 @@ final class DefaultServerConfig implements ServerConfig {
 
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
+    private final float http2StreamWindowUpdateRatio;
     private final long http2MaxStreamsPerConnection;
     private final int http2MaxFrameSize;
     private final long http2MaxHeaderListSize;
@@ -131,8 +132,8 @@ final class DefaultServerConfig implements ServerConfig {
             long maxConnectionAgeMillis,
             int maxNumRequestsPerConnection, long connectionDrainDurationMicros,
             int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
-            long http2MaxStreamsPerConnection, int http2MaxFrameSize, long http2MaxHeaderListSize,
-            int http2MaxResetFramesPerWindow, int http2MaxResetFramesWindowSeconds,
+            float http2StreamWindowUpdateRatio, long http2MaxStreamsPerConnection, int http2MaxFrameSize,
+            long http2MaxHeaderListSize, int http2MaxResetFramesPerWindow, int http2MaxResetFramesWindowSeconds,
             int http1MaxInitialLineLength, int http1MaxHeaderSize,
             int http1MaxChunkSize, GracefulShutdown gracefulShutdown,
             BlockingTaskExecutor blockingTaskExecutor,
@@ -171,6 +172,7 @@ final class DefaultServerConfig implements ServerConfig {
                                                                  "connectionDrainDurationMicros");
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
         this.http2InitialStreamWindowSize = http2InitialStreamWindowSize;
+        this.http2StreamWindowUpdateRatio = http2StreamWindowUpdateRatio;
         this.http2MaxStreamsPerConnection = http2MaxStreamsPerConnection;
         this.http2MaxFrameSize = http2MaxFrameSize;
         this.http2MaxHeaderListSize = http2MaxHeaderListSize;
@@ -544,6 +546,11 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public int http2InitialStreamWindowSize() {
         return http2InitialStreamWindowSize;
+    }
+
+    @Override
+    public float http2StreamWindowSizeRatio() {
+        return http2StreamWindowUpdateRatio;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1RequestDecoder.java
@@ -260,8 +260,7 @@ final class Http1RequestDecoder extends ChannelDuplexHandler {
                                             eventLoop, id, 1, headers, false, inboundTrafficController,
                                             serviceConfig.maxRequestLength(), routingCtx,
                                             ExchangeType.BIDI_STREAMING,
-                                            System.nanoTime(), SystemInfo.currentTimeMicros(), true, false
-                                    );
+                                            System.nanoTime(), SystemInfo.currentTimeMicros(), true);
                             assert encoder instanceof ServerHttp1ObjectEncoder;
                             ((ServerHttp1ObjectEncoder) encoder).webSocketUpgrading();
                             final ChannelPipeline pipeline = ctx.pipeline();

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -36,7 +36,6 @@ import io.netty.util.AsciiString;
 
 final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler {
 
-    private final ServerConfig cfg;
     private final GracefulShutdownSupport gracefulShutdownSupport;
     private final Http2RequestDecoder requestDecoder;
     @Nullable
@@ -51,13 +50,12 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
         super(decoder, encoder, initialSettings, newKeepAliveHandler(encoder, channel, cfg, keepAliveTimer));
 
-        this.cfg = cfg;
         this.gracefulShutdownSupport = gracefulShutdownSupport;
 
         gracefulConnectionShutdownHandler = new Http2GracefulConnectionShutdownHandler(
                 cfg.connectionDrainDurationMicros());
 
-        requestDecoder = new Http2RequestDecoder(cfg, channel, scheme, keepAliveHandler());
+        requestDecoder = new Http2RequestDecoder(cfg, channel, scheme, keepAliveHandler(), decoder);
         connection().addListener(requestDecoder);
         decoder().frameListener(requestDecoder);
     }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -79,6 +79,7 @@ import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
 import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
 import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
+import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -88,6 +89,7 @@ import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
+import io.netty.handler.codec.http2.Http2LocalFlowController;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.flush.FlushConsolidationHandler;
@@ -275,6 +277,9 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                 /* validateHeaders */ true, config.http2MaxHeaderListSize());
         Http2FrameReader reader = new DefaultHttp2FrameReader(headersDecoder);
         reader = new Http2InboundFrameLogger(reader, frameLogger);
+        final Http2LocalFlowController flowController =
+                new DefaultHttp2LocalFlowController(connection, config.http2StreamWindowSizeRatio(), false);
+        connection.local().flowController(flowController);
         return new DefaultHttp2ConnectionDecoder(connection, encoder, reader);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -198,6 +198,15 @@ public interface ServerConfig {
     int http2InitialStreamWindowSize();
 
     /**
+     * Returns the threshold ratio of the HTTP/2 stream flow-control window at which a
+     * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-6.9">WINDOW_UPDATE</a> frame will be sent.
+     * When the size of the flow-control window drops below the specified ratio (relative to the initial window
+     * size), a {@code WINDOW_UPDATE} frame is triggered to replenish the window.
+     */
+    @UnstableApi
+    float http2StreamWindowSizeRatio();
+
+    /**
      * Returns the maximum number of concurrent streams per HTTP/2 connection.
      */
     long http2MaxStreamsPerConnection();

--- a/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/StreamingDecodedHttpRequest.java
@@ -20,6 +20,8 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -47,8 +49,6 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     private final boolean http1WebSocket;
     private final CompletableFuture<Void> whenResponseSent = new CompletableFuture<>();
 
-    private boolean shouldResetOnlyIfRemoteIsOpen;
-
     @Nullable
     private ServiceRequestContext ctx;
     private long transferredBytes;
@@ -64,7 +64,7 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
                                 boolean keepAlive, InboundTrafficController inboundTrafficController,
                                 long maxRequestLength, RoutingContext routingCtx, ExchangeType exchangeType,
                                 long requestStartTimeNanos, long requestStartTimeMicros,
-                                boolean http1WebSocket, boolean shouldResetOnlyIfRemoteIsOpen) {
+                                boolean http1WebSocket) {
         super(headers);
 
         this.eventLoop = eventLoop;
@@ -79,7 +79,6 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
         this.requestStartTimeNanos = requestStartTimeNanos;
         this.requestStartTimeMicros = requestStartTimeMicros;
         this.http1WebSocket = http1WebSocket;
-        this.shouldResetOnlyIfRemoteIsOpen = shouldResetOnlyIfRemoteIsOpen;
     }
 
     @Override
@@ -173,7 +172,7 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     protected void onRemoval(HttpObject obj) {
         if (obj instanceof HttpData) {
             final int length = ((HttpData) obj).length();
-            inboundTrafficController.dec(length);
+            inboundTrafficController.dec(id, length);
         }
     }
 
@@ -246,5 +245,10 @@ final class StreamingDecodedHttpRequest extends DefaultHttpRequest implements De
     @Override
     public boolean isHttp1WebSocket() {
         return http1WebSocket;
+    }
+
+    @VisibleForTesting
+    InboundTrafficController inboundTrafficController() {
+        return inboundTrafficController;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -206,6 +206,11 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
+    public float http2StreamWindowSizeRatio() {
+        return delegate.http2StreamWindowSizeRatio();
+    }
+
+    @Override
     public long http2MaxStreamsPerConnection() {
         return delegate.http2MaxStreamsPerConnection();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientFlowControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientFlowControlTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.client.DecodedHttpResponse;
+import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2LocalFlowController;
+import io.netty.handler.codec.http2.Http2Stream;
+
+/**
+ * Makes sure Armeria HTTP client respects HTTP/2 flow control setting.
+ */
+public class HttpClientFlowControlTest {
+    private static final Logger logger = LoggerFactory.getLogger(HttpClientFlowControlTest.class);
+
+    private static final String PATH = "/test";
+    private static final int CONNECTION_WINDOW = 1024 * 1024; // 1MB connection window
+    private static final int STREAM_WINDOW = CONNECTION_WINDOW / 2; // 512KB stream window
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(PATH, (ctx, req) -> {
+                return HttpResponse.of(
+                        ResponseHeaders.of(HttpStatus.OK),
+                        HttpData.wrap(
+                                new byte[CONNECTION_WINDOW + 1025])); // a slightly larger than 1MB response
+            });
+        }
+    };
+
+    @Test
+    void flowControl() throws Exception {
+        try (ClientFactory clientFactory = ClientFactory.builder()
+                .http2InitialStreamWindowSize(STREAM_WINDOW)
+                .http2InitialConnectionWindowSize(CONNECTION_WINDOW)
+                .build()) {
+            final WebClient client = WebClient.builder(server.uri(SessionProtocol.H2C))
+                    .factory(clientFactory)
+                    .build();
+
+            final DecodedHttpResponse res1 = (DecodedHttpResponse) client.get(PATH);
+
+            // wait sometime for first stream to read response from server, until InboundTrafficController
+            // kicks in
+            await().untilAsserted(() -> {
+                assertThat(res1.writtenBytes()).isEqualTo(STREAM_WINDOW);
+            });
+            final InboundTrafficController controller = res1.inboundTrafficController();
+            final Http2ConnectionDecoder decoder = controller.decoder();
+            final Http2LocalFlowController flowController = decoder.flowController();
+            final Http2Connection connection = decoder.connection();
+            final Http2Stream stream3 = connection.stream(3);
+            // Used up the flow control window for the first response
+            assertThat(flowController.windowSize(stream3)).isZero();
+            // assert that the controller is not suspended by the first response
+            assertThat(controller.isSuspended()).isFalse();
+
+            // The first stream should not interfere with the second stream.
+            final DecodedHttpResponse res2 = (DecodedHttpResponse) client.get(PATH);
+            await().untilAsserted(() -> {
+                assertThat(res2.writtenBytes()).isEqualTo(STREAM_WINDOW);
+            });
+
+            final Http2Stream stream5 = connection.stream(5);
+            assertThat(flowController.windowSize(stream5)).isZero();
+
+            assertThat(flowController.windowSize(connection.connectionStream())).isEqualTo(0);
+            assertThat(controller.isSuspended()).isFalse();
+
+            logger.debug("Start aggregating the first response to release the flow control window.");
+            final AggregatedHttpResponse aggRes1 = res1.aggregate().join();
+            assertThat(aggRes1.status()).isEqualTo(HttpStatus.OK);
+            assertThat(aggRes1.content().length()).isEqualTo(CONNECTION_WINDOW + 1025);
+
+            final AggregatedHttpResponse aggRes2 = res2.aggregate().join();
+            assertThat(aggRes2.status()).isEqualTo(HttpStatus.OK);
+            assertThat(aggRes2.content().length()).isEqualTo(CONNECTION_WINDOW + 1025);
+
+            assertThat(flowController.windowSize(connection.connectionStream())).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void testStreamWindowUpdateRatio() {
+        assertThatThrownBy(() -> ClientFactory.builder().http2StreamWindowUpdateRatio(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("http2StreamWindowUpdateRatio: 0.0 (expected: > 0 and < 1.0)");
+
+        assertThatThrownBy(() -> ClientFactory.builder().http2StreamWindowUpdateRatio(1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("http2StreamWindowUpdateRatio: 1.0 (expected: > 0 and < 1.0)");
+
+        assertThatCode(() -> {
+            ClientFactory.builder().http2StreamWindowUpdateRatio(0.5f);
+        }).doesNotThrowAnyException();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpResponseWrapperTest.java
@@ -159,8 +159,10 @@ class HttpResponseWrapperTest {
         assertThat(channel).isNotNull();
         final TestHttpResponseDecoder decoder = new TestHttpResponseDecoder(channel, controller);
 
+        final int id = 1;
+        res.setId(id);
         res.init(controller);
-        return decoder.addResponse(null, 1, res, cctx, cctx.eventLoop());
+        return decoder.addResponse(null, id, res, cctx, cctx.eventLoop());
     }
 
     private static class TestHttpResponseDecoder extends AbstractHttpResponseDecoder {

--- a/core/src/test/java/com/linecorp/armeria/server/HttpServerFlowControlTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpServerFlowControlTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.ExchangeType;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.common.InboundTrafficController;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.codec.http2.Http2Connection;
+import io.netty.handler.codec.http2.Http2ConnectionDecoder;
+import io.netty.handler.codec.http2.Http2LocalFlowController;
+import io.netty.handler.codec.http2.Http2Stream;
+
+/**
+ * Makes sure Armeria HTTP server respects HTTP/2 flow control setting.
+ */
+public class HttpServerFlowControlTest {
+    private static final Logger logger = LoggerFactory.getLogger(HttpServerFlowControlTest.class);
+
+    private static final String PATH = "/test";
+    private static final int CONNECTION_WINDOW = 1024 * 1024; // 1MB connection window
+    public static final int DATA_SIZE = CONNECTION_WINDOW + 1025;
+    private static final int STREAM_WINDOW = CONNECTION_WINDOW / 2; // 512KB stream window
+
+    private static final AtomicInteger reqCounter = new AtomicInteger();
+    private static CountDownLatch latch;
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http2InitialConnectionWindowSize(CONNECTION_WINDOW);
+            sb.http2InitialStreamWindowSize(STREAM_WINDOW);
+            sb.service(PATH, (ctx, req) -> {
+                final CompletableFuture<HttpResponse> future = CompletableFuture.supplyAsync(() -> {
+                    final StreamingDecodedHttpRequest decodedReq = (StreamingDecodedHttpRequest) req;
+                    await().untilAsserted(() -> {
+                        assertThat(decodedReq.transferredBytes()).isEqualTo(STREAM_WINDOW);
+                    });
+                    reqCounter.incrementAndGet();
+                    final InboundTrafficController controller = decodedReq.inboundTrafficController();
+                    final Http2ConnectionDecoder decoder = controller.decoder();
+                    final Http2LocalFlowController flowController = decoder.flowController();
+                    final Http2Connection connection = decoder.connection();
+                    final Http2Stream stream = connection.stream(decodedReq.streamId());
+                    assertThat(flowController.windowSize(stream)).isZero();
+                    assertThat(controller.isSuspended()).isFalse();
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    final AggregatedHttpRequest aggReq = req.aggregate().join();
+                    return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT,
+                                           "Received: " + aggReq.content().length());
+                }, ctx.blockingTaskExecutor());
+
+                return HttpResponse.of(future);
+            });
+
+            sb.service("/aggregate", new HttpService() {
+
+                @Override
+                public ExchangeType exchangeType(RoutingContext routingContext) {
+                    return ExchangeType.UNARY;
+                }
+
+                @Override
+                public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+                    final CompletableFuture<HttpResponse> future = CompletableFuture.supplyAsync(() -> {
+                        final StreamingDecodedHttpRequest decodedReq = (StreamingDecodedHttpRequest) req;
+                        await().untilAsserted(() -> {
+                            // non-streaming request should not be suspended by flow control.
+                            assertThat(decodedReq.transferredBytes()).isEqualTo(DATA_SIZE);
+                        });
+
+                        final AggregatedHttpRequest aggReq = req.aggregate().join();
+                        return HttpResponse.of(HttpStatus.OK, MediaType.PLAIN_TEXT,
+                                               "Received: " + aggReq.content().length());
+                    }, ctx.blockingTaskExecutor());
+
+                    return HttpResponse.of(future);
+                }
+            });
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        reqCounter.set(0);
+        latch = new CountDownLatch(1);
+    }
+
+    @Test
+    void flowControl() throws Exception {
+        final WebClient client = WebClient.of(server.uri(SessionProtocol.H2C));
+
+        final CompletableFuture<AggregatedHttpResponse> res1 =
+                client.post(PATH, HttpData.wrap(new byte[DATA_SIZE])).aggregate();
+        await().untilAtomic(reqCounter, Matchers.is(1));
+
+        final CompletableFuture<AggregatedHttpResponse> res2 =
+                client.post(PATH, HttpData.wrap(new byte[DATA_SIZE])).aggregate();
+        await().untilAtomic(reqCounter, Matchers.is(2));
+
+        final ServiceRequestContext sctx2 = server.requestContextCaptor().take();
+        final StreamingDecodedHttpRequest decodedServerReq = (StreamingDecodedHttpRequest) sctx2.request();
+        final Http2ConnectionDecoder decoder = decodedServerReq.inboundTrafficController().decoder();
+        final Http2LocalFlowController flowController = decoder.flowController();
+        final Http2Connection connection = decoder.connection();
+        assertThat(flowController.windowSize(connection.connectionStream())).isEqualTo(0);
+
+        logger.debug("Start aggregating the responses to release the flow control window.");
+        latch.countDown();
+        final AggregatedHttpResponse aggRes1 = res1.join();
+        assertThat(aggRes1.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggRes1.contentUtf8()).isEqualTo("Received: " + DATA_SIZE);
+
+        final AggregatedHttpResponse aggRes2 = res2.join();
+        assertThat(aggRes2.status()).isEqualTo(HttpStatus.OK);
+        assertThat(aggRes2.contentUtf8()).isEqualTo("Received: " + DATA_SIZE);
+
+        assertThat(flowController.windowSize(connection.connectionStream())).isGreaterThan(0);
+    }
+
+    @Test
+    void ignoreFlowControlForNonStreamRequest() throws Exception {
+        final WebClient client = WebClient.of(server.uri(SessionProtocol.H2C));
+
+        final AggregatedHttpResponse res =
+                client.post(PATH, HttpData.wrap(new byte[DATA_SIZE])).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("Received: " + DATA_SIZE);
+    }
+
+    @Test
+    void testStreamWindowUpdateRatio() {
+        assertThatThrownBy(() -> Server.builder().http2StreamWindowUpdateRatio(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("http2StreamWindowUpdateRatio: 0.0 (expected: > 0 and < 1.0)");
+
+        assertThatThrownBy(() -> Server.builder().http2StreamWindowUpdateRatio(1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("http2StreamWindowUpdateRatio: 1.0 (expected: > 0 and < 1.0)");
+
+        assertThatCode(() -> {
+            Server.builder().http2StreamWindowUpdateRatio(0.5f);
+        }).doesNotThrowAnyException();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/StreamingDecodedHttpRequestTest.java
@@ -111,7 +111,7 @@ class StreamingDecodedHttpRequestTest {
                 request = new StreamingDecodedHttpRequest(sctx.eventLoop(), 1, 1, headers, true,
                                                           InboundTrafficController.disabled(),
                                                           sctx.maxRequestLength(), sctx.routingContext(),
-                                                          ExchangeType.BIDI_STREAMING, 0, 0, false, false);
+                                                          ExchangeType.BIDI_STREAMING, 0, 0, false);
         request.init(sctx);
         return request;
     }


### PR DESCRIPTION
Motivation:

Since `InboundTrafficController` operates at the TCP level, it isn't aligned with HTTP/2 flow control. As a result, a stream may receive more than its stream window size allows and interfering with other streams from receiving data.

Related: #6253

Modifications:

- Integrated `InboundTrafficController` with HTTP/2 `Http2LocalFlowController`
  - Invokes `Http2LocalFlowController.consumeBytes()` when steam data is consumed to send a `WINDOW_UPDATE` frame.
- Introduced `{ServerBuilder,ClientFactoryBuilder}.http2StreamWindowUpdateRatio` to customize the threshold to send WINDOW_UPDATE frames.
- Fixed `client.Http2ResponseDecoder` and `server.Http2RequestDecoder` to defer reporting the consumed data length.
  - The length is not reported via `InboundTrafficController` when the data is consumed in userland.

Result:

- Fixed a bug where HTTP/2 flow control did not work properly, and stream-level windowing was ignored.
- Closes #6253

