### PR TITLE
Add option to force reload values in `AsyncLoader`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/AsyncLoader.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AsyncLoader.java
@@ -77,5 +77,14 @@ public interface AsyncLoader<T> {
      * Returns a {@link CompletableFuture} which will be completed with the loaded value.
      * A new value is fetched by the loader only if nothing is cached or the cache value has expired.
      */
-    CompletableFuture<T> load();
+    default CompletableFuture<T> load() {
+        return load(false);
+    }
+
+    /**
+     * Returns a {@link CompletableFuture} which will be completed with the loaded value.
+     * If {@code forceLoad} is {@code true}, a new value is always fetched by the loader.
+     * Otherwise, a new value is fetched only if nothing is cached or the cache value has expired.
+     */
+    CompletableFuture<T> load(boolean forceLoad);
 }

--- a/nacos/src/main/java/com/linecorp/armeria/internal/nacos/LoginClient.java
+++ b/nacos/src/main/java/com/linecorp/armeria/internal/nacos/LoginClient.java
@@ -57,6 +57,7 @@ final class LoginClient extends SimpleDecoratingHttpClient {
 
     private final AsyncLoader<LoginResult> tokenLoader =
             AsyncLoader.<LoginResult>builder(cache -> loginInternal())
+                       .name("nacos-login")
                        .expireIf(LoginResult::isExpired)
                        .build();
 


### PR DESCRIPTION
Motivation:

If `AsyncLoader` provides a way to load the cached value dynamically, we may flexibly respond to external changes. For example, if the certificates of Athenz changes, the cached OAuth2 keys need to be refreshed.

Modifications:

- Main change) Add `load(boolean forceLoad)` to `AsyncLoader` to fetch a new value from the given loader.
- Add `refreshAfterLoad()` option to `AsyncLoaderBuilder` to easily refresh a cached value after the load.
- `Add `name()` option to `AsyncLoaderBuilder`.
  - The name is used to a prefix when logging.
  - Cached values are excluded from the logging because they can be sensitive when used with a token client.

Result:

You can now focibliy refresh the cached value in `AsyncLoader`
