### PR TITLE
Support `Athenz-Role-Auth` header in Athenz module

### DIFF
--- a/athenz/src/main/java/com/linecorp/armeria/common/athenz/TokenType.java
+++ b/athenz/src/main/java/com/linecorp/armeria/common/athenz/TokenType.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.common.athenz;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.internal.common.athenz.AthenzHeaderNames;
 
@@ -28,24 +29,52 @@ import io.netty.util.AsciiString;
 @UnstableApi
 public enum TokenType {
     /**
-     * Athenz role token.
-     */
-    ROLE_TOKEN(AthenzHeaderNames.YAHOO_ROLE_AUTH),
-    /**
      * Athenz access token.
      */
-    ACCESS_TOKEN(HttpHeaderNames.AUTHORIZATION);
+    ACCESS_TOKEN(HttpHeaderNames.AUTHORIZATION, false, "Bearer"),
+    /**
+     * Athenz role token. {@value "Athenz-Role-Auth"} is used as the header name for this token type.
+     */
+    ATHENZ_ROLE_TOKEN(AthenzHeaderNames.ATHENZ_ROLE_AUTH, true, null),
+    /**
+     * The legacy Athenz role token used by Yahoo. {@value "Yahoo-Role-Auth"} is used as the
+     * header name for this token type.
+     */
+    YAHOO_ROLE_TOKEN(AthenzHeaderNames.YAHOO_ROLE_AUTH, true, null);
 
-    TokenType(AsciiString headerName) {
+    TokenType(AsciiString headerName, boolean isRoleToken, @Nullable String authScheme) {
         this.headerName = headerName;
+        this.isRoleToken = isRoleToken;
+        this.authScheme = authScheme;
     }
 
     private final AsciiString headerName;
+    private final boolean isRoleToken;
+    @Nullable
+    private final String authScheme;
 
     /**
      * Returns the header name used to pass the token.
      */
     public AsciiString headerName() {
         return headerName;
+    }
+
+    /**
+     * Returns whether this token type is a role token.
+     */
+    public boolean isRoleToken() {
+        return isRoleToken;
+    }
+
+    /**
+     * Returns the authentication scheme used for this token type, or {@code null} if not applicable.
+     * For example, {@link TokenType#ACCESS_TOKEN} uses "Bearer" as the authentication scheme,
+     * while {@link TokenType#YAHOO_ROLE_TOKEN} and {@link TokenType#ATHENZ_ROLE_TOKEN} do not use
+     * any authentication scheme.
+     */
+    @Nullable
+    public String authScheme() {
+        return authScheme;
     }
 }

--- a/athenz/src/main/java/com/linecorp/armeria/common/athenz/TokenType.java
+++ b/athenz/src/main/java/com/linecorp/armeria/common/athenz/TokenType.java
@@ -33,11 +33,11 @@ public enum TokenType {
      */
     ACCESS_TOKEN(HttpHeaderNames.AUTHORIZATION, false, "Bearer"),
     /**
-     * Athenz role token. {@value "Athenz-Role-Auth"} is used as the header name for this token type.
+     * Athenz role token. {@code "Athenz-Role-Auth"} is used as the header name for this token type.
      */
     ATHENZ_ROLE_TOKEN(AthenzHeaderNames.ATHENZ_ROLE_AUTH, true, null),
     /**
-     * The legacy Athenz role token used by Yahoo. {@value "Yahoo-Role-Auth"} is used as the
+     * The legacy Athenz role token used by Yahoo. {@code "Yahoo-Role-Auth"} is used as the
      * header name for this token type.
      */
     YAHOO_ROLE_TOKEN(AthenzHeaderNames.YAHOO_ROLE_AUTH, true, null);

--- a/athenz/src/main/java/com/linecorp/armeria/internal/common/athenz/AthenzHeaderNames.java
+++ b/athenz/src/main/java/com/linecorp/armeria/internal/common/athenz/AthenzHeaderNames.java
@@ -22,7 +22,9 @@ import io.netty.util.AsciiString;
 
 public final class AthenzHeaderNames {
 
-    public static final AsciiString YAHOO_ROLE_AUTH = HttpHeaderNames.of("yahoo-role-auth");
+    public static final AsciiString YAHOO_ROLE_AUTH = HttpHeaderNames.of("Yahoo-Role-Auth");
+
+    public static final AsciiString ATHENZ_ROLE_AUTH = HttpHeaderNames.of("Athenz-Role-Auth");
 
     private AthenzHeaderNames() {}
 }

--- a/athenz/src/main/java/com/linecorp/armeria/server/athenz/RequiresAthenzRole.java
+++ b/athenz/src/main/java/com/linecorp/armeria/server/athenz/RequiresAthenzRole.java
@@ -81,7 +81,9 @@ public @interface RequiresAthenzRole {
     /**
      * The required {@link TokenType}.
      */
-    TokenType[] tokenType() default { TokenType.ROLE_TOKEN, TokenType.ACCESS_TOKEN };
+    TokenType[] tokenType() default {
+            TokenType.ACCESS_TOKEN, TokenType.ATHENZ_ROLE_TOKEN, TokenType.YAHOO_ROLE_TOKEN
+    };
 
     /**
      * A special parameter in order to specify the order of a {@link Decorator}.

--- a/athenz/src/test/java/com/linecorp/armeria/common/athenz/TokenTypeTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/common/athenz/TokenTypeTest.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.common.athenz;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 

--- a/athenz/src/test/java/com/linecorp/armeria/common/athenz/TokenTypeTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/common/athenz/TokenTypeTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.athenz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TokenTypeTest {
+
+    @Test
+    void testAccessToken() {
+        final TokenType tokenType = TokenType.ACCESS_TOKEN;
+        assertThat(tokenType.headerName().toString()).isEqualToIgnoringCase("Authorization");
+        assertThat(tokenType.isRoleToken()).isFalse();
+        assertThat(tokenType.authScheme()).isEqualTo("Bearer");
+    }
+
+    @Test
+    void testYahooRoleToken() {
+        final TokenType tokenType = TokenType.YAHOO_ROLE_TOKEN;
+        assertThat(tokenType.headerName().toString()).isEqualToIgnoringCase("Yahoo-Role-Auth");
+        assertThat(tokenType.isRoleToken()).isTrue();
+        assertThat(tokenType.authScheme()).isNull();
+    }
+
+    @Test
+    void testAthenzRoleToken() {
+        final TokenType tokenType = TokenType.ATHENZ_ROLE_TOKEN;
+        assertThat(tokenType.headerName().toString()).isEqualToIgnoringCase("Athenz-Role-Auth");
+        assertThat(tokenType.isRoleToken()).isTrue();
+        assertThat(tokenType.authScheme()).isNull();
+    }
+}

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzAnnotatedServiceTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzAnnotatedServiceTest.java
@@ -76,9 +76,11 @@ class AthenzAnnotatedServiceTest {
     };
 
     @CsvSource({
-            "foo-service, ROLE_TOKEN",
+            "foo-service, YAHOO_ROLE_TOKEN",
+            "foo-service, ATHENZ_ROLE_TOKEN",
             "foo-service, ACCESS_TOKEN",
-            "test-service, ROLE_TOKEN",
+            "test-service, YAHOO_ROLE_TOKEN",
+            "test-service, ATHENZ_ROLE_TOKEN",
             "test-service, ACCESS_TOKEN"
     })
     @ParameterizedTest
@@ -98,9 +100,11 @@ class AthenzAnnotatedServiceTest {
     }
 
     @CsvSource({
-            "foo-service, ROLE_TOKEN, false",
+            "foo-service, YAHOO_ROLE_TOKEN, false",
+            "foo-service, ATHENZ_ROLE_TOKEN, false",
             "foo-service, ACCESS_TOKEN, false",
-            "test-service, ROLE_TOKEN, true",
+            "test-service, YAHOO_ROLE_TOKEN, true",
+            "test-service, ATHENZ_ROLE_TOKEN, true",
             "test-service, ACCESS_TOKEN, true"
     })
     @ParameterizedTest
@@ -122,7 +126,7 @@ class AthenzAnnotatedServiceTest {
                         .isInstanceOf(AccessDeniedException.class)
                         .hasMessage("Failed to obtain an Athenz %s token. " +
                                     "(domain: testing, roles: test_role_admin)",
-                                    tokenType == TokenType.ROLE_TOKEN ? "role" : "access");
+                                    tokenType.isRoleToken() ? "role" : "access");
             }
         }
     }

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzIntegrationTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzIntegrationTest.java
@@ -74,6 +74,10 @@ class AthenzIntegrationTest {
                 if (!authorization.isEmpty()) {
                     return HttpResponse.of("YahooRoleAuth " + authorization);
                 }
+                authorization = req.headers().get(AthenzHeaderNames.ATHENZ_ROLE_AUTH, "");
+                if (!authorization.isEmpty()) {
+                    return HttpResponse.of("AthenzRoleAuth " + authorization);
+                }
                 // Should not reach here.
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
             });
@@ -92,6 +96,10 @@ class AthenzIntegrationTest {
                 authorization = req.headers().get(AthenzHeaderNames.YAHOO_ROLE_AUTH, "");
                 if (!authorization.isEmpty()) {
                     return HttpResponse.of("YahooRoleAuth " + authorization);
+                }
+                authorization = req.headers().get(AthenzHeaderNames.ATHENZ_ROLE_AUTH, "");
+                if (!authorization.isEmpty()) {
+                    return HttpResponse.of("AthenzRoleAuth " + authorization);
                 }
                 // Should not reach here.
                 return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -119,8 +127,11 @@ class AthenzIntegrationTest {
             final AggregatedHttpResponse response = client.get("/admin");
             assertThat(response.status()).isEqualTo(HttpStatus.OK);
             switch (tokenType) {
-                case ROLE_TOKEN:
+                case YAHOO_ROLE_TOKEN:
                     assertThat(response.contentUtf8()).startsWith("YahooRoleAuth ");
+                    break;
+                case ATHENZ_ROLE_TOKEN:
+                    assertThat(response.contentUtf8()).startsWith("AthenzRoleAuth ");
                     break;
                 case ACCESS_TOKEN:
                     assertThat(response.contentUtf8()).startsWith("Authorization ");
@@ -144,7 +155,7 @@ class AthenzIntegrationTest {
                     client.get("/admin");
                 }).isInstanceOf(AccessDeniedException.class)
                   .hasMessage("Failed to obtain an Athenz " +
-                              (tokenType == TokenType.ROLE_TOKEN ? "role" : "access") +
+                              (tokenType.isRoleToken() ? "role" : "access") +
                               " token. (domain: testing, roles: test_role_admin)");
                 final ClientRequestContext ctx = captor.get();
                 // Make sure the RequestLog is completed when the request was rejected by the decorator.


### PR DESCRIPTION
Motivation:

I realized that Athenz has replaced the `Yahoo-Role-Auth` header with `Athenz-Role-Auth` header for sending role tokens.

Modifications:

- Raname the orignal `ROLE_TOKEN` to `YAHOO_ROLE_TOKEN`
- Add `ATHENZ_ROLE_TOKEN`

Result:

Users can use `Athenz-Role-Auth` header for sending role tokens.
