### PR TITLE
Fix flaky `RetryingRpcClientTest.doNotRetryWhenResponseIsCancelled()`

### DIFF
--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/it/client/retry/RetryingRpcClientTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +51,6 @@ import com.linecorp.armeria.client.retry.RetryRuleWithContent;
 import com.linecorp.armeria.client.retry.RetryingRpcClient;
 import com.linecorp.armeria.client.thrift.ThriftClients;
 import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
@@ -330,47 +328,36 @@ class RetryingRpcClientTest {
 
     @Test
     void doNotRetryWhenResponseIsCancelled() throws Exception {
-        final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
-        final HelloService.Iface client =
-                ThriftClients.builder(server.httpUri())
-                             .path("/thrift")
-                             .decorator((delegate, ctx, req) -> {
-                                 final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
-                                 final HttpResponse response = HttpResponse.of(future);
-                                 // Add a delay to simulate a response was cancelled
-                                 // before the request is sent.
-                                 ctx.eventLoop().schedule(() -> {
-                                     try {
-                                         future.complete(delegate.execute(ctx, req));
-                                     } catch (Exception e) {
-                                         future.completeExceptionally(e);
-                                     }
-                                 }, 500, TimeUnit.MILLISECONDS);
-                                 return response;
-                             })
-                             .rpcDecorator(RetryingRpcClient.builder(retryAlways).newDecorator())
-                             .rpcDecorator((delegate, ctx, req) -> {
-                                 context.set(ctx);
-                                 final RpcResponse res = delegate.execute(ctx, req);
-                                 res.cancel(true);
-                                 return res;
-                             })
-                             .build(HelloService.Iface.class);
-        when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            final AtomicReference<ClientRequestContext> context = new AtomicReference<>();
+            final HelloService.Iface client =
+                    ThriftClients.builder(server.httpUri())
+                                 .path("/thrift")
+                                 .factory(factory)
+                                 .rpcDecorator(RetryingRpcClient.builder(retryAlways).newDecorator())
+                                 .rpcDecorator((delegate, ctx, req) -> {
+                                     context.set(ctx);
+                                     final RpcResponse res = delegate.execute(ctx, req);
+                                     res.cancel(true);
+                                     return res;
+                                 })
+                                 .build(HelloService.Iface.class);
+            when(serviceHandler.hello(anyString())).thenThrow(new IllegalArgumentException());
 
-        assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);
+            assertThatThrownBy(() -> client.hello("hello")).isInstanceOf(CancellationException.class);
 
-        await().untilAsserted(() -> {
+            await().untilAsserted(() -> {
+                verify(serviceHandler, only()).hello("hello");
+            });
+            final RequestLog log = context.get().log().whenComplete().join();
+
+            // ClientUtil.completeLogIfIncomplete() records exceptions caused by response cancellations.
+            assertThat(log.requestCause()).isExactlyInstanceOf(CancellationException.class);
+            assertThat(log.responseCause()).isExactlyInstanceOf(CancellationException.class);
+
+            // Sleep 1 second more to check if there was another retry.
+            TimeUnit.SECONDS.sleep(1);
             verify(serviceHandler, only()).hello("hello");
-        });
-        final RequestLog log = context.get().log().whenComplete().join();
-
-        // ClientUtil.completeLogIfIncomplete() records exceptions caused by response cancellations.
-        assertThat(log.requestCause()).isExactlyInstanceOf(CancellationException.class);
-        assertThat(log.responseCause()).isExactlyInstanceOf(CancellationException.class);
-
-        // Sleep 1 second more to check if there was another retry.
-        TimeUnit.SECONDS.sleep(1);
-        verify(serviceHandler, only()).hello("hello");
+        }
     }
 }


### PR DESCRIPTION
Motivation:

https://github.com/line/armeria/actions/runs/16953427414/job/48050706187?pr=6353#step:10:2165
```java
RetryingRpcClientTest > doNotRetryWhenResponseIsCancelled() FAILED
    java.lang.AssertionError:
    Expecting actual not to be null
        at com.linecorp.armeria.it.client.retry.RetryingRpcClientTest.doNotRetryWhenResponseIsCancelled(RetryingRpcClientTest.java:353)
```
The flaky test assumes that the request is aborted by the response cancellation before the request is sent to the wire. However, if the connection is already established, the request might be written before `response.cancel(true)` is invoked.

Modifications:

- Add a delay before writing the request so it can be cancelled earlier.

Result:

Less noisy CI builds.
