### PR TITLE
Add Implement JsonRpcService

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/AbstractJsonRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/AbstractJsonRpcResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * The base for {@link SimpleJsonResponse} and {@link DefaultJsonRpcResponse} microbenchmarks.
+ */
+@UnstableApi
+public abstract class AbstractJsonRpcResponse implements JsonRpcResponse {
+    private final Object result;
+    private final JsonRpcError error;
+
+    /**
+    * Creates a new instance with result.
+    */
+    public AbstractJsonRpcResponse(Object result) {
+        this.result = requireNonNull(result, "result");
+        this.error = null;
+    }
+
+    /**
+    * Creates a new instance with error.
+    */
+    public AbstractJsonRpcResponse(JsonRpcError error) {
+        this.result = null;
+        this.error = error;
+    }
+
+    @Override
+    @JsonProperty
+    public final @Nullable Object result() {
+        return result;
+    }
+
+    @Override
+    @JsonProperty
+    public final @Nullable JsonRpcError error() {
+        return error;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/DefaultJsonRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/DefaultJsonRpcRequest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Default {@link JsonRpcRequest} implementation.
+ */
+@UnstableApi
+final class DefaultJsonRpcRequest implements JsonRpcRequest {
+    private final Object id;
+    private final String method;
+    private final List<Object> params;
+    private final String version;
+
+    DefaultJsonRpcRequest(@Nullable Object id, String method, Iterable<?> params) {
+        this(id, method, copyParams(params), JsonRpcConstants.JSON_RPC_VERSION);
+    }
+
+    DefaultJsonRpcRequest(@Nullable Object id, String method, Object... params) {
+        this(id, method, copyParams(params), JsonRpcConstants.JSON_RPC_VERSION);
+    }
+
+    @JsonCreator
+    private DefaultJsonRpcRequest(
+            @JsonProperty("id") @Nullable Object id,
+            @JsonProperty("method") String method,
+            @JsonProperty("params") @Nullable List<Object> params,
+            @JsonProperty("jsonrpc") String version) {
+        checkArgument(JsonRpcConstants.JSON_RPC_VERSION.equals(version),
+            "jsonrpc: %s (expected: 2.0)", version);
+        checkArgument(id == null || id instanceof Number || id instanceof String,
+            "id type: %s (expected: Null or Number or String)",
+            Optional.ofNullable(id).map(Object::getClass).orElse(null));
+
+        this.id = id;
+        this.method = requireNonNull(method, "method");
+        this.params = params == null ? ImmutableList.of() : params;
+        this.version = version;
+    }
+
+    private static List<Object> copyParams(Iterable<?> params) {
+        requireNonNull(params, "params");
+        if (params instanceof ImmutableList) {
+            //noinspection unchecked
+            return (List<Object>) params;
+        }
+        return ImmutableList.copyOf(params);
+    }
+
+    private static List<Object> copyParams(Object... params) {
+        return copyParams(() -> Arrays.stream(params).iterator());
+    }
+
+    @Override
+    public @Nullable Object id() {
+        return id;
+    }
+
+    @Override
+    public String method() {
+        return method;
+    }
+
+    @Override
+    public List<Object> params() {
+        return params;
+    }
+
+    @Override
+    public String version() {
+        return version;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, method, params);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof JsonRpcRequest)) {
+            return false;
+        }
+
+        final JsonRpcRequest that = (JsonRpcRequest) obj;
+        return Objects.equals(id, that.id()) &&
+               Objects.equals(method, that.method()) &&
+               Objects.equals(params, that.params());
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("id", id())
+                          .add("method", method())
+                          .add("params", params())
+                          .add("jsonrpc", version()).toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcConstants.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * JSON-RPC constants.
+ */
+@UnstableApi
+public final class JsonRpcConstants {
+    public static final String JSON_RPC_VERSION = "2.0";
+
+    private JsonRpcConstants() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcError.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcError.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * A JSON-RPC 2.0 error object.
+ */
+@UnstableApi
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class JsonRpcError {
+
+    /**
+     * Invalid Request (-32600).
+     * The JSON sent is not a valid Request object.
+     */
+    public static final JsonRpcError INVALID_REQUEST = new JsonRpcError(-32600, "Invalid Request");
+
+    /**
+     * Method not found (-32601).
+     * The method does not exist / is not available.
+     */
+    public static final JsonRpcError METHOD_NOT_FOUND = new JsonRpcError(-32601, "Method not found");
+
+    /**
+     * Invalid params (-32602).
+     * Invalid method parameter(s).
+     */
+    public static final JsonRpcError INVALID_PARAMS = new JsonRpcError(-32602, "Invalid params");
+
+    /**
+     * Internal error (-32603).
+     * Internal JSON-RPC error.
+     */
+    public static final JsonRpcError INTERNAL_ERROR = new JsonRpcError(-32603, "Internal error");
+
+    /**
+     * Parse error (-32700).
+     * Invalid JSON was received by the server.
+     * An error occurred on the server while parsing the JSON text.
+     */
+    public static final JsonRpcError PARSE_ERROR = new JsonRpcError(-32700, "Parse error");
+
+    private final int code;
+    private final String message;
+    @Nullable
+    private final Object data;
+
+    /**
+     * Creates a new instance with the specified code, message, and optional data.
+     */
+    @JsonCreator
+    public JsonRpcError(@JsonProperty("code") int code,
+            @JsonProperty("message") String message,
+            @JsonProperty("data") @Nullable Object data) {
+        this.code = code;
+        this.message = requireNonNull(message, "message");
+        this.data = data;
+    }
+
+    /**
+     * Creates a new instance with the specified code and message, and no additional data.
+     */
+    public JsonRpcError(int code, String message) {
+        this(code, requireNonNull(message, "message"), null);
+    }
+
+    /**
+     * Creates a new {@link JsonRpcError} instance with the same code and message as this instance.
+     */
+    public JsonRpcError withData(@Nullable Object data) {
+        if (data == null) {
+            return this;
+        }
+
+        return new JsonRpcError(this.code, this.message, data);
+    }
+
+    /**
+     * Returns the error code.
+     */
+    @JsonProperty
+    public int code() {
+        return code;
+    }
+
+    /**
+     * Returns the error message.
+     */
+    @JsonProperty
+    public String message() {
+        return message;
+    }
+
+    /**
+     * Returns the optional, application-defined data.
+     */
+    @JsonProperty
+    @Nullable
+    public Object data() {
+        return data;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcRequest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.internal.common.JacksonUtil;
+
+/**
+ * A Json-RPC request.
+ */
+@UnstableApi
+public interface JsonRpcRequest {
+    /**
+    * Creates a new instance with no parameter.
+    */
+    static JsonRpcRequest of(@Nullable Object id, String method) {
+        return new DefaultJsonRpcRequest(id, method, ImmutableList.of());
+    }
+
+    /**
+     * Creates a new instance with a single parameter.
+     */
+    static JsonRpcRequest of(@Nullable Object id, String method, @Nullable Object parameter) {
+        final List<Object> parameters = parameter == null ? ImmutableList.of()
+                                                          : ImmutableList.of(parameter);
+        return new DefaultJsonRpcRequest(id, method, parameters);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static JsonRpcRequest of(@Nullable Object id, String method, Iterable<?> params) {
+        requireNonNull(params, "params");
+        return of(id, method, params);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    static JsonRpcRequest of(@Nullable Object id, String method, Object... params) {
+        requireNonNull(params, "params");
+        return new DefaultJsonRpcRequest(id, method, params);
+    }
+
+    /**
+    * Creates a new instance with a JsonNode.
+    */
+    static JsonRpcRequest of(JsonNode node) throws JsonProcessingException {
+        requireNonNull(node, "node");
+        checkArgument(node.isObject(), "node.isObject(): %s (expected: true)", node.isObject());
+        return JacksonUtil.newDefaultObjectMapper().treeToValue(node, DefaultJsonRpcRequest.class);
+    }
+
+    /**
+    * Returns the ID of the JSON-RPC request.
+    * type must be Number or String
+    */
+    @Nullable
+    Object id();
+
+    /**
+     * Returns the JSON-RPC method name.
+     */
+    String method();
+
+    /**
+     * Returns the parameters for the JSON-RPC method.
+     */
+    List<Object> params();
+
+    /**
+     * Returns the JSON-RPC version.
+     */
+    String version();
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/JsonRpcResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * A Json-RPC.
+ */
+@UnstableApi
+public interface JsonRpcResponse {
+    /**
+    * Creates a new instance with result.
+    */
+    static JsonRpcResponse of(Object result) {
+        return new SimpleJsonResponse(result);
+    }
+
+    /**
+    * Creates a new instance with error.
+    */
+    static JsonRpcResponse of(JsonRpcError error) {
+        return new SimpleJsonResponse(error);
+    }
+
+    /**
+     * Returns the JSON-RPC result.
+     */
+    @Nullable
+    Object result();
+
+    /**
+    * Returns the JSON-RPC error.
+    */
+    @Nullable
+    JsonRpcError error();
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/SimpleJsonResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/SimpleJsonResponse.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.common.jsonrpc;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+@UnstableApi
+final class SimpleJsonResponse extends AbstractJsonRpcResponse {
+    SimpleJsonResponse(Object result) {
+        super(result);
+    }
+
+    SimpleJsonResponse(JsonRpcError error) {
+        super(error);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/jsonrpc/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/common/jsonrpc/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+* Common classes for <a href="https://www.jsonrpc.org/specification">the JSON-RPC</a>.
+*/
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.common.jsonrpc;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/core/src/main/java/com/linecorp/armeria/server/jsonrpc/DefaultJsonRpcResponse.java
+++ b/core/src/main/java/com/linecorp/armeria/server/jsonrpc/DefaultJsonRpcResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.jsonrpc.AbstractJsonRpcResponse;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcConstants;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcError;
+
+@UnstableApi
+@JsonInclude(JsonInclude.Include.NON_NULL)
+final class DefaultJsonRpcResponse extends AbstractJsonRpcResponse {
+    private final Object id;
+
+    DefaultJsonRpcResponse(Object id, Object result) {
+        super(result);
+        this.id = requireNonNull(id, "id");
+    }
+
+    DefaultJsonRpcResponse(@Nullable Object id, JsonRpcError error) {
+        super(error);
+        this.id = id;
+    }
+
+    @JsonProperty
+    public @Nullable Object id() {
+        return id;
+    }
+
+    @JsonProperty("jsonrpc")
+    public String version() {
+        return JsonRpcConstants.JSON_RPC_VERSION;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.jsonrpc;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcRequest;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcResponse;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+/**
+ * Implement this interface to handle incoming {@link JsonRpcRequest}.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface JsonRpcHandler {
+    /**
+    * Handles the incoming {@link JsonRpcRequest} and returns {@link JsonRpcResponse}.
+    */
+    CompletableFuture<JsonRpcResponse> handle(ServiceRequestContext ctx, JsonRpcRequest request);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcService.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcError;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcRequest;
+import com.linecorp.armeria.common.jsonrpc.JsonRpcResponse;
+import com.linecorp.armeria.common.sse.ServerSentEvent;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.internal.common.JacksonUtil;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.streaming.ServerSentEvents;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * A JSON-RPC {@link HttpService}.
+ */
+@UnstableApi
+public final class JsonRpcService implements HttpService {
+    private static final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
+
+    private final boolean shouldUseSse;
+    private final Map<String, JsonRpcHandler> methodHandlers;
+
+    /**
+    * Returns a new {@link JsonRpcServiceBuilder}.
+    */
+    public static JsonRpcServiceBuilder builder() {
+        return new JsonRpcServiceBuilder();
+    }
+
+    JsonRpcService(boolean shouldUseSse, Map<String, JsonRpcHandler> methodHandlers) {
+        this.shouldUseSse = shouldUseSse;
+        this.methodHandlers = requireNonNull(methodHandlers, "methodHandlers");
+    }
+
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+        return HttpResponse.of(
+            req.aggregate()
+               .thenApply(JsonRpcService::parseRequestContentAsJson)
+               .thenApply(json -> dispatchRequest(ctx, json))
+               .exceptionally(e -> {
+                    if (e.getCause() instanceof JsonProcessingException) {
+                        return HttpResponse.ofJson(HttpStatus.BAD_REQUEST, "Invalid JSON format");
+                    }
+                    return HttpResponse.ofFailure(e);
+                })
+            );
+    }
+
+    private static JsonNode parseRequestContentAsJson(AggregatedHttpRequest request) {
+        try {
+            return mapper.readTree(request.contentUtf8());
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private HttpResponse dispatchRequest(ServiceRequestContext ctx, JsonNode rawRequest) {
+        if (rawRequest.isObject()) {
+            return handleUnaryRequest(ctx, rawRequest);
+        } else if (rawRequest.isArray()) {
+            return handleBatchRequests(ctx, rawRequest);
+        } else {
+            // If the request is neither an object nor an array, return an error response.
+            return HttpResponse.ofJson(HttpStatus.BAD_REQUEST, "Invalid JSON-RPC request format.");
+        }
+    }
+
+    private HttpResponse handleUnaryRequest(ServiceRequestContext ctx, JsonNode unary) {
+        return HttpResponse.of(
+            executeRpcCall(ctx, unary)
+                .thenApply(HttpResponse::ofJson));
+    }
+
+    private HttpResponse handleBatchRequests(ServiceRequestContext ctx, JsonNode batch) {
+        final List<CompletableFuture<DefaultJsonRpcResponse>> requests =
+            StreamSupport.stream(batch.spliterator(), false)
+                         .map(item -> executeRpcCall(ctx, item))
+                         .toList();
+
+        if (shouldUseSse) {
+            return ServerSentEvents.fromPublisher(
+                Flux.create(sink -> {
+                    requests.forEach(item -> item.thenApply(JsonRpcService::toServerSentEvent)
+                                                 .thenAccept(sse -> {
+                                                        if (sse != null) {
+                                                            sink.next(sse);
+                                                        }
+                                                    }));
+
+                    CompletableFuture.allOf(requests.toArray(CompletableFuture[]::new))
+                                     .thenAccept(a -> sink.complete());
+                }));
+        } else {
+            return HttpResponse.of(
+                CompletableFuture.allOf(requests.toArray(CompletableFuture[]::new))
+                                 .thenApply(v -> requests.stream()
+                                                         .map(req -> req.join())
+                                                         .filter(x -> x != null)
+                                                         .toList())
+                                 .thenApply(HttpResponse::ofJson));
+        }
+    }
+
+    private CompletableFuture<DefaultJsonRpcResponse> executeRpcCall(ServiceRequestContext ctx, JsonNode node) {
+        return UnmodifiableFuture.completedFuture(node)
+                .thenApply(JsonRpcService::parseNodeAsRpcRequest)
+                .thenApply(req -> invokeMethod(ctx, req))
+                .exceptionally(e -> {
+                    if (e instanceof IllegalArgumentException) {
+                        return new DefaultJsonRpcResponse(null, JsonRpcError.PARSE_ERROR);
+                    }
+                    return new DefaultJsonRpcResponse(null, JsonRpcError.INTERNAL_ERROR.withData(e));
+                });
+    }
+
+    private static JsonRpcRequest parseNodeAsRpcRequest(JsonNode node) {
+        try {
+            return JsonRpcRequest.of(node);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private DefaultJsonRpcResponse invokeMethod(ServiceRequestContext ctx, JsonRpcRequest req) {
+        final JsonRpcHandler handler = methodHandlers.get(req.method());
+        if (handler == null) {
+            return new DefaultJsonRpcResponse(req.id(), JsonRpcError.METHOD_NOT_FOUND);
+        }
+        return handler.handle(ctx, req)
+                .thenApply(res -> buildFinalResponse(req, res))
+                .join();
+    }
+
+    private DefaultJsonRpcResponse buildFinalResponse(JsonRpcRequest request, JsonRpcResponse response) {
+        if (response instanceof DefaultJsonRpcResponse) {
+            return (DefaultJsonRpcResponse) response;
+        }
+
+        if (response.result() != null && response.error() == null) {
+            return new DefaultJsonRpcResponse(request.id(), response.result());
+        }
+        if (response.error() != null && response.result() == null) {
+            return new DefaultJsonRpcResponse(request.id(), response.error());
+        }
+        return null;
+    }
+
+    private static ServerSentEvent toServerSentEvent(DefaultJsonRpcResponse response) {
+        try {
+            return ServerSentEvent.ofData(mapper.writeValueAsString(response));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/jsonrpc/JsonRpcServiceBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.jsonrpc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Constructs a {@link JsonRpcService} to serve Json-RPC services from within Armeria.
+ */
+@UnstableApi
+public class JsonRpcServiceBuilder {
+    private Map<String, JsonRpcHandler> methodHandlers = new HashMap<>();
+    private boolean useSse;
+
+    JsonRpcServiceBuilder() {}
+
+    /**
+    * Adds a Json-RPC {@link JsonRpcHandler} to this {@link JsonRpcServiceBuilder}.
+    */
+    public JsonRpcServiceBuilder addHandler(String methodName, JsonRpcHandler handler) {
+        methodHandlers.put(methodName, handler);
+        return this;
+    }
+
+    /**
+     * Use Sever-Sent Event (SSE) to send batched responses.
+     */
+    public JsonRpcServiceBuilder useSse(boolean useSse) {
+        this.useSse = useSse;
+        return this;
+    }
+
+    /**
+     * Constructs a new {@link JsonRpcService}.
+     */
+    public JsonRpcService build() {
+        return new JsonRpcService(useSse, methodHandlers);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/jsonrpc/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/server/jsonrpc/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+* Server-side classes for <a href="https://www.jsonrpc.org/specification">the JSON-RPC</a>.
+*/
+@UnstableApi
+@NonNullByDefault
+package com.linecorp.armeria.server.jsonrpc;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;


### PR DESCRIPTION
Related:

- #6286 
- #6222

Motivation:

- Json RPC implementation must precede to implement the MCP mentioned in #6179  

Modifications:

- Add Implement JsonRpcService

Result:

- Closes #6286 
