### PR TITLE
Support retries for `XdsPreprocessor`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java
@@ -320,12 +320,12 @@ final class Http2ResponseDecoder extends AbstractHttpResponseDecoder implements 
         }
 
         final Http2Error http2Error = Http2Error.valueOf(errorCode);
-        final ClosedStreamException cause =
-                new ClosedStreamException("received a RST_STREAM frame: " + http2Error);
 
         if (http2Error == Http2Error.REFUSED_STREAM) {
-            res.close(UnprocessedRequestException.of(cause));
+            res.close(UnprocessedRequestException.of(RefusedStreamException.get()));
         } else {
+            final ClosedStreamException cause =
+                    new ClosedStreamException("received a RST_STREAM frame: " + http2Error);
             res.close(cause);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
@@ -25,7 +26,7 @@ import com.linecorp.armeria.common.util.Sampler;
  * to 0 which means a client can't send anything 2) or when a server sent a
  * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.4">REFUSED_STREAM</a> frame.
  */
-public final class RefusedStreamException extends RuntimeException {
+public final class RefusedStreamException extends ClosedStreamException {
 
     private static final long serialVersionUID = 4865362114731585884L;
 
@@ -36,13 +37,18 @@ public final class RefusedStreamException extends RuntimeException {
      * the result of {@link Sampler#isSampled(Object)} of {@link Flags#verboseExceptionSampler()}.
      */
     public static RefusedStreamException get() {
-        return Flags.verboseExceptionSampler().isSampled(RefusedStreamException.class) ?
-               new RefusedStreamException() : INSTANCE;
+        return isSampled() ? new RefusedStreamException() : INSTANCE;
     }
 
-    private RefusedStreamException() {}
+    private RefusedStreamException() {
+        super(null, null, true, isSampled());
+    }
 
     private RefusedStreamException(@SuppressWarnings("unused") boolean dummy) {
         super(null, null, false, false);
+    }
+
+    private static boolean isSampled() {
+        return Flags.verboseExceptionSampler().isSampled(RefusedStreamException.class);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/RefusedStreamException.java
@@ -20,9 +20,10 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.util.Sampler;
 
 /**
- * A {@link RuntimeException} raised when a server set
+ * A {@link RuntimeException} raised when 1) a server set
  * HTTP/2 <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-5.1.2">{@code MAX_CONCURRENT_STREAMS}</a>
- * to 0, which means a client can't send anything.
+ * to 0 which means a client can't send anything 2) or when a server sent a
+ * <a href="https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.4">REFUSED_STREAM</a> frame.
  */
 public final class RefusedStreamException extends RuntimeException {
 

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientRefusedStreamTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientRefusedStreamTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.internal.testing.NettyServerExtension;
 
 import io.netty.channel.Channel;
@@ -53,7 +52,7 @@ class Http2ClientRefusedStreamTest {
                      .get("/").aggregate().join();
         }).isInstanceOf(CompletionException.class)
           .hasCauseInstanceOf(UnprocessedRequestException.class)
-          .hasRootCauseInstanceOf(ClosedStreamException.class);
+          .hasRootCauseInstanceOf(RefusedStreamException.class);
     }
 
     private static final class RefusedStreamH2CHandler extends SimpleH2CServerHandler {

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteEntryMatcherTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteEntryMatcherTest.java
@@ -485,9 +485,7 @@ class RouteEntryMatcherTest {
     @MethodSource("headerMatch_args")
     void headerMatch(HeaderMatcher headerMatcher, RequestHeaders requestHeaders, boolean expectedResult) {
         final HeaderMatcherImpl matcher = new HeaderMatcherImpl(headerMatcher);
-        final HttpRequest req = HttpRequest.of(requestHeaders);
-        final ClientRequestContext ctx = ClientRequestContext.of(req);
-        assertThat(matcher.matches(ctx)).isEqualTo(expectedResult);
+        assertThat(matcher.matches(requestHeaders)).isEqualTo(expectedResult);
     }
 
     /**
@@ -730,30 +728,30 @@ class RouteEntryMatcherTest {
     @DisplayName("Test isGrpcRequest method with various content types")
     void isGrpcRequestTest() {
         // Test with null request
-        assertThat(RouteEntryMatcher.isGrpcRequest(null)).isFalse();
+        assertThat(XdsCommonUtil.isGrpcRequest(null)).isFalse();
 
         // Test with request that has no content type header
         final HttpRequest requestWithoutContentType =
                 HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/api"));
-        assertThat(RouteEntryMatcher.isGrpcRequest(requestWithoutContentType)).isFalse();
+        assertThat(XdsCommonUtil.isGrpcRequest(requestWithoutContentType)).isFalse();
 
         // Test with exact "grpc" subtype
         final HttpRequest grpcRequest =
                 HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/api",
                                                  HttpHeaderNames.CONTENT_TYPE, "application/grpc"));
-        assertThat(RouteEntryMatcher.isGrpcRequest(grpcRequest)).isTrue();
+        assertThat(XdsCommonUtil.isGrpcRequest(grpcRequest)).isTrue();
 
         // Test with "grpc+" prefix subtype
         final HttpRequest grpcPlusRequest =
                 HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/api",
                                                  HttpHeaderNames.CONTENT_TYPE, "application/grpc+proto"));
-        assertThat(RouteEntryMatcher.isGrpcRequest(grpcPlusRequest)).isTrue();
+        assertThat(XdsCommonUtil.isGrpcRequest(grpcPlusRequest)).isTrue();
 
         // Test with non-grpc subtype that looks similar (grpc-web)
         final HttpRequest nonGrpcRequest =
                 HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/api",
                                                  HttpHeaderNames.CONTENT_TYPE, "application/grpc-web"));
-        assertThat(RouteEntryMatcher.isGrpcRequest(nonGrpcRequest)).isFalse();
+        assertThat(XdsCommonUtil.isGrpcRequest(nonGrpcRequest)).isFalse();
     }
 
     private static Stream<Arguments> deprecatedHeaderMatcher_args() {

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
@@ -1,0 +1,768 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.RefusedStreamException;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+
+class RetryTest {
+
+    //language=YAML
+    private static final String bootstrap =
+            """
+                static_resources:
+                  listeners:
+                  - name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                .v3.HttpConnectionManager
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  cluster: my-cluster
+                                  retry_policy: %s
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  clusters:
+                  - name: my-cluster
+                    type: STATIC
+                    load_assignment:
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8080
+                """;
+
+    public static Stream<Arguments> retryOnResponseHeader_args() {
+        return Stream.of(
+                // RETRY_ON_5XX
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500), 2),
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(502), 2),
+                // RETRY_ON_GATEWAY_ERROR
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(502), 2),
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(503), 2),
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(504), 2),
+                // RETRY_ON_RETRIABLE_4XX
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-4xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(409), 2),
+                // RETRY_ON_ENVOY_RATE_LIMITED
+                Arguments.of("""
+                             {
+                               retry_on: "envoy-ratelimited",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(429).add("x-envoy-ratelimited", "true").build(), 2),
+                // RETRY_ON_RETRIABLE_STATUS_CODES
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-status-codes",
+                               retriable_status_codes: [418, 422],
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(418), 2),
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-status-codes",
+                               retriable_status_codes: [418, 422],
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(422), 2),
+                // RETRY_ON_RETRIABLE_HEADERS
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-headers",
+                               retriable_headers: [
+                                 {
+                                   name: "x-should-retry",
+                                   string_match: { exact: "true" }
+                                 }
+                               ],
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("x-should-retry", "true").build(), 2),
+                // RETRY_ON_GRPC_CANCELLED
+                Arguments.of("""
+                             {
+                               retry_on: "cancelled",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "1").build(), 2),
+                // RETRY_ON_GRPC_DEADLINE_EXCEEDED
+                Arguments.of("""
+                             {
+                               retry_on: "deadline-exceeded",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "4").build(), 2),
+                // RETRY_ON_GRPC_RESOURCE_EXHAUSTED
+                Arguments.of("""
+                             {
+                               retry_on: "resource-exhausted",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "8").build(), 2),
+                // RETRY_ON_GRPC_UNAVAILABLE
+                Arguments.of("""
+                             {
+                               retry_on: "unavailable",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "14").build(), 2),
+                // RETRY_ON_GRPC_INTERNAL
+                Arguments.of("""
+                             {
+                               retry_on: "internal",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "13").build(), 2),
+                // No retry cases
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(200), 0),
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500), 0),
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-4xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(400), 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryOnResponseHeader_args")
+    void retryOnResponseHeader(String retryOptions, ResponseHeaders responseHeaders, int numRetries) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> {
+                                     return HttpResponse.of(responseHeaders);
+                                 })
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+            assertThat(ctx.log().children()).hasSize(numRetries + 1);
+        }
+    }
+
+    public static Stream<Arguments> retryOnReset_args() {
+        return Stream.of(
+                // RETRY_ON_RESET - retries on any exception
+                Arguments.of("""
+                             {
+                               retry_on: "reset",
+                               num_retries: 2
+                             }
+                             """, new RuntimeException("Generic exception"), 2),
+                // RETRY_ON_RESET_BEFORE_REQUEST - retries on UnprocessedRequestException
+                Arguments.of("""
+                             {
+                               retry_on: "reset-before-request",
+                               num_retries: 2
+                             }
+                             """, UnprocessedRequestException.of(new RuntimeException("Before request")), 2),
+                // RETRY_ON_REFUSED_STREAM - retries on RefusedStreamException wrapped in
+                // UnprocessedRequestException
+                Arguments.of("""
+                             {
+                               retry_on: "refused-stream",
+                               num_retries: 2
+                             }
+                             """, UnprocessedRequestException.of(RefusedStreamException.get()), 2),
+                // No retry cases
+                Arguments.of("""
+                             {
+                               retry_on: "reset-before-request",
+                               num_retries: 2
+                             }
+                             """, new RuntimeException("Not UnprocessedRequestException"), 0),
+                Arguments.of("""
+                             {
+                               retry_on: "refused-stream",
+                               num_retries: 2
+                             }
+                             """, UnprocessedRequestException.of(
+                        new RuntimeException("Not RefusedStreamException")), 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryOnReset_args")
+    void retryOnReset(String retryOptions, Throwable cause, int numRetries) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                assertThatThrownBy(() -> {
+                    WebClient.builder(preprocessor)
+                             .decorator((delegate, ctx0, req) -> HttpResponse.ofFailure(cause))
+                             .build()
+                             .blocking()
+                             .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                }).isEqualTo(cause);
+                ctx = captor.get();
+            }
+            assertThat(ctx.log().children()).hasSize(numRetries + 1);
+        }
+    }
+
+    public static Stream<Arguments> retryLimit_args() {
+        return Stream.of(
+                // Test explicit num_retries limit
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 3
+                             }
+                             """, ResponseHeaders.of(500), 3),
+                // Test omitted num_retries (should use Armeria's default)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx"
+                             }
+                             """, ResponseHeaders.of(500), Flags.defaultMaxTotalAttempts() - 1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryLimit_args")
+    void retryLimit(String retryOptions, ResponseHeaders responseHeaders, int expectedRetries) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> HttpResponse.of(responseHeaders))
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+
+            // Verify the exact number of retry attempts (original + retries)
+            assertThat(ctx.log().children()).hasSize(expectedRetries + 1);
+        }
+    }
+
+    public static Stream<Arguments> perTryTimeout_args() {
+        return Stream.of(
+                // Test explicit per_try_timeout
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2,
+                               per_try_timeout: "5s"
+                             }
+                             """, ResponseHeaders.of(500), 5000L),
+                // Test omitted per_try_timeout (should use default timeout)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500), Flags.defaultResponseTimeoutMillis())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("perTryTimeout_args")
+    void perTryTimeout(String retryOptions, ResponseHeaders responseHeaders, long expectedTimeoutMillis) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        final ArrayDeque<ClientRequestContext> childCtxs = new ArrayDeque<>();
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> {
+                                     childCtxs.add(ctx0);
+                                     return HttpResponse.of(responseHeaders);
+                                 })
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+
+            // Verify retries occurred
+            assertThat(ctx.log().children()).hasSize(3); // 2 retries + 1 original = 3 total
+            assertThat(childCtxs).hasSize(3);
+
+            for (ClientRequestContext childCtx : childCtxs) {
+                // Allow small tolerance for timing variations
+                assertThat(childCtx.responseTimeoutMillis())
+                        .isCloseTo(expectedTimeoutMillis, withinPercentage(10.0));
+            }
+        }
+    }
+
+    public static Stream<Arguments> retryBackoff_args() {
+        return Stream.of(
+                // Test custom base_interval (100ms base)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2,
+                               retry_back_off: {
+                                 base_interval: "0.1s",
+                                 max_interval: "1s"
+                               }
+                             }
+                             """, ResponseHeaders.of(500), 100L, 200L),
+                // Test default backoff (25ms base)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500), 25L, 50L),
+                // Test different intervals (50ms base)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2,
+                               retry_back_off: {
+                                 base_interval: "0.05s",
+                                 max_interval: "2s"
+                               }
+                             }
+                             """, ResponseHeaders.of(500), 50L, 100L),
+                // Test max_interval capping - base would double to 200ms but max caps at 150ms
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2,
+                               retry_back_off: {
+                                 base_interval: "0.1s",
+                                 max_interval: "0.15s"
+                               }
+                             }
+                             """, ResponseHeaders.of(500), 100L, 150L)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryBackoff_args")
+    void retryBackoff(String retryOptions, ResponseHeaders responseHeaders,
+                      long expectedFirstDelayMillis, long expectedSecondDelayMillis) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> HttpResponse.of(responseHeaders))
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+
+            // Verify retry attempts occurred
+            assertThat(ctx.log().children()).hasSize(3); // 2 retries + 1 original = 3 total
+            // Verify backoff timing using unified end-to-start measurement
+            verifyBackoffTiming(ctx, List.of(expectedFirstDelayMillis, expectedSecondDelayMillis));
+        }
+    }
+
+    public static Stream<Arguments> rateLimitedBackoff_args() {
+        return Stream.of(
+                // Test rate limited backoff with retry-after header in seconds
+                Arguments.of("""
+                              {
+                                retry_on: "5xx",
+                                num_retries: 2,
+                                rate_limited_retry_back_off: {
+                                  reset_headers: [{
+                                    name: "retry-after",
+                                    format: "SECONDS"
+                                  }],
+                                  max_interval: "10s"
+                                }
+                              }
+                              """,
+                             ResponseHeaders.builder(500).add("retry-after", "1").build(), 1000L, 1000L),
+                // Test rate limited backoff exceeding max_interval (should skip)
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2,
+                               rate_limited_retry_back_off: {
+                                 reset_headers: [{
+                                   name: "retry-after",
+                                   format: "SECONDS"
+                                 }],
+                                 max_interval: "1s"
+                               }
+                             }
+                             """,
+                             ResponseHeaders.builder(500).add("retry-after", "5").build(),
+                             25L, 50L) // Falls back to exponential: 25ms (1st retry), 50ms (2nd retry)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("rateLimitedBackoff_args")
+    void rateLimitedBackoff(String retryOptions, ResponseHeaders responseHeaders,
+                            long expectedFirstDelayMillis, long expectedSecondDelayMillis) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                WebClient.builder(preprocessor)
+                         .decorator((delegate, ctx0, req) -> HttpResponse.of(responseHeaders))
+                         .build()
+                         .blocking()
+                         .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                ctx = captor.get();
+            }
+
+            // Verify retry attempts occurred
+            assertThat(ctx.log().children()).hasSize(3); // 2 retries + 1 original = 3 total
+            // Verify backoff timing using unified end-to-start measurement
+            verifyBackoffTiming(ctx, List.of(expectedFirstDelayMillis, expectedSecondDelayMillis));
+        }
+    }
+
+    private static void verifyBackoffTiming(ClientRequestContext ctx, List<Long> expectedDelaysMillis) {
+        final var children = ctx.log().children();
+        final int numRetries = expectedDelaysMillis.size();
+
+        // Verify we have enough attempts to measure the expected delays
+        assertThat(children).hasSizeGreaterThanOrEqualTo(numRetries + 1);
+
+        // Measure actual backoff delays from end of previous attempt to start of next attempt
+        for (int i = 0; i < numRetries; i++) {
+            final long previousAttemptEndTimeNanos =
+                    children.get(i).ensureComplete().responseEndTimeNanos();
+            final long currentAttemptStartTimeNanos =
+                    children.get(i + 1).ensureComplete().requestStartTimeNanos();
+
+            final long actualDelayMillis = TimeUnit.NANOSECONDS.toMillis(
+                    currentAttemptStartTimeNanos - previousAttemptEndTimeNanos);
+            final long expectedDelayMillis = expectedDelaysMillis.get(i);
+
+            // Verify delay matches expected value (tolerance for 50% jitter + responseTimeout recalc)
+            assertThat(actualDelayMillis).isCloseTo(expectedDelayMillis, withinPercentage(60.0));
+        }
+    }
+
+    public static Stream<Arguments> retryOnRequestHeaders_args() {
+        return Stream.of(
+                // Test x-envoy-retry-on header adds retry policies (with existing config retry_on)
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-on", "5xx").build(), 2),
+                // Test x-envoy-retry-on with multiple policies
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(502),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-on", "5xx,gateway-error").build(), 2),
+                // Test x-envoy-retry-grpc-on header adds gRPC retry policies
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("grpc-status", "14").build(),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-grpc-on", "unavailable").build(), 2),
+                // Test x-envoy-max-retries header overrides config
+                Arguments.of("""
+                             {
+                               retry_on: "5xx",
+                               num_retries: 3
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-max-retries", "5").build(), 5),
+                // Test x-envoy-retriable-status-codes header adds to existing config status codes
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-status-codes",
+                               retriable_status_codes: [500, 502],
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retriable-status-codes", "418,422").build(), 2),
+                // Test header-added status codes also work
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-status-codes",
+                               retriable_status_codes: [500, 502],
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(418),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retriable-status-codes", "418,422").build(), 2),
+                // Test x-envoy-retriable-header-names header adds retriable headers
+                Arguments.of("""
+                             {
+                               retry_on: "retriable-headers",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.builder(200).add("x-should-retry", "yes").build(),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retriable-header-names", "x-should-retry").build(), 2),
+                // Test multiple request headers combined
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 1
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-on", "5xx")
+                                           .add("x-envoy-max-retries", "4").build(), 4),
+                // Test no retry when request header doesn't match response
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(400),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-on", "5xx").build(), 0),
+                // Test gRPC retry header doesn't match HTTP status
+                Arguments.of("""
+                             {
+                               retry_on: "gateway-error",
+                               num_retries: 2
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-grpc-on", "unavailable").build(), 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retryOnRequestHeaders_args")
+    void retryOnRequestHeaders(String retryOptions, ResponseHeaders responseHeaders,
+                               RequestHeaders requestHeaders, int expectedRetries) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> HttpResponse.of(responseHeaders))
+                                 .build()
+                                 .blocking()
+                                 .execute(requestHeaders);
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+            assertThat(ctx.log().children()).hasSize(expectedRetries + 1);
+        }
+    }
+
+    public static Stream<Arguments> retriableRequestHeaders_args() {
+        return Stream.of(
+                // Test retriable_request_headers matching (should retry)
+                Arguments.of("""
+                             {
+                               num_retries: 2,
+                               retriable_request_headers: [
+                                 {
+                                   name: "x-can-retry",
+                                   string_match: { exact: "true" }
+                                 }
+                               ]
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-can-retry", "true")
+                                           .add("x-envoy-retry-on", "5xx")
+                                           .add("x-envoy-max-retries", "2").build(), 2),
+                // Test retriable_request_headers not matching (should not retry even with retry header)
+                Arguments.of("""
+                             {
+                               num_retries: 2,
+                               retriable_request_headers: [
+                                 {
+                                   name: "x-can-retry",
+                                   string_match: { exact: "true" }
+                                 }
+                               ]
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-can-retry", "false")
+                                           .add("x-envoy-retry-on", "5xx")
+                                           .add("x-envoy-max-retries", "2").build(), 0),
+                // Test retriable_request_headers missing header (should not retry)
+                Arguments.of("""
+                             {
+                               num_retries: 2,
+                               retriable_request_headers: [
+                                 {
+                                   name: "x-can-retry",
+                                   string_match: { exact: "true" }
+                                 }
+                               ]
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-envoy-retry-on", "5xx")
+                                           .add("x-envoy-max-retries", "2").build(), 0),
+                // Test multiple retriable_request_headers (OR condition)
+                Arguments.of("""
+                             {
+                               num_retries: 2,
+                               retriable_request_headers: [
+                                 {
+                                   name: "x-can-retry",
+                                   string_match: { exact: "true" }
+                                 },
+                                 {
+                                   name: "x-force-retry",
+                                   string_match: { exact: "yes" }
+                                 }
+                               ]
+                             }
+                             """, ResponseHeaders.of(500),
+                             RequestHeaders.builder(HttpMethod.GET, "/")
+                                           .add("x-force-retry", "yes")
+                                           .add("x-envoy-retry-on", "5xx")
+                                           .add("x-envoy-max-retries", "2").build(), 2)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("retriableRequestHeaders_args")
+    void retriableRequestHeaders(String retryOptions, ResponseHeaders responseHeaders,
+                                 RequestHeaders requestHeaders, int expectedRetries) {
+        final String formattedBootstrap = bootstrap.formatted(retryOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(formattedBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> HttpResponse.of(responseHeaders))
+                                 .build()
+                                 .blocking()
+                                 .execute(requestHeaders);
+                assertThat(res.status().code()).isEqualTo(responseHeaders.status().code());
+                ctx = captor.get();
+            }
+            assertThat(ctx.log().children()).hasSize(expectedRetries + 1);
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RouteMatcherTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RouteMatcherTest.java
@@ -153,6 +153,8 @@ class RouteMatcherTest {
                                   cluster: my-cluster2
                         http_filters:
                         - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                   clusters:
                   - name: my-cluster1
                     type: STATIC

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TimeoutTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TimeoutTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Flags;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+
+class TimeoutTest {
+
+    private static final long DEFAULT_RESPONSE_TIMEOUT_MILLIS = Flags.defaultResponseTimeoutMillis();
+
+    //language=YAML
+    private static final String connManagerBootstrap =
+            """
+                static_resources:
+                  listeners:
+                  - name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                .v3.HttpConnectionManager
+                        common_http_protocol_options: %s
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: /
+                                route: %s
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  clusters:
+                  - name: my-cluster
+                    type: STATIC
+                    load_assignment:
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8080
+                """;
+
+    public static Stream<Arguments> responseTimeout_args() {
+        return Stream.of(
+                // Test conn mgr max_stream_duration only
+                Arguments.of("""
+                             { max_stream_duration: 123s }
+                             """, """
+                             { cluster: my-cluster }
+                             """, 123_000),
+                // Test route timeout only
+                Arguments.of("""
+                             {}
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 123s
+                             }
+                             """, 123_000),
+                // Test route max_stream_duration only
+                Arguments.of("""
+                             {}
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               max_stream_duration: { max_stream_duration: 123s }
+                             }
+                             """, 123_000),
+                // Test conn mgr max_stream_duration + route timeout (route timeout wins)
+                Arguments.of("""
+                             { max_stream_duration: 321s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 123s
+                             }
+                             """, 123_000),
+                // Test conn mgr max_stream_duration + route max_stream_duration (route wins)
+                Arguments.of("""
+                             { max_stream_duration: 321s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               max_stream_duration: { max_stream_duration: 123s }
+                             }
+                             """, 123_000),
+                // Test route timeout + route max_stream_duration (max_stream_duration wins)
+                Arguments.of("""
+                             {}
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 123s,
+                               max_stream_duration: { max_stream_duration: 321s }
+                             }
+                             """, 123_000),
+                // Test all three configs: max_stream_duration wins over timeout
+                Arguments.of("""
+                             { max_stream_duration: 999s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 123s,
+                               max_stream_duration: { max_stream_duration: 321s }
+                             }
+                             """, 123_000),
+                // Test precedence: route max_stream_duration wins over route timeout
+                Arguments.of("""
+                             { max_stream_duration: 50s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 321s,
+                               max_stream_duration: { max_stream_duration: 123s }
+                             }
+                             """, 123_000),
+                // Test no timeouts specified - should use default
+                Arguments.of("""
+                             {}
+                             """, """
+                             { cluster: my-cluster }
+                             """, DEFAULT_RESPONSE_TIMEOUT_MILLIS),
+                // Test zero timeouts
+                Arguments.of("""
+                             { max_stream_duration: 0s }
+                             """, """
+                             { cluster: my-cluster }
+                             """, 0),
+                Arguments.of("""
+                             {}
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 0s
+                             }
+                             """, 0),
+                Arguments.of("""
+                             {}
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               max_stream_duration: { max_stream_duration: 0s }
+                             }
+                             """, 0),
+                // Test zero route timeout wins over non-zero conn mgr max_stream_duration
+                Arguments.of("""
+                             { max_stream_duration: 123s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               timeout: 0s
+                             }
+                             """, 0),
+                // Test zero route max_stream_duration with non-zero conn mgr max_stream_duration
+                Arguments.of("""
+                             { max_stream_duration: 123s }
+                             """, """
+                             {
+                               cluster: my-cluster,
+                               max_stream_duration: { max_stream_duration: 0s }
+                             }
+                             """, 0)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("responseTimeout_args")
+    void responseTimeout(String connManagerOptions, String routeOptions, long expectedMillis) {
+        final String yamlBootstrap = connManagerBootstrap.formatted(connManagerOptions, routeOptions);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(yamlBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .responseTimeoutMillis(DEFAULT_RESPONSE_TIMEOUT_MILLIS)
+                                 .decorator((delegate, ctx0, req) -> HttpResponse.of(200))
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(200);
+                ctx = captor.get();
+            }
+            assertThat(ctx.responseTimeoutMillis()).isEqualTo(expectedMillis);
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/VirtualHostRoutingTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/VirtualHostRoutingTest.java
@@ -69,6 +69,8 @@ class VirtualHostRoutingTest {
                                   cluster: my-cluster2
                         http_filters:
                         - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                   clusters:
                   - name: my-cluster1
                     type: STATIC

--- a/xds/src/main/java/com/linecorp/armeria/xds/ListenerXdsResource.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ListenerXdsResource.java
@@ -110,7 +110,7 @@ public final class ListenerXdsResource implements XdsResource {
             return null;
         }
         final HttpFilter lastHttpFilter = httpFilters.get(httpFilters.size() - 1);
-        if (!ROUTER_TYPE_URL.equals(lastHttpFilter.getName())) {
+        if (!ROUTER_TYPE_URL.equals(lastHttpFilter.getTypedConfig().getTypeUrl())) {
             // the router should be the last/terminal filter
             return null;
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ConfigSupplier.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ConfigSupplier.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import java.util.function.Function;
+
+import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
@@ -49,4 +52,8 @@ interface ConfigSupplier {
     ClusterSnapshot clusterSnapshot();
 
     RouteEntry routeEntry();
+
+    @Nullable Function<? super HttpClient, ? extends HttpClient> retryingDecorator();
+
+    long responseTimeoutMillis();
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ConfigSupplier.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/ConfigSupplier.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.xds.client.endpoint;
 import java.util.function.Function;
 
 import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
@@ -53,7 +54,7 @@ interface ConfigSupplier {
 
     RouteEntry routeEntry();
 
-    @Nullable Function<? super HttpClient, ? extends HttpClient> retryingDecorator();
+    @Nullable Function<? super HttpClient, RetryingClient> retryingDecorator();
 
     long responseTimeoutMillis();
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.xds.client.endpoint;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
+import java.util.function.Function;
 
 import com.google.protobuf.Message;
 
@@ -28,6 +29,7 @@ import com.linecorp.armeria.client.ClientPreprocessors;
 import com.linecorp.armeria.client.ClientPreprocessorsBuilder;
 import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.DecoratingRpcClientFunction;
+import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -84,6 +86,12 @@ final class FilterUtil {
             }
             builder.add(xdsFilter.httpDecorator());
             builder.addRpc(xdsFilter.rpcDecorator());
+        }
+        final Function<? super HttpClient, ? extends HttpClient> retryingDecorator =
+                configSupplier.retryingDecorator();
+        if (retryingDecorator != null) {
+            // add the retrying decorator as the first (outermost) decorator if exists
+            builder.add(retryingDecorator);
         }
         return builder.build();
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/FilterUtil.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.DecoratingRpcClientFunction;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.RpcPreprocessor;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ListenerSnapshot;
 import com.linecorp.armeria.xds.ParsedFilterConfig;
@@ -87,7 +88,7 @@ final class FilterUtil {
             builder.add(xdsFilter.httpDecorator());
             builder.addRpc(xdsFilter.rpcDecorator());
         }
-        final Function<? super HttpClient, ? extends HttpClient> retryingDecorator =
+        final Function<? super HttpClient, RetryingClient> retryingDecorator =
                 configSupplier.retryingDecorator();
         if (retryingDecorator != null) {
             // add the retrying decorator as the first (outermost) decorator if exists

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RetryStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RetryStateFactory.java
@@ -70,9 +70,12 @@ final class RetryStateFactory {
     private static final AsciiString REQUEST_HEADER_GRPC_RETRY_ON = HttpHeaderNames.of("x-envoy-retry-grpc-on");
     private static final AsciiString REQUEST_HEADER_RETRY_ON = HttpHeaderNames.of("x-envoy-retry-on");
     private static final AsciiString REQUEST_HEADER_MAX_RETRIES = HttpHeaderNames.of("x-envoy-max-retries");
-    private static final AsciiString REQUEST_HEADER_RETRIABLE_STATUS_CODES = HttpHeaderNames.of("x-envoy-retriable-status-codes");
-    private static final AsciiString REQUEST_HEADER_RETRIABLE_HEADER_NAMES = HttpHeaderNames.of("x-envoy-retriable-header-names");
-    private static final AsciiString RESPONSE_HEADER_X_ENVOY_RATELIMITED = HttpHeaderNames.of("x-envoy-ratelimited");
+    private static final AsciiString REQUEST_HEADER_RETRIABLE_STATUS_CODES =
+            HttpHeaderNames.of("x-envoy-retriable-status-codes");
+    private static final AsciiString REQUEST_HEADER_RETRIABLE_HEADER_NAMES =
+            HttpHeaderNames.of("x-envoy-retriable-header-names");
+    private static final AsciiString RESPONSE_HEADER_X_ENVOY_RATELIMITED =
+            HttpHeaderNames.of("x-envoy-ratelimited");
     private static final AsciiString RESPONSE_HEADER_GRPC_STATUS = HttpHeaderNames.of("grpc-status");
 
     private static final Set<AsciiString> REQUEST_RETRY_HEADER_NAMES =

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RetryStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RetryStateFactory.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.RefusedStreamException;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.retry.Backoff;
+import com.linecorp.armeria.client.retry.RetryConfig;
+import com.linecorp.armeria.client.retry.RetryConfigBuilder;
+import com.linecorp.armeria.client.retry.RetryConfigMapping;
+import com.linecorp.armeria.client.retry.RetryDecision;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.xds.client.endpoint.RouteEntryMatcher.HeaderMatcherImpl;
+
+import io.envoyproxy.envoy.config.route.v3.HeaderMatcher;
+import io.envoyproxy.envoy.config.route.v3.RetryPolicy;
+import io.envoyproxy.envoy.config.route.v3.RetryPolicy.RateLimitedRetryBackOff;
+import io.envoyproxy.envoy.config.route.v3.RetryPolicy.ResetHeader;
+import io.envoyproxy.envoy.config.route.v3.RetryPolicy.RetryBackOff;
+import io.grpc.Status;
+
+final class RetryStateFactory {
+
+    private static final String REQUEST_HEADER_GRPC_RETRY_ON = "x-envoy-retry-grpc-on";
+    private static final String REQUEST_HEADER_RETRY_ON = "x-envoy-retry-on";
+    private static final String REQUEST_HEADER_MAX_RETRIES = "x-envoy-max-retries";
+    private static final String REQUEST_HEADER_RETRIABLE_STATUS_CODES = "x-envoy-retriable-status-codes";
+    private static final String REQUEST_HEADER_RETRIABLE_HEADER_NAMES = "x-envoy-retriable-header-names";
+    private static final String RESPONSE_HEADER_X_ENVOY_RATELIMITED = "x-envoy-ratelimited";
+    private static final String RESPONSE_HEADER_GRPC_STATUS = "grpc-status";
+
+    private static final Set<String> REQUEST_RETRY_HEADER_NAMES =
+            ImmutableSet.of(REQUEST_HEADER_GRPC_RETRY_ON, REQUEST_HEADER_RETRY_ON,
+                            REQUEST_HEADER_MAX_RETRIES, REQUEST_HEADER_RETRIABLE_STATUS_CODES,
+                            REQUEST_HEADER_RETRIABLE_HEADER_NAMES);
+
+    private final List<HeaderMatcherImpl> retriableRequestHeadersMatchers;
+    private final RetryStateImpl defaultRetryState;
+    private final RetryConfig<HttpResponse> defaultRetryConfig;
+
+    RetryStateFactory(RetryPolicy retryPolicy) {
+        final Set<RetryPolicyTypes> policies = ImmutableSet.copyOf(parseRetryOn(retryPolicy.getRetryOn()));
+        final List<HeaderMatcherImpl> retriableResponseHeaderMatchers =
+                retryPolicy.getRetriableHeadersList().stream().map(HeaderMatcherImpl::new)
+                           .collect(ImmutableList.toImmutableList());
+        retriableRequestHeadersMatchers = retryPolicy.getRetriableRequestHeadersList().stream()
+                                                     .map(HeaderMatcherImpl::new)
+                                                     .collect(ImmutableList.toImmutableList());
+        final Set<Integer> retriableStatusCodes =
+                ImmutableSet.copyOf(retryPolicy.getRetriableStatusCodesList());
+        final int numRetries = XdsCommonUtil.uint32ValueToInt(retryPolicy.getNumRetries(), -1);
+        defaultRetryState = new RetryStateImpl(retryPolicy, policies, numRetries, retriableStatusCodes,
+                                               retriableResponseHeaderMatchers);
+        defaultRetryConfig = createRetryConfig(defaultRetryState);
+    }
+
+    private static RetryConfig<HttpResponse> createRetryConfig(RetryStateImpl retryState) {
+        final RetryConfigBuilder<HttpResponse> builder = RetryConfig.builder(retryState);
+        if (retryState.perTryTimeoutMillis > 0) {
+            builder.responseTimeoutMillisForEachAttempt(retryState.perTryTimeoutMillis);
+        }
+        if (retryState.numRetries > 0) {
+            builder.maxTotalAttempts(retryState.numRetries + 1);
+        }
+        return builder.build();
+    }
+
+    Function<? super HttpClient, ? extends HttpClient> retryingDecorator() {
+        final RetryConfigMapping<HttpResponse> mapping = (ctx, req0) -> {
+            final HttpRequest req = (HttpRequest) req0;
+            for (String headerName: REQUEST_RETRY_HEADER_NAMES) {
+                if (req.headers().contains(headerName)) {
+                    final RetryStateImpl retryState = createRetryState(req.headers(), defaultRetryState,
+                                                                       retriableRequestHeadersMatchers);
+                    return createRetryConfig(retryState);
+                }
+            }
+            return defaultRetryConfig;
+        };
+        return RetryingClient.builderWithMapping(mapping).newDecorator();
+    }
+
+    private static RetryStateImpl createRetryState(RequestHeaders requestHeaders,
+                                                   RetryStateImpl defaultRetryState,
+                                                   List<HeaderMatcherImpl> retriableRequestHeadersMatchers) {
+        Set<RetryPolicyTypes> policies = defaultRetryState.policies;
+
+        final String retryOn = requestHeaders.get(REQUEST_HEADER_RETRY_ON);
+        if (retryOn != null) {
+            final ImmutableSet.Builder<RetryPolicyTypes> tempPolicies = ImmutableSet.builder();
+            tempPolicies.addAll(policies);
+            tempPolicies.addAll(parseRetryOn(retryOn));
+            policies = ImmutableSet.copyOf(tempPolicies.build());
+        }
+
+        final String grpcRetryOn = requestHeaders.get(REQUEST_HEADER_GRPC_RETRY_ON);
+        if (grpcRetryOn != null) {
+            final ImmutableSet.Builder<RetryPolicyTypes> tempPolicies = ImmutableSet.builder();
+            tempPolicies.addAll(policies);
+            tempPolicies.addAll(parseRetryOn(grpcRetryOn));
+            policies = ImmutableSet.copyOf(tempPolicies.build());
+        }
+
+        if (!retriableRequestHeadersMatchers.isEmpty()) {
+            boolean shouldRetry = false;
+            for (HeaderMatcherImpl headerMatcher: retriableRequestHeadersMatchers) {
+                if (headerMatcher.matches(requestHeaders)) {
+                    shouldRetry = true;
+                    break;
+                }
+            }
+            if (!shouldRetry) {
+                policies = ImmutableSet.of();
+            }
+        }
+
+        int numRetries = defaultRetryState.numRetries;
+        if (!policies.isEmpty()) {
+            final Integer maxRetries = requestHeaders.getInt(REQUEST_HEADER_MAX_RETRIES);
+            if (maxRetries != null) {
+                numRetries = maxRetries;
+            }
+        }
+
+        Set<Integer> retriableStatusCodes = defaultRetryState.retriableStatusCodes;
+        final String headerStatusCodes = requestHeaders.get(REQUEST_HEADER_RETRIABLE_STATUS_CODES);
+        if (headerStatusCodes != null) {
+            final String[] splitStatusCodes = headerStatusCodes.split(",");
+            final int expectedSize = splitStatusCodes.length + retriableStatusCodes.size();
+            final ImmutableSet.Builder<Integer> builder = ImmutableSet.builderWithExpectedSize(expectedSize);
+            for (String statusCodeStr : splitStatusCodes) {
+                final Integer statusCode = XdsCommonUtil.simpleAtoi(statusCodeStr);
+                if (statusCode == null) {
+                    continue;
+                }
+                builder.add(statusCode);
+            }
+            builder.addAll(retriableStatusCodes);
+            retriableStatusCodes = builder.build();
+        }
+
+        List<HeaderMatcherImpl> retriableResponseHeaderMatchers =
+                defaultRetryState.retriableResponseHeaderMatchers;
+        final String retriableHeaderNames = requestHeaders.get(REQUEST_HEADER_RETRIABLE_HEADER_NAMES);
+        if (retriableHeaderNames != null) {
+            final String[] splitHeaderNames = retriableHeaderNames.split(",");
+            final int expectedSize = splitHeaderNames.length + retriableResponseHeaderMatchers.size();
+            final ImmutableList.Builder<HeaderMatcherImpl> builder =
+                    ImmutableList.builderWithExpectedSize(expectedSize);
+            for (String headerName : splitHeaderNames) {
+                builder.add(new HeaderMatcherImpl(HeaderMatcher.newBuilder()
+                                                               .setName(headerName.trim()).build()));
+            }
+            builder.addAll(retriableResponseHeaderMatchers);
+            retriableResponseHeaderMatchers = builder.build();
+        }
+
+        return new RetryStateImpl(defaultRetryState.retryPolicy, policies, numRetries, retriableStatusCodes,
+                                  retriableResponseHeaderMatchers);
+    }
+
+    private static Set<RetryPolicyTypes> parseRetryOn(String retryOn) {
+        if (retryOn.isEmpty()) {
+            return ImmutableSet.of();
+        }
+        final ImmutableSet.Builder<RetryPolicyTypes> policies = ImmutableSet.builder();
+        for (String policyName: retryOn.split(",")) {
+            final RetryPolicyTypes policy = RetryPolicyTypes.fromPolicyName(policyName);
+            if (policy != null) {
+                policies.add(policy);
+            }
+        }
+        return ImmutableSet.copyOf(policies.build());
+    }
+
+    private static class RetryStateImpl implements RetryRule {
+
+        private static final ResponseHeaders EMPTY_RESPONSE_HEADERS = ResponseHeaders.of(0);
+
+        private final RetryPolicy retryPolicy;
+        private final int numRetries;
+        private final DelegatingBackoff backoff;
+        private final Set<RetryPolicyTypes> policies;
+        private final Set<Integer> retriableStatusCodes;
+        private final List<HeaderMatcherImpl> retriableResponseHeaderMatchers;
+        private final RetryDecision shouldRetry;
+        private final long perTryTimeoutMillis;
+
+        RetryStateImpl(RetryPolicy retryPolicy, Set<RetryPolicyTypes> policies,
+                       int numRetries, Set<Integer> retriableStatusCodes,
+                       List<HeaderMatcherImpl> retriableResponseHeaderMatchers) {
+            this.retryPolicy = retryPolicy;
+            this.numRetries = numRetries;
+            final RetryBackOff retryBackOff = retryPolicy.getRetryBackOff();
+            final long baseIntervalMillis =
+                    XdsCommonUtil.durationToMillis(retryBackOff.getBaseInterval(), 25);
+            final long maxIntervalMillis =
+                    XdsCommonUtil.durationToMillis(retryBackOff.getMaxInterval(), baseIntervalMillis * 10);
+            final Backoff defaultBackoff = Backoff.builderForExponential()
+                                                  .initialDelayMillis(baseIntervalMillis)
+                                                  .maxDelayMillis(maxIntervalMillis)
+                                                  .jitter(0, 0.5)
+                                                  .build();
+            backoff = new DelegatingBackoff(defaultBackoff);
+            shouldRetry = RetryDecision.retry(backoff);
+            this.policies = policies;
+            this.retriableStatusCodes = retriableStatusCodes;
+            this.retriableResponseHeaderMatchers = retriableResponseHeaderMatchers;
+            perTryTimeoutMillis = XdsCommonUtil.durationToMillis(retryPolicy.getPerTryTimeout(), -1);
+        }
+
+        private RetryDecision handleReset(ClientRequestContext ctx, Throwable cause) {
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_RESET)) {
+                return shouldRetry;
+            }
+            if (!(cause instanceof UnprocessedRequestException)) {
+                return RetryDecision.noRetry();
+            }
+            // Only UnprocessedRequestException related rules from now on
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_RESET_BEFORE_REQUEST)) {
+                return shouldRetry;
+            }
+            final Throwable upeCause = cause.getCause();
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_REFUSED_STREAM)) {
+                if (upeCause instanceof RefusedStreamException) {
+                    return shouldRetry;
+                }
+            }
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_CONNECT_FAILURE)) {
+                final RequestLog log = ctx.log().getIfAvailable(RequestLogProperty.SESSION);
+                if (log != null && log.channel() == null) {
+                    return shouldRetry;
+                }
+            }
+            return RetryDecision.noRetry();
+        }
+
+        private RetryDecision handleResponseHeaders(ResponseHeaders responseHeaders) {
+            if (responseHeaders.contains(RESPONSE_HEADER_X_ENVOY_RATELIMITED)) {
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_ENVOY_RATE_LIMITED)) {
+                    return shouldRetry;
+                }
+                return RetryDecision.noRetry();
+            }
+
+            final HttpStatus status = responseHeaders.status();
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_5XX)) {
+                if (status.isServerError()) {
+                    return shouldRetry;
+                }
+            }
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_GATEWAY_ERROR)) {
+                if (status.code() >= 502 && status.code() < 505) {
+                    return shouldRetry;
+                }
+            }
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_RETRIABLE_4XX)) {
+                if (status.code() == HttpStatus.CONFLICT.code()) {
+                    return shouldRetry;
+                }
+            }
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_RETRIABLE_STATUS_CODES)) {
+                if (retriableStatusCodes.contains(status.code())) {
+                    return shouldRetry;
+                }
+            }
+            if (policies.contains(RetryPolicyTypes.RETRY_ON_RETRIABLE_HEADERS)) {
+                for (HeaderMatcherImpl headerMatcher : retriableResponseHeaderMatchers) {
+                    if (headerMatcher.matches(responseHeaders)) {
+                        return shouldRetry;
+                    }
+                }
+            }
+            final Integer grpcStatus = responseHeaders.getInt(RESPONSE_HEADER_GRPC_STATUS);
+            if (grpcStatus != null) {
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_GRPC_CANCELLED) &&
+                    grpcStatus == Status.CANCELLED.getCode().value()) {
+                    return shouldRetry;
+                }
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_GRPC_DEADLINE_EXCEEDED) &&
+                    grpcStatus == Status.DEADLINE_EXCEEDED.getCode().value()) {
+                    return shouldRetry;
+                }
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_GRPC_RESOURCE_EXHAUSTED) &&
+                    grpcStatus == Status.RESOURCE_EXHAUSTED.getCode().value()) {
+                    return shouldRetry;
+                }
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_GRPC_UNAVAILABLE) &&
+                    grpcStatus == Status.UNAVAILABLE.getCode().value()) {
+                    return shouldRetry;
+                }
+                if (policies.contains(RetryPolicyTypes.RETRY_ON_GRPC_INTERNAL) &&
+                    grpcStatus == Status.INTERNAL.getCode().value()) {
+                    return shouldRetry;
+                }
+            }
+
+            return RetryDecision.noRetry();
+        }
+
+        @Nullable
+        private Backoff backoff(ResponseHeaders responseHeaders) {
+            if (!retryPolicy.hasRateLimitedRetryBackOff()) {
+                return null;
+            }
+            final RateLimitedRetryBackOff backOff = retryPolicy.getRateLimitedRetryBackOff();
+            final long maxIntervalMillis = XdsCommonUtil.durationToMillis(backOff.getMaxInterval(), 300_000);
+            for (ResetHeader resetHeader: backOff.getResetHeadersList()) {
+                final String headerValue = responseHeaders.get(resetHeader.getName());
+                if (headerValue == null) {
+                    continue;
+                }
+                final Long seconds = XdsCommonUtil.simpleAtol(headerValue);
+                if (seconds == null) {
+                    continue;
+                }
+                final long intervalMillis;
+                switch (resetHeader.getFormat()) {
+                    case UNIX_TIMESTAMP:
+                        final long nowSeconds = Instant.now().getEpochSecond();
+                        intervalMillis =  TimeUnit.SECONDS.toMillis(seconds - nowSeconds);
+                        break;
+                    case SECONDS:
+                    case UNRECOGNIZED:
+                        intervalMillis = TimeUnit.SECONDS.toMillis(seconds);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unsupported format: " + resetHeader.getFormat());
+                }
+                if (intervalMillis > maxIntervalMillis) {
+                    continue;
+                }
+                if (intervalMillis < 0) {
+                    continue;
+                }
+                final long upperBoundMillis = (long) Math.floor(intervalMillis * 1.5);
+                return Backoff.random(intervalMillis, upperBoundMillis);
+            }
+            return null;
+        }
+
+        @Override
+        public CompletionStage<RetryDecision> shouldRetry(ClientRequestContext ctx, @Nullable Throwable cause) {
+            if (cause != null) {
+                return UnmodifiableFuture.completedFuture(handleReset(ctx, cause));
+            }
+            final RequestLog log = ctx.log().getIfAvailable(RequestLogProperty.RESPONSE_HEADERS);
+            final ResponseHeaders responseHeaders;
+            if (log == null) {
+                responseHeaders = EMPTY_RESPONSE_HEADERS;
+            } else {
+                responseHeaders = log.responseHeaders();
+            }
+            backoff.updateDelegate(backoff(responseHeaders));
+            return UnmodifiableFuture.completedFuture(handleResponseHeaders(responseHeaders));
+        }
+    }
+
+    /**
+     * A workaround to avoid {@link RetryingClient} resetting the attempt count
+     * when the backoff reference changes.
+     */
+    private static final class DelegatingBackoff implements Backoff {
+
+        private final Backoff defaultDelegate;
+        @Nullable
+        private Backoff delegate;
+
+        private DelegatingBackoff(Backoff defaultDelegate) {
+            this.defaultDelegate = defaultDelegate;
+        }
+
+        private void updateDelegate(@Nullable Backoff delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long nextDelayMillis(int numAttemptsSoFar) {
+            final Backoff delegate = this.delegate;
+            if (delegate == null) {
+                return defaultDelegate.nextDelayMillis(numAttemptsSoFar);
+            }
+            return delegate.nextDelayMillis(numAttemptsSoFar);
+        }
+    }
+
+    private enum RetryPolicyTypes {
+        RETRY_ON_5XX("5xx"),
+        RETRY_ON_GATEWAY_ERROR("gateway-error"),
+        RETRY_ON_RETRIABLE_4XX("retriable-4xx"),
+        RETRY_ON_RETRIABLE_STATUS_CODES("retriable-status-codes"),
+        RETRY_ON_RETRIABLE_HEADERS("retriable-headers"),
+        RETRY_ON_ENVOY_RATE_LIMITED("envoy-ratelimited"),
+        // grpc
+        RETRY_ON_GRPC_CANCELLED("cancelled"),
+        RETRY_ON_GRPC_DEADLINE_EXCEEDED("deadline-exceeded"),
+        RETRY_ON_GRPC_RESOURCE_EXHAUSTED("resource-exhausted"),
+        RETRY_ON_GRPC_UNAVAILABLE("unavailable"),
+        RETRY_ON_GRPC_INTERNAL("internal"),
+        // reset
+        RETRY_ON_HTTP3_POST_CONNECT_FAILURE("http3-post-connect-failure"), // http3 is not supported
+        RETRY_ON_CONNECT_FAILURE("connect-failure"),
+        RETRY_ON_REFUSED_STREAM("refused-stream"),
+        RETRY_ON_RESET("reset"),
+        RETRY_ON_RESET_BEFORE_REQUEST("reset-before-request");
+
+        private final String policyName;
+
+        private static final Map<String, RetryPolicyTypes> name2policy;
+
+        static {
+            final ImmutableMap.Builder<String, RetryPolicyTypes> name2policyBuilder = ImmutableMap.builder();
+            for (RetryPolicyTypes retryPolicy : RetryPolicyTypes.values()) {
+                name2policyBuilder.put(retryPolicy.policyName, retryPolicy);
+            }
+            name2policy =  name2policyBuilder.build();
+        }
+
+        RetryPolicyTypes(String policyName) {
+            this.policyName = policyName;
+        }
+
+        @Nullable
+        static RetryPolicyTypes fromPolicyName(String name) {
+            return name2policy.get(name);
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
@@ -83,6 +83,11 @@ final class RouterFilter<I extends Request, O extends Response> implements Prepr
             }
         }
 
+        final long responseTimeoutMillis = selectedRoute.responseTimeoutMillis();
+        if (responseTimeoutMillis > 0) {
+            ctx.setResponseTimeoutMillis(responseTimeoutMillis);
+        }
+
         final UpstreamTlsContext tlsContext = clusterSnapshot.xdsResource().upstreamTlsContext();
         if (tlsContext != null) {
             ctx.setSessionProtocol(SessionProtocol.HTTPS);

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SelectedRoute.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SelectedRoute.java
@@ -23,6 +23,7 @@ import com.google.protobuf.Duration;
 import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
@@ -48,7 +49,7 @@ final class SelectedRoute implements ConfigSupplier {
     private final RpcClient rpcClient;
     private final RouteEntryMatcher routeEntryMatcher;
     @Nullable
-    private final Function<? super HttpClient, ? extends HttpClient> retryingDecorator;
+    private final Function<? super HttpClient, RetryingClient> retryingDecorator;
     private final long responseTimeoutMillis;
 
     SelectedRoute(ListenerSnapshot listenerSnapshot, RouteSnapshot routeSnapshot,
@@ -159,7 +160,7 @@ final class SelectedRoute implements ConfigSupplier {
     }
 
     @Override
-    public @Nullable Function<? super HttpClient, ? extends HttpClient> retryingDecorator() {
+    public @Nullable Function<? super HttpClient, RetryingClient> retryingDecorator() {
         return retryingDecorator;
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SelectedRoute.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SelectedRoute.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import java.util.function.Function;
+
+import com.google.protobuf.Duration;
+
 import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.RpcClient;
@@ -25,6 +29,12 @@ import com.linecorp.armeria.xds.ListenerSnapshot;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.RouteSnapshot;
 import com.linecorp.armeria.xds.VirtualHostSnapshot;
+
+import io.envoyproxy.envoy.config.core.v3.HttpProtocolOptions;
+import io.envoyproxy.envoy.config.route.v3.RetryPolicy;
+import io.envoyproxy.envoy.config.route.v3.RouteAction;
+import io.envoyproxy.envoy.config.route.v3.RouteAction.MaxStreamDuration;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 
 final class SelectedRoute implements ConfigSupplier {
 
@@ -37,6 +47,9 @@ final class SelectedRoute implements ConfigSupplier {
     @Nullable
     private final RpcClient rpcClient;
     private final RouteEntryMatcher routeEntryMatcher;
+    @Nullable
+    private final Function<? super HttpClient, ? extends HttpClient> retryingDecorator;
+    private final long responseTimeoutMillis;
 
     SelectedRoute(ListenerSnapshot listenerSnapshot, RouteSnapshot routeSnapshot,
                   VirtualHostSnapshot virtualHostSnapshot, RouteEntry routeEntry) {
@@ -44,15 +57,65 @@ final class SelectedRoute implements ConfigSupplier {
         this.routeSnapshot = routeSnapshot;
         this.virtualHostSnapshot = virtualHostSnapshot;
         this.routeEntry = routeEntry;
+        routeEntryMatcher = new RouteEntryMatcher(routeEntry);
+        final RouteAction routeAction = routeEntry.route().getRoute();
+        final RetryPolicy retryPolicy = routeAction.getRetryPolicy();
+        if (retryPolicy == RetryPolicy.getDefaultInstance()) {
+            retryingDecorator = null;
+        } else {
+            retryingDecorator = new RetryStateFactory(retryPolicy).retryingDecorator();
+        }
+        responseTimeoutMillis = computeResponseTimeoutMillis(listenerSnapshot, routeEntry);
+
         final ClientDecoration upstreamFilter = FilterUtil.buildUpstreamFilter(this);
-        if (upstreamFilter == ClientDecoration.of()) {
+        if (upstreamFilter == ClientDecoration.of() ||
+            (upstreamFilter.decorators().isEmpty() && upstreamFilter.rpcDecorators().isEmpty())) {
             httpClient = null;
             rpcClient = null;
         } else {
             httpClient = upstreamFilter.decorate(DelegatingHttpClient.INSTANCE);
             rpcClient = upstreamFilter.rpcDecorate(DelegatingRpcClient.INSTANCE);
         }
-        routeEntryMatcher = new RouteEntryMatcher(routeEntry);
+    }
+
+    private static long computeResponseTimeoutMillis(ListenerSnapshot listenerSnapshot, RouteEntry routeEntry) {
+        final long responseTimeoutMillis = computeResponseTimeoutMillis0(listenerSnapshot, routeEntry);
+        if (responseTimeoutMillis == 0) {
+            return Long.MAX_VALUE;
+        } else {
+            return responseTimeoutMillis;
+        }
+    }
+
+    private static long computeResponseTimeoutMillis0(ListenerSnapshot listenerSnapshot,
+                                                      RouteEntry routeEntry) {
+        final HttpConnectionManager connManager = listenerSnapshot.xdsResource().connectionManager();
+        if (connManager == null) {
+            return -1;
+        }
+        final MaxStreamDuration routeMaxStreamDuration = routeEntry.route().getRoute().getMaxStreamDuration();
+        final HttpProtocolOptions protocolOptions = connManager.getCommonHttpProtocolOptions();
+        final long maxStreamDurationMillis = maxStreamDurationMillis(routeMaxStreamDuration, protocolOptions);
+        final long timeoutMillis =
+                XdsCommonUtil.durationToMillis(routeEntry.route().getRoute().getTimeout(), -1);
+        if (maxStreamDurationMillis == -1) {
+            return timeoutMillis;
+        }
+        if (timeoutMillis == -1) {
+            return maxStreamDurationMillis;
+        }
+        return Math.min(timeoutMillis, maxStreamDurationMillis);
+    }
+
+    private static long maxStreamDurationMillis(MaxStreamDuration routeMaxStreamDuration,
+                                                HttpProtocolOptions options) {
+        if (routeMaxStreamDuration.getMaxStreamDuration() != Duration.getDefaultInstance()) {
+            return XdsCommonUtil.durationToMillis(routeMaxStreamDuration.getMaxStreamDuration());
+        }
+        if (options.getMaxStreamDuration() != Duration.getDefaultInstance()) {
+            return XdsCommonUtil.durationToMillis(options.getMaxStreamDuration());
+        }
+        return -1;
     }
 
     RouteEntryMatcher routeEntryMatcher() {
@@ -93,5 +156,15 @@ final class SelectedRoute implements ConfigSupplier {
     @Override
     public RouteEntry routeEntry() {
         return routeEntry;
+    }
+
+    @Override
+    public @Nullable Function<? super HttpClient, ? extends HttpClient> retryingDecorator() {
+        return retryingDecorator;
+    }
+
+    @Override
+    public long responseTimeoutMillis() {
+        return responseTimeoutMillis;
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsCommonUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsCommonUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import com.google.common.primitives.Ints;
+import com.google.protobuf.Duration;
+import com.google.protobuf.UInt32Value;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+final class XdsCommonUtil {
+
+    static long durationToMillis(Duration duration, long defaultValue) {
+        if (duration == Duration.getDefaultInstance()) {
+            return defaultValue;
+        }
+        return durationToMillis(duration);
+    }
+
+    static long durationToMillis(Duration duration) {
+        return java.time.Duration.ofSeconds(duration.getSeconds(), duration.getNanos()).toMillis();
+    }
+
+    static int uint32ValueToInt(UInt32Value uInt32Value, int defaultValue) {
+        if (uInt32Value == UInt32Value.getDefaultInstance()) {
+            return defaultValue;
+        }
+        return Ints.saturatedCast(uInt32Value.getValue());
+    }
+
+    @Nullable
+    static Integer simpleAtoi(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    static Long simpleAtol(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    static boolean isGrpcRequest(@Nullable HttpRequest req) {
+        if (req == null) {
+            return false;
+        }
+        final MediaType contentType = req.contentType();
+        if (contentType == null) {
+            return false;
+        }
+        final String subtype = contentType.subtype();
+        return "grpc".equals(subtype) || subtype.startsWith("grpc+");
+    }
+
+    private XdsCommonUtil() {}
+}


### PR DESCRIPTION
Motivation:

This changeset attempts to implement retries automatically for xDS clients.
While doing so, three points are modified:
1) In order to support the rule `refused-stream`, `RefusedStreamException` is returned instead of `ClosedStreamException`. As this better reflects why a request was closed, I believe this is preferable independent of this changeset.
2) A bug where a router's `Filter#getName` was used instead of `Filter#getTypeUrl` was found. This behavior was fixed. Note that this bug only affects `Xds*Preprocessor`s, and `XdsEndpointGroup` remains unaffected.
3) `RetryStateFactory` has been introduced which creates a `RetryingClient` based on the retry policy. The expected behavior can be found here:
documentation ref: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter
api ref: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-retrypolicy
upstream ref: https://github.com/envoyproxy/envoy/blob/main/source/common/router/retry_state_impl.cc

Additionally, there are some features that haven't been implemented due to low impact relative to high implementation cost:
- `retry_priority` , `retry_host_predicate`, `retry_options_predicates`, `host_selection_retry_max_attempts `
  - These options refer to how endpoint selection is done for retries (e.g. retries shouldn't select canary servers, etc..). As I don't have an idea on how this can be implemented cleanly, let me defer implementation of these parameters for now.
- There are slight differences in implementation with upstream.
  - If `retry_policy` isn't defined, retry headers aren't applied whereas upstream does.
  - Retry-related headers are removed upstream by default, whereas the current implementation doesn't do this.
As most implementations won't be using retry headers for requests extensively, I prefer to keep the implementation simple. If requested later on, these can be implemented.

4) `ResponseTimeout` respects xDS timeout configurations. Support for this field was done to test `RetryPolicy#perTryTimeout`.
ref: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout
upstream ref (conn_manager): https://github.com/envoyproxy/envoy/blob/960c1c41df955a85a184fc3c028d7b1ad78c9b04/source/common/http/conn_manager_impl.cc#L1641-L1727
upstream ref (router): https://github.com/envoyproxy/envoy/blob/960c1c41df955a85a184fc3c028d7b1ad78c9b04/source/common/router/router.cc#L177-L263

In the context of armeria, the min of `max_stream_duration` and `route.timeout` is used to determine `responseTimeout`.
Note that the background of `max_stream_duration` is to limit the timeout of bidi streams: https://github.com/envoyproxy/envoy/issues/10274#issuecomment-595872459

Modifications:

- Modified to close a response with `RefusedStreamException` when a reset with `REFUSED_STREAM` is received.
- Modified to use `getTypeUrl` when determining the router filter
- Introduced `RetryStateFactory` which parses retry related configurations and creates a `RetryingClient`.
  - `RouterFilter` adds a `RetryingClient` if the corresponding `RetryPolicy` is defined.
-  Added `SelectedRoute#computeResponseTimeoutMillis` to compute the `responseTimeout` to be used

Result:

- Retries for xDS are supported

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
