### PR TITLE
Fix bugs when validating xDS filter configuration

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -620,6 +620,8 @@ javadocs = "https://fasterxml.github.io/jackson-modules-java8/javadoc/datatypes/
 [libraries.jackson-datatype-jsr310]
 module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 javadocs = "https://fasterxml.github.io/jackson-modules-java8/javadoc/datetime/2.14/"
+[libraries.jackson-dataformat-yaml]
+module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
 [libraries.jackson-kotlin]
 module = "com.fasterxml.jackson.module:jackson-module-kotlin"
 [libraries.jackson-scala_v212]

--- a/it/xds-client/build.gradle
+++ b/it/xds-client/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    testImplementation project(':xds')
+    testImplementation libs.jackson.dataformat.yaml
+    testImplementation libs.protobuf.java.util
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/EndpointCollectingDecorator.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/EndpointCollectingDecorator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingHttpClientFunction;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+
+final class EndpointCollectingDecorator implements DecoratingHttpClientFunction {
+
+    private final BlockingQueue<Endpoint> endpointsQueue = new LinkedBlockingQueue<>();
+
+    BlockingQueue<Endpoint> endpointsQueue() {
+        return endpointsQueue;
+    }
+
+    @Override
+    public HttpResponse execute(HttpClient delegate, ClientRequestContext ctx, HttpRequest req)
+            throws Exception {
+        final Endpoint endpoint = ctx.endpoint();
+        if (endpoint == null) {
+            return HttpResponse.of(400);
+        }
+        endpointsQueue.add(endpoint);
+        return HttpResponse.of(200);
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RoutingTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RoutingTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+
+class RoutingTest {
+
+    @Test
+    void basicCase() {
+        final String bootstrap =
+                """
+                static_resources:
+                  listeners:
+                  - name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                .v3.HttpConnectionManager
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: "/"
+                                route:
+                                  cluster: my-cluster1
+                        http_filters:
+                        - name: envoy.filters.http.router
+                  clusters:
+                  - name: my-cluster1
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: my-cluster1
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8081
+                """;
+        final EndpointCollectingDecorator collector = new EndpointCollectingDecorator();
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(bootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final AggregatedHttpResponse res =
+                    WebClient.builder(preprocessor).decorator(collector).build()
+                             .blocking().get("/");
+            assertThat(res.status().code()).isEqualTo(200);
+            assertThat(collector.endpointsQueue()).hasSize(1);
+            final Endpoint endpoint = collector.endpointsQueue().poll();
+            assertThat(endpoint.port()).isEqualTo(8081);
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsResourceReader.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsResourceReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.Parser;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
+
+public final class XdsResourceReader {
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private static final Parser parser =
+            JsonFormat.parser().usingTypeRegistry(TypeRegistry.newBuilder()
+                                                              .add(HttpConnectionManager.getDescriptor())
+                                                              .add(Router.getDescriptor())
+                                                              .build());
+
+    public static Bootstrap fromYaml(String yaml) {
+        final Bootstrap.Builder bootstrapBuilder = Bootstrap.newBuilder();
+        try {
+            final JsonNode jsonNode = mapper.reader().readTree(yaml);
+            parser.merge(jsonNode.toString(), bootstrapBuilder);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return bootstrapBuilder.build();
+    }
+
+    private XdsResourceReader() {}
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -244,6 +244,7 @@ includeWithFlags ':it:thrift-fullcamel',                       'java', 'relocate
 includeWithFlags ':it:thrift0.9.1',                            'java', 'relocate'
 includeWithFlags ':it:trace-context-leak',                     'java', 'relocate'
 includeWithFlags ':it:websocket',                              'java11', 'relocate'
+includeWithFlags ':it:xds-client',                             'java17'
 includeWithFlags ':jetty9.3',                                  'java', 'relocate'
 project(':jetty9.3').projectDir = file('jetty/jetty9.3')
 includeWithFlags ':testing-internal',                          'java', 'relocate'

--- a/xds/src/main/java/com/linecorp/armeria/xds/ParsedFilterConfig.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ParsedFilterConfig.java
@@ -95,7 +95,11 @@ public final class ParsedFilterConfig {
         this.disabled = disabled;
     }
 
+    @Nullable
     private static <T extends Message> T maybeParseConfig(Any config, Class<? extends T> clazz) {
+        if (config == Any.getDefaultInstance()) {
+            return null;
+        }
         try {
             return config.unpack(clazz);
         } catch (InvalidProtocolBufferException e) {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
@@ -99,7 +99,8 @@ final class FilterUtil {
             }
             throw new IllegalArgumentException("Couldn't find filter factory: " + httpFilter.getName());
         }
-        checkArgument(httpFilter.getConfigTypeCase() == ConfigTypeCase.TYPED_CONFIG,
+        checkArgument(httpFilter.getConfigTypeCase() == ConfigTypeCase.TYPED_CONFIG ||
+                      httpFilter.getConfigTypeCase() == ConfigTypeCase.CONFIGTYPE_NOT_SET,
                       "Only 'typed_config' is supported, but '%s' was supplied",
                       httpFilter.getConfigTypeCase());
         return new DefaultXdsFilter<>(filterFactory, httpFilter, overrideConfigSupplier);

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
@@ -95,7 +95,7 @@ final class XdsEndpointUtil {
                 break;
             default:
                 throw new UnsupportedOperationException(
-                        "Cluster (" + cluster.getName() + ") is attempting to use an" +
+                        "Cluster (" + cluster.getName() + ") is attempting to use an " +
                         "unsupported cluster type: (" + cluster.getType() + "). " +
                         "Only (STATIC, STRICT_DNS, EDS) are supported.");
         }


### PR DESCRIPTION
Motivation:

After merging https://github.com/line/armeria/pull/6299, I found some bugs when the filter config is not specified.
In detail:
- If the filter config is not specified, `ConfigTypeCase.CONFIGTYPE_NOT_SET` may be set.
- The config passed may be a default `Any` type if not specified

The bugs were found while implementing an integration test

Modifications:

- Modified not to fail filter config parsing when `ConfigTypeCase.CONFIGTYPE_NOT_SET`
- Modified to return a null config if the default `Any` is specified

Result:

- Filters which do not specify a config send requests correctly

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
