### PR TITLE
Add support for Thrift 0.22.0

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -168,6 +168,7 @@ thrift018 = { strictly = "0.18.1" }
 thrift019 = { strictly = "0.19.0" }
 thrift020 = { strictly = "0.20.0" }
 thrift021 = { strictly = "0.21.0" }
+thrift022 = { strictly = "0.22.0" }
 tomcat8 = "8.5.100"
 tomcat9 = "9.0.96"
 tomcat10 = "10.1.31"
@@ -1385,6 +1386,14 @@ exclusions = [
 module = "org.apache.thrift:libthrift"
 version.ref = "thrift021"
 javadocs = "https://www.javadoc.io/doc/org.apache.thrift/libthrift/0.21.0/"
+exclusions = [
+    "javax.annotation:javax.annotation-api",
+    "org.apache.httpcomponents:httpcore",
+    "org.apache.httpcomponents:httpclient"]
+[libraries.thrift022]
+module = "org.apache.thrift:libthrift"
+version.ref = "thrift022"
+javadocs = "https://www.javadoc.io/doc/org.apache.thrift/libthrift/0.22.0/"
 exclusions = [
     "javax.annotation:javax.annotation-api",
     "org.apache.httpcomponents:httpcore",

--- a/settings.gradle
+++ b/settings.gradle
@@ -189,6 +189,8 @@ includeWithFlags ':thrift0.20',                          'java11', 'publish', 'r
 project(':thrift0.20').projectDir = file('thrift/thrift0.20')
 includeWithFlags ':thrift0.21',                          'java11', 'publish', 'relocate', 'no_aggregation', 'native'
 project(':thrift0.21').projectDir = file('thrift/thrift0.21')
+includeWithFlags ':thrift0.22',                          'java11', 'publish', 'relocate', 'no_aggregation', 'native'
+project(':thrift0.22').projectDir = file('thrift/thrift0.22')
 includeWithFlags ':tomcat8',                             'java', 'publish', 'relocate', 'no_aggregation'
 includeWithFlags ':tomcat9',                             'java', 'publish', 'relocate', 'no_aggregation'
 includeWithFlags ':tomcat10',                            'java11', 'publish', 'relocate'

--- a/thrift/thrift0.22/build.gradle
+++ b/thrift/thrift0.22/build.gradle
@@ -1,0 +1,102 @@
+// This module builds and publishes 'armeria-thrift0.22', which is compiled with
+// the source code of ':thrift0.13', ':thrift0.14.0', ':thrift0.21.0'.
+
+dependencies {
+    api libs.thrift022
+
+    api libs.javax.annotation
+
+    testImplementation project(':prometheus1')
+
+    // thrift api depends on httpclient5
+    testImplementation libs.apache.httpclient5
+
+    // Jetty, for testing TServlet interoperability.
+    testImplementation libs.jetty11.webapp
+    testImplementation libs.jetty11.http2.server
+
+    // Dropwizard and Prometheus, for testing metrics integration
+    testImplementation libs.dropwizard.metrics.core
+    testImplementation libs.prometheus.metrics.exposition.formats
+
+    // micrometer tracing
+    testImplementation (libs.micrometer.tracing.integration.test) {
+        exclude group: "org.mockito"
+    }
+    testImplementation libs.brave6.instrumentation.http.tests
+    testImplementation libs.logback14
+}
+
+// Use the sources from ':thrift0.13', ':thrift0.14', and ':thrift0.21'.
+// Some modules are empty so no need to copy anything.
+// NB: We should never add these directories using the 'sourceSets' directive because that will make
+//     them added to more than one project and having a source directory with more than one output directory
+//     will confuse IDEs such as IntelliJ IDEA.
+def thrift013ProjectDir = "${rootProject.projectDir}/thrift/thrift0.13"
+def thrift014ProjectDir = "${rootProject.projectDir}/thrift/thrift0.14"
+def thrift017ProjectDir = "${rootProject.projectDir}/thrift/thrift0.17"
+def thrift018ProjectDir = "${rootProject.projectDir}/thrift/thrift0.18"
+def thrift019ProjectDir = "${rootProject.projectDir}/thrift/thrift0.19"
+def thrift021ProjectDir = "${rootProject.projectDir}/thrift/thrift0.21"
+
+// Copy common files from ':thrift0.13', ':thrift0.14', and ':thrift0.21' to gen-src directory
+// in order to use them as a source set.
+task generateSources(type: Copy) {
+    from("${thrift013ProjectDir}/src/main/java") {
+        exclude '**/TByteBufTransport.java'
+        exclude '**/ThriftCallService.java'
+        exclude '**/ThriftFunction.java'
+        exclude '**/ThriftServiceMetadata.java'
+        exclude '**/common/thrift/package-info.java'
+        exclude '**/server/thrift/package-info.java'
+    }
+    from("${thrift014ProjectDir}/src/main/java") {
+        exclude '**/internal/common/thrift/package-info.java'
+    }
+    from "${thrift021ProjectDir}/src/main/java"
+    into "${project.ext.genSrcDir}/main/java"
+}
+
+task generateTestSources(type: Copy) {
+    from("${thrift013ProjectDir}/src/test/java") {
+        exclude '**/THttp2Client.java'
+        exclude '**/ThriftDocServicePluginTest.java'
+        exclude '**/ApacheClientUtils.java'
+        exclude '**/ServletTestUtils.java'
+    }
+    from "${thrift014ProjectDir}/src/test/java"
+    from "${thrift017ProjectDir}/src/test/java"
+    from "${thrift018ProjectDir}/src/test/java"
+    from "${thrift019ProjectDir}/src/test/java"
+    into "${project.ext.genSrcDir}/test/java"
+}
+
+def thriftFullVersion = libs.thrift022.get().versionConstraint.requiredVersion
+ext {
+    thriftVersion = thriftFullVersion.substring(0, thriftFullVersion.lastIndexOf('.'));
+    testThriftSrcDirs = ["$thrift013ProjectDir/src/test/thrift", "$projectDir/src/test/thrift",
+                         "$thrift018ProjectDir/src/test/thrift"]
+}
+
+tasks.generateSources.dependsOn(generateTestSources)
+tasks.compileJava.dependsOn(generateSources)
+tasks.compileTestJava.dependsOn(generateSources)
+
+tasks.processResources.from("${thrift013ProjectDir}/src/main/resources") {
+    exclude '**/thrift-options.properties'
+}
+tasks.processTestResources.from "${thrift013ProjectDir}/src/test/resources"
+tasks.sourcesJar.from "${thrift013ProjectDir}/src/main/resources"
+
+// Keep the original Guava references in ThriftListenableFuture,
+// which is the only place we expose Guava classes in our public API.
+// NB: Keep this same with ':thrift0.13'.
+tasks.shadedJar.exclude 'com/linecorp/armeria/common/thrift/ThriftListenableFuture*'
+tasks.shadedJar.doLast {
+    ant.jar(update: true, destfile: tasks.shadedJar.archiveFile.get().asFile) {
+        sourceSets.main.output.classesDirs.each { classesDir ->
+            fileset(dir: "$classesDir",
+                    includes: 'com/linecorp/armeria/common/thrift/ThriftListenableFuture*')
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

This PR is a follow-up to #6254, and adds support for Thrift 0.22.

Modifications:

- Added the `thrift0.22` module, using the same setup as `thrift0.21`

Result:

- Armeria supports Thrift 0.22.0