### PR TITLE
feat: accept empty content body in HttpJsonTranscodingService

### DIFF
--- a/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/it/grpc/HttpJsonTranscodingTest.java
@@ -917,7 +917,7 @@ public class HttpJsonTranscodingTest {
     }
 
     @Test
-    void shouldDenyEmptyJson() {
+    void shouldAcceptEmptyJson() {
         final String emptyJson = "";
         final RequestHeaders headers = RequestHeaders.builder()
                                                      .method(HttpMethod.POST)
@@ -925,7 +925,19 @@ public class HttpJsonTranscodingTest {
                                                      .contentType(MediaType.JSON)
                                                      .build();
         final AggregatedHttpResponse response = webClient.execute(headers, emptyJson).aggregate().join();
-        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void shouldAcceptEmptyContentBody() {
+        final HttpData emptyContentBody = HttpData.empty();
+        final RequestHeaders headers = RequestHeaders.builder()
+                .method(HttpMethod.POST)
+                .path("/v1/echo/response_body/repeated")
+                .contentType(MediaType.JSON)
+                .build();
+        final AggregatedHttpResponse response = webClient.execute(headers, emptyContentBody).aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test


### PR DESCRIPTION
Motivation

HttpJsonTranscodingService currently fails with 400 Bad Request when handling a request with Content-Type: application/json and no body, even if the corresponding google.api.http rule uses body: "*". This behavior is inconsistent with common implementations such as Envoy and grpc-gateway, which treat empty bodies as {} in such cases.

⸻

Modifications

- **HttpJsonTranscodingService**
  - Added a fallback to use an empty JSON object when body empty ( content-length: 0 )
  - Treat **empty request bodies** as `{}` when **all** of the following are true:
    - **Content-Type**: `application/json`
    - **google.api.http rule**: `body: "*"`

⸻

Result

- Closes #6319.
- Users can now send requests with Content-Type: application/json and an empty body without receiving a 400 Bad Request error.
- Ensures better compatibility with gRPC transcoding conventions from other ecosystems