### PR TITLE
Add Athenz documentation and example

### DIFF
--- a/athenz/src/test/java/com/linecorp/armeria/client/athenz/AccessTokenClientTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/client/athenz/AccessTokenClientTest.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.armeria.client.athenz;
 
-import static com.linecorp.armeria.server.athenz.AthenzExtension.ATHENZ_CERTS;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.CA_CERT_FILE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_DOMAIN_NAME;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.USER_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.ATHENZ_CERTS;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.CA_CERT_FILE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.USER_ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;

--- a/athenz/src/test/java/com/linecorp/armeria/client/athenz/RoleTokenClientTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/client/athenz/RoleTokenClientTest.java
@@ -96,9 +96,9 @@ class RoleTokenClientTest {
     @Test
     void shouldRefreshTokenBeforeExpiry() throws Exception {
         final TlsKeyPair tlsKeyPair = TlsKeyPair.ofSelfSigned();
-        try(ZtsBaseClient ztsBaseClient = ZtsBaseClient.builder(mockServer.httpUri())
-                                                         .keyPair(() -> tlsKeyPair)
-                                                         .build()) {
+        try (ZtsBaseClient ztsBaseClient = ZtsBaseClient.builder(mockServer.httpUri())
+                                                        .keyPair(() -> tlsKeyPair)
+                                                        .build()) {
             final RoleTokenClient roleTokenClient = new RoleTokenClient(ztsBaseClient, "test",
                                                                         ImmutableList.of("role1", "role2"),
                                                                         Duration.ofSeconds(10));

--- a/athenz/src/test/java/com/linecorp/armeria/client/athenz/RoleTokenClientTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/client/athenz/RoleTokenClientTest.java
@@ -96,22 +96,23 @@ class RoleTokenClientTest {
     @Test
     void shouldRefreshTokenBeforeExpiry() throws Exception {
         final TlsKeyPair tlsKeyPair = TlsKeyPair.ofSelfSigned();
-        final ZtsBaseClient ztsBaseClient = ZtsBaseClient.builder(mockServer.httpUri())
+        try(ZtsBaseClient ztsBaseClient = ZtsBaseClient.builder(mockServer.httpUri())
                                                          .keyPair(() -> tlsKeyPair)
-                                                         .build();
-        final RoleTokenClient roleTokenClient = new RoleTokenClient(ztsBaseClient, "test",
-                                                                    ImmutableList.of("role1", "role2"),
-                                                                    Duration.ofSeconds(10));
-        final RoleToken roleToken = new RoleToken();
-        roleToken.setToken("test-token");
-        roleToken.setExpiryTime(Instant.now().plusSeconds(5).getEpochSecond());
-        roleTokenRef.set(roleToken);
-        final String token0 = roleTokenClient.getToken().join();
-        assertThat(token0).isEqualTo("test-token");
-        roleToken.setToken("test-token1");
-        roleToken.setExpiryTime(Instant.now().plusSeconds(5).getEpochSecond());
-        // Should return the cached token immediately and refresh it in the background.
-        assertThat(roleTokenClient.getToken().join()).isEqualTo(token0);
-        await().untilAtomic(requestCount, Matchers.is(2));
+                                                         .build()) {
+            final RoleTokenClient roleTokenClient = new RoleTokenClient(ztsBaseClient, "test",
+                                                                        ImmutableList.of("role1", "role2"),
+                                                                        Duration.ofSeconds(10));
+            final RoleToken roleToken = new RoleToken();
+            roleToken.setToken("test-token");
+            roleToken.setExpiryTime(Instant.now().plusSeconds(5).getEpochSecond());
+            roleTokenRef.set(roleToken);
+            final String token0 = roleTokenClient.getToken().join();
+            assertThat(token0).isEqualTo("test-token");
+            roleToken.setToken("test-token1");
+            roleToken.setExpiryTime(Instant.now().plusSeconds(5).getEpochSecond());
+            // Should return the cached token immediately and refresh it in the background.
+            assertThat(roleTokenClient.getToken().join()).isEqualTo(token0);
+            await().untilAtomic(requestCount, Matchers.is(2));
+        }
     }
 }

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzAnnotatedServiceTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzAnnotatedServiceTest.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.armeria.server.athenz;
 
-import static com.linecorp.armeria.server.athenz.AthenzExtension.ADMIN_ROLE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_DOMAIN_NAME;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_SERVICE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.USER_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.ADMIN_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_SERVICE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.USER_ROLE;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzDocker.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzDocker.java
@@ -78,6 +78,7 @@ public class AthenzDocker implements SafeCloseable {
     private URI ztsUri;
     @Nullable
     private ZMSClient zmsClient;
+    private boolean initialized;
 
     public AthenzDocker(File dockerComposeFile) {
         composeContainer =
@@ -94,10 +95,24 @@ public class AthenzDocker implements SafeCloseable {
         return zmsClient;
     }
 
-    public void initialize() {
-        logger.info("Starting Docker compose for Athenz tests...");
-        composeContainer.start();
-        defaultScaffold();
+    public boolean initialize() {
+        if (initialized) {
+            return true;
+        }
+
+        try {
+            logger.info("Starting Docker compose for Athenz tests...");
+            composeContainer.start();
+            defaultScaffold();
+            return initialized = true;
+        } catch (Exception e) {
+            logger.warn("Failed to initialize Athenz Docker container", e);
+            return initialized = false;
+        }
+    }
+
+    public boolean isInitialized() {
+        return initialized;
     }
 
     /**

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzDocker.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzDocker.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.athenz;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.net.ssl.SSLContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import com.google.common.collect.ImmutableList;
+import com.oath.auth.Utils;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.zms.Assertion;
+import com.yahoo.athenz.zms.AssertionEffect;
+import com.yahoo.athenz.zms.Policy;
+import com.yahoo.athenz.zms.PublicKeyEntry;
+import com.yahoo.athenz.zms.Role;
+import com.yahoo.athenz.zms.ServiceIdentity;
+import com.yahoo.athenz.zms.TopLevelDomain;
+import com.yahoo.athenz.zms.ZMSClient;
+import com.yahoo.athenz.zts.ZTSClient;
+
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.client.athenz.ZtsBaseClient;
+import com.linecorp.armeria.common.TlsKeyPair;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+import io.micrometer.core.instrument.util.IOUtils;
+
+public class AthenzDocker implements SafeCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(AthenzDocker.class);
+
+    public static final String ZMS_SERVICE_NAME = "zms-server";
+    public static final String ZTS_SERVICE_NAME = "zts-server";
+    public static final int ZMS_PORT = 4443;
+    public static final int ZTS_PORT = 8443;
+
+    public static final String ATHENZ_CERTS = "/docker/certs/";
+    public static final String CA_CERT_FILE = ATHENZ_CERTS + "CAs/athenz_ca_cert.pem";
+    public static final String TEST_DOMAIN_NAME = "testing";
+    public static final String TEST_SERVICE = "test-service";
+    public static final String FOO_SERVICE = "foo-service";
+
+    public static final String ADMIN_ROLE = "test_role_admin";
+    public static final String USER_ROLE = "test_role_users";
+    public static final String ADMIN_POLICY = "admin-policy";
+    public static final String USER_POLICY = "user-policy";
+
+    private final ComposeContainer composeContainer;
+
+    @Nullable
+    private URI ztsUri;
+    @Nullable
+    private ZMSClient zmsClient;
+
+    public AthenzDocker(File dockerComposeFile) {
+        composeContainer =
+                new ComposeContainer(dockerComposeFile)
+                        .withLocalCompose(true)
+                        .withExposedService(ZMS_SERVICE_NAME, ZMS_PORT, Wait.forHealthcheck())
+                        .withExposedService(ZTS_SERVICE_NAME, ZTS_PORT, Wait.forHealthcheck());
+    }
+
+    private ZMSClient zmsClient() {
+        if (zmsClient == null) {
+            zmsClient = newZmsClient();
+        }
+        return zmsClient;
+    }
+
+    public void initialize() {
+        logger.info("Starting Docker compose for Athenz tests...");
+        composeContainer.start();
+        defaultScaffold();
+    }
+
+    /**
+     * Override this method to create your own test domain, services, roles, and policies.
+     */
+    protected void scaffold(ZMSClient zmsClient) {}
+
+    @Override
+    public void close() {
+        composeContainer.stop();
+    }
+
+    private void defaultScaffold() {
+        logger.info("Creating default Athenz domain, services, roles, and policies...");
+        try {
+            // Delete test domain if it exists
+            deleteDomain(TEST_DOMAIN_NAME);
+        } catch (Exception e) {
+            // Ignore if the domain does not exist
+        }
+
+        // Create test domain
+        createDomain(TEST_DOMAIN_NAME);
+        // Create test service
+        final String testServicePublicKeyId = createService(TEST_SERVICE);
+        final String fooServicePublicKeyId = createService(FOO_SERVICE);
+
+        createRole(USER_ROLE, ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE,
+                                               TEST_DOMAIN_NAME + '.' + FOO_SERVICE));
+        // Admin role is only granted to the test service
+        createRole(ADMIN_ROLE, ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE));
+
+        createPolicy(USER_POLICY, USER_ROLE, "files", "obtain");
+        createPolicy(ADMIN_POLICY, ADMIN_ROLE, "secrets", "obtain");
+
+        // Create user-defined roles and policies.
+        scaffold(zmsClient());
+
+        try (ZTSClient ztsAdminClient = newZtsClient("domain-admin")) {
+            // Wait for ZTS to sync.
+            final int maxIterations = 20;
+            for (int i = 1; i <= maxIterations; i++) {
+                try {
+                    final com.yahoo.athenz.zts.ServiceIdentity testServiceIdentity =
+                            ztsAdminClient.getServiceIdentity(TEST_DOMAIN_NAME, TEST_SERVICE);
+                    boolean found = testServiceIdentity.getPublicKeys()
+                                                       .stream()
+                                                       .anyMatch(key -> {
+                                                           return key.getId().equals(testServicePublicKeyId);
+                                                       });
+                    if (!found) {
+                        continue;
+                    }
+                    final com.yahoo.athenz.zts.ServiceIdentity fooServiceIdentity =
+                            ztsAdminClient.getServiceIdentity(TEST_DOMAIN_NAME, FOO_SERVICE);
+                    found = fooServiceIdentity.getPublicKeys()
+                                              .stream()
+                                              .anyMatch(key -> {
+                                                  return key.getId().equals(fooServicePublicKeyId);
+                                              });
+                    if (found) {
+                        // We have the service identities, so we can stop waiting.
+                        break;
+                    }
+                } catch (Exception e) {
+                    if (i == maxIterations) {
+                        throw new IllegalStateException("Failed to find test service identities", e);
+                    } else {
+                        // Swallow the exception and retry
+                    }
+                }
+
+                logger.debug("Test service identities not found yet, retrying... (attempts: {})", i);
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    public void createPolicy(String policyName, String roleName, String resourceName, String action) {
+        final String assertionRole = TEST_DOMAIN_NAME + ":role." + roleName;
+        final String assertionResource = TEST_DOMAIN_NAME + ':' + resourceName;
+        final Assertion assertion = new Assertion();
+        assertion.setRole(assertionRole);
+        assertion.setAction(action);
+        assertion.setResource(assertionResource);
+        assertion.setEffect(AssertionEffect.ALLOW);
+
+        final Policy policyToCreate = new Policy();
+        policyToCreate.setName(TEST_DOMAIN_NAME + ":policy." + policyName);
+        policyToCreate.setAssertions(ImmutableList.of(assertion));
+
+        zmsClient().putPolicy(TEST_DOMAIN_NAME, policyName, "create-policy-audit-ref", policyToCreate);
+    }
+
+    public void createRole(String roleName, List<String> members) {
+        final Role role = new Role().setName(TEST_DOMAIN_NAME + ":role." + roleName)
+                                    .setMembers(members);
+        zmsClient().putRole(TEST_DOMAIN_NAME, roleName, "create-role-audit-ref", role);
+    }
+
+    public String createService(String serviceName) {
+        final String publicCert = readFile(ATHENZ_CERTS + serviceName + "/public.pem");
+        final String ybase64PublicKey = Crypto.ybase64EncodeString(publicCert);
+        final String publicKeyId = serviceName + "_public_key";
+
+        final PublicKeyEntry publicKeyEntry = new PublicKeyEntry();
+        publicKeyEntry.setId(publicKeyId);
+        publicKeyEntry.setKey(ybase64PublicKey);
+        final ServiceIdentity serviceIdentity = new ServiceIdentity();
+        serviceIdentity.setName(TEST_DOMAIN_NAME + '.' + serviceName);
+        serviceIdentity.setPublicKeys(Collections.singletonList(publicKeyEntry));
+
+        zmsClient().putServiceIdentity(TEST_DOMAIN_NAME, serviceName, "create-service-audit-ref",
+                                       serviceIdentity);
+        return publicKeyId;
+    }
+
+    public void deleteDomain(String domainName) {
+        zmsClient().deleteTopLevelDomain(domainName, "delete-domain-audit-ref");
+    }
+
+    public void createDomain(String domainName) {
+        final TopLevelDomain domain = new TopLevelDomain();
+        domain.setName(domainName);
+        domain.setDescription("A test domain created by the Java client.");
+        domain.setAdminUsers(ImmutableList.of("user.github-7654321"));
+        zmsClient().postTopLevelDomain("create-domain-audit-ref", domain);
+    }
+
+    public URI ztsUri() {
+        if (ztsUri == null) {
+            final String serviceHost = composeContainer.getServiceHost(ZTS_SERVICE_NAME, ZTS_PORT);
+            final int servicePort = composeContainer.getServicePort(ZTS_SERVICE_NAME, ZTS_PORT);
+            ztsUri = URI.create("https://" + serviceHost + ':' + servicePort);
+        }
+        return ztsUri;
+    }
+
+    public ZtsBaseClient newZtsBaseClient(String serviceName) {
+        return newZtsBaseClient(serviceName, webClientBuilder -> {});
+    }
+
+    public ZtsBaseClient newZtsBaseClient(String serviceName,
+                                          Consumer<WebClientBuilder> webClientConfigurer) {
+        final String serviceKeyFile = ATHENZ_CERTS + serviceName + "/key.pem";
+        final String serviceCertFile = ATHENZ_CERTS + serviceName + "/cert.pem";
+        try (InputStream serviceKey = AthenzDocker.class.getResourceAsStream(serviceKeyFile);
+             InputStream serviceCert = AthenzDocker.class.getResourceAsStream(serviceCertFile);
+             InputStream caCert = AthenzDocker.class.getResourceAsStream(CA_CERT_FILE)) {
+            final TlsKeyPair tlsKeyPair = TlsKeyPair.of(serviceKey, serviceCert);
+            return ZtsBaseClient.builder(ztsUri())
+                                .keyPair(() -> tlsKeyPair)
+                                .trustedCertificate(caCert)
+                                .configureWebClient(webClientConfigurer)
+                                .build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ZMSClient newZmsClient() {
+        final String serviceHost = composeContainer.getServiceHost(ZMS_SERVICE_NAME, ZMS_PORT);
+        final int servicePort = composeContainer.getServicePort(ZMS_SERVICE_NAME, ZMS_PORT);
+        final String zmsUrl = "https://" + serviceHost + ':' + servicePort;
+        return new ZMSClient(zmsUrl, getSslContext("domain-admin"));
+    }
+
+    private ZTSClient newZtsClient(String serviceName) {
+        final String serviceHost = composeContainer.getServiceHost(ZTS_SERVICE_NAME, ZTS_PORT);
+        final Integer servicePort = composeContainer.getServicePort(ZTS_SERVICE_NAME, ZTS_PORT);
+        final String ztsUrl = "https://" + serviceHost + ':' + servicePort;
+        return new ZTSClient(ztsUrl, getSslContext(serviceName));
+    }
+
+    private static SSLContext getSslContext(String serviceName) {
+        final String domainAdminCertFile = ATHENZ_CERTS + serviceName + "/cert.pem";
+        final String domainAdminKeyFile = ATHENZ_CERTS + serviceName + "/key.pem";
+        return getSSLContext(CA_CERT_FILE, domainAdminKeyFile, domainAdminCertFile);
+    }
+
+    private static SSLContext getSSLContext(String caCertFile,
+                                            String athenzPrivateKeyFile, String athenzPublicCertFile) {
+        final String caCert = readFile(caCertFile);
+        final String athenzPublicCert = readFile(athenzPublicCertFile);
+        final String athenzPrivateKey = readFile(athenzPrivateKeyFile);
+        try {
+            return Utils.buildSSLContext(caCert, athenzPublicCert, athenzPrivateKey);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String readFile(String fileName) {
+        try (InputStream is = AthenzDocker.class.getResourceAsStream(fileName)) {
+            return IOUtils.toString(is);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to read file: " + fileName, e);
+        }
+    }
+}

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzExtension.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzExtension.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.server.athenz;
 
+import static org.assertj.core.api.Assumptions.assumeThat;
+
 import java.io.File;
 import java.net.URI;
 import java.util.function.Consumer;
@@ -56,7 +58,7 @@ public class AthenzExtension extends AbstractAllOrEachExtension {
 
     @Override
     protected void before(ExtensionContext context) throws Exception {
-        delegate.initialize();
+        assumeThat(delegate.initialize()).isTrue();
     }
 
     @Override

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzExtension.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzExtension.java
@@ -16,259 +16,56 @@
 
 package com.linecorp.armeria.server.athenz;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.util.Collections;
-import java.util.List;
 import java.util.function.Consumer;
 
-import javax.net.ssl.SSLContext;
-
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.ComposeContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
-import com.google.common.collect.ImmutableList;
-import com.oath.auth.Utils;
-import com.yahoo.athenz.auth.util.Crypto;
-import com.yahoo.athenz.zms.Assertion;
-import com.yahoo.athenz.zms.AssertionEffect;
-import com.yahoo.athenz.zms.Policy;
-import com.yahoo.athenz.zms.PublicKeyEntry;
-import com.yahoo.athenz.zms.Role;
-import com.yahoo.athenz.zms.ServiceIdentity;
-import com.yahoo.athenz.zms.TopLevelDomain;
 import com.yahoo.athenz.zms.ZMSClient;
-import com.yahoo.athenz.zts.ZTSClient;
 
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.client.athenz.ZtsBaseClient;
-import com.linecorp.armeria.common.TlsKeyPair;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.testing.junit5.common.AbstractAllOrEachExtension;
-
-import io.micrometer.core.instrument.util.IOUtils;
 
 public class AthenzExtension extends AbstractAllOrEachExtension {
 
-    private static final Logger logger = LoggerFactory.getLogger(AthenzExtension.class);
-
-    public static final String ZMS_SERVICE_NAME = "zms-server";
-    public static final String ZTS_SERVICE_NAME = "zts-server";
-    public static final int ZMS_PORT = 4443;
-    public static final int ZTS_PORT = 8443;
-
-    public static final String ATHENZ_CERTS = "/docker/certs/";
-    public static final String CA_CERT_FILE = ATHENZ_CERTS + "CAs/athenz_ca_cert.pem";
-    public static final String TEST_DOMAIN_NAME = "testing";
-    public static final String TEST_SERVICE = "test-service";
-    public static final String FOO_SERVICE = "foo-service";
-
-    public static final String ADMIN_ROLE = "test_role_admin";
-    public static final String USER_ROLE = "test_role_users";
-    public static final String ADMIN_POLICY = "admin-policy";
-    public static final String USER_POLICY = "user-policy";
-
-    private final ComposeContainer composeContainer;
-
-    @Nullable
-    private URI ztsUri;
-    @Nullable
-    private ZMSClient zmsClient;
+    private final AthenzDocker delegate;
 
     public AthenzExtension() {
-        composeContainer =
-                new ComposeContainer(new File("src/test/resources/docker/docker-compose.yml"))
-                        .withLocalCompose(true)
-                        .withExposedService(ZMS_SERVICE_NAME, ZMS_PORT, Wait.forHealthcheck())
-                        .withExposedService(ZTS_SERVICE_NAME, ZTS_PORT, Wait.forHealthcheck());
+        delegate = new AthenzDocker(new File("src/test/resources/docker/docker-compose.yml")) {
+            @Override
+            protected void scaffold(ZMSClient zmsClient) {
+                AthenzExtension.this.scaffold(zmsClient);
+            }
+        };
     }
 
-    private ZMSClient zmsClient() {
-        if (zmsClient == null) {
-            zmsClient = newZmsClient();
-        }
-        return zmsClient;
+    public URI ztsUri() {
+        return delegate.ztsUri();
+    }
+
+    public ZtsBaseClient newZtsBaseClient(String serviceName) {
+        return delegate.newZtsBaseClient(serviceName);
+    }
+
+    public ZtsBaseClient newZtsBaseClient(String serviceName,
+                                          Consumer<WebClientBuilder> webClientConfigurer) {
+        return delegate.newZtsBaseClient(serviceName, webClientConfigurer);
     }
 
     @Override
     protected void before(ExtensionContext context) throws Exception {
-        composeContainer.start();
-        logger.info("Starting Docker compose container for Athenz tests");
-        defaultScaffold();
-        scaffold(zmsClient());
+        delegate.initialize();
     }
 
     @Override
     public void after(ExtensionContext context) throws Exception {
-        composeContainer.stop();
+        delegate.close();
     }
 
     /**
      * Override this method to create your own test domain, services, roles, and policies.
      */
     protected void scaffold(ZMSClient zmsClient) {}
-
-    private void defaultScaffold() {
-        // Create test domain
-        createDomain();
-        // Create test service
-        final String testServicePublicKeyId = createService(TEST_SERVICE);
-        final String fooServicePublicKeyId = createService(FOO_SERVICE);
-
-        createRole(USER_ROLE, ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE,
-                                               TEST_DOMAIN_NAME + '.' + FOO_SERVICE));
-        // Admin role is only granted to the test service
-        createRole(ADMIN_ROLE, ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE));
-
-        createPolicy(USER_POLICY, USER_ROLE, "files");
-        createPolicy(ADMIN_POLICY, ADMIN_ROLE, "secrets");
-
-        try (ZTSClient ztsAdminClient = newZtsClient("domain-admin")) {
-            // Wait for ZTS to sync
-            await().untilAsserted(() -> {
-                try {
-                    final com.yahoo.athenz.zts.ServiceIdentity testServiceIdentity =
-                            ztsAdminClient.getServiceIdentity(TEST_DOMAIN_NAME, TEST_SERVICE);
-                    assertThat(testServiceIdentity.getPublicKeys()).anyMatch(publicKey -> {
-                        return publicKey.getId().equals(testServicePublicKeyId);
-                    });
-
-                    final com.yahoo.athenz.zts.ServiceIdentity fooServiceIdentity =
-                            ztsAdminClient.getServiceIdentity(TEST_DOMAIN_NAME, FOO_SERVICE);
-                    assertThat(fooServiceIdentity.getPublicKeys()).anyMatch(publicKey -> {
-                        return publicKey.getId().equals(fooServicePublicKeyId);
-                    });
-                } catch (Exception e) {
-                    throw new AssertionError(e);
-                }
-            });
-        }
-    }
-
-    private void createPolicy(String policyName, String roleName, String resourceName) {
-        final String assertionRole = TEST_DOMAIN_NAME + ":role." + roleName;
-        final String assertionAction = "obtain";
-        final String assertionResource = TEST_DOMAIN_NAME + ':' + resourceName;
-        final Assertion assertion = new Assertion();
-        assertion.setRole(assertionRole);
-        assertion.setAction(assertionAction);
-        assertion.setResource(assertionResource);
-        assertion.setEffect(AssertionEffect.ALLOW);
-
-        final Policy policyToCreate = new Policy();
-        policyToCreate.setName(TEST_DOMAIN_NAME + ":policy." + policyName);
-        policyToCreate.setAssertions(ImmutableList.of(assertion));
-
-        zmsClient().putPolicy(TEST_DOMAIN_NAME, policyName, "create-policy-audit-ref", policyToCreate);
-    }
-
-    private void createRole(String roleName, List<String> members) {
-        final Role role = new Role().setName(TEST_DOMAIN_NAME + ":role." + roleName)
-                                    .setMembers(members);
-        zmsClient().putRole(TEST_DOMAIN_NAME, roleName, "create-role-audit-ref", role);
-    }
-
-    private String createService(String serviceName) {
-        final String publicCert = readFile(ATHENZ_CERTS + serviceName + "/public.pem");
-        final String ybase64PublicKey = Crypto.ybase64EncodeString(publicCert);
-        final String publicKeyId = serviceName + "_public_key";
-
-        final PublicKeyEntry publicKeyEntry = new PublicKeyEntry();
-        publicKeyEntry.setId(publicKeyId);
-        publicKeyEntry.setKey(ybase64PublicKey);
-        final ServiceIdentity serviceIdentity = new ServiceIdentity();
-        serviceIdentity.setName(TEST_DOMAIN_NAME + '.' + serviceName);
-        serviceIdentity.setPublicKeys(Collections.singletonList(publicKeyEntry));
-
-        zmsClient().putServiceIdentity(TEST_DOMAIN_NAME, serviceName, "create-service-audit-ref",
-                                       serviceIdentity);
-        return publicKeyId;
-    }
-
-    private void createDomain() {
-        final TopLevelDomain domain = new TopLevelDomain();
-        domain.setName(TEST_DOMAIN_NAME);
-        domain.setDescription("A test domain created by the Java client.");
-        domain.setAdminUsers(ImmutableList.of("user.github-7654321"));
-        zmsClient().postTopLevelDomain("create-domain-audit-ref", domain);
-    }
-
-    public URI ztsUri() {
-        if (ztsUri == null) {
-            final String serviceHost = composeContainer.getServiceHost(ZTS_SERVICE_NAME, ZTS_PORT);
-            final int servicePort = composeContainer.getServicePort(ZTS_SERVICE_NAME, ZTS_PORT);
-            ztsUri = URI.create("https://" + serviceHost + ':' + servicePort);
-        }
-        return ztsUri;
-    }
-
-    public ZtsBaseClient newZtsBaseClient(String serviceName) {
-        return newZtsBaseClient(serviceName, webClientBuilder -> {});
-    }
-
-    public ZtsBaseClient newZtsBaseClient(String serviceName,
-                                          Consumer<WebClientBuilder> webClientConfigurer) {
-        final String serviceKeyFile = ATHENZ_CERTS + serviceName + "/key.pem";
-        final String serviceCertFile = ATHENZ_CERTS + serviceName + "/cert.pem";
-        try (InputStream serviceKey = AthenzExtension.class.getResourceAsStream(serviceKeyFile);
-             InputStream serviceCert = AthenzExtension.class.getResourceAsStream(serviceCertFile);
-             InputStream caCert = AthenzExtension.class.getResourceAsStream(CA_CERT_FILE)) {
-            final TlsKeyPair tlsKeyPair = TlsKeyPair.of(serviceKey, serviceCert);
-            return ZtsBaseClient.builder(ztsUri())
-                                .keyPair(() -> tlsKeyPair)
-                                .trustedCertificate(caCert)
-                                .configureWebClient(webClientConfigurer)
-                                .build();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private ZMSClient newZmsClient() {
-        final String serviceHost = composeContainer.getServiceHost(ZMS_SERVICE_NAME, ZMS_PORT);
-        final int servicePort = composeContainer.getServicePort(ZMS_SERVICE_NAME, ZMS_PORT);
-        final String zmsUrl = "https://" + serviceHost + ':' + servicePort;
-        return new ZMSClient(zmsUrl, getSslContext("domain-admin"));
-    }
-
-    private ZTSClient newZtsClient(String serviceName) {
-        final String serviceHost = composeContainer.getServiceHost(ZTS_SERVICE_NAME, ZTS_PORT);
-        final Integer servicePort = composeContainer.getServicePort(ZTS_SERVICE_NAME, ZTS_PORT);
-        final String ztsUrl = "https://" + serviceHost + ':' + servicePort;
-        return new ZTSClient(ztsUrl, getSslContext(serviceName));
-    }
-
-    private static SSLContext getSslContext(String serviceName) {
-        final String domainAdminCertFile = ATHENZ_CERTS + serviceName + "/cert.pem";
-        final String domainAdminKeyFile = ATHENZ_CERTS + serviceName + "/key.pem";
-        return getSSLContext(CA_CERT_FILE, domainAdminKeyFile, domainAdminCertFile);
-    }
-
-    private static SSLContext getSSLContext(String caCertFile,
-                                            String athenzPrivateKeyFile, String athenzPublicCertFile) {
-        final String caCert = readFile(caCertFile);
-        final String athenzPublicCert = readFile(athenzPublicCertFile);
-        final String athenzPrivateKey = readFile(athenzPrivateKeyFile);
-        try {
-            return Utils.buildSSLContext(caCert, athenzPublicCert, athenzPrivateKey);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static String readFile(String fileName) {
-        try (InputStream is = AthenzIntegrationTest.class.getResourceAsStream(fileName)) {
-            return IOUtils.toString(is);
-        } catch (Exception e) {
-            throw new IllegalStateException("Failed to read file: " + fileName, e);
-        }
-    }
 }

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzIntegrationTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzIntegrationTest.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.server.athenz;
 
-import static com.linecorp.armeria.server.athenz.AthenzExtension.ADMIN_ROLE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.FOO_SERVICE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_DOMAIN_NAME;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_SERVICE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.USER_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.ADMIN_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.FOO_SERVICE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_SERVICE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.USER_ROLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzInvalidPolicyDataTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzInvalidPolicyDataTest.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.server.athenz;
 
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_DOMAIN_NAME;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_SERVICE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_SERVICE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoaderTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoaderTest.java
@@ -16,10 +16,10 @@
 
 package com.linecorp.armeria.server.athenz;
 
-import static com.linecorp.armeria.server.athenz.AthenzExtension.ADMIN_POLICY;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.ADMIN_ROLE;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_DOMAIN_NAME;
-import static com.linecorp.armeria.server.athenz.AthenzExtension.TEST_SERVICE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.ADMIN_POLICY;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.ADMIN_ROLE;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
+++ b/core/src/test/java12/com/linecorp/armeria/server/JavaHttpClientUpgradeTest.java
@@ -38,12 +38,14 @@ import org.junit.jupiter.params.provider.EnumSource;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.internal.testing.FlakyTest;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.channel.ChannelPipeline;
 
+@FlakyTest
 class JavaHttpClientUpgradeTest {
 
     static int maxRequestLength = 10;

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -1316,6 +1316,8 @@ exclusions = "org.springframework.boot:spring-boot-starter-reactor-netty"
 module = "org.springframework.boot:spring-boot-configuration-processor"
 version.ref = "spring-boot3"
 
+[libraries.testcontainers-core]
+module = "org.testcontainers:testcontainers"
 [libraries.testcontainers-consul]
 module = "org.testcontainers:consul"
 [libraries.testcontainers-junit-jupiter]

--- a/examples/athenz/build.gradle
+++ b/examples/athenz/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'application'
+}
+
+dependencies {
+    implementation project(':core')
+    implementation project(':athenz')
+    implementation project(':grpc')
+    implementation libs.testcontainers.core
+    implementation libs.athenz.zms.client
+    implementation libs.athenz.zts.client
+    runtimeOnly libs.slf4j.simple
+
+    testImplementation project(':junit5')
+    testImplementation libs.assertj
+    testImplementation libs.junit5.jupiter.api
+    testImplementation libs.testcontainers.junit.jupiter
+}
+
+application {
+    mainClass.set('example.armeria.athenz.Main')
+}
+
+// Copy the Athenz Docker resources from ':athenz'.
+task copyTestResources(type: Copy) {
+    from("${rootProject.projectDir}/athenz/src/test") {
+        include 'resources/**'
+        include '**/AthenzDocker.java'
+    }
+    into "${project.ext.genSrcDir}/main"
+}
+
+tasks.compileJava.dependsOn(tasks.copyTestResources)
+tasks.processResources.dependsOn(tasks.copyTestResources)

--- a/examples/athenz/build.gradle
+++ b/examples/athenz/build.gradle
@@ -32,3 +32,4 @@ task copyTestResources(type: Copy) {
 
 tasks.compileJava.dependsOn(tasks.copyTestResources)
 tasks.processResources.dependsOn(tasks.copyTestResources)
+tasks.sourcesJar.dependsOn(tasks.copyTestResources)

--- a/examples/athenz/src/main/java/example/armeria/athenz/GrpcServiceImpl.java
+++ b/examples/athenz/src/main/java/example/armeria/athenz/GrpcServiceImpl.java
@@ -1,0 +1,21 @@
+package example.armeria.athenz;
+
+import com.linecorp.armeria.server.athenz.RequiresAthenzRole;
+
+import example.armeria.grpc.Hello.HelloReply;
+import example.armeria.grpc.Hello.HelloRequest;
+import example.armeria.grpc.HelloServiceGrpc.HelloServiceImplBase;
+import io.grpc.stub.StreamObserver;
+
+final class GrpcServiceImpl extends HelloServiceImplBase {
+    @RequiresAthenzRole(resource = "greeting", action = "hello")
+    @Override
+    public void hello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
+        final String name = request.getName();
+        final HelloReply reply = HelloReply.newBuilder()
+                                           .setMessage("Hello, " + name + '!')
+                                           .build();
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/examples/athenz/src/main/java/example/armeria/athenz/Main.java
+++ b/examples/athenz/src/main/java/example/armeria/athenz/Main.java
@@ -1,0 +1,122 @@
+package example.armeria.athenz;
+
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+
+import java.io.File;
+import java.net.URI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.yahoo.athenz.zms.ZMSClient;
+
+import com.linecorp.armeria.client.athenz.ZtsBaseClient;
+import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerListenerAdapter;
+import com.linecorp.armeria.server.athenz.AthenzDocker;
+import com.linecorp.armeria.server.athenz.AthenzPolicyConfig;
+import com.linecorp.armeria.server.athenz.AthenzServiceDecoratorFactory;
+import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.docs.DocServiceFilter;
+import com.linecorp.armeria.server.grpc.GrpcService;
+
+import example.armeria.grpc.Hello.HelloRequest;
+import example.armeria.grpc.HelloServiceGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
+
+public final class Main {
+
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+    public static void main(String[] args) throws Exception {
+        final AthenzDocker athenzDocker = newAthenzDocker();
+        final Server server = newServer(8080, 8443, athenzDocker.ztsUri());
+
+        server.closeOnJvmShutdown(athenzDocker::close);
+
+        server.start().join();
+
+        logger.info("Server has been started. Serving DocService at http://127.0.0.1:{}/docs",
+                    server.activeLocalPort());
+    }
+
+    private static Server newServer(int httpPort, int httpsPort, URI ztsUri) throws Exception {
+        final ServerBuilder sb = Server.builder();
+        sb.http(httpPort)
+          .https(httpsPort)
+          .tlsSelfSigned();
+        configureServices(sb);
+        configureAthenz(sb, ztsUri);
+        return sb.build();
+    }
+
+    static AthenzDocker newAthenzDocker() {
+        final AthenzDocker athenzDocker =
+                new AthenzDocker(new File("gen-src/main/resources/docker/docker-compose.yml")) {
+                    @Override
+                    protected void scaffold(ZMSClient zmsClient) {
+                        createRole("test_role",
+                                   ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE,
+                                                    TEST_DOMAIN_NAME + '.' + FOO_SERVICE));
+                        createPolicy("greeting-policy", "test_role", "greeting", "hello");
+                    }
+                };
+        athenzDocker.initialize();
+        return athenzDocker;
+    }
+
+    static void configureAthenz(ServerBuilder sb, URI ztsUri) {
+        final String providerKeyFile = "gen-src/main/resources/docker/certs/test-service/key.pem";
+        final String providerCertFile = "gen-src/main/resources/docker/certs/test-service/cert.pem";
+        final String caCertFile = "gen-src/main/resources/docker/certs/CAs/athenz_ca_cert.pem";
+
+        final ZtsBaseClient ztsBaseClient =
+                ZtsBaseClient.builder(ztsUri)
+                             .keyPair(providerKeyFile, providerCertFile)
+                             // caCertFile may not be necessary in production, but it is required for testing.
+                             .trustedCertificate(caCertFile)
+                             .build();
+
+        final AthenzServiceDecoratorFactory decoratorFactory = AthenzServiceDecoratorFactory
+                .builder(ztsBaseClient)
+                .policyConfig(new AthenzPolicyConfig(TEST_DOMAIN_NAME))
+                .build();
+
+        final DependencyInjector dependencyInjector =
+                DependencyInjector.ofSingletons(decoratorFactory)
+                                  .orElse(DependencyInjector.ofReflective());
+        sb.dependencyInjector(dependencyInjector, false);
+        sb.serverListener(new ServerListenerAdapter() {
+            @Override
+            public void serverStopped(Server server) {
+                ztsBaseClient.close();
+            }
+        });
+    }
+
+    static void configureServices(ServerBuilder sb) {
+        final HelloRequest exampleRequest = HelloRequest.newBuilder().setName("Armeria").build();
+        final GrpcService grpcService =
+                GrpcService.builder()
+                           .addService(new GrpcServiceImpl())
+                           .enableUnframedRequests(true)
+                           .build();
+        sb.service("prefix:/grpc", grpcService)
+          .annotatedService("/rest", new RestServiceImpl())
+
+          // You can access the documentation service at http://127.0.0.1:8080/docs.
+          // See https://armeria.dev/docs/server-docservice for more information.
+          .serviceUnder("/docs",
+                        DocService.builder()
+                                  .exampleRequests(HelloServiceGrpc.SERVICE_NAME,
+                                                   "Hello", exampleRequest)
+                                  .exclude(DocServiceFilter.ofServiceName(
+                                          ServerReflectionGrpc.SERVICE_NAME))
+                                  .build());
+    }
+
+    private Main() {}
+}

--- a/examples/athenz/src/main/java/example/armeria/athenz/Main.java
+++ b/examples/athenz/src/main/java/example/armeria/athenz/Main.java
@@ -32,7 +32,10 @@ public final class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     public static void main(String[] args) throws Exception {
+        // Assuming you have Docker installed and running, this example will start a
+        // ZTS (ZMS and ZTS) server using Docker Compose.
         final AthenzDocker athenzDocker = newAthenzDocker();
+        athenzDocker.initialize();
         final Server server = newServer(8080, 8443, athenzDocker.ztsUri());
 
         server.closeOnJvmShutdown(athenzDocker::close);
@@ -54,18 +57,15 @@ public final class Main {
     }
 
     static AthenzDocker newAthenzDocker() {
-        final AthenzDocker athenzDocker =
-                new AthenzDocker(new File("gen-src/main/resources/docker/docker-compose.yml")) {
-                    @Override
-                    protected void scaffold(ZMSClient zmsClient) {
-                        createRole("test_role",
-                                   ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE,
-                                                    TEST_DOMAIN_NAME + '.' + FOO_SERVICE));
-                        createPolicy("greeting-policy", "test_role", "greeting", "hello");
-                    }
-                };
-        athenzDocker.initialize();
-        return athenzDocker;
+        return new AthenzDocker(new File("gen-src/main/resources/docker/docker-compose.yml")) {
+            @Override
+            protected void scaffold(ZMSClient zmsClient) {
+                createRole("test_role",
+                           ImmutableList.of(TEST_DOMAIN_NAME + '.' + TEST_SERVICE,
+                                            TEST_DOMAIN_NAME + '.' + FOO_SERVICE));
+                createPolicy("greeting-policy", "test_role", "greeting", "hello");
+            }
+        };
     }
 
     static void configureAthenz(ServerBuilder sb, URI ztsUri) {

--- a/examples/athenz/src/main/java/example/armeria/athenz/RestServiceImpl.java
+++ b/examples/athenz/src/main/java/example/armeria/athenz/RestServiceImpl.java
@@ -1,0 +1,13 @@
+package example.armeria.athenz;
+
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.athenz.RequiresAthenzRole;
+
+final class RestServiceImpl {
+
+    @RequiresAthenzRole(resource = "greeting", action = "hello")
+    @Get("/hello/{name}")
+    public String hello(String name) {
+        return "Hello, " + name + '!';
+    }
+}

--- a/examples/athenz/src/main/proto/hello.proto
+++ b/examples/athenz/src/main/proto/hello.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package example.grpc.hello;
+option java_package = "example.armeria.grpc";
+
+service HelloService {
+  rpc Hello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
+++ b/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
@@ -45,10 +45,10 @@ class AthenzTest {
         }
     };
 
-    private ZtsBaseClient ztsBaseClient;
+    private static ZtsBaseClient ztsBaseClient;
 
-    @BeforeEach
-    void setUp() {
+    @BeforeAll
+    static void beforeAll() {
         final String tenantKeyFile = "gen-src/main/resources/docker/certs/foo-service/key.pem";
         final String tenantCertFile = "gen-src/main/resources/docker/certs/foo-service/cert.pem";
         final String caCertFile = "gen-src/main/resources/docker/certs/CAs/athenz_ca_cert.pem";
@@ -62,6 +62,7 @@ class AthenzTest {
 
     @AfterAll
     static void afterAll() {
+        ztsBaseClient.close();
         athenzDocker.close();
     }
 

--- a/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
+++ b/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
@@ -6,6 +6,7 @@ import static example.armeria.athenz.Main.configureServices;
 import static example.armeria.athenz.Main.newAthenzDocker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,12 +35,13 @@ import io.grpc.StatusRuntimeException;
 @EnabledIfDockerAvailable
 class AthenzTest {
 
-    static AthenzDocker athenzDocker = newAthenzDocker();
+    private static final AthenzDocker athenzDocker = newAthenzDocker();
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
+            athenzDocker.initialize();
             configureServices(sb);
             configureAthenz(sb, athenzDocker.ztsUri());
         }
@@ -49,6 +51,7 @@ class AthenzTest {
 
     @BeforeAll
     static void beforeAll() {
+        assumeThat(athenzDocker.isInitialized()).isTrue();
         final String tenantKeyFile = "gen-src/main/resources/docker/certs/foo-service/key.pem";
         final String tenantCertFile = "gen-src/main/resources/docker/certs/foo-service/cert.pem";
         final String caCertFile = "gen-src/main/resources/docker/certs/CAs/athenz_ca_cert.pem";

--- a/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
+++ b/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
@@ -54,7 +54,8 @@ class AthenzTest {
         final String caCertFile = "gen-src/main/resources/docker/certs/CAs/athenz_ca_cert.pem";
         ztsBaseClient = ZtsBaseClient.builder(athenzDocker.ztsUri())
                                      .keyPair(tenantKeyFile, tenantCertFile)
-                                     // caCertFile may not be necessary in production, but it is required for testing.
+                                     // caCertFile may not be necessary in production,
+                                     // but it is required for testing.
                                      .trustedCertificate(caCertFile)
                                      .build();
     }

--- a/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
+++ b/examples/athenz/src/test/java/example/armeria/athenz/AthenzTest.java
@@ -1,0 +1,125 @@
+package example.armeria.athenz;
+
+import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
+import static example.armeria.athenz.Main.configureAthenz;
+import static example.armeria.athenz.Main.configureServices;
+import static example.armeria.athenz.Main.newAthenzDocker;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.junit.jupiter.EnabledIfDockerAvailable;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.athenz.AthenzClient;
+import com.linecorp.armeria.client.athenz.ZtsBaseClient;
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.athenz.TokenType;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.athenz.AthenzDocker;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import example.armeria.grpc.Hello.HelloReply;
+import example.armeria.grpc.Hello.HelloRequest;
+import example.armeria.grpc.HelloServiceGrpc.HelloServiceBlockingStub;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+
+@EnabledIfDockerAvailable
+class AthenzTest {
+
+    static AthenzDocker athenzDocker = newAthenzDocker();
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            configureServices(sb);
+            configureAthenz(sb, athenzDocker.ztsUri());
+        }
+    };
+
+    private ZtsBaseClient ztsBaseClient;
+
+    @BeforeEach
+    void setUp() {
+        final String tenantKeyFile = "gen-src/main/resources/docker/certs/foo-service/key.pem";
+        final String tenantCertFile = "gen-src/main/resources/docker/certs/foo-service/cert.pem";
+        final String caCertFile = "gen-src/main/resources/docker/certs/CAs/athenz_ca_cert.pem";
+        ztsBaseClient = ZtsBaseClient.builder(athenzDocker.ztsUri())
+                                     .keyPair(tenantKeyFile, tenantCertFile)
+                                     // caCertFile may not be necessary in production, but it is required for testing.
+                                     .trustedCertificate(caCertFile)
+                                     .build();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        athenzDocker.close();
+    }
+
+    @Test
+    void rest_shouldRejectUnauthorizedRequest() {
+        final BlockingWebClient client =
+                WebClient.builder(server.httpUri())
+                         .build()
+                         .blocking();
+        final AggregatedHttpResponse response0 = client.get("/rest/hello/Armeria");
+        assertThat(response0.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void rest_shouldAccessResource() {
+        final BlockingWebClient clientWithAthenz =
+                WebClient.builder(server.httpUri())
+                         // Use the AthenzClient to obtain an access token for the specified role.
+                         .decorator(AthenzClient.newDecorator(ztsBaseClient,
+                                                              TEST_DOMAIN_NAME,
+                                                              "test_role",
+                                                              TokenType.ACCESS_TOKEN))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse response1 = clientWithAthenz.get("/rest/hello/Armeria");
+        assertThat(response1.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void grpc_shouldRejectUnauthorizedRequest() {
+        final HelloServiceBlockingStub client =
+                GrpcClients.builder(server.httpUri())
+                           .pathPrefix("/grpc")
+                           .build(HelloServiceBlockingStub.class);
+
+        assertThatThrownBy(() -> {
+            client.hello(HelloRequest.newBuilder()
+                                     .setName("Armeria")
+                                     .build());
+        }).isInstanceOfSatisfying(StatusRuntimeException.class, cause -> {
+            assertThat(cause.getStatus().getCode()).isEqualTo(Code.UNAUTHENTICATED);
+        });
+    }
+
+    @Test
+    void grpc_shouldAccessResource() {
+        final HelloServiceBlockingStub client =
+                GrpcClients.builder(server.httpUri())
+                           .pathPrefix("/grpc")
+                            .decorator(AthenzClient.newDecorator(ztsBaseClient,
+                                                                 TEST_DOMAIN_NAME,
+                                                                 "test_role",
+                                                                 TokenType.ACCESS_TOKEN))
+                           .build(HelloServiceBlockingStub.class);
+
+        final HelloReply response = client.hello(HelloRequest.newBuilder()
+                                                             .setName("Armeria")
+                                                             .build());
+        assertThat(response.getMessage()).isEqualTo("Hello, Armeria!");
+    }
+}

--- a/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
+++ b/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
@@ -19,7 +19,7 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.producers.Production;
 
-public class Main {
+public final class Main {
 
     @Module(subcomponents = MainGraph.Component.class)
     abstract static class MainModule {

--- a/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
+++ b/examples/context-propagation/dagger/src/main/java/example/armeria/contextpropagation/dagger/Main.java
@@ -19,7 +19,7 @@ import dagger.Module;
 import dagger.Provides;
 import dagger.producers.Production;
 
-public final class Main {
+public class Main {
 
     @Module(subcomponents = MainGraph.Component.class)
     abstract static class MainModule {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 ## Disable TLSv1.3 because it triggers handshake failures on some hosts we access.
 systemProp.https.protocols=TLSv1,TLSv1.1,TLSv1.2
 
-jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/*/scalapb/**,META-INF/versions/**
+jacocoExclusions=com/linecorp/armeria/internal/common/CurrentJavaVersionSpecific,com/linecorp/armeria/*/scalapb/**,example/armeria/grpc/**,META-INF/versions/**
 shadowExclusions=META-INF/services/java.security.Provider
 org.gradle.caching = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -263,6 +263,8 @@ includeWithFlags ':site'
 // Examples
 includeWithFlags ':examples:annotated-http-service',               'java11'
 includeWithFlags ':examples:annotated-http-service-kotlin',        'java11', 'kotlin'
+includeWithFlags ':examples:athenz-example',                       'java11'
+project(':examples:athenz-example').projectDir = file('examples/athenz')
 includeWithFlags ':examples:context-propagation-dagger-example',   'java11'
 project(':examples:context-propagation-dagger-example').projectDir = file('examples/context-propagation/dagger')
 includeWithFlags ':examples:context-propagation-kotlin-example',   'java11', 'kotlin'

--- a/site/src/pages/docs/advanced-athenz.mdx
+++ b/site/src/pages/docs/advanced-athenz.mdx
@@ -21,7 +21,7 @@ dependencies={[
 
 The <type://ZtsBaseClient> is a client used to interact with the [Athenz ZTS (authZ Token System)](https://athenz.github.io/athenz/system_view/#zts-authz-token-system).
 It is required to create <type://AthenzClient> and <type://AthenzService> decorators.
-You can create an instance of ZtsBaseClient as follows:
+You can create an instance of <type://ZtsBaseClient> as follows:
 
 ```java
 import com.linecorp.armeria.client.athenz.ZtsBaseClient;

--- a/site/src/pages/docs/advanced-athenz.mdx
+++ b/site/src/pages/docs/advanced-athenz.mdx
@@ -1,0 +1,173 @@
+import versions from '../../../gen-src/versions.json';
+
+# Athenz integration
+
+This document explains how to integrate Armeria with Athenz, a platform for service authentication and 
+authorization. It assumes that you have already configured an Athenz domain and installed the necessary service
+identity certificates locally.
+
+## Prerequisites
+
+Add the following dependencies to your build.gradle file:
+
+<RequiredDependencies
+boms={[{ groupId: 'com.linecorp.armeria', artifactId: 'armeria-bom' }]}
+dependencies={[
+{ groupId: 'com.linecorp.armeria', artifactId: 'armeria-athenz' },
+]}
+/>
+
+## Creating a ZTS client
+
+The <type://ZtsBaseClient> is a client used to interact with the [Athenz ZTS (authZ Token System)](https://athenz.github.io/athenz/system_view/#zts-authz-token-system).
+It is required to create <type://AthenzClient> and <type://AthenzService> decorators.
+You can create an instance of ZtsBaseClient as follows:
+
+```java
+import com.linecorp.armeria.client.athenz.ZtsBaseClient;
+import com.linecorp.armeria.client.athenz.ZtsBaseClientBuilder;
+
+ZtsBaseClient ztsBaseClient =
+    ZtsBaseClient
+        .builder("https://athenz.example.com:8443/zts/v1")
+        // You need to specify your Athenz service key and certificate files.
+        .keyPair("/var/lib/athenz/service.key.pem", 
+                 "/var/lib/athenz/service.cert.pem")
+        // Uncomment the following line to use a proxy.
+        // .proxyUri("http://my-proxy.example.com:8080")
+        .build();
+
+// ...
+
+// Close the client when it is no longer needed.
+ztsBaseClient.close();
+```
+
+## Checking permissions with the <type://AthenzService> decorator
+
+You can enforce Athenz authorization on your services by applying the <type://AthenzService> decorator. 
+This decorator intercepts incoming requests and validates the client's token against the configured Athenz policies.
+
+The code below configures a decorator for paths under `/files`. It will only grant access to requests that 
+present a token with the specified `action` ("get") and `resource` ("files") for your Athenz domain. 
+The `action` and `resource` must correspond to an assertion you have configured in Athenz.
+
+```java
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.athenz.AthenzService;
+import com.linecorp.armeria.server.athenz.AthenzPolicyConfig;
+
+ServerBuilder serverBuilder = Server.builder();
+serverBuilder.decoratorUnder(
+    "/files",
+    AthenzService.builder(ztsBaseClient)
+                 .action("get")
+                 .resource("files")
+                 .policyConfig(new AthenzPolicyConfig("your-domain"))
+                 .newDecorator());
+serverBuilder.serviceUnder("/files", FileService.of(...));
+...
+```
+
+The <type://AthenzPolicyConfig> object replaces the need for a `zpu.conf` file. It allows the server to download
+policy files directly at startup and perform authorization checks without relying on the [`zpu`](https://athenz.github.io/athenz/setup_zpu/)
+command-line utility.
+
+If you are only using the decorator for permission checks, this is all the configuration required to integrate Athenz with Armeria.
+
+## Checking permissions with the <type://@RequiresAthenzRole> annotation
+
+As an alternative to programmatically applying decorators, you can use the <type://@RequiresAthenzRole> annotation
+on service methods or classes for a more declarative approach.
+
+```java
+import com.linecorp.armeria.server.athenz.RequiresAthenzRole;
+
+class MyService {
+    // Decorate the method with `@RequiresAthenzRole` to check the Athenz role.
+    @RequiresAthenzRole(resource = "user", action = "get")
+    @ProducesJson
+    @Get("/user")
+    public CompletableFuture<User> getUser() {
+        // ...
+    }
+}
+```
+
+To enable this annotation, you must register an <type://AthenzServiceDecoratorFactory> with the server. 
+This factory uses the <type://ZtsBaseClient> to create the necessary decorators that enforce the roles specified
+in the annotations.
+
+```java
+import com.linecorp.armeria.common.DependencyInjector;
+import com.linecorp.armeria.server.athenz.AthenzPolicyConfig;
+import com.linecorp.armeria.server.athenz.AthenzServiceDecoratorFactory;
+import com.linecorp.armeria.server.athenz.AthenzServiceDecoratorFactoryBuilder;
+
+// Create and register `AthenzServiceDecoratorFactory`.
+AthenzServiceDecoratorFactory athenzDecoratorFactory =
+  AthenzServiceDecoratorFactory
+    .builder(ztsBaseClient)
+    .policyConfig(new AthenzPolicyConfig("my-domain"))
+    .build();
+
+DependencyInjector di =
+  DependencyInjector.ofSingletons(athenzDecoratorFactory)
+                    .orElse(DependencyInjector.ofReflective());
+serverBuilder.dependencyInjector(di, true);
+```
+
+The <type://@RequiresAthenzRole> annotation can be applied not only to annotated services but also to methods in 
+Thrift and gRPC services.
+
+```java
+class UserGrpcServiceImpl extends UserGrpcServiceImplBase {
+  @RequiresAthenzRole(resource = "user", action = "get")
+  public void getUser(UserRequest request,
+                      StreamObserver<UserResponse> responseObserver) {
+    // ...
+  }
+}
+```
+
+## Obtaining athenz tokens with <type://AthenzClient>
+
+To communicate with other Athenz-protected services, you can use the <type://AthenzClient> decorator.
+This client automatically acquires an Athenz token from the ZTS, caches it, and attaches it to outgoing requests.
+It also handles token refreshes before expiration, so you do not need to manage the token lifecycle yourself.
+
+To obtain an access token and send it in the `Authorization` header, configure the decorator with <type://TokenType#ACCESS_TOKEN>.
+
+```java
+import com.linecorp.armeria.client.athenz.AthenzClient;
+import com.linecorp.armeria.common.athenz.TokenType;
+
+WebClient client =
+  WebClient
+    .builder("https://api.example.com/")
+    .decorator(AthenzClient.newDecorator(ztsBaseClient, "my-domain",
+                                         TokenType.ACCESS_TOKEN))
+    .build();
+ 
+// An Athenz access token is automatically acquired and set in the `Authorization` header.
+client.get("/files");
+```
+
+To obtain a role token and send it in a role token header (e.g., Athenz-Role-Auth or Yahoo-Role-Auth), specify
+<type://TokenType#ATHENZ_ROLE_TOKEN> or <type://TokenType#YAHOO_ROLE_TOKEN>.
+
+```java
+WebClient client =
+WebClient
+  .builder("https://api.example.com/")
+  .decorator(AthenzClient.newDecorator(ztsBaseClient, "my-domain",
+                                       TokenType.ATHENZ_ROLE_TOKEN))
+  .build();
+```
+
+<Tip>
+
+Visit [athenz-example](https://github.com/line/armeria/tree/main/examples/athenz) to check out a fully working example.
+
+</Tip>

--- a/site/src/pages/docs/advanced-athenz.mdx
+++ b/site/src/pages/docs/advanced-athenz.mdx
@@ -2,9 +2,9 @@ import versions from '../../../gen-src/versions.json';
 
 # Athenz integration
 
-This document explains how to integrate Armeria with Athenz, a platform for service authentication and 
-authorization. It assumes that you have already configured an Athenz domain and installed the necessary service
-identity certificates locally.
+This document explains how to integrate Armeria with [Athenz](https://www.athenz.io/), a platform for service
+authentication and authorization. It assumes that you have already configured an Athenz domain and installed 
+the necessary service identity certificates locally.
 
 ## Prerequisites
 

--- a/site/src/pages/docs/toc.json
+++ b/site/src/pages/docs/toc.json
@@ -49,6 +49,7 @@
     "advanced-unit-testing",
     "advanced-production-checklist",
     "advanced-saml",
+    "advanced-athenz",
     "advanced-spring-boot-integration",
     "advanced-spring-webflux-integration",
     "advanced-dropwizard-integration",

--- a/site/src/pages/release-notes/1.33.0.mdx
+++ b/site/src/pages/release-notes/1.33.0.mdx
@@ -4,9 +4,9 @@ date: 2025-08-06
 
 ## 🌟 New features
 
-- **Athenz integration**: You can now use the new `armeria-athenz` module to easily obtain and validate Athenz
+- **Athenz Integration**: You can now use the new `armeria-athenz` module to easily obtain and validate Athenz
   tokens for secure service-to-service communication. #6050 #6321
-  - Server-side validation: Use <type://RequiresAthenzRole> to protect your annotated service endpoints.
+  - Server-side validation: Use <type://@RequiresAthenzRole> to protect your annotated service endpoints.
     ```java
     // Prepare a `ZtsBaseClient` to communicate with
     // the Athenz ZTS server.
@@ -51,56 +51,56 @@ date: 2025-08-06
       .build();
     ```
 - **Content Sanitization for Logs**: You can now mask sensitive information for <type://AnnotatedService> and
-    <type://THttpService> using the flexible <type://ContentSanitizer>. #6311 #6268
-    ```java
-    // For annotated services, use a custom annotation
-    // and mark sensitive fields.
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Sensitive {}
+  <type://THttpService> using the flexible <type://ContentSanitizer>. #6311 #6268
+  ```java
+  // For annotated services, use a custom annotation
+  // and mark sensitive fields.
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface Sensitive {}
 
-    class UserRequest {
-        private String name;
-        @Sensitive // This field will be masked in logs.
-        private String phoneNumber;
-        ...
-    }
+  class UserRequest {
+      private String name;
+      @Sensitive // This field will be masked in logs.
+      private String phoneNumber;
+      ...
+  }
 
-    // For Thrift services, set an annotation to the field.
-    struct SecretStruct {
-      1: string hello;
-      2: string secret (sensitive = "");
-    }
+  // For Thrift services, set an annotation to the field.
+  struct SecretStruct {
+    1: string hello;
+    2: string secret (sensitive = "");
+  }
 
-    // Create `FieldMaskerSelector`s for both types.
-    BeanFieldMaskerSelector beanMasker =
-       FieldMaskerSelector.ofBean(fieldInfo -> {
-           Sensitive sensitive = fieldInfo.getAnnotation(Sensitive.class);
-           if (sensitive != null) {
-               return FieldMasker.nullify();  // 👈👈👈
-           } else {
-               return FieldMasker.fallthrough();
-           }
-       });
+  // Create `FieldMaskerSelector`s for both types.
+  BeanFieldMaskerSelector beanMasker =
+     FieldMaskerSelector.ofBean(fieldInfo -> {
+         Sensitive sensitive = fieldInfo.getAnnotation(Sensitive.class);
+         if (sensitive != null) {
+             return FieldMasker.nullify();  // 👈👈👈
+         } else {
+             return FieldMasker.fallthrough();
+         }
+     });
 
-    ThriftFieldMaskerSelector thriftMasker =
-      ThriftFieldMaskerSelector
-         .builder()
-         .onFieldAnnotation("sensitive", FieldMasker.nullify())  // 👈👈👈
-         .build();
+  ThriftFieldMaskerSelector thriftMasker =
+    ThriftFieldMaskerSelector
+       .builder()
+       .onFieldAnnotation("sensitive", FieldMasker.nullify())  // 👈👈👈
+       .build();
 
-    // Build a `ContentSanitizer` and add it to your `LogFormatter`.
-    ContentSanitizer<String> sanitizer =
-      ContentSanitizer.builder()
-                      .fieldMaskerSelector(beanMasker)
-                      .fieldMaskerSelector(thriftMasker)
-                      .buildForText();
-    LogFormatter formatter = LogFormatter.builderForText()
-                                        .contentSanitizer(contentSanitizer)
-                                        .build();
+  // Build a `ContentSanitizer` and add it to your `LogFormatter`.
+  ContentSanitizer<String> sanitizer =
+    ContentSanitizer.builder()
+                    .fieldMaskerSelector(beanMasker)
+                    .fieldMaskerSelector(thriftMasker)
+                    .buildForText();
+  LogFormatter formatter = LogFormatter.builderForText()
+                                      .contentSanitizer(contentSanitizer)
+                                      .build();
 
-    // Use the formatter in `LoggingService`.
-    ...
-    ```
+  // Use the formatter in `LoggingService`.
+  ...
+  ```
 - **XDS-based Client Preprocessors**: You can now use <type://XdsHttpPreprocessor> and <type://XdsRpcPreprocessor>
   to create clients that route requests according to your xDS configuration. #6299
   ```java


### PR DESCRIPTION
Motivation:

The documentation and examples help users quickly integrate Athenz.

Modifications:

- Add `advanced-athenz.mdx` for Athenz documentation
- Move Athenz docker logic from `AthenzExtension` into `AthenzDocker` so that it can be used independently of JUnit.
- Add `examples/athenz` for providing fully working Athenz examples

Result:

More comprehensive documentation

