### PR TITLE
Server doesn't send a `RST_STREAM` frame after `endStream` is sent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -301,7 +301,10 @@ final class Http2ResponseDecoder extends AbstractHttpResponseDecoder implements 
         keepAliveChannelRead();
         final HttpResponseWrapper res = getResponse(streamIdToId(streamId));
         if (res == null || !res.isOpen()) {
-            if (conn.streamMayHaveExisted(streamId)) {
+            final Http2Stream stream = conn.stream(streamId);
+            if (stream != null) {
+                // the stream was active, but will be closed now
+            } else if (conn.streamMayHaveExisted(streamId)) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("{} Received a late RST_STREAM frame for a closed stream: {}",
                                  ctx.channel(), streamId);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2ObjectEncoder.java
@@ -24,6 +24,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection.PropertyKey;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Error;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -32,6 +33,7 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
     private final ChannelHandlerContext ctx;
     private final Http2ConnectionEncoder encoder;
     private final KeepAliveHandler keepAliveHandler;
+    private final PropertyKey endStreamSentKey;
     private volatile boolean closed;
 
     protected Http2ObjectEncoder(ChannelHandlerContext connectionHandlerCtx,
@@ -39,6 +41,7 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
         ctx = connectionHandlerCtx;
         encoder = connectionHandler.encoder();
         keepAliveHandler = connectionHandler.keepAliveHandler();
+        endStreamSentKey = encoder.connection().newKey();
     }
 
     @Override
@@ -65,6 +68,7 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
             final KeepAliveHandler keepAliveHandler = keepAliveHandler();
             keepAliveHandler.onReadOrWrite();
             // Write to an existing stream.
+            maybeSetEndStreamSent(streamId, endStream);
             return encoder.writeData(ctx, streamId, toByteBuf(data), 0, endStream, ctx.newPromise());
         }
 
@@ -118,6 +122,21 @@ public abstract class Http2ObjectEncoder implements HttpObjectEncoder {
                 // The response has been sent already.
                 return false;
         }
+    }
+
+    protected boolean isEndStreamSent(Http2Stream stream) {
+        return stream.getProperty(endStreamSentKey) != null;
+    }
+
+    protected void maybeSetEndStreamSent(int streamId, boolean endStream) {
+        if (!endStream) {
+            return;
+        }
+        final Http2Stream stream = encoder.connection().stream(streamId);
+        if (stream == null) {
+            return;
+        }
+        stream.setProperty(endStreamSentKey, true);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java
@@ -59,7 +59,6 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
 
         final Http2Headers converted = convertHeaders(headers, isTrailersEmpty);
         onKeepAliveReadOrWrite();
-        maybeSetEndStreamSent(streamId, endStream);
         return encoder().writeHeaders(ctx(), streamId, converted, 0, endStream, ctx().newPromise());
     }
 
@@ -99,7 +98,6 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
 
         final Http2Headers converted = ArmeriaHttpUtil.toNettyHttp2ServerTrailers(headers);
         onKeepAliveReadOrWrite();
-        maybeSetEndStreamSent(streamId, true);
         return encoder().writeHeaders(ctx(), streamId, converted, 0, true, ctx().newPromise());
     }
 
@@ -145,7 +143,7 @@ final class ServerHttp2ObjectEncoder extends Http2ObjectEncoder implements Serve
         if (stream == null) {
             return;
         }
