### PR TITLE
Implement `TlsProvider` for periodic key pair refreshing

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientFactory.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Streams;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.TlsProvider;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ReleasableHolder;
@@ -257,6 +258,10 @@ final class DefaultClientFactory implements ClientFactory {
     private void closeAsync(CompletableFuture<?> future) {
         if (leakTracker != null) {
             leakTracker.close(this);
+        }
+        final TlsProvider tlsProvider = options().tlsProvider();
+        if (tlsProvider.autoClose()) {
+            tlsProvider.close();
         }
 
         final CompletableFuture<?>[] delegateCloseFutures =

--- a/core/src/main/java/com/linecorp/armeria/common/DependencyInjector.java
+++ b/core/src/main/java/com/linecorp/armeria/common/DependencyInjector.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.common.ReflectiveDependencyInjector;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.annotation.Decorator;
 import com.linecorp.armeria.server.annotation.DecoratorFactory;
@@ -55,6 +56,13 @@ public interface DependencyInjector extends SafeCloseable {
      */
     static DependencyInjector ofSingletons(Iterable<Object> singletons) {
         return new DefaultDependencyInjector(singletons);
+    }
+
+    /**
+     * Returns a {@link DependencyInjector} that creates dependencies using reflection and injects them.
+     */
+    static DependencyInjector ofReflective() {
+        return new ReflectiveDependencyInjector();
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/RefreshingTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/RefreshingTlsProvider.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+final class RefreshingTlsProvider implements TlsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefreshingTlsProvider.class);
+
+    private final Supplier<TlsKeyPair> keyPairSupplier;
+    private final Duration interval;
+    private final ScheduledExecutorService executor;
+    private final ScheduledFuture<?> scheduledFuture;
+    private final List<X509Certificate> certificates;
+
+    private volatile TlsKeyPair keyPair;
+
+    RefreshingTlsProvider(Supplier<TlsKeyPair> keyPairSupplier,
+                          List<X509Certificate> certificates,
+                          @Nullable Consumer<TlsKeyPair> onKeyPairUpdated,
+                          Duration interval,
+                          ScheduledExecutorService executor) {
+        this.keyPairSupplier = keyPairSupplier;
+        this.certificates = certificates;
+        this.interval = interval;
+        this.executor = executor;
+
+        keyPair = keyPairSupplier.get();
+        scheduledFuture = executor.scheduleAtFixedRate(() -> {
+            try {
+                final TlsKeyPair newKeyPair = keyPairSupplier.get();
+                requireNonNull(newKeyPair, "keyPairSupplier returned null");
+                if (!Objects.equals(keyPair, newKeyPair)) {
+                    keyPair = newKeyPair;
+                    if (onKeyPairUpdated != null) {
+                        try {
+                            onKeyPairUpdated.accept(newKeyPair);
+                        } catch (Throwable t) {
+                            logger.warn("Failed to notify TLS key pair update listeners", t);
+                        }
+                    }
+                }
+            } catch (Throwable t) {
+                logger.warn("Failed to refresh a new TlsKeyPair:", t);
+            }
+        }, interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public TlsKeyPair keyPair(String hostname) {
+        return keyPair;
+    }
+
+    @Override
+    public List<X509Certificate> trustedCertificates(String hostname) {
+        return certificates;
+    }
+
+    @Override
+    public void close() {
+        scheduledFuture.cancel(true);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("keyPairSupplier", keyPairSupplier)
+                          .add("interval", interval)
+                          .add("executor", executor)
+                          .add("keyPair", keyPair)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -95,7 +95,6 @@ import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.armeria.common.util.TlsEngineType;
 import com.linecorp.armeria.internal.common.BuiltInDependencyInjector;
-import com.linecorp.armeria.internal.common.ReflectiveDependencyInjector;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
 import com.linecorp.armeria.internal.server.RouteDecoratingService;
@@ -1197,6 +1196,10 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         requireNonNull(tlsProvider, "tlsProvider");
         this.tlsProvider = tlsProvider;
         tlsConfig = null;
+
+        if (tlsProvider.autoClose()) {
+            shutdownSupports.add(ShutdownSupport.of(tlsProvider));
+        }
         return this;
     }
 
@@ -1230,6 +1233,10 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     public ServerBuilder tlsProvider(TlsProvider tlsProvider, ServerTlsConfig tlsConfig) {
         tlsProvider(tlsProvider);
         this.tlsConfig = requireNonNull(tlsConfig, "tlsConfig");
+
+        if (tlsProvider.autoClose()) {
+            shutdownSupports.add(ShutdownSupport.of(tlsProvider));
+        }
         return this;
     }
 
@@ -2504,7 +2511,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         if (dependencyInjector != null) {
             return dependencyInjector;
         }
-        final ReflectiveDependencyInjector reflectiveDependencyInjector = new ReflectiveDependencyInjector();
+        final DependencyInjector reflectiveDependencyInjector = DependencyInjector.ofReflective();
         shutdownSupports.add(ShutdownSupport.of(reflectiveDependencyInjector));
         return reflectiveDependencyInjector;
     }

--- a/core/src/test/java/com/linecorp/armeria/common/RefreshingTlsProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/RefreshingTlsProviderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+class RefreshingTlsProviderTest {
+
+    @Test
+    void shouldRefreshTlsKeyPairPeriodically() throws InterruptedException {
+        final TlsKeyPair keyPair = TlsKeyPair.ofSelfSigned();
+        final AtomicInteger counter = new AtomicInteger();
+        final TlsProvider tlsProvider = TlsProvider.ofScheduled(() -> {
+            counter.incrementAndGet();
+            return keyPair;
+        }, Duration.ofSeconds(1));
+        Thread.sleep(2000);
+        assertThat(counter.get()).isGreaterThanOrEqualTo(2);
+        tlsProvider.close();
+    }
+
+    @Test
+    void shouldReturnKeyTlsKeyPairOnUpdate() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        final TlsProvider tlsProvider = TlsProvider.ofScheduled(() -> {
+            counter.incrementAndGet();
+            return TlsKeyPair.ofSelfSigned();
+        }, Duration.ofSeconds(1));
+        final TlsKeyPair initialKeyPair = tlsProvider.keyPair("*");
+        Thread.sleep(2000);
+        final TlsKeyPair newKeyPair = tlsProvider.keyPair("*");
+        assertThat(counter.get()).isGreaterThanOrEqualTo(2);
+        assertThat(newKeyPair).isNotSameAs(initialKeyPair);
+    }
+
+    @Test
+    void shouldNotifyListenerOnKeyPair() throws InterruptedException {
+        final AtomicReference<TlsKeyPair> keyPairRef = new AtomicReference<>();
+        keyPairRef.set(TlsKeyPair.ofSelfSigned());
+
+        final AtomicReference<TlsKeyPair> capturedKeyPairRef = new AtomicReference<>();
+        final TlsProvider tlsProvider =
+                TlsProvider.ofScheduled(() -> keyPairRef.get(),
+                                        ImmutableList.of(), capturedKeyPairRef::set,
+                                        Duration.ofMillis(100),
+                                        CommonPools.blockingTaskExecutor());
+        assertThat(capturedKeyPairRef).hasNullValue();
+        Thread.sleep(1000);
+        assertThat(capturedKeyPairRef).hasNullValue();
+        keyPairRef.set(TlsKeyPair.ofSelfSigned());
+        await().untilAsserted(() -> {
+            assertThat(capturedKeyPairRef).hasValue(keyPairRef.get());
+        });
+        tlsProvider.close();
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/HandlerRegistry.java
@@ -71,7 +71,6 @@ import com.google.common.collect.ImmutableSet;
 import com.linecorp.armeria.common.DependencyInjector;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
-import com.linecorp.armeria.internal.common.ReflectiveDependencyInjector;
 import com.linecorp.armeria.internal.common.grpc.InternalGrpcExceptionHandler;
 import com.linecorp.armeria.internal.server.annotation.AnnotationUtil;
 import com.linecorp.armeria.internal.server.annotation.DecoratorAnnotationUtil;
@@ -312,7 +311,7 @@ final class HandlerRegistry {
                     ImmutableSet.builder();
             final ImmutableMap.Builder<ServerMethodDefinition<?, ?>, GrpcExceptionHandlerFunction>
                     grpcExceptionHandlersBuilder = ImmutableMap.builder();
-            final DependencyInjector dependencyInjector = new ReflectiveDependencyInjector();
+            final DependencyInjector dependencyInjector = DependencyInjector.ofReflective();
             for (Entry entry : entries) {
                 final ServerServiceDefinition service = entry.service();
                 final String path = entry.path();


### PR DESCRIPTION
Motivation:

Athenz SIA refreshes the certs every 24 hours by default. https://github.com/AthenZ/k8s-athenz-identity#configuration In order to comply with the specification, `TlsProvider` should detect the updated certs and automatically refresh them.
Additionally, there were similar requests from Armeria users. https://github.com/line/armeria/issues/6054

Modifications:

- Add `RefreshingTlsProvider` that periodically refreshes the given `TlsKeyPair` provider.
  - Currently, only one `TlsKeyPair` is supported for `RefreshingTlsProvider`
  - TODO) Integrate `MappedTlsProvider` with `RefreshingTlsProvider` to build a more flexible `TlsProvider` using `TlsProviderBuilder`
- Expose `ReflectiveDependencyInjector` via public API via `DependencyInjector.ofReflective()`
  - This is unrelated to this PR, but added to minimize conflicts when merging the main branch into #6321 

Result:

You can now periodically refresh `TlsKeyPair` when using `TlsProvider.ofSheduled()`

```java
File keyFile = ...;
Fie certFile = ...;

TlsProvider.ofScheduled(() -> {
  return TlsKeyPair.of(keyFile, certFile);
}, Duration.ofHours(1));
```