### PR TITLE
Fix typo in TextHeadersSanitizer

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextHeadersSanitizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextHeadersSanitizer.java
@@ -55,7 +55,7 @@ final class TextHeadersSanitizer implements HeadersSanitizer<String> {
 
         final StringBuilder sb = new StringBuilder();
         if (headers.isEndOfStream()) {
-            sb.append("[EOS], ");
+            sb.append("[EOS, ");
         } else {
             sb.append('[');
         }


### PR DESCRIPTION
Currently, it produces `headers=[EOS], ...]`. It should be `headers=[EOS, ...]`.