-        if ((stream.state().localSideOpen() && !isEndStreamSent(stream)) || stream.state().remoteSideOpen()) {
+        if (stream.state().remoteSideOpen()) {
             encoder().writeRstStream(ctx(), streamId, http2Error.code(), ctx().voidPromise());
             ctx().flush();
         }

--- a/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.internal.testing.netty.SimpleHttp2Connection;
+import com.linecorp.armeria.internal.testing.netty.SimpleHttp2Connection.Http2Stream;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.DefaultHttp2HeadersFrame;
+import io.netty.handler.codec.http2.Http2DataFrame;
+import io.netty.handler.codec.http2.Http2Frame;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2HeadersFrame;
+import io.netty.handler.logging.LogLevel;
+
+class Http2ResetStreamTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service("/", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    @Test
+    void rstStreamShouldNotBeRecv() throws Exception {
+        final Deque<Integer> rstStreamFrames = new ArrayDeque<>();
+        final Http2FrameLogger frameLogger = new Http2FrameLogger(LogLevel.DEBUG, Http2ResetStreamTest.class) {
+            @Override
+            public void logRstStream(Direction direction, ChannelHandlerContext ctx, int streamId,
+                                     long errorCode) {
+                rstStreamFrames.offer(streamId);
+                super.logRstStream(direction, ctx, streamId, errorCode);
+            }
+        };
+        final SimpleHttp2Connection conn = SimpleHttp2Connection.of(server.httpUri(), frameLogger);
+        final Http2Stream stream = conn.createStream();
+        final DefaultHttp2Headers headers = new DefaultHttp2Headers();
+        headers.method("GET");
+        headers.path("/");
+        final Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(headers, true);
+        stream.sendFrame(headersFrame).syncUninterruptibly();
+
+        await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
+        final Http2Frame responseHeaderFrame = stream.take();
+        assertThat(responseHeaderFrame).isInstanceOf(Http2HeadersFrame.class);
+        assertThat(((Http2HeadersFrame) responseHeaderFrame).headers().status()).asString().isEqualTo("200");
+
+        Http2Frame dataFrame = stream.take();
+        assertThat(dataFrame).isInstanceOf(Http2DataFrame.class);
+        assertThat(((Http2DataFrame) dataFrame).content().toString(StandardCharsets.UTF_8))
+                .asString().isEqualTo("hello");
+
+        dataFrame = stream.take();
+        assertThat(dataFrame).isInstanceOf(Http2DataFrame.class);
+        assertThat(((Http2DataFrame) dataFrame).isEndStream()).isTrue();
+
+        await().atLeast(100, TimeUnit.MILLISECONDS)
+               .untilAsserted(() -> assertThat(rstStreamFrames).isEmpty());
+
+        conn.close();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
@@ -63,8 +63,8 @@ class Http2ResetStreamTest {
                 super.logRstStream(direction, ctx, streamId, errorCode);
             }
         };
-        try (final SimpleHttp2Connection conn = SimpleHttp2Connection.of(server.httpUri(), frameLogger);
-             final Http2Stream stream = conn.createStream()) {
+        try (SimpleHttp2Connection conn = SimpleHttp2Connection.of(server.httpUri(), frameLogger);
+             Http2Stream stream = conn.createStream()) {
             final DefaultHttp2Headers headers = new DefaultHttp2Headers();
             headers.method("GET");
             headers.path("/");

--- a/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http2ResetStreamTest.java
@@ -74,7 +74,8 @@ class Http2ResetStreamTest {
             await().untilAsserted(() -> assertThat(stream.isOpen()).isFalse());
             final Http2Frame responseHeaderFrame = stream.take();
             assertThat(responseHeaderFrame).isInstanceOf(Http2HeadersFrame.class);
-            assertThat(((Http2HeadersFrame) responseHeaderFrame).headers().status()).asString().isEqualTo("200");
+            assertThat(((Http2HeadersFrame) responseHeaderFrame).headers().status())
+                    .asString().isEqualTo("200");
 
             Http2Frame dataFrame = stream.take();
             assertThat(dataFrame).isInstanceOf(Http2DataFrame.class);

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/NettyServerExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/NettyServerExtension.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.internal.testing;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -52,6 +53,10 @@ public abstract class NettyServerExtension extends AbstractAllOrEachExtension {
 
     public final Endpoint endpoint() {
         return Endpoint.unsafeCreate(address().getHostString(), address().getPort());
+    }
+
+    public final URI httpUri() {
+        return URI.create("http://" + address().getHostString() + ':' + address().getPort());
     }
 
     protected abstract void configure(Channel ch) throws Exception;

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/Http2ClientFrameInitializer.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/Http2ClientFrameInitializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.testing.netty;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2FrameCodec;
+import io.netty.handler.codec.http2.Http2FrameCodecBuilder;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2MultiplexHandler;
+import io.netty.handler.ssl.SslContext;
+
+final class Http2ClientFrameInitializer extends ChannelInitializer<Channel> {
+
+    @Nullable
+    private final SslContext sslCtx;
+    @Nullable
+    private final Http2FrameLogger frameLogger;
+
+    Http2ClientFrameInitializer(@Nullable SslContext sslCtx, @Nullable Http2FrameLogger frameLogger) {
+        this.sslCtx = sslCtx;
+        this.frameLogger = frameLogger;
+    }
+
+    @Override
+    protected void initChannel(Channel ch) throws Exception {
+        if (sslCtx != null) {
+            ch.pipeline().addFirst(sslCtx.newHandler(ch.alloc()));
+        }
+        final Http2FrameCodecBuilder builder = Http2FrameCodecBuilder.forClient();
+        if (frameLogger != null) {
+            builder.frameLogger(frameLogger);
+        }
+        final Http2FrameCodec http2FrameCodec = builder.build();
+        ch.pipeline().addLast(http2FrameCodec);
+        ch.pipeline().addLast(new Http2MultiplexHandler(new SimpleChannelInboundHandler() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+            }
+        }));
+    }
+}

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/HttpFrameAggregator.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/HttpFrameAggregator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.testing.netty;
+
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http2.Http2Frame;
+import io.netty.util.ReferenceCountUtil;
+
+final class HttpFrameAggregator extends SimpleChannelInboundHandler<Http2Frame> implements SafeCloseable {
+
+    HttpFrameAggregator() {
+        super(false);
+    }
+
+    private final BlockingDeque<Http2Frame> frames = new LinkedBlockingDeque<>();
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Http2Frame msg) throws Exception {
+        frames.offer(msg);
+    }
+
+    BlockingDeque<Http2Frame> frames() {
+        return frames;
+    }
+
+    @Override
+    public void close() {
+        while (!frames.isEmpty()) {
+            final Http2Frame frame = frames.poll();
+            if (frame != null) {
+                ReferenceCountUtil.release(frame);
+            }
+        }
+    }
+}

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/SimpleHttp2Connection.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/SimpleHttp2Connection.java
@@ -23,7 +23,6 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.SafeCloseable;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
@@ -71,8 +70,6 @@ public final class SimpleHttp2Connection implements SafeCloseable {
 
         // Start the client.
         channel = b.connect().syncUninterruptibly().channel();
-        // just don't worry about memory leaks at all
-        channel.config().setAllocator(UnpooledByteBufAllocator.DEFAULT);
     }
 
     public Channel channel() {

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/SimpleHttp2Connection.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/SimpleHttp2Connection.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.testing.netty;
+
+import java.net.URI;
+
+import javax.net.ssl.SSLException;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http2.Http2Frame;
+import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.codec.http2.Http2FrameStream;
+import io.netty.handler.codec.http2.Http2Stream.State;
+import io.netty.handler.codec.http2.Http2StreamChannel;
+import io.netty.handler.codec.http2.Http2StreamChannelBootstrap;
+import io.netty.handler.codec.http2.Http2StreamFrame;
+import io.netty.handler.ssl.SslContext;
+
+public final class SimpleHttp2Connection implements SafeCloseable {
+
+    public static SimpleHttp2Connection of(URI uri) {
+        return of(uri.getHost(), uri.getPort(), null);
+    }
+
+    public static SimpleHttp2Connection of(URI uri, Http2FrameLogger frameLogger) {
+        return of(uri.getHost(), uri.getPort(), frameLogger);
+    }
+
+    public static SimpleHttp2Connection of(String host, int port, @Nullable Http2FrameLogger frameLogger) {
+        try {
+            return new SimpleHttp2Connection(host, port, null, frameLogger);
+        } catch (SSLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private final EventLoopGroup clientWorkerGroup = new NioEventLoopGroup();
+    private final Channel channel;
+
+    private SimpleHttp2Connection(String host, int port, @Nullable SslContext sslCtx,
+                                  @Nullable Http2FrameLogger frameLogger) throws SSLException {
+        final Bootstrap b = new Bootstrap();
+        b.group(clientWorkerGroup);
+        b.channel(NioSocketChannel.class);
+        b.option(ChannelOption.SO_KEEPALIVE, true);
+        b.remoteAddress(host, port);
+        b.handler(new Http2ClientFrameInitializer(sslCtx, frameLogger));
+
+        // Start the client.
+        channel = b.connect().syncUninterruptibly().channel();
+        // just don't worry about memory leaks at all
+        channel.config().setAllocator(UnpooledByteBufAllocator.DEFAULT);
+    }
+
+    public Channel channel() {
+        return channel;
+    }
+
+    public Http2Stream createStream() {
+        try {
+            return new Http2Stream(channel);
+        } catch (SSLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        channel.close().syncUninterruptibly();
+        clientWorkerGroup.shutdownGracefully();
+    }
+
+    public static class Http2Stream implements SafeCloseable {
+
+        private final Http2StreamChannel streamChannel;
+        private final HttpFrameAggregator aggregator = new HttpFrameAggregator();
+
+        Http2Stream(Channel channel) throws SSLException {
+            final Http2StreamChannelBootstrap streamChannelBootstrap = new Http2StreamChannelBootstrap(channel);
+            streamChannel = streamChannelBootstrap.open().syncUninterruptibly().getNow();
+            streamChannel.pipeline().addLast(aggregator);
+        }
+
+        public Http2FrameStream frameStream() {
+            return streamChannel.stream();
+        }
+
+        public boolean isOpen() {
+            final State state = frameStream().state();
+            return state.localSideOpen() || state.remoteSideOpen();
+        }
+
+        public boolean isEmpty() {
+            return aggregator.frames().isEmpty();
+        }
+
+        public ChannelFuture sendFrame(Http2StreamFrame frame) {
+            return streamChannel.writeAndFlush(frame);
+        }
+
+        public Http2Frame take() {
+            try {
+                return aggregator.frames().take();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void close() {
+            aggregator.close();
+            streamChannel.close();
+        }
+    }
+}

--- a/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/package-info.java
+++ b/testing-internal/src/main/java/com/linecorp/armeria/internal/testing/netty/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Common testing utilities.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.testing.netty;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;


### PR DESCRIPTION
Motivation:

The PR #6166 modified server-side behavior to send a `RST_STREAM` frame when the corresponding Armeria's `HttpRequest` and `HttpResponse` are completed. The assumption was that since the user was done using the `HttpRequest` and `HttpResponse`, the underlying stream can be cleaned up.

https://github.com/line/armeria/blob/a4bcb3e3b2a90a41b0066601d97da2fb04af5347/core/src/main/java/com/linecorp/armeria/server/ServerHttp2ObjectEncoder.java#L146-L149

The code was written to check Netty's `Http2Stream` before sending a `RST_STREAM` - this is because sending a `endStream` would close the underlying stream anyways regardless of whether a `RST_STREAM` is sent.

However, when frames are flow controlled, `Http2Stream`'s state is updated after armeria's post-response future is invoked. To be more specific, it seems like Netty's implementation updates the state by adding a listener on the `write*` future when the flow controlled frame is completed.
This is awkward because Armeria also completes the `HttpResponse` when a write future with `endStream` is completed.

1. Armeria layer: Write `endStream` and wait on the write future before invoking `res.close`

https://github.com/line/armeria/blob/a4bcb3e3b2a90a41b0066601d97da2fb04af5347/core/src/main/java/com/linecorp/armeria/server/AbstractHttpResponseSubscriber.java#L397-L417

2. `RequestAndResponseCompleteHandler` is completed

https://github.com/line/armeria/blob/a4bcb3e3b2a90a41b0066601d97da2fb04af5347/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java#L847-L848

4. `Http2Stream.state` is updated (the future is invoked after Armeria's)

https://github.com/netty/netty/blob/a919dd3a53a50da080dc925a6fb085c81cab6294/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java#L629

Note that there is no issue when receiving requests since the state is updated before the `Http2FrameListener` is invoked.

i.e. https://github.com/netty/netty/blob/a919dd3a53a50da080dc925a6fb085c81cab6294/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java#L257

I propose that we track a separate state which determines whether an `endStream` was sent. This value can be used to determine whether a separate `RST_STREAM` should be sent to close the underlying stream.

Modifications:

- Added a `endStreamSentKey` property key which indicates whether an `endStream` was sent for a `Http2Stream`.
- Check if `endStreamSentKey` was set when determining whether `RST_STREAM` should be used to clean up the underlying stream.
  - To determine if the local side (server->client) is open, both `Http2Stream.State.localSideOpen() == true` and `endStreamSentKey == false` must be satisfied.
  - If the remote is open (client->server), then the `RST_STREAM` is sent regardless.
- For client-side, a late `RST_STREAM` is always logged if the response is closed. If the stream is active, then the `RST_STREAM` was sent to close the stream and hence there is no need to log with WARN level.
- Added `SimpleHttp2Connection` to easily send and receive HTTP2 frames directly from test code

Result:

- An unecessary `RST_STREAM` is not sent after the server sends an `endStream`.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
