### PR TITLE
Exclude `SslContext.buildKeyStore()` from BlockHound reports

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
@@ -67,5 +67,7 @@ public final class CoreBlockHoundIntegration implements BlockHoundIntegration {
         // Thread.yield can be called
         builder.allowBlockingCallsInside(
                 "java.util.concurrent.FutureTask", "handlePossibleCancellationInterrupt");
+        // SecureRandom.nextBytes() can be called
+        builder.allowBlockingCallsInside("io.netty.handler.ssl.SslContext", "buildKeyStore");
     }
 }


### PR DESCRIPTION
Motivation:

BlockHound reported `SslContext.buildKeyStore()` as a blocking operation.
```
Thread[#82,armeria-common-worker-epoll-3-7,5,main]
java.lang.Exception: java.io.FileInputStream#readBytes
	at com.linecorp.armeria.internal.testing.InternalTestingBlockHoundIntegration.writeBlockingMethod(InternalTestingBlockHoundIntegration.java:86)
	at reactor.blockhound.BlockHound$Builder.lambda$install$8(BlockHound.java:488)
	at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:89)
	at java.base/java.io.FileInputStream.readBytes(FileInputStream.java)
	at java.base/java.io.FileInputStream.read(FileInputStream.java:287)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:119)
	at java.base/sun.security.provider.NativePRNG$RandomIO.readFully(NativePRNG.java:432)
	at java.base/sun.security.provider.NativePRNG$RandomIO.ensureBufferValid(NativePRNG.java:535)
	at java.base/sun.security.provider.NativePRNG$RandomIO.implNextBytes(NativePRNG.java:554)
	at java.base/sun.security.provider.NativePRNG.engineNextBytes(NativePRNG.java:224)
	at java.base/java.security.SecureRandom.nextBytes(SecureRandom.java:768)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.getSalt(PKCS12KeyStore.java:812)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.getPBEAlgorithmParameters(PKCS12KeyStore.java:823)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.encryptPrivateKey(PKCS12KeyStore.java:905)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.setKeyEntry(PKCS12KeyStore.java:643)
	at java.base/sun.security.pkcs12.PKCS12KeyStore.engineSetKeyEntry(PKCS12KeyStore.java:601)
	at java.base/sun.security.util.KeyStoreDelegator.engineSetKeyEntry(KeyStoreDelegator.java:114)
	at java.base/java.security.KeyStore.setKeyEntry(KeyStore.java:1192)
	at io.netty.handler.ssl.SslContext.buildKeyStore(SslContext.java:1162)
	at io.netty.handler.ssl.ReferenceCountedOpenSslClientContext.newSessionContext(ReferenceCountedOpenSslClientContext.java:115)
	at io.netty.handler.ssl.OpenSslClientContext.<init>(OpenSslClientContext.java:200)
	at io.netty.handler.ssl.SslContext.newClientContextInternal(SslContext.java:850)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:679)
	at com.linecorp.armeria.internal.common.util.SslContextUtil.supportedProtocols(SslContextUtil.java:199)
	at com.linecorp.armeria.internal.common.util.SslContextUtil.lambda$createSslContext$1(SslContextUtil.java:109)
	at com.linecorp.armeria.internal.common.util.MinifiedBouncyCastleProvider.call(MinifiedBouncyCastleProvider.java:97)
	at com.linecorp.armeria.internal.common.util.SslContextUtil.createSslContext(SslContextUtil.java:104)
	at com.linecorp.armeria.internal.common.SslContextFactory.newSslContext(SslContextFactory.java:191)
	at com.linecorp.armeria.internal.common.SslContextFactory.create(SslContextFactory.java:153)
```
It seems to be ignored because:
- SecureRandom will be finished quickly in most cases
- The created SslContext is cached. So the method is not invoked frequently.

Modifications:

- Added `io.netty.handler.ssl.SslContext.buildKeyStore` to the allowed blocking calls.

Result:

Remove a false positive BlockHound reporting
