### PR TITLE
Emit Netty event loop metrics provided by MicroMeter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,6 +270,7 @@ configure(projectsWithFlags('java')) {
         testRuntimeOnly libs.checkerframework // Required by guava-testlib
         testImplementation libs.assertj
         testImplementation libs.mockito
+        testImplementation libs.mockito.inline
         testImplementation libs.apache.httpclient5
         testImplementation libs.hamcrest
         testImplementation libs.hamcrest.library

--- a/core/src/main/java/com/linecorp/armeria/common/metric/EventLoopMetrics.java
+++ b/core/src/main/java/com/linecorp/armeria/common/metric/EventLoopMetrics.java
@@ -98,6 +98,7 @@ public final class EventLoopMetrics extends AbstractCloseableMeterBinder {
             return result;
         }
 
+        @Deprecated // use the same metric with micrometer namespace instead
         double pendingTasks() {
             int result = 0;
             for (EventLoopGroup group : registry) {

--- a/core/src/test/java/com/linecorp/armeria/common/CommonPoolsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/CommonPoolsTest.java
@@ -1,0 +1,35 @@
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import com.linecorp.armeria.common.util.EventLoopGroups;
+
+import io.micrometer.core.instrument.binder.netty4.NettyEventExecutorMetrics;
+import io.netty.channel.EventLoopGroup;
+
+public class CommonPoolsTest {
+    @Test
+    public void testEventLoopMetricsBinding() throws Exception {
+        final EventLoopGroup testGroup = EventLoopGroups.newEventLoopGroup(1);
+
+        try {
+            try (MockedConstruction<NettyEventExecutorMetrics> microMeterEventloopMetrics =
+                         Mockito.mockConstruction(NettyEventExecutorMetrics.class)) {
+                CommonPools.bindEventLoopMetricsForWorkerGroup(testGroup);
+
+                assertThat(microMeterEventloopMetrics.constructed().isEmpty()).isFalse();
+
+                final NettyEventExecutorMetrics instance = microMeterEventloopMetrics.constructed().get(0);
+                verify(instance).bindTo(any());
+            }
+        } finally {
+            testGroup.shutdownNow();
+        }
+    }
+}

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -919,6 +919,9 @@ version.ref = "mockito"
 [libraries.mockito-junit-jupiter]
 module = "org.mockito:mockito-junit-jupiter"
 version.ref = "mockito"
+[libraries.mockito-inline]
+module = "org.mockito:mockito-inline"
+version.ref = "mockito"
 
 [libraries.monix-reactive_v212]
 module = "io.monix:monix-reactive_2.12"


### PR DESCRIPTION
Motivation:

Use Micrometer out-of-the-box provided netty metrics.

Modifications:

- Micrometer's MeterBinder for Netty event loops is registered when CommonPools is created.
- Added a unit test to verify registration of the above MeterBinder
- Added a mockito inline dependency for mocking final, static etc.

Result:

- Closes #6274
- User should see new metrics with name `netty.eventexecutor.tasks.pending`
