### PR TITLE
Fix flaky test in WebSocketServiceHttp2RequestCompleteTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHttp2RequestCompleteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHttp2RequestCompleteTest.java
@@ -112,7 +112,7 @@ class WebSocketServiceHttp2RequestCompleteTest {
                                                  .requestAutoAbortDelayMillis(Long.MAX_VALUE)
                                                  .build()
                                                  .execute(requestWriter).split();
-        split.headers().thenAccept(headers -> assertThat(headers.status()).isSameAs(HttpStatus.OK));
+        assertThat(split.headers().join().status()).isSameAs(HttpStatus.OK);
         split.body().subscribe(bodySubscriber);
 
         final ServiceRequestContext sctx = server.requestContextCaptor().take();


### PR DESCRIPTION
Motivation:
The test calls `updateRequest` on the client with an arbitrary request because the client closes the request upon receiving a response from the server, which triggers the WebSocket close frame. However, there's a race condition: `updateRequest` can be invoked after the client has already closed the request, leading to test failures. See:
https://github.com/line/armeria/blob/b78d9515dc8b4b997dd65787f717443b38a21869/core/src/test/java/com/linecorp/armeria/server/websocket/WebSocketServiceHttp2RequestCompleteTest.java#L117

Result:
- Close #6156
- Close #6215
