### PR TITLE
Fix typo in client-side service discovery docs

### DIFF
--- a/site/src/pages/docs/client-service-discovery.mdx
+++ b/site/src/pages/docs/client-service-discovery.mdx
@@ -319,7 +319,7 @@ use <type://EurekaEndpointGroupBuilder>:
 import com.linecorp.armeria.client.eureka.EurekaEndpointGroupBuilder;
 
 EurekaEndpointGroupBuilder builder =
-        EurekaEndpointGroup.builder("https://eureka.com:8001/eureka/v2");
+        EurekaEndpointGroup.builder("https://eureka.com:8001/eureka/v2")
                            .regions("aws")
                            .appName("myApplication");
 EurekaEndpointGroup eurekaEndpointGroup = builder.build();
@@ -361,7 +361,7 @@ If you want to get the information of certain [datacenter](https://www.consul.io
 import com.linecorp.armeria.client.consul.ConsulEndpointGroupBuilder;
 
 ConsulEndpointGroupBuilder builder =
-        ConsulEndpointGroup.builder("http://my-consul.com:8500", "my-service");
+        ConsulEndpointGroup.builder("http://my-consul.com:8500", "my-service")
                            .datacenter("ds1")
                            .filter("ServicePort == 8080")
                            .build();

--- a/site/src/pages/docs/client-service-discovery.mdx
+++ b/site/src/pages/docs/client-service-discovery.mdx
@@ -363,8 +363,7 @@ import com.linecorp.armeria.client.consul.ConsulEndpointGroupBuilder;
 ConsulEndpointGroupBuilder builder =
         ConsulEndpointGroup.builder("http://my-consul.com:8500", "my-service")
                            .datacenter("ds1")
-                           .filter("ServicePort == 8080")
-                           .build();
+                           .filter("ServicePort == 8080");
 ConsulEndpointGroup consulEndpointGroup = builder.build();
 ```
 


### PR DESCRIPTION
Modifications:

- In `client-service-discovery.mdx`, some EndpointGroup example code has typo
  - There are semicolon right after `builder(...)` but it has more successive method calls.
  - In `ConsulEndpointGroupBuilder` example, `build()` should not be called.

Result:

- Fixed typo and errors in docs

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
