### PR TITLE
Disable BlockHound reporting for Kubernetes client testing

### DIFF
--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/KubernetesTestingBlockHoundIntegration.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/KubernetesTestingBlockHoundIntegration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes;
+
+import reactor.blockhound.BlockHound.Builder;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+public class KubernetesTestingBlockHoundIntegration implements BlockHoundIntegration {
+    @Override
+    public void applyTo(Builder builder) {
+        // TODO(ikhoon): Remove this once https://github.com/eclipse-vertx/vert.x/pull/5637 is released.
+        builder.allowBlockingCallsInside("io.netty.util.concurrent.FastThreadLocalRunnable", "run");
+    }
+}

--- a/kubernetes/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/kubernetes/src/test/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+com.linecorp.armeria.client.kubernetes.KubernetesTestingBlockHoundIntegration


### PR DESCRIPTION
Motivation:

It is inconvient and time-consuming to check all CI results due to the false-positive BlockHound reports. Therefore, I propose disabling BlockHound reporting until [the patched version](https://github.com/eclipse-vertx/vert.x/pull/5637) is released.

Modifications:

- Add `FastThreadLocalRunnable.run` to `allowBlockingCallsInside` for disabling the reports

Result:

Less noisy CI builds

