### PR TITLE
Update BlockHound rules for Netty 4.2

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
@@ -69,5 +69,7 @@ public final class CoreBlockHoundIntegration implements BlockHoundIntegration {
                 "java.util.concurrent.FutureTask", "handlePossibleCancellationInterrupt");
         // SecureRandom.nextBytes() can be called
         builder.allowBlockingCallsInside("io.netty.handler.ssl.SslContext", "buildKeyStore");
+        // StampedLock.writeLock() can be called
+        builder.allowBlockingCallsInside("io.netty.buffer.AdaptivePoolingAllocator", "allocate");
     }
 }


### PR DESCRIPTION
`AdaptivePoolingAllocator.allocate()` is reported as a blocking operation because it calls `StampedLock.writeLock()`. However, since that is used solely for synchronization purposes, the report can be considered a false positive.
https://github.com/line/armeria/actions/runs/16767389726/job/47475215110?pr=6341
```java
java.lang.Exception: jdk.internal.misc.Unsafe#park
	at com.linecorp.armeria.internal.testing.InternalTestingBlockHoundIntegration.writeBlockingMethod(InternalTestingBlockHoundIntegration.java:86)
	at reactor.blockhound.BlockHound$Builder.lambda$install$8(BlockHound.java:488)
	at reactor.blockhound.BlockHoundRuntime.checkBlocking(BlockHoundRuntime.java:89)
	at java.base/jdk.internal.misc.Unsafe.park(Unsafe.java)
	at java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:221)
	at java.base/java.util.concurrent.locks.StampedLock.acquireWrite(StampedLock.java:1251)
	at java.base/java.util.concurrent.locks.StampedLock.writeLock(StampedLock.java:480)
	at io.netty.buffer.AdaptivePoolingAllocator$Magazine.free(AdaptivePoolingAllocator.java:1043)
	at io.netty.buffer.AdaptivePoolingAllocator$MagazineGroup.tryExpandMagazines(AdaptivePoolingAllocator.java:450)
	at io.netty.buffer.AdaptivePoolingAllocator$MagazineGroup.allocate(AdaptivePoolingAllocator.java:417)
	at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:257)
	at io.netty.buffer.AdaptivePoolingAllocator.reallocate(AdaptivePoolingAllocator.java:319)
	at io.netty.buffer.AdaptivePoolingAllocator$AdaptiveByteBuf.capacity(AdaptivePoolingAllocator.java:1493)
	at io.netty.buffer.AbstractByteBuf.ensureWritable0(AbstractByteBuf.java:305)
	at io.netty.buffer.AbstractByteBuf.ensureWritable(AbstractByteBuf.java:280)
	at io.netty.handler.ssl.SslHandler.wrap(SslHandler.java:1170)
	at io.netty.handler.ssl.SslHandler.wrap(SslHandler.java:892)
```