### PR TITLE
Bump Bouncy Castle to 1.81 and use `*-jdk18on`

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -8,7 +8,7 @@ asm = "9.7.1"
 assertj = "3.27.3"
 awaitility = "4.3.0"
 blockhound = "1.0.11.RELEASE"
-bouncycastle = "1.70"
+bouncycastle = "1.81"
 brave5 = "5.18.1"
 brave6 = "6.1.0"
 brotli4j = "1.18.0"
@@ -241,15 +241,15 @@ module = "io.projectreactor.tools:blockhound"
 version.ref = "blockhound"
 
 [libraries.bouncycastle-bcpkix]
-module = "org.bouncycastle:bcpkix-jdk15on"
+module = "org.bouncycastle:bcpkix-jdk18on"
 version.ref = "bouncycastle"
 relocations = { from = "org.bouncycastle", to = "com.linecorp.armeria.internal.shaded.bouncycastle" }
 [libraries.bouncycastle-bcprov]
-module = "org.bouncycastle:bcprov-jdk15on"
+module = "org.bouncycastle:bcprov-jdk18on"
 version.ref = "bouncycastle"
 relocations = { from = "org.bouncycastle", to = "com.linecorp.armeria.internal.shaded.bouncycastle" }
 [libraries.bouncycastle-bcutil]
-module = "org.bouncycastle:bcutil-jdk15on"
+module = "org.bouncycastle:bcutil-jdk18on"
 version.ref = "bouncycastle"
 relocations = { from = "org.bouncycastle", to = "com.linecorp.armeria.internal.shaded.bouncycastle" }
 

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -38,6 +38,17 @@ configure(relocatedProjects) {
         // Exclude the module metadata that'll become invalid after relocation.
         exclude '**/module-info.class'
 
+        // Exclude the MRJARs files that are not compatible with the target Java version.
+        exclude { details ->
+            def path = details.path  // e.g., META-INF/versions/15/com/example/Foo.class
+            def matcher = path =~ /^META-INF\/versions\/(\d+)\/.*$/
+            if (matcher.matches()) {
+                def version = matcher[0][1].toInteger()
+                return version > project.ext.targetJavaVersion
+            }
+            return false
+        }
+
         def shadowExclusions = []
         if (rootProject.hasProperty('shadowExclusions')) {
             shadowExclusions = rootProject.findProperty('shadowExclusions').split(",")


### PR DESCRIPTION
Motivation:

The new versions of Bouncy Castle for Java have been released under names ending with `*-jdk18on`. However, Armeria was still using `*-jdk15on` because the `dependencyUpdates` task could not detect the renamed artifacts.

Modifications:

- Bump Bouncy Castle version to 1.81 from 1.70
- Modified `java-shade.gradle` to exclude MRJAR files whose versions are higher than the target Java version.
  - Bouncy Castle MRJAR provides optimized implementations for Java 9, 11, 15 and so on.
  - As Bouncy Castle is shaded to the Armeria core module, class files for higher than Java 8 should be removed.

Result:

- Bouncy Castle: 1.70 -> 1.81
