### PR TITLE
Fixed caching by updating web-licenses

### DIFF
--- a/licenses/web-licenses.txt
+++ b/licenses/web-licenses.txt
@@ -249,36 +249,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-bignumber.js
-MIT
-The MIT License (MIT)
-=====================
-
-Copyright © `<2021>` `Michael Mclaughlin`
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the “Software”), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-
-
 character-entities-legacy
 MIT
 (The MIT License)
@@ -1719,30 +1689,6 @@ MIT
 
 isarray
 MIT
-
-json-bigint
-MIT
-The MIT License (MIT)
-
-Copyright (c) 2013 Andrey Sidorov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 
 jsonminify
 MIT


### PR DESCRIPTION
Fixed caching by updating web-licenses to be in line with the state after the build

Motivation:

We've noticed that if you run two consecutive clean builds, the 2nd build has a lot of cache misses, due to the `<subproject>/build/resources/main/META-INF/com.linecorp.armeria.versions.properties` [differs (in each subproject)](https://ge.solutions-team.gradle.com/c/ualzqlfqciga4/woog2eg6cpf5e/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure&expanded=WyJybWt6ZzRkY2xkcGZtLWNsYXNzcGF0aCIsInJta3pnNGRjbGRwZm0tY2xhc3NwYXRoLTAtMCJd#change-rmkzg4dcldpfm-classpath-0-0-0). After an investigation, we found that the property `<subproject>.repoStatus` differs, which is caused by the git state not being clean after the first build because of changes in the `licenses/web-licenses.txt` file. 

After updating the `licenses/web-licenses.txt` file to the state after running the `./gradlew build` command, we can see that there are [no cacheble tasks input differences](https://ge.solutions-team.gradle.com/c/ofntb3pvm6hk6/kqxto4fpyklk6/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure), which means that the second build finishes in [4m 54s](https://ge.solutions-team.gradle.com/s/kqxto4fpyklk6) instead of [48m 22s (before the fix)](https://ge.solutions-team.gradle.com/s/woog2eg6cpf5e).

Modifications:

- Updated the `licenses/web-licenses.txt` file to the state after running the `./gradlew build` command.

Result:

- Faster consecutive clean builds
