### PR TITLE
feat(docservice): Support Jackson polymorphism annotations

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePlugin.java
@@ -16,12 +16,12 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.armeria.internal.server.annotation.KotlinUtil.isKFunction;
 import static com.linecorp.armeria.internal.server.annotation.KotlinUtil.isReturnTypeNothing;
 import static com.linecorp.armeria.internal.server.annotation.KotlinUtil.kFunctionGenericReturnType;
 import static com.linecorp.armeria.internal.server.annotation.KotlinUtil.kFunctionReturnType;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
 import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
 import static com.linecorp.armeria.server.docs.FieldLocation.PATH;
 import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
@@ -29,24 +29,15 @@ import static com.linecorp.armeria.server.docs.FieldLocation.UNSPECIFIED;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.lang.reflect.TypeVariable;
-import java.lang.reflect.WildcardType;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -84,124 +75,18 @@ import com.linecorp.armeria.server.docs.StructInfo;
 import com.linecorp.armeria.server.docs.TypeSignature;
 import com.linecorp.armeria.server.docs.TypeSignatureType;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * A {@link DocServicePlugin} implementation that supports the {@link AnnotatedService}.
  */
 public final class AnnotatedDocServicePlugin implements DocServicePlugin {
 
-    @VisibleForTesting
-    static final TypeSignature VOID = TypeSignature.ofBase("void");
-    @VisibleForTesting
-    static final TypeSignature BOOLEAN = TypeSignature.ofBase("boolean");
-    @VisibleForTesting
-    static final TypeSignature BYTE = TypeSignature.ofBase("byte");
-    @VisibleForTesting
-    static final TypeSignature SHORT = TypeSignature.ofBase("short");
-    @VisibleForTesting
-    static final TypeSignature INT = TypeSignature.ofBase("int");
-    @VisibleForTesting
-    static final TypeSignature LONG = TypeSignature.ofBase("long");
-    @VisibleForTesting
-    static final TypeSignature FLOAT = TypeSignature.ofBase("float");
-    @VisibleForTesting
-    static final TypeSignature DOUBLE = TypeSignature.ofBase("double");
-    @VisibleForTesting
-    static final TypeSignature CHAR = TypeSignature.ofBase("char");
-    @VisibleForTesting
-    static final TypeSignature STRING = TypeSignature.ofBase("string");
-    @VisibleForTesting
-    static final TypeSignature BINARY = TypeSignature.ofBase("binary");
-
-    private static final ObjectWriter objectWriter = JacksonUtil.newDefaultObjectMapper()
-                                                                .writerWithDefaultPrettyPrinter();
+    private static final ObjectWriter objectWriter =
+            JacksonUtil.newDefaultObjectMapper().writerWithDefaultPrettyPrinter();
 
     private static final DescriptiveTypeInfoProvider DEFAULT_REQUEST_DESCRIPTIVE_TYPE_INFO_PROVIDER =
             new DefaultDescriptiveTypeInfoProvider(true);
     private static final DescriptiveTypeInfoProvider DEFAULT_RESPONSE_DESCRIPTIVE_TYPE_INFO_PROVIDER =
             new DefaultDescriptiveTypeInfoProvider(false);
-
-    @Override
-    public String name() {
-        return "annotated";
-    }
-
-    @Override
-    public Set<Class<? extends Service<?, ?>>> supportedServiceTypes() {
-        return ImmutableSet.of(AnnotatedService.class);
-    }
-
-    @Override
-    public ServiceSpecification generateSpecification(Set<ServiceConfig> serviceConfigs,
-                                                      DocServiceFilter filter,
-                                                      DescriptiveTypeInfoProvider descriptiveTypeInfoProvider) {
-        requireNonNull(serviceConfigs, "serviceConfigs");
-        requireNonNull(filter, "filter");
-        requireNonNull(descriptiveTypeInfoProvider, "descriptiveTypeInfoProvider");
-
-        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
-        final Map<Class<?>, DescriptionInfo> serviceDescription = new HashMap<>();
-        serviceConfigs.forEach(sc -> {
-            final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
-            if (service != null) {
-                final Class<?> serviceClass = service.serviceClass();
-                final String className = serviceClass.getName();
-                final String methodName = service.methodName();
-                if (!filter.test(name(), className, methodName)) {
-                    return;
-                }
-                addMethodInfo(methodInfos, sc.virtualHost().hostnamePattern(), service, serviceClass);
-                addServiceDescription(serviceDescription, serviceClass);
-            }
-        });
-
-        return generate(serviceDescription, methodInfos, descriptiveTypeInfoProvider);
-    }
-
-    private static void addServiceDescription(Map<Class<?>, DescriptionInfo> serviceDescription,
-                                              Class<?> serviceClass) {
-        serviceDescription.computeIfAbsent(serviceClass, AnnotatedServiceFactory::findDescription);
-    }
-
-    private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos,
-                                      String hostnamePattern, DefaultAnnotatedService service,
-                                      Class<?> serviceClass) {
-
-        final Route route = service.route();
-        final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
-        final Method method = service.method();
-        final int overloadId = service.overloadId();
-        final TypeSignature returnTypeSignature = getReturnTypeSignature(method);
-        final List<FieldInfo> fieldInfos = fieldInfos(service.annotatedValueResolvers());
-        route.methods().forEach(
-                httpMethod -> {
-                    final MethodInfo methodInfo = new MethodInfo(
-                            serviceClass.getName(), method.getName(), overloadId, returnTypeSignature,
-                            fieldInfos, ImmutableList.of(),
-                            ImmutableList.of(endpoint), httpMethod,
-                            AnnotatedServiceFactory.findDescription(method));
-
-                    methodInfos.computeIfAbsent(serviceClass, unused -> new HashSet<>()).add(methodInfo);
-                });
-    }
-
-    private static TypeSignature getReturnTypeSignature(Method method) {
-        if (isKFunction(method)) {
-            if (isReturnTypeNothing(method)) {
-                return toTypeSignature(kFunctionReturnType(method));
-            }
-            return toTypeSignature(kFunctionGenericReturnType(method));
-        }
-        return toTypeSignature(method.getGenericReturnType());
-    }
-
-    @VisibleForTesting
-    static EndpointInfo endpointInfo(Route route, String hostnamePattern) {
-        final EndpointInfoBuilder builder = endpointInfoBuilder(route, hostnamePattern);
-        builder.availableMimeTypes(availableMimeTypes(route));
-        return builder.build();
-    }
 
     public static EndpointInfoBuilder endpointInfoBuilder(Route route, String hostnamePattern) {
         final EndpointInfoBuilder builder;
@@ -229,6 +114,47 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
                 throw new Error();
         }
         return builder;
+    }
+
+    private static void addServiceDescription(Map<Class<?>, DescriptionInfo> serviceDescription,
+                                              Class<?> serviceClass) {
+        serviceDescription.computeIfAbsent(serviceClass, AnnotatedServiceFactory::findDescription);
+    }
+
+    private static void addMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos, String hostnamePattern,
+                                      DefaultAnnotatedService service, Class<?> serviceClass) {
+
+        final Route route = service.route();
+        final EndpointInfo endpoint = endpointInfo(route, hostnamePattern);
+        final Method method = service.method();
+        final int overloadId = service.overloadId();
+        final TypeSignature returnTypeSignature = getReturnTypeSignature(method);
+        final List<FieldInfo> fieldInfos = fieldInfos(service.annotatedValueResolvers());
+        route.methods().forEach(httpMethod -> {
+            final MethodInfo methodInfo = new MethodInfo(serviceClass.getName(), method.getName(), overloadId,
+                                                         returnTypeSignature, fieldInfos, ImmutableList.of(),
+                                                         ImmutableList.of(endpoint), httpMethod,
+                                                         AnnotatedServiceFactory.findDescription(method));
+
+            methodInfos.computeIfAbsent(serviceClass, unused -> new HashSet<>()).add(methodInfo);
+        });
+    }
+
+    private static TypeSignature getReturnTypeSignature(Method method) {
+        if (isKFunction(method)) {
+            if (isReturnTypeNothing(method)) {
+                return toTypeSignature(kFunctionReturnType(method));
+            }
+            return toTypeSignature(kFunctionGenericReturnType(method));
+        }
+        return toTypeSignature(method.getGenericReturnType());
+    }
+
+    @VisibleForTesting
+    static EndpointInfo endpointInfo(Route route, String hostnamePattern) {
+        final EndpointInfoBuilder builder = endpointInfoBuilder(route, hostnamePattern);
+        builder.availableMimeTypes(availableMimeTypes(route));
+        return builder.build();
     }
 
     private static Set<MediaType> availableMimeTypes(Route route) {
@@ -277,11 +203,10 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
             } else {
                 typeSignature = toTypeSignature(resolver.elementType());
             }
-            return FieldInfo.builder(resolver.httpElementName(), typeSignature)
-                            .requirement(resolver.shouldExist() ?
-                                         FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
-                            .descriptionInfo(resolver.description())
-                            .build();
+            return FieldInfo.builder(resolver.httpElementName(), typeSignature).requirement(
+                                    resolver.shouldExist() ?
+                                    FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
+                            .descriptionInfo(resolver.description()).build();
         }
 
         if (annotationType != Param.class && annotationType != Header.class) {
@@ -303,127 +228,10 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
         } else {
             signature = toTypeSignature(resolver.elementType());
         }
-        return FieldInfo.builder(resolver.httpElementName(), signature)
-                        .location(location(resolver))
-                        .requirement(resolver.shouldExist() ? FieldRequirement.REQUIRED
-                                                            : FieldRequirement.OPTIONAL)
-                        .descriptionInfo(resolver.description())
-                        .build();
-    }
-
-    static TypeSignature toTypeSignature(Type type) {
-        requireNonNull(type, "type");
-
-        if (type instanceof JavaType) {
-            return toTypeSignature((JavaType) type);
-        }
-
-        // The data types defined by the OpenAPI Specification:
-
-        if (type == Void.class || type == void.class) {
-            return VOID;
-        }
-        if (type == Boolean.class || type == boolean.class) {
-            return BOOLEAN;
-        }
-        if (type == Byte.class || type == byte.class) {
-            return BYTE;
-        }
-        if (type == Short.class || type == short.class) {
-            return SHORT;
-        }
-        if (type == Integer.class || type == int.class) {
-            return INT;
-        }
-        if (type == Long.class || type == long.class) {
-            return LONG;
-        }
-        if (type == Float.class || type == float.class) {
-            return FLOAT;
-        }
-        if (type == Double.class || type == double.class) {
-            return DOUBLE;
-        }
-        if (type == Character.class || type == char.class) {
-            return CHAR;
-        }
-        if (type == String.class) {
-            return STRING;
-        }
-        if (type == byte[].class || type == Byte[].class ||
-            type == ByteBuffer.class || type == ByteBuf.class) {
-            return BINARY;
-        }
-        // End of data types defined by the OpenAPI Specification.
-
-        if (type instanceof ParameterizedType) {
-            final ParameterizedType parameterizedType = (ParameterizedType) type;
-            final Class<?> rawType = (Class<?>) parameterizedType.getRawType();
-            if (List.class.isAssignableFrom(rawType)) {
-                return TypeSignature.ofList(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
-            }
-            if (Set.class.isAssignableFrom(rawType)) {
-                return TypeSignature.ofSet(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
-            }
-
-            if (Map.class.isAssignableFrom(rawType)) {
-                final TypeSignature key = toTypeSignature(parameterizedType.getActualTypeArguments()[0]);
-                final TypeSignature value = toTypeSignature(parameterizedType.getActualTypeArguments()[1]);
-                return TypeSignature.ofMap(key, value);
-            }
-
-            if (Optional.class.isAssignableFrom(rawType) || "scala.Option".equals(rawType.getName())) {
-                return TypeSignature.ofOptional(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
-            }
-
-            final List<TypeSignature> actualTypes = Stream.of(parameterizedType.getActualTypeArguments())
-                                                          .map(AnnotatedDocServicePlugin::toTypeSignature)
-                                                          .collect(toImmutableList());
-            return TypeSignature.ofContainer(rawType.getSimpleName(), actualTypes);
-        }
-
-        if (type instanceof WildcardType) {
-            // Create an unresolved type with an empty string so that the type name will be '?'.
-            return TypeSignature.ofUnresolved("");
-        }
-        if (type instanceof TypeVariable) {
-            return TypeSignature.ofBase(type.getTypeName());
-        }
-        if (type instanceof GenericArrayType) {
-            return TypeSignature.ofList(toTypeSignature(((GenericArrayType) type).getGenericComponentType()));
-        }
-
-        if (!(type instanceof Class)) {
-            return TypeSignature.ofBase(type.getTypeName());
-        }
-
-        final Class<?> clazz = (Class<?>) type;
-        if (clazz.isArray()) {
-            // If it's an array, return it as a list.
-            return TypeSignature.ofList(toTypeSignature(clazz.getComponentType()));
-        }
-
-        return TypeSignature.ofStruct(clazz);
-    }
-
-    static TypeSignature toTypeSignature(JavaType type) {
-        if (type.isArrayType() || type.isCollectionLikeType()) {
-            return TypeSignature.ofList(toTypeSignature(type.getContentType()));
-        }
-
-        if (type.isMapLikeType()) {
-            final TypeSignature key = toTypeSignature(type.getKeyType());
-            final TypeSignature value = toTypeSignature(type.getContentType());
-            return TypeSignature.ofMap(key, value);
-        }
-
-        if (Optional.class.isAssignableFrom(type.getRawClass()) ||
-            "scala.Option".equals(type.getRawClass().getName())) {
-            return TypeSignature.ofOptional(
-                    toTypeSignature(type.getBindings().getBoundType(0)));
-        }
-
-        return toTypeSignature(type.getRawClass());
+        return FieldInfo.builder(resolver.httpElementName(), signature).location(location(resolver))
+                        .requirement(
+                                resolver.shouldExist() ? FieldRequirement.REQUIRED : FieldRequirement.OPTIONAL)
+                        .descriptionInfo(resolver.description()).build();
     }
 
     private static FieldLocation location(AnnotatedValueResolver resolver) {
@@ -443,31 +251,26 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     static ServiceSpecification generate(Map<Class<?>, DescriptionInfo> serviceDescription,
                                          Map<Class<?>, Set<MethodInfo>> methodInfos,
                                          DescriptiveTypeInfoProvider descriptiveTypeInfoProvider) {
-        final Set<ServiceInfo> serviceInfos = methodInfos
-                .entrySet().stream()
-                .map(entry -> {
-                    final Class<?> service = entry.getKey();
-                    return new ServiceInfo(service.getName(), entry.getValue(),
-                                           serviceDescription.getOrDefault(service, DescriptionInfo.empty()));
-                })
-                .collect(toImmutableSet());
+        final Set<ServiceInfo> serviceInfos = methodInfos.entrySet().stream().map(entry -> {
+            final Class<?> service = entry.getKey();
+            return new ServiceInfo(service.getName(), entry.getValue(),
+                                   serviceDescription.getOrDefault(service, DescriptionInfo.empty()));
+        }).collect(toImmutableSet());
 
-        final Set<DescriptiveTypeSignature> requestDescriptiveTypes =
-                serviceInfos.stream()
-                            .flatMap(s -> s.findDescriptiveTypes(true).stream())
-                            .collect(toImmutableSet());
+        final Set<DescriptiveTypeSignature> requestDescriptiveTypes = serviceInfos.stream().flatMap(
+                s -> s.findDescriptiveTypes(true).stream()).collect(toImmutableSet());
 
-        return ServiceSpecification.generate(
-                serviceInfos,
-                typeSignature -> newDescriptiveTypeInfo(typeSignature, descriptiveTypeInfoProvider,
-                                                        requestDescriptiveTypes));
+        return ServiceSpecification.generate(serviceInfos,
+                                             typeSignature -> newDescriptiveTypeInfo(
+                                                     typeSignature,
+                                                     descriptiveTypeInfoProvider,
+                                                     requestDescriptiveTypes));
     }
 
     @VisibleForTesting
-    static DescriptiveTypeInfo newDescriptiveTypeInfo(
-            DescriptiveTypeSignature typeSignature,
-            DescriptiveTypeInfoProvider provider,
-            Set<DescriptiveTypeSignature> requestDescriptiveTypes) {
+    static DescriptiveTypeInfo newDescriptiveTypeInfo(DescriptiveTypeSignature typeSignature,
+                                                      DescriptiveTypeInfoProvider provider,
+                                                      Set<DescriptiveTypeSignature> requestDescriptiveTypes) {
         final Object typeDescriptor = typeSignature.descriptor();
         if (typeSignature instanceof RequestObjectTypeSignature) {
             final Object annotatedValueResolvers =
@@ -483,11 +286,11 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
             return descriptiveTypeInfo;
         }
         if (requestDescriptiveTypes.contains(typeSignature)) {
-            descriptiveTypeInfo =
-                    DEFAULT_REQUEST_DESCRIPTIVE_TYPE_INFO_PROVIDER.newDescriptiveTypeInfo(typeDescriptor);
+            descriptiveTypeInfo = DEFAULT_REQUEST_DESCRIPTIVE_TYPE_INFO_PROVIDER.newDescriptiveTypeInfo(
+                    typeDescriptor);
         } else {
-            descriptiveTypeInfo =
-                    DEFAULT_RESPONSE_DESCRIPTIVE_TYPE_INFO_PROVIDER.newDescriptiveTypeInfo(typeDescriptor);
+            descriptiveTypeInfo = DEFAULT_RESPONSE_DESCRIPTIVE_TYPE_INFO_PROVIDER.newDescriptiveTypeInfo(
+                    typeDescriptor);
         }
         if (descriptiveTypeInfo != null) {
             return descriptiveTypeInfo;
@@ -498,14 +301,50 @@ public final class AnnotatedDocServicePlugin implements DocServicePlugin {
     }
 
     @Override
+    public String name() {
+        return "annotated";
+    }
+
+    @Override
+    public Set<Class<? extends Service<?, ?>>> supportedServiceTypes() {
+        return ImmutableSet.of(AnnotatedService.class);
+    }
+
+    @Override
+    public ServiceSpecification generateSpecification(Set<ServiceConfig> serviceConfigs,
+                                                      DocServiceFilter filter,
+                                                      DescriptiveTypeInfoProvider descriptiveTypeInfoProvider) {
+        requireNonNull(serviceConfigs, "serviceConfigs");
+        requireNonNull(filter, "filter");
+        requireNonNull(descriptiveTypeInfoProvider, "descriptiveTypeInfoProvider");
+
+        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
+        final Map<Class<?>, DescriptionInfo> serviceDescription = new HashMap<>();
+        serviceConfigs.forEach(sc -> {
+            final DefaultAnnotatedService service = sc.service().as(DefaultAnnotatedService.class);
+            if (service != null) {
+                final Class<?> serviceClass = service.serviceClass();
+                final String className = serviceClass.getName();
+                final String methodName = service.methodName();
+                if (!filter.test(name(), className, methodName)) {
+                    return;
+                }
+                addMethodInfo(methodInfos, sc.virtualHost().hostnamePattern(), service, serviceClass);
+                addServiceDescription(serviceDescription, serviceClass);
+            }
+        });
+
+        return generate(serviceDescription, methodInfos, descriptiveTypeInfoProvider);
+    }
+
+    @Override
     public Set<Class<?>> supportedExampleRequestTypes() {
         return ImmutableSet.of(TreeNode.class);
     }
 
     @Override
     @Nullable
-    public String serializeExampleRequest(String serviceName, String methodName,
-                                          Object exampleRequest) {
+    public String serializeExampleRequest(String serviceName, String methodName, Object exampleRequest) {
         try {
             return objectWriter.writeValueAsString(exampleRequest);
         } catch (JsonProcessingException e) {

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultDescriptiveTypeInfoProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/DefaultDescriptiveTypeInfoProvider.java
@@ -18,8 +18,8 @@ package com.linecorp.armeria.internal.server.annotation;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.toTypeSignature;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedValueResolver.isAnnotatedNullable;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
 import static java.util.Objects.requireNonNull;
 
 import java.lang.reflect.AnnotatedElement;
@@ -74,29 +74,6 @@ public final class DefaultDescriptiveTypeInfoProvider implements DescriptiveType
         this.request = request;
     }
 
-    @Nullable
-    @Override
-    public DescriptiveTypeInfo newDescriptiveTypeInfo(Object typeDescriptor) {
-        requireNonNull(typeDescriptor, "typeDescriptor");
-        if (!(typeDescriptor instanceof Class)) {
-            return null;
-        }
-        final Class<?> clazz = (Class<?>) typeDescriptor;
-        if (clazz.isEnum()) {
-            return newEnumInfo(clazz);
-        }
-
-        if (HttpResponse.class.isAssignableFrom(clazz)) {
-            return HTTP_RESPONSE_INFO;
-        }
-
-        if (request) {
-            return requestStructInfo(clazz);
-        } else {
-            return responseStructInfo(clazz);
-        }
-    }
-
     private static EnumInfo newEnumInfo(Class<?> enumClass) {
         final String name = enumClass.getName();
 
@@ -118,123 +95,6 @@ public final class DefaultDescriptiveTypeInfoProvider implements DescriptiveType
         return new EnumInfo(name, values, classDescriptionInfo(enumClass));
     }
 
-    private StructInfo requestStructInfo(Class<?> type) {
-        final JavaType javaType = mapper.constructType(type);
-        if (!mapper.canDeserialize(javaType)) {
-            return newReflectiveStructInfo(type);
-        }
-        return new StructInfo(type.getName(), requestFieldInfos(javaType),
-                              classDescriptionInfo(javaType.getRawClass()));
-    }
-
-    private List<FieldInfo> requestFieldInfos(JavaType javaType) {
-        if (!mapper.canDeserialize(javaType)) {
-            return ImmutableList.of();
-        }
-
-        final BeanDescription description = mapper.getDeserializationConfig().introspect(javaType);
-        final List<BeanPropertyDefinition> properties = description.findProperties();
-        if (properties.isEmpty()) {
-            return newReflectiveStructInfo(javaType.getRawClass()).fields();
-        }
-
-        return properties.stream()
-                         .map(property -> fieldInfos(javaType,
-                                                     property.getName(),
-                                                     property.getInternalName(),
-                                                     property.getPrimaryType()))
-                         .collect(toImmutableList());
-    }
-
-    private StructInfo responseStructInfo(Class<?> type) {
-        if (!mapper.canSerialize(type)) {
-            return newReflectiveStructInfo(type);
-        }
-        final JavaType javaType = mapper.constructType(type);
-        return new StructInfo(type.getName(), responseFieldInfos(javaType), classDescriptionInfo(type));
-    }
-
-    private List<FieldInfo> responseFieldInfos(JavaType javaType) {
-        if (!mapper.canSerialize(javaType.getRawClass())) {
-            return ImmutableList.of();
-        }
-
-        final BeanDescription description = mapper.getSerializationConfig().introspect(javaType);
-        final List<BeanPropertyDefinition> properties = description.findProperties();
-        if (properties.isEmpty()) {
-            return newReflectiveStructInfo(javaType.getRawClass()).fields();
-        }
-
-        return properties.stream()
-                         .map(property -> fieldInfos(javaType,
-                                                     property.getName(),
-                                                     property.getInternalName(),
-                                                     property.getPrimaryType()))
-                         .collect(toImmutableList());
-    }
-
-    private FieldInfo fieldInfos(JavaType javaType, String name, String internalName, JavaType fieldType) {
-        TypeSignature typeSignature = toTypeSignature(fieldType);
-        final FieldRequirement fieldRequirement;
-        if (typeSignature.type() == TypeSignatureType.OPTIONAL) {
-            typeSignature = ((ContainerTypeSignature) typeSignature).typeParameters().get(0);
-            if (typeSignature.type().hasTypeDescriptor()) {
-                final Object descriptor =
-                        ((DescriptiveTypeSignature) typeSignature).descriptor();
-                if (descriptor instanceof Class) {
-                    fieldType = mapper.constructType((Class<?>) descriptor);
-                }
-            }
-            fieldRequirement = FieldRequirement.OPTIONAL;
-        } else {
-            fieldRequirement = fieldRequirement(javaType, fieldType, internalName);
-        }
-
-        final DescriptionInfo descriptionInfo = fieldDescriptionInfo(javaType, fieldType, internalName);
-        return FieldInfo.builder(name, typeSignature)
-                        .requirement(fieldRequirement)
-                        .descriptionInfo(descriptionInfo)
-                        .build();
-    }
-
-    private FieldRequirement fieldRequirement(JavaType classType, JavaType fieldType, String fieldName) {
-        if (fieldType.isPrimitive()) {
-            return FieldRequirement.REQUIRED;
-        }
-
-        if (KotlinUtil.isData(classType.getRawClass())) {
-            // Only the parameters in the constructor of data classes correctly provide
-            // `isMarkedNullable` information.
-            final FieldRequirement requirement =
-                    extractFromConstructor(classType, fieldType, fieldName, parameter -> {
-                        if (isNullable(parameter)) {
-                            return FieldRequirement.OPTIONAL;
-                        } else {
-                            return FieldRequirement.REQUIRED;
-                        }
-                    });
-            if (requirement != null) {
-                return requirement;
-            }
-        }
-
-        final FieldRequirement requirement =
-                extractFieldMeta(classType, fieldType, fieldName, element -> {
-                    if (request) {
-                        if (element instanceof Method) {
-                            // Use the first parameter information for the setter method
-                            element = ((Method) element).getParameters()[0];
-                        }
-                    }
-                    if (isNullable(element)) {
-                        return FieldRequirement.OPTIONAL;
-                    }
-                    return FieldRequirement.REQUIRED;
-                });
-
-        return firstNonNull(requirement, FieldRequirement.UNSPECIFIED);
-    }
-
     static boolean isNullable(AnnotatedElement element) {
         return isAnnotatedNullable(element) || KotlinUtil.isMarkedNullable(element);
     }
@@ -245,28 +105,6 @@ public final class DefaultDescriptiveTypeInfoProvider implements DescriptiveType
             return DescriptionInfo.from(description);
         } else {
             return DescriptionInfo.empty();
-        }
-    }
-
-    private DescriptionInfo fieldDescriptionInfo(JavaType classType, JavaType fieldType, String fieldName) {
-        final Description description = extractFieldMeta(classType, fieldType, fieldName, element -> {
-            return AnnotationUtil.findFirst(element, Description.class);
-        });
-
-        if (description != null) {
-            return DescriptionInfo.from(description);
-        } else {
-            return DescriptionInfo.empty();
-        }
-    }
-
-    @Nullable
-    private <T> T extractFieldMeta(JavaType classType, JavaType fieldType, String fieldName,
-                                   Function<AnnotatedElement, @Nullable T> extractor) {
-        if (request) {
-            return extractRequestFieldMeta(classType, fieldType, fieldName, extractor);
-        } else {
-            return extractResponseFieldMeta(classType, fieldType, fieldName, extractor);
         }
     }
 
@@ -429,5 +267,167 @@ public final class DefaultDescriptiveTypeInfoProvider implements DescriptiveType
 
     private static StructInfo newReflectiveStructInfo(Class<?> clazz) {
         return (StructInfo) ReflectiveDescriptiveTypeInfoProvider.INSTANCE.newDescriptiveTypeInfo(clazz);
+    }
+
+    @Nullable
+    @Override
+    public DescriptiveTypeInfo newDescriptiveTypeInfo(Object typeDescriptor) {
+        requireNonNull(typeDescriptor, "typeDescriptor");
+        if (!(typeDescriptor instanceof Class)) {
+            return null;
+        }
+        final Class<?> clazz = (Class<?>) typeDescriptor;
+        if (clazz.isEnum()) {
+            return newEnumInfo(clazz);
+        }
+
+        if (HttpResponse.class.isAssignableFrom(clazz)) {
+            return HTTP_RESPONSE_INFO;
+        }
+
+        if (request) {
+            return requestStructInfo(clazz);
+        } else {
+            return responseStructInfo(clazz);
+        }
+    }
+
+    private StructInfo requestStructInfo(Class<?> type) {
+        final JavaType javaType = mapper.constructType(type);
+        if (!mapper.canDeserialize(javaType)) {
+            return newReflectiveStructInfo(type);
+        }
+        return new StructInfo(type.getName(), requestFieldInfos(javaType),
+                              classDescriptionInfo(javaType.getRawClass()));
+    }
+
+    private List<FieldInfo> requestFieldInfos(JavaType javaType) {
+        if (!mapper.canDeserialize(javaType)) {
+            return ImmutableList.of();
+        }
+
+        final BeanDescription description = mapper.getDeserializationConfig().introspect(javaType);
+        final List<BeanPropertyDefinition> properties = description.findProperties();
+        if (properties.isEmpty()) {
+            return newReflectiveStructInfo(javaType.getRawClass()).fields();
+        }
+
+        return properties.stream()
+                         .map(property -> fieldInfos(javaType,
+                                                     property.getName(),
+                                                     property.getInternalName(),
+                                                     property.getPrimaryType()))
+                         .collect(toImmutableList());
+    }
+
+    private StructInfo responseStructInfo(Class<?> type) {
+        if (!mapper.canSerialize(type)) {
+            return newReflectiveStructInfo(type);
+        }
+        final JavaType javaType = mapper.constructType(type);
+        return new StructInfo(type.getName(), responseFieldInfos(javaType), classDescriptionInfo(type));
+    }
+
+    private List<FieldInfo> responseFieldInfos(JavaType javaType) {
+        if (!mapper.canSerialize(javaType.getRawClass())) {
+            return ImmutableList.of();
+        }
+
+        final BeanDescription description = mapper.getSerializationConfig().introspect(javaType);
+        final List<BeanPropertyDefinition> properties = description.findProperties();
+        if (properties.isEmpty()) {
+            return newReflectiveStructInfo(javaType.getRawClass()).fields();
+        }
+
+        return properties.stream()
+                         .map(property -> fieldInfos(javaType,
+                                                     property.getName(),
+                                                     property.getInternalName(),
+                                                     property.getPrimaryType()))
+                         .collect(toImmutableList());
+    }
+
+    private FieldInfo fieldInfos(JavaType javaType, String name, String internalName, JavaType fieldType) {
+        TypeSignature typeSignature = toTypeSignature(fieldType);
+        final FieldRequirement fieldRequirement;
+        if (typeSignature.type() == TypeSignatureType.OPTIONAL) {
+            typeSignature = ((ContainerTypeSignature) typeSignature).typeParameters().get(0);
+            if (typeSignature.type().hasTypeDescriptor()) {
+                final Object descriptor =
+                        ((DescriptiveTypeSignature) typeSignature).descriptor();
+                if (descriptor instanceof Class) {
+                    fieldType = mapper.constructType((Class<?>) descriptor);
+                }
+            }
+            fieldRequirement = FieldRequirement.OPTIONAL;
+        } else {
+            fieldRequirement = fieldRequirement(javaType, fieldType, internalName);
+        }
+
+        final DescriptionInfo descriptionInfo = fieldDescriptionInfo(javaType, fieldType, internalName);
+        return FieldInfo.builder(name, typeSignature)
+                        .requirement(fieldRequirement)
+                        .descriptionInfo(descriptionInfo)
+                        .build();
+    }
+
+    private FieldRequirement fieldRequirement(JavaType classType, JavaType fieldType, String fieldName) {
+        if (fieldType.isPrimitive()) {
+            return FieldRequirement.REQUIRED;
+        }
+
+        if (KotlinUtil.isData(classType.getRawClass())) {
+            // Only the parameters in the constructor of data classes correctly provide
+            // `isMarkedNullable` information.
+            final FieldRequirement requirement =
+                    extractFromConstructor(classType, fieldType, fieldName, parameter -> {
+                        if (isNullable(parameter)) {
+                            return FieldRequirement.OPTIONAL;
+                        } else {
+                            return FieldRequirement.REQUIRED;
+                        }
+                    });
+            if (requirement != null) {
+                return requirement;
+            }
+        }
+
+        final FieldRequirement requirement =
+                extractFieldMeta(classType, fieldType, fieldName, element -> {
+                    if (request) {
+                        if (element instanceof Method) {
+                            // Use the first parameter information for the setter method
+                            element = ((Method) element).getParameters()[0];
+                        }
+                    }
+                    if (isNullable(element)) {
+                        return FieldRequirement.OPTIONAL;
+                    }
+                    return FieldRequirement.REQUIRED;
+                });
+
+        return firstNonNull(requirement, FieldRequirement.UNSPECIFIED);
+    }
+
+    private DescriptionInfo fieldDescriptionInfo(JavaType classType, JavaType fieldType, String fieldName) {
+        final Description description = extractFieldMeta(classType, fieldType, fieldName, element -> {
+            return AnnotationUtil.findFirst(element, Description.class);
+        });
+
+        if (description != null) {
+            return DescriptionInfo.from(description);
+        } else {
+            return DescriptionInfo.empty();
+        }
+    }
+
+    @Nullable
+    private <T> T extractFieldMeta(JavaType classType, JavaType fieldType, String fieldName,
+                                   Function<AnnotatedElement, @Nullable T> extractor) {
+        if (request) {
+            return extractRequestFieldMeta(classType, fieldType, fieldName, extractor);
+        } else {
+            return extractResponseFieldMeta(classType, fieldType, fieldName, extractor);
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ReflectiveDescriptiveTypeInfoProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/ReflectiveDescriptiveTypeInfoProvider.java
@@ -17,8 +17,8 @@
 package com.linecorp.armeria.internal.server.annotation;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.toTypeSignature;
 import static com.linecorp.armeria.internal.server.annotation.DefaultDescriptiveTypeInfoProvider.isNullable;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DiscriminatorInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DiscriminatorInfo.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.docs;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Metadata about a discriminator object, which is used for polymorphism.
+ */
+@UnstableApi
+public final class DiscriminatorInfo {
+
+    private final String propertyName;
+    private final Map<String, String> mapping;
+
+    /**
+     * Creates a new instance.
+     */
+    public DiscriminatorInfo(String propertyName, Map<String, String> mapping) {
+        this.propertyName = requireNonNull(propertyName, "propertyName");
+        this.mapping = ImmutableMap.copyOf(requireNonNull(mapping, "mapping"));
+    }
+
+    /**
+     * Returns the name of the property that is used to differentiate between schemas.
+     */
+    @JsonProperty
+    public String propertyName() {
+        return propertyName;
+    }
+
+    /**
+     * Returns the map of payload values to schema names.
+     */
+    @JsonProperty
+    public Map<String, String> mapping() {
+        return mapping;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DiscriminatorInfo)) {
+            return false;
+        }
+        final DiscriminatorInfo that = (DiscriminatorInfo) o;
+        return propertyName.equals(that.propertyName) && mapping.equals(that.mapping);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(propertyName, mapping);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("propertyName", propertyName).add("mapping", mapping)
+                          .toString();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceTypeUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/DocServiceTypeUtil.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.docs;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.google.common.annotations.VisibleForTesting;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.netty.buffer.ByteBuf;
+
+/**
+ * A utility class for {@link DocService}.
+ */
+@UnstableApi
+public final class DocServiceTypeUtil {
+
+    @VisibleForTesting
+    public static final TypeSignature VOID = TypeSignature.ofBase("void");
+    @VisibleForTesting
+    public static final TypeSignature BOOLEAN = TypeSignature.ofBase("boolean");
+    @VisibleForTesting
+    public static final TypeSignature BYTE = TypeSignature.ofBase("byte");
+    @VisibleForTesting
+    public static final TypeSignature SHORT = TypeSignature.ofBase("short");
+    @VisibleForTesting
+    public static final TypeSignature INT = TypeSignature.ofBase("int");
+    @VisibleForTesting
+    public static final TypeSignature LONG = TypeSignature.ofBase("long");
+    @VisibleForTesting
+    public static final TypeSignature FLOAT = TypeSignature.ofBase("float");
+    @VisibleForTesting
+    public static final TypeSignature DOUBLE = TypeSignature.ofBase("double");
+    @VisibleForTesting
+    public static final TypeSignature CHAR = TypeSignature.ofBase("char");
+    @VisibleForTesting
+    public static final TypeSignature STRING = TypeSignature.ofBase("string");
+    @VisibleForTesting
+    public static final TypeSignature BINARY = TypeSignature.ofBase("binary");
+
+    /**
+     * Creates a {@link TypeSignature} from the specified {@link JavaType}.
+     * This method acts as a bridge between Jackson's type representation and Armeria's documentation model.
+     */
+    public static TypeSignature toTypeSignature(JavaType type) {
+        if (type.isArrayType() || type.isCollectionLikeType()) {
+            return TypeSignature.ofList(toTypeSignature(type.getContentType()));
+        }
+
+        if (type.isMapLikeType()) {
+            final TypeSignature key = toTypeSignature(type.getKeyType());
+            final TypeSignature value = toTypeSignature(type.getContentType());
+            return TypeSignature.ofMap(key, value);
+        }
+
+        if (Optional.class.isAssignableFrom(type.getRawClass()) ||
+            "scala.Option".equals(type.getRawClass().getName())) {
+            return TypeSignature.ofOptional(
+                    toTypeSignature(type.getBindings().getBoundType(0)));
+        }
+
+        return toTypeSignature(type.getRawClass());
+    }
+
+    /**
+     * Creates a {@link TypeSignature} from the specified {@link Type}.
+     */
+    public static TypeSignature toTypeSignature(Type type) {
+        requireNonNull(type, "type");
+
+        if (type instanceof JavaType) {
+            return toTypeSignature((JavaType) type);
+        }
+
+        if (type == Void.class || type == void.class) {
+            return VOID;
+        }
+        if (type == Boolean.class || type == boolean.class) {
+            return BOOLEAN;
+        }
+        if (type == Byte.class || type == byte.class) {
+            return BYTE;
+        }
+        if (type == Short.class || type == short.class) {
+            return SHORT;
+        }
+        if (type == Integer.class || type == int.class) {
+            return INT;
+        }
+        if (type == Long.class || type == long.class) {
+            return LONG;
+        }
+        if (type == Float.class || type == float.class) {
+            return FLOAT;
+        }
+        if (type == Double.class || type == double.class) {
+            return DOUBLE;
+        }
+        if (type == Character.class || type == char.class) {
+            return CHAR;
+        }
+        if (type == String.class) {
+            return STRING;
+        }
+        if (type == byte[].class || type == Byte[].class ||
+            type == ByteBuffer.class || type == ByteBuf.class) {
+            return BINARY;
+        }
+
+        if (type instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType) type;
+            final Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+            if (List.class.isAssignableFrom(rawType)) {
+                return TypeSignature.ofList(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
+            }
+            if (Set.class.isAssignableFrom(rawType)) {
+                return TypeSignature.ofSet(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
+            }
+
+            if (Map.class.isAssignableFrom(rawType)) {
+                final TypeSignature key = toTypeSignature(parameterizedType.getActualTypeArguments()[0]);
+                final TypeSignature value = toTypeSignature(parameterizedType.getActualTypeArguments()[1]);
+                return TypeSignature.ofMap(key, value);
+            }
+
+            if (Optional.class.isAssignableFrom(rawType) || "scala.Option".equals(rawType.getName())) {
+                return TypeSignature.ofOptional(toTypeSignature(parameterizedType.getActualTypeArguments()[0]));
+            }
+
+            final List<TypeSignature> actualTypes = Stream.of(parameterizedType.getActualTypeArguments())
+                                                          .map(DocServiceTypeUtil::toTypeSignature)
+                                                          .collect(toImmutableList());
+            return TypeSignature.ofContainer(rawType.getSimpleName(), actualTypes);
+        }
+
+        if (type instanceof WildcardType) {
+            return TypeSignature.ofUnresolved("");
+        }
+        if (type instanceof TypeVariable) {
+            return TypeSignature.ofBase(type.getTypeName());
+        }
+        if (type instanceof GenericArrayType) {
+            return TypeSignature.ofList(toTypeSignature(((GenericArrayType) type).getGenericComponentType()));
+        }
+
+        if (!(type instanceof Class)) {
+            return TypeSignature.ofBase(type.getTypeName());
+        }
+
+        final Class<?> clazz = (Class<?>) type;
+        if (clazz.isArray()) {
+            return TypeSignature.ofList(toTypeSignature(clazz.getComponentType()));
+        }
+
+        return TypeSignature.ofStruct(clazz);
+    }
+
+    private DocServiceTypeUtil() {}
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/EnumInfo.java
@@ -85,6 +85,13 @@ public final class EnumInfo implements DescriptiveTypeInfo {
         this.descriptionInfo = requireNonNull(descriptionInfo, "descriptionInfo");
     }
 
+    private static List<EnumValueInfo> toEnumValues(Class<? extends Enum<?>> enumType) {
+        final Class<?> rawEnumType = requireNonNull(enumType, "enumType");
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        final Set<Enum> values = EnumSet.allOf((Class<Enum>) rawEnumType);
+        return values.stream().map(e -> new EnumValueInfo(e.name())).collect(toImmutableList());
+    }
+
     @Override
     public String name() {
         return name;
@@ -130,13 +137,6 @@ public final class EnumInfo implements DescriptiveTypeInfo {
         }
 
         return new EnumInfo(name, values, descriptionInfo);
-    }
-
-    private static List<EnumValueInfo> toEnumValues(Class<? extends Enum<?>> enumType) {
-        final Class<?> rawEnumType = requireNonNull(enumType, "enumType");
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        final Set<Enum> values = EnumSet.allOf((Class<Enum>) rawEnumType);
-        return values.stream().map(e -> new EnumValueInfo(e.name())).collect(toImmutableList());
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/docs/JacksonPolymorphismTypeInfoProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/JacksonPolymorphismTypeInfoProvider.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server.docs;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.JacksonUtil;
+import com.linecorp.armeria.server.annotation.Description;
+
+/**
+ * A {@link DescriptiveTypeInfoProvider} that provides {@link DescriptiveTypeInfo} for a polymorphic
+ * type by inspecting Jackson annotations such as {@link JsonTypeInfo} and {@link JsonSubTypes}.
+ */
+public final class JacksonPolymorphismTypeInfoProvider implements DescriptiveTypeInfoProvider {
+
+    private static final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
+
+    @Override
+    @Nullable
+    public DescriptiveTypeInfo newDescriptiveTypeInfo(Object typeDescriptor) {
+        requireNonNull(typeDescriptor, "typeDescriptor");
+        if (!(typeDescriptor instanceof Class)) {
+            return null;
+        }
+
+        final Class<?> clazz = (Class<?>) typeDescriptor;
+        final JsonTypeInfo jsonTypeInfo = clazz.getAnnotation(JsonTypeInfo.class);
+        final JsonSubTypes jsonSubTypes = clazz.getAnnotation(JsonSubTypes.class);
+
+        if (jsonTypeInfo == null || jsonSubTypes == null) {
+
+            return null;
+        }
+
+        final String propertyName = jsonTypeInfo.property();
+        if (propertyName.isEmpty()) {
+            return null;
+        }
+
+        final Map<String, String> mapping = new LinkedHashMap<>();
+        Arrays.stream(jsonSubTypes.value()).forEach(subType -> {
+            final Class<?> subClass = subType.value();
+            final String key = subType.name() == null || subType.name().isEmpty() ?
+                               subClass.getSimpleName() : subType.name();
+            final String schemaName = TypeSignature.ofStruct(subClass).name();
+            mapping.put(key, "#/definitions/" + schemaName);
+        });
+
+        final DiscriminatorInfo discriminator = new DiscriminatorInfo(propertyName, mapping);
+
+        final List<TypeSignature> oneOf =
+                Arrays.stream(jsonSubTypes.value())
+                      .map(subType -> TypeSignature.ofStruct(subType.value()))
+                      .collect(toImmutableList());
+
+        final JavaType javaType = mapper.constructType(clazz);
+        final BeanDescription description = mapper.getSerializationConfig().introspect(javaType);
+        final List<BeanPropertyDefinition> properties = description.findProperties();
+
+        final List<FieldInfo> fields = properties.stream()
+                                                 .map(prop -> FieldInfo.of(prop.getName(),
+                                                                           toTypeSignature(
+                                                                                   prop.getPrimaryType())))
+                                                 .collect(toImmutableList());
+
+        final Description classDescription = clazz.getAnnotation(Description.class);
+
+        final DescriptionInfo descriptionInfo =
+                classDescription == null ? DescriptionInfo.empty() : DescriptionInfo.from(classDescription);
+
+        return new StructInfo(clazz.getName(), null, fields,
+                              descriptionInfo, oneOf, discriminator);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/docs/JsonSchemaGenerator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/JsonSchemaGenerator.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -13,15 +13,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.armeria.server.docs;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -30,9 +30,8 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.common.JacksonUtil;
@@ -40,358 +39,352 @@ import com.linecorp.armeria.internal.common.JacksonUtil;
 /**
  * Generates a JSON Schema from the given service specification.
  *
- * @see <a href="https://json-schema.org/">JSON schema</a>
+ * @see <a href="https://json-schema.org/">JSON Schema</a>
  */
 final class JsonSchemaGenerator {
-
     private static final Logger logger = LoggerFactory.getLogger(JsonSchemaGenerator.class);
-
     private static final ObjectMapper mapper = JacksonUtil.newDefaultObjectMapper();
 
-    private static final List<FieldLocation> VALID_FIELD_LOCATIONS = ImmutableList.of(
-            FieldLocation.BODY,
-            FieldLocation.UNSPECIFIED);
-
-    private static final List<String> MEMORIZED_JSON_TYPES = ImmutableList.of("array", "object");
-
-    /**
-     * Generate an array of json schema specifications for each method inside the service.
-     *
-     * @param serviceSpecification the service specification to generate the json schema from.
-     *
-     * @return ArrayNode that contains service specifications
-     */
-    static ArrayNode generate(ServiceSpecification serviceSpecification) {
-        // TODO: Test for Thrift and annotated services
-        final JsonSchemaGenerator generator = new JsonSchemaGenerator(serviceSpecification);
-        return generator.generate();
-    }
-
-    private final Set<ServiceInfo> serviceInfos;
-    private final Map<String, StructInfo> typeSignatureToStructMapping;
-    private final Map<String, EnumInfo> typeNameToEnumMapping;
+    private final ServiceSpecification serviceSpecification;
+    private final Map<String, StructInfo> structs;
+    private final Map<String, EnumInfo> enums;
 
     private JsonSchemaGenerator(ServiceSpecification serviceSpecification) {
-        serviceInfos = serviceSpecification.services();
-        final ImmutableMap.Builder<String, StructInfo> typeSignatureToStructMappingBuilder =
+        this.serviceSpecification = requireNonNull(serviceSpecification, "serviceSpecification");
+
+        final ImmutableMap.Builder<String, StructInfo> structsBuilder =
                 ImmutableMap.builderWithExpectedSize(serviceSpecification.structs().size());
-        for (StructInfo struct : serviceSpecification.structs()) {
-            typeSignatureToStructMappingBuilder.put(struct.name(), struct);
-            if (struct.alias() != null && !struct.alias().equals(struct.name())) {
-                // TypeSignature.signature() could be StructInfo.alias() if the type is a protobuf Message.
-                typeSignatureToStructMappingBuilder.put(struct.alias(), struct);
+        for (final StructInfo structInfo : serviceSpecification.structs()) {
+            structsBuilder.put(structInfo.name(), structInfo);
+            if (structInfo.alias() != null) {
+                structsBuilder.put(structInfo.alias(), structInfo);
             }
         }
-        typeSignatureToStructMapping = typeSignatureToStructMappingBuilder.build();
-        typeNameToEnumMapping = serviceSpecification.enums().stream().collect(
-                toImmutableMap(EnumInfo::name, Function.identity()));
+        structs = structsBuilder.build();
+
+        enums = serviceSpecification.enums().stream()
+                                    .collect(toImmutableMap(EnumInfo::name, Function.identity()));
     }
 
-    private ArrayNode generate() {
-        final ArrayNode definitions = mapper.createArrayNode();
-
-        final Set<ObjectNode> methodDefinitions =
-                serviceInfos.stream()
-                            .flatMap(serviceInfo -> serviceInfo.methods().stream().map(this::generate))
-                            .collect(toImmutableSet());
-
-        return definitions.addAll(methodDefinitions);
+    // Public static entry point
+    static ArrayNode generate(ServiceSpecification serviceSpecification) {
+        return new JsonSchemaGenerator(serviceSpecification).doGenerate();
     }
 
-    /**
-     * Generate the JSON Schema for the given {@link MethodInfo}.
-     *
-     * @param methodInfo the method to generate the JSON Schema for.
-     *
-     * @return ObjectNode containing the JSON schema for the parameter type.
-     */
-    private ObjectNode generate(MethodInfo methodInfo) {
+    private static String getSchemaType(TypeSignature typeSignature) {
+        switch (typeSignature.type()) {
+            case ENUM:
+                return "string";
+            case ITERABLE:
+                return "array";
+            case MAP:
+            case STRUCT:
+                return "object";
+        }
+
+        // Base types
+        switch (typeSignature.name().toLowerCase()) {
+            case "boolean":
+            case "bool":
+                return "boolean";
+            case "short":
+            case "float":
+            case "double":
+                return "number";
+            case "i8":
+            case "i16":
+            case "i32":
+            case "i64":
+            case "integer":
+            case "int":
+            case "long":
+            case "int32":
+            case "int64":
+            case "uint32":
+            case "uint64":
+            case "sint32":
+            case "sint64":
+            case "fixed32":
+            case "fixed64":
+            case "sfixed32":
+            case "sfixed64":
+                return "integer";
+            case "binary":
+            case "byte":
+            case "bytes":
+            case "string":
+                return "string";
+            default:
+                return "object";
+        }
+    }
+
+    // Renamed private instance method that does the actual work
+    private ArrayNode doGenerate() {
+        final ObjectNode definitions = generateDefinitions(); // 항상 생성
+        final ArrayNode methodSchemas = mapper.createArrayNode();
+        for (final ServiceInfo svc : serviceSpecification.services()) {
+            for (final MethodInfo m : svc.methods()) {
+                final ObjectNode schema = generateMethodSchema(m, definitions); // 항상 전달
+                methodSchemas.add(schema);
+            }
+        }
+        return methodSchemas;
+    }
+
+    private ObjectNode generateDefinitions() {
+        final ObjectNode definitionsNode = mapper.createObjectNode();
+        for (final StructInfo structInfo : serviceSpecification.structs()) {
+            definitionsNode.set(structInfo.name(), generateStructDefinition(structInfo));
+        }
+        for (final EnumInfo enumInfo : serviceSpecification.enums()) {
+            definitionsNode.set(enumInfo.name(), generateEnumDefinition(enumInfo));
+        }
+        return definitionsNode;
+    }
+
+    private ObjectNode generateStructDefinition(StructInfo structInfo) {
+        final ObjectNode schemaNode = mapper.createObjectNode();
+        schemaNode.put("type", "object");
+        schemaNode.put("title", structInfo.name());
+        final String docString = structInfo.descriptionInfo().docString();
+        if (docString != null && !docString.isEmpty()) {
+            schemaNode.put("description", docString);
+        }
+
+        final List<TypeSignature> oneOf = structInfo.oneOf();
+        if (oneOf != null && !oneOf.isEmpty()) {
+            final ArrayNode oneOfNode = schemaNode.putArray("oneOf");
+            oneOf.forEach(sub -> {
+                final ObjectNode ref = mapper.createObjectNode();
+                ref.put("$ref", "#/definitions/" + sub.name());
+                oneOfNode.add(ref);
+            });
+
+            final DiscriminatorInfo discriminator = structInfo.discriminator();
+            if (discriminator != null) {
+                final ObjectNode disc = schemaNode.putObject("discriminator");
+                disc.put("propertyName", discriminator.propertyName());
+                if (discriminator.mapping() != null && !discriminator.mapping().isEmpty()) {
+                    final ObjectNode mapping = disc.putObject("mapping");
+                    discriminator.mapping().forEach(mapping::put);
+                }
+            }
+            return schemaNode; // oneOf면 properties/required는 생략
+        }
+
+        // 일반 struct
+        final ObjectNode props = mapper.createObjectNode();
+        final ArrayNode required = mapper.createArrayNode();
+        for (final FieldInfo field : structInfo.fields()) {
+            props.set(field.name(), generateFieldSchema(field, /*useDefinitions=*/true));
+            if (field.requirement() == FieldRequirement.REQUIRED) {
+                required.add(field.name());
+            }
+        }
+        if (props.size() > 0) {
+            schemaNode.set("properties", props);
+        }
+        if (required.size() > 0) {
+            schemaNode.set("required", required);
+        }
+        return schemaNode;
+    }
+
+    private ObjectNode generateEnumDefinition(EnumInfo enumInfo) {
+        final ObjectNode schemaNode = mapper.createObjectNode();
+        schemaNode.put("type", "string");
+        final ArrayNode enumValues = mapper.createArrayNode();
+        enumInfo.values().forEach(value -> enumValues.add(value.name()));
+        schemaNode.set("enum", enumValues);
+        return schemaNode;
+    }
+
+    private boolean useDefinitions(MethodInfo methodInfo) {
+        // Heuristic: gRPC services usually have one parameter and represent the unpacked message.
+        // Annotated services have multiple parameters or one that isn't a known struct.
+        if (methodInfo.parameters().size() == 1) {
+            final FieldInfo firstParam = methodInfo.parameters().get(0);
+            return structs.get(firstParam.typeSignature().signature()) == null;
+        }
+        return methodInfo.parameters().size() > 1 || methodInfo.parameters().isEmpty();
+    }
+
+    private ObjectNode generateMethodSchema(MethodInfo methodInfo, @Nullable ObjectNode definitions) {
         final ObjectNode root = mapper.createObjectNode();
+        root.put("$id", methodInfo.id());
+        root.put("title", methodInfo.name());
+        final String docString = methodInfo.descriptionInfo().docString();
+        if (docString != null && !docString.isEmpty()) {
+            root.put("description", docString);
+        }
+        root.put("additionalProperties", false);
+        root.put("type", "object");
 
-        root.put("$id", methodInfo.id())
-            .put("title", methodInfo.name())
-            .put("description", methodInfo.descriptionInfo().docString())
-            .put("additionalProperties", false)
-            // TODO: Assumes every method takes an object, which is only valid for RPC based services
-            //  and most of the REST services.
-            .put("type", "object");
+        if (!methodInfo.useParameterAsRoot()) {
+            // REST
+            final ObjectNode propertiesNode = mapper.createObjectNode();
+            final ArrayNode requiredNode = mapper.createArrayNode();
 
-        final List<FieldInfo> methodFields;
-        final Map<TypeSignature, String> visited = new HashMap<>();
-        final String currentPath = "#";
-
-        if (methodInfo.useParameterAsRoot()) {
-            final TypeSignature signature = methodInfo.parameters().get(0)
-                                                      .typeSignature();
-            final StructInfo structInfo = typeSignatureToStructMapping.get(signature.signature());
-            if (structInfo == null) {
-                logger.debug("Could not find root parameter with signature: {}", signature);
-                root.put("additionalProperties", true);
-                methodFields = ImmutableList.of();
-            } else {
-                methodFields = structInfo.fields();
+            for (final FieldInfo field : methodInfo.parameters()) {
+                propertiesNode.set(field.name(), generateFieldSchema(field, /*useDefinitions=*/true));
+                if (field.requirement() == FieldRequirement.REQUIRED) {
+                    requiredNode.add(field.name());
+                }
             }
-            visited.put(signature, currentPath);
-        } else {
-            methodFields = methodInfo.parameters();
+            if (propertiesNode.size() > 0) {
+                root.set("properties", propertiesNode);
+            }
+            if (requiredNode.size() > 0) {
+                root.set("required", requiredNode);
+            }
+            root.set("definitions", definitions); // definitions 필수
+            return root;
         }
 
-        generateProperties(methodFields, visited, currentPath, root);
+        // gRPC
+        final Map<TypeSignature, String> visited = new HashMap<>();
+        final FieldInfo firstParam = methodInfo.parameters().get(0);
+        final StructInfo structInfo = structs.get(firstParam.typeSignature().signature());
+
+        if (structInfo != null) {
+            visited.put(firstParam.typeSignature(), "#");
+            generateProperties(structInfo.fields(), visited, "#", root);
+        }
         return root;
     }
 
-    /**
-     * Generate the JSON Schema for the given {@link FieldInfo} and add it to the given {@link ObjectNode}
-     * and add required fields to the {@link ArrayNode}.
-     *
-     * @param field field to generate schema for
-     * @param visited map of visited types and their paths
-     * @param path current path in tree traversal of fields
-     * @param parent the parent to add schema properties
-     * @param required the array node to add required field names, if parent doesn't support, it is null.
-     */
-    private void generateField(FieldInfo field, Map<TypeSignature, String> visited, String path,
-                               ObjectNode parent,
-                               @Nullable ArrayNode required) {
+    private ObjectNode generateFieldSchema(FieldInfo field, boolean useDefinitions) {
         final ObjectNode fieldNode = mapper.createObjectNode();
-        final TypeSignature fieldTypeSignature = field.typeSignature();
+        final TypeSignature typeSignature = field.typeSignature();
+        final String docString = field.descriptionInfo().docString();
+        if (docString != null && !docString.isEmpty()) {
+            fieldNode.put("description", docString);
+        }
 
-        fieldNode.put("description", field.descriptionInfo().docString());
+        if (useDefinitions) {
+            // REST: STRUCT/ENUM은 $ref (기존 기대와 호환)
+            if (typeSignature.type() == TypeSignatureType.STRUCT ||
+                typeSignature.type() == TypeSignatureType.ENUM) {
+                fieldNode.put("$ref", "#/definitions/" + typeSignature.name());
+                return fieldNode;
+            }
+        }
 
-        // Fill required fields for the current object.
+        // gRPC (inline) 또는 나머지 타입
+        final String schemaType = getSchemaType(typeSignature);
+        fieldNode.put("type", schemaType);
+
+        switch (typeSignature.type()) {
+            case ENUM:
+                // gRPC (inline)에서만 여기 타는데, enum 값 인라인
+                final EnumInfo enumInfo = enums.get(typeSignature.name());
+                if (enumInfo != null) {
+                    final ArrayNode enumValues = mapper.createArrayNode();
+                    enumInfo.values().forEach(v -> enumValues.add(v.name()));
+                    fieldNode.set("enum", enumValues);
+                }
+                break;
+            case ITERABLE:
+                final TypeSignature itemType =
+                        ((ContainerTypeSignature) typeSignature).typeParameters().get(0);
+                fieldNode.set("items", generateFieldSchema(FieldInfo.of("", itemType), useDefinitions));
+                break;
+            case MAP:
+                final TypeSignature valueType =
+                        ((MapTypeSignature) typeSignature).valueTypeSignature();
+                fieldNode.set("additionalProperties",
+                              generateFieldSchema(FieldInfo.of("", valueType), useDefinitions));
+                break;
+            default:
+                // BASE/STRUCT(여기 올 일 없음)/UNRESOLVED 등은 type만으로 처리
+        }
+        return fieldNode;
+    }
+
+    private void generateProperties(List<FieldInfo> fields, Map<TypeSignature, String> visited,
+                                    String path, ObjectNode parent) {
+        final ObjectNode propertiesNode = mapper.createObjectNode();
+        final ArrayNode requiredNode = mapper.createArrayNode();
+
+        for (final FieldInfo field : fields) {
+            generateFieldSchemaInline(field, visited, path + "/properties", propertiesNode, requiredNode);
+        }
+
+        if (propertiesNode.size() > 0) {
+            parent.set("properties", propertiesNode);
+        }
+        if (requiredNode.size() > 0) {
+            parent.set("required", requiredNode);
+        }
+    }
+
+    private void generateFieldSchemaInline(FieldInfo field, Map<TypeSignature, String> visited,
+                                           String path, ObjectNode parent, @Nullable ArrayNode required) {
+        final ObjectNode fieldNode = mapper.createObjectNode();
+        final TypeSignature typeSignature = field.typeSignature();
+        final String docString = field.descriptionInfo().docString();
+        if (docString != null && !docString.isEmpty()) {
+            fieldNode.put("description", docString);
+        }
+
         if (required != null && field.requirement() == FieldRequirement.REQUIRED) {
             required.add(field.name());
         }
 
-        if (visited.containsKey(fieldTypeSignature)) {
-            // If field is already visited, add a reference to the field instead of iterating its children.
-            final String pathName = visited.get(fieldTypeSignature);
-            fieldNode.put("$ref", pathName);
-        } else {
-            final String schemaType = getSchemaType(field.typeSignature());
-
-            // Field is not visited, create a new type definition for it.
-            fieldNode.put("type", schemaType);
-
-            if (field.typeSignature().type() == TypeSignatureType.ENUM) {
-                fieldNode.set("enum", getEnumType(field.typeSignature()));
-            }
-
-            final String currentPath;
-            if (field.name().isEmpty()) {
-                currentPath = path;
-            } else {
-                currentPath = path + '/' + field.name();
-            }
-
-            // Only Struct types map to custom objects to we need reference to those structs.
-            // Having references to primitives do not make sense.
-            if (MEMORIZED_JSON_TYPES.contains(schemaType)) {
-                visited.put(fieldTypeSignature, currentPath);
-            }
-
-            // Based on field type, we need to call the appropriate method to generate the schema.
-            // For example maps have `additionalProperties` field, arrays have `items` field and structs
-            // have `properties` field.
-            if (field.typeSignature().type() == TypeSignatureType.MAP) {
-                generateMapFields(fieldNode, field, visited, currentPath);
-            } else if (field.typeSignature().type() == TypeSignatureType.ITERABLE) {
-                generateArrayFields(fieldNode, field, visited, currentPath);
-            } else if ("object".equals(schemaType)) {
-                generateStructFields(fieldNode, field, visited, currentPath);
-            }
-        }
-
-        // Set current field inside the returned object.
-        // If field is nameless, unpack it.
-        // Example:
-        // For `list<int> x` we should have `{"x": {"items": {"type": "integer"}}}`
-        // Not `{"x": {"items": {"": {"type": "integer"}}}}`
-        if (field.name().isEmpty()) {
-            parent.setAll(fieldNode);
-        } else {
+        if (visited.containsKey(typeSignature)) {
+            fieldNode.put("$ref", visited.get(typeSignature));
             parent.set(field.name(), fieldNode);
-        }
-    }
-
-    /**
-     * Generate properties for the given fields and writes to the object node.
-     *
-     * @param fields list of fields that the child has.
-     * @param visited a map of visited fields, required for cycle detection.
-     * @param path current path as defined in JSON Schema spec, required for cyclic references.
-     * @param parent object node that the results will be written to.
-     */
-    private void generateProperties(List<FieldInfo> fields, Map<TypeSignature, String> visited, String path,
-                                    ObjectNode parent) {
-        final ObjectNode objectNode = mapper.createObjectNode();
-        final ArrayNode required = mapper.createArrayNode();
-
-        for (FieldInfo field : fields) {
-            if (VALID_FIELD_LOCATIONS.contains(field.location())) {
-                generateField(field, visited, path + "/properties", objectNode, required);
-            }
+            return;
         }
 
-        parent.set("properties", objectNode);
-        parent.set("required", required);
-    }
+        final String currentPath = path + '/' + field.name();
+        final String schemaType = getSchemaType(typeSignature);
+        fieldNode.put("type", schemaType);
 
-    /**
-     * Create the JSON node for a map field.
-     * Example for `map(string, int)`: {"type": "object", "additionalProperties": {"type": "integer"}}
-     *
-     * @see <a href="https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties">JSON Schema</a>
-     */
-    private void generateMapFields(ObjectNode fieldNode, FieldInfo field, Map<TypeSignature, String> visited,
-                                   String path) {
-        final ObjectNode additionalProperties = mapper.createObjectNode();
-
-        // Keys are always converted to strings.
-        final TypeSignature valueType = ((MapTypeSignature) field.typeSignature()).valueTypeSignature();
-        // Create a field info with no name. Field infos with no name are considered to be unpacked.
-        final FieldInfo valueFieldInfo = FieldInfo.builder("", valueType)
-                                                  .location(FieldLocation.BODY)
-                                                  .requirement(FieldRequirement.OPTIONAL)
-                                                  .build();
-
-        // Recursively generate the field.
-        generateField(valueFieldInfo, visited, path + "/additionalProperties", additionalProperties, null);
-
-        fieldNode.set("additionalProperties", additionalProperties);
-    }
-
-    /**
-     * Create the JSON node for an array field.
-     * Example for `list(int)`: {"type": "array", "items": {"type": "integer"}}
-     *
-     * @see <a href="https://json-schema.org/understanding-json-schema/reference/array.html">JSON Schema</a>
-     */
-    private void generateArrayFields(ObjectNode fieldNode, FieldInfo field, Map<TypeSignature, String> visited,
-                                     String path) {
-        final ObjectNode items = mapper.createObjectNode();
-
-        final TypeSignature itemsType =
-                ((ContainerTypeSignature) field.typeSignature()).typeParameters().get(0);
-        // Create a field info with no name. Field infos with no name are considered to be unpacked.
-        final FieldInfo itemFieldInfo = FieldInfo.builder("", itemsType)
-                                                 .location(FieldLocation.BODY)
-                                                 .requirement(FieldRequirement.OPTIONAL)
-                                                 .build();
-
-        generateField(itemFieldInfo, visited, path + "/items", items, null);
-
-        fieldNode.set("items", items);
-    }
-
-    /**
-     * Create the JSON node for a struct (object) field. Most custom classes are serialized as structs.
-     * Example for `Foo(Integer x)`: {"type": "object", "properties": {"x": {"type": "integer"}}}
-     *
-     * @see <a href="https://json-schema.org/understanding-json-schema/reference/object.html#properties">JSON Schema</a>
-     */
-    private void generateStructFields(ObjectNode fieldNode, FieldInfo field, Map<TypeSignature, String> visited,
-                                      String path) {
-
-        final StructInfo fieldStructInfo = typeSignatureToStructMapping.get(field.typeSignature().signature());
-        fieldNode.put("additionalProperties", fieldStructInfo == null);
-
-        if (fieldStructInfo == null) {
-            logger.debug("Could not find struct with signature: {}",
-                         field.typeSignature().signature());
+        if (ImmutableSet.of("object", "array").contains(schemaType)) {
+            visited.put(typeSignature, currentPath);
         }
 
-        // Iterate over each child field, generate their definitions.
-        if (fieldStructInfo != null && !fieldStructInfo.fields().isEmpty()) {
-            generateProperties(fieldStructInfo.fields(), visited, path, fieldNode);
+        switch (typeSignature.type()) {
+            case ENUM:
+                final EnumInfo enumInfo = enums.get(typeSignature.name());
+                if (enumInfo != null) {
+                    final ArrayNode enumValues = mapper.createArrayNode();
+                    enumInfo.values().forEach(value -> enumValues.add(value.name()));
+                    fieldNode.set("enum", enumValues);
+                }
+                break;
+            case STRUCT:
+                final StructInfo structInfo = structs.get(typeSignature.signature());
+                if (structInfo == null) {
+                    fieldNode.put("additionalProperties", true);
+                } else {
+                    fieldNode.put("additionalProperties", false);
+                    if (!structInfo.fields().isEmpty()) {
+                        generateProperties(structInfo.fields(), visited, currentPath, fieldNode);
+                    }
+                }
+                break;
+            case ITERABLE:
+                final TypeSignature itemType = ((ContainerTypeSignature) typeSignature).typeParameters().get(0);
+                final ObjectNode itemsNode = mapper.createObjectNode();
+                generateFieldSchemaInline(FieldInfo.of("", itemType), visited, path + "/items", itemsNode,
+                                          null);
+                if (itemsNode.has("")) {
+                    fieldNode.set("items", itemsNode.get(""));
+                }
+                break;
+            case MAP:
+                final TypeSignature valueType = ((MapTypeSignature) typeSignature).valueTypeSignature();
+                final ObjectNode additionalPropertiesNode = mapper.createObjectNode();
+                generateFieldSchemaInline(FieldInfo.of("", valueType), visited, path + "/additionalProperties",
+                                          additionalPropertiesNode, null);
+                if (additionalPropertiesNode.has("")) {
+                    fieldNode.set("additionalProperties", additionalPropertiesNode.get(""));
+                }
+                break;
         }
-    }
-
-    /**
-     * Get the JSON type for the given enum type.
-     * Example: `enum Foo { BAR, BAZ }`: {"type": "string", "enum": ["BAR", "BAZ"]}
-     */
-    private ArrayNode getEnumType(TypeSignature type) {
-        final ArrayNode enumArray = mapper.createArrayNode();
-        final EnumInfo enumInfo = typeNameToEnumMapping.get(type.signature());
-
-        if (enumInfo != null) {
-            enumInfo.values().forEach(x -> enumArray.add(x.name()));
-        }
-
-        return enumArray;
-    }
-
-    /**
-     * Get the JSON type for the given type. Unknown types are returned as `object`.
-     * This list can be extended to support more types.
-     *
-     * @see <a href="https://json-schema.org/understanding-json-schema/reference/type.html">JSON Schema</a>
-     */
-    private static String getSchemaType(TypeSignature typeSignature) {
-        if (typeSignature.type() == TypeSignatureType.ENUM) {
-            return "string";
-        }
-
-        if (typeSignature.type() == TypeSignatureType.ITERABLE) {
-            switch (typeSignature.name().toLowerCase()) {
-                case "repeated":
-                case "list":
-                case "array":
-                case "set":
-                    return "array";
-                default:
-                    return "object";
-            }
-        }
-
-        if (typeSignature.type() == TypeSignatureType.MAP) {
-            return "object";
-        }
-
-        if (typeSignature.type() == TypeSignatureType.BASE) {
-            switch (typeSignature.name().toLowerCase()) {
-                case "boolean":
-                case "bool":
-                    return "boolean";
-                case "short":
-                case "number":
-                case "float":
-                case "double":
-                    return "number";
-                case "i":
-                case "i8":
-                case "i16":
-                case "i32":
-                case "i64":
-                case "integer":
-                case "int":
-                case "l32":
-                case "l64":
-                case "long":
-                case "long32":
-                case "long64":
-                case "int32":
-                case "int64":
-                case "uint32":
-                case "uint64":
-                case "sint32":
-                case "sint64":
-                case "fixed32":
-                case "fixed64":
-                case "sfixed32":
-                case "sfixed64":
-                    return "integer";
-                case "binary":
-                case "byte":
-                case "bytes":
-                case "string":
-                    return "string";
-                default:
-                    return "object";
-            }
-        }
-
-        return "object";
+        parent.set(field.name(), fieldNode);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/MethodInfo.java
@@ -169,6 +169,16 @@ public final class MethodInfo {
         this.descriptionInfo = requireNonNull(descriptionInfo, "descriptionInfo");
     }
 
+    private static String createId(String serviceName, String name, int overloadId, HttpMethod httpMethod) {
+        final String methodName;
+        if (overloadId > 0) {
+            methodName = name + '-' + overloadId;
+        } else {
+            methodName = name;
+        }
+        return serviceName + '/' + methodName + '/' + httpMethod.name();
+    }
+
     /**
      * Returns the id of this function. It's a form of {@code serviceName/methodName/httpMethod}.
      * The {@code methodName} might have {@code -x} suffix if the method is overloaded.
@@ -350,15 +360,5 @@ public final class MethodInfo {
                           .add("httpMethod", httpMethod())
                           .add("descriptionInfo", descriptionInfo())
                           .toString();
-    }
-
-    private static String createId(String serviceName, String name, int overloadId, HttpMethod httpMethod) {
-        final String methodName;
-        if (overloadId > 0) {
-            methodName = name + '-' + overloadId;
-        } else {
-            methodName = name;
-        }
-        return serviceName + '/' + methodName + '/' + httpMethod.name();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecification.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/ServiceSpecification.java
@@ -92,37 +92,6 @@ public final class ServiceSpecification {
         return new ServiceSpecification(services, enums.values(), structs.values(), exceptions.values());
     }
 
-    private static void generateDescriptiveTypeInfos(
-            Function<DescriptiveTypeSignature, ? extends DescriptiveTypeInfo> descriptiveTypeInfoFactory,
-            Map<String, EnumInfo> enums, Map<String, StructInfo> structs,
-            Map<String, ExceptionInfo> exceptions, Set<DescriptiveTypeSignature> descriptiveTypes) {
-
-        descriptiveTypes.forEach(type -> {
-            final String typeName = type.name();
-            if (enums.containsKey(typeName) ||
-                structs.containsKey(typeName) ||
-                exceptions.containsKey(typeName)) {
-                return;
-            }
-
-            final DescriptiveTypeInfo newInfo = descriptiveTypeInfoFactory.apply(type);
-            if (newInfo instanceof EnumInfo) {
-                enums.put(newInfo.name(), (EnumInfo) newInfo);
-                return;
-            }
-            if (newInfo instanceof StructInfo) {
-                structs.put(newInfo.name(), (StructInfo) newInfo);
-            } else if (newInfo instanceof ExceptionInfo) {
-                exceptions.put(newInfo.name(), (ExceptionInfo) newInfo);
-            } else {
-                throw new Error(); // Should never reach here.
-            }
-
-            generateDescriptiveTypeInfos(descriptiveTypeInfoFactory, enums, structs, exceptions,
-                                         newInfo.findDescriptiveTypes());
-        });
-    }
-
     private final Set<ServiceInfo> services;
     private final Set<EnumInfo> enums;
     private final Set<StructInfo> structs;
@@ -175,6 +144,37 @@ public final class ServiceSpecification {
         } else {
             this.docServiceRoute = null;
         }
+    }
+
+    private static void generateDescriptiveTypeInfos(
+            Function<DescriptiveTypeSignature, ? extends DescriptiveTypeInfo> descriptiveTypeInfoFactory,
+            Map<String, EnumInfo> enums, Map<String, StructInfo> structs,
+            Map<String, ExceptionInfo> exceptions, Set<DescriptiveTypeSignature> descriptiveTypes) {
+
+        descriptiveTypes.forEach(type -> {
+            final String typeName = type.name();
+            if (enums.containsKey(typeName) ||
+                structs.containsKey(typeName) ||
+                exceptions.containsKey(typeName)) {
+                return;
+            }
+
+            final DescriptiveTypeInfo newInfo = descriptiveTypeInfoFactory.apply(type);
+            if (newInfo instanceof EnumInfo) {
+                enums.put(newInfo.name(), (EnumInfo) newInfo);
+                return;
+            }
+            if (newInfo instanceof StructInfo) {
+                structs.put(newInfo.name(), (StructInfo) newInfo);
+            } else if (newInfo instanceof ExceptionInfo) {
+                exceptions.put(newInfo.name(), (ExceptionInfo) newInfo);
+            } else {
+                throw new Error(); // Should never reach here.
+            }
+
+            generateDescriptiveTypeInfos(descriptiveTypeInfoFactory, enums, structs, exceptions,
+                                         newInfo.findDescriptiveTypes());
+        });
     }
 
     private static <T extends DescriptiveTypeInfo> Set<T> collectDescriptiveTypeInfo(

--- a/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
+++ b/core/src/main/java/com/linecorp/armeria/server/docs/StructInfo.java
@@ -46,29 +46,47 @@ public final class StructInfo implements DescriptiveTypeInfo {
     private final List<FieldInfo> fields;
     private final DescriptionInfo descriptionInfo;
 
+    private final List<TypeSignature> oneOf;
+    @Nullable
+    private final DiscriminatorInfo discriminator;
+
     /**
      * Creates a new instance.
      */
     public StructInfo(String name, Iterable<FieldInfo> fields) {
-        this(name, null, fields, DescriptionInfo.empty());
+        this(name, null, fields, DescriptionInfo.empty(), ImmutableList.of(), null);
     }
 
     /**
      * Creates a new instance.
      */
     public StructInfo(String name, Iterable<FieldInfo> fields, DescriptionInfo descriptionInfo) {
-        this(name, null, fields, descriptionInfo);
+        this(name, null, fields, descriptionInfo, ImmutableList.of(), null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @deprecated Use {@link #StructInfo(String, String, Iterable,
+     * DescriptionInfo, Iterable, DiscriminatorInfo)}
+     */
+    @Deprecated
+    public StructInfo(String name, @Nullable String alias, Iterable<FieldInfo> fields,
+                      DescriptionInfo descriptionInfo) {
+        this(name, alias, fields, descriptionInfo, ImmutableList.of(), null);
     }
 
     /**
      * Creates a new instance.
      */
     public StructInfo(String name, @Nullable String alias, Iterable<FieldInfo> fields,
-                      DescriptionInfo descriptionInfo) {
+                      DescriptionInfo descriptionInfo, Iterable<TypeSignature> oneOf,
+                      @Nullable DiscriminatorInfo discriminator) {
         this.name = requireNonNull(name, "name");
         this.alias = alias;
         this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields"));
         this.descriptionInfo = requireNonNull(descriptionInfo, "descriptionInfo");
+        this.oneOf = ImmutableList.copyOf(requireNonNull(oneOf, "oneOf"));
+        this.discriminator = discriminator;
     }
 
     @Override
@@ -101,8 +119,7 @@ public final class StructInfo implements DescriptiveTypeInfo {
         if (alias.equals(this.alias)) {
             return this;
         }
-
-        return new StructInfo(name, alias, fields, descriptionInfo);
+        return new StructInfo(name, alias, fields, descriptionInfo, oneOf, discriminator);
     }
 
     /**
@@ -122,8 +139,7 @@ public final class StructInfo implements DescriptiveTypeInfo {
         if (fields.equals(this.fields)) {
             return this;
         }
-
-        return new StructInfo(name, alias, fields, descriptionInfo);
+        return new StructInfo(name, alias, fields, descriptionInfo, oneOf, discriminator);
     }
 
     /**
@@ -144,14 +160,33 @@ public final class StructInfo implements DescriptiveTypeInfo {
         if (descriptionInfo.equals(this.descriptionInfo)) {
             return this;
         }
+        return new StructInfo(name, alias, fields, descriptionInfo, oneOf, discriminator);
+    }
 
-        return new StructInfo(name, alias, fields, descriptionInfo);
+    /**
+     * Returns the list of subtypes for polymorphism.
+     */
+    @JsonProperty
+    @JsonInclude(Include.NON_EMPTY)
+    public List<TypeSignature> oneOf() {
+        return oneOf;
+    }
+
+    /**
+     * Returns the discriminator information for polymorphism.
+     */
+    @JsonProperty
+    @JsonInclude(Include.NON_NULL)
+    @Nullable
+    public DiscriminatorInfo discriminator() {
+        return discriminator;
     }
 
     @Override
     public Set<DescriptiveTypeSignature> findDescriptiveTypes() {
         final Set<DescriptiveTypeSignature> collectedDescriptiveTypes = new HashSet<>();
         fields().forEach(f -> ServiceInfo.findDescriptiveTypes(collectedDescriptiveTypes, f.typeSignature()));
+        oneOf().forEach(t -> ServiceInfo.findDescriptiveTypes(collectedDescriptiveTypes, t)); // oneOf 타입 추가
         return ImmutableSortedSet.copyOf(comparing(TypeSignature::name), collectedDescriptiveTypes);
     }
 
@@ -160,21 +195,21 @@ public final class StructInfo implements DescriptiveTypeInfo {
         if (this == o) {
             return true;
         }
-
         if (!(o instanceof StructInfo)) {
             return false;
         }
-
         final StructInfo that = (StructInfo) o;
         return name.equals(that.name) &&
                Objects.equals(alias, that.alias) &&
                fields.equals(that.fields) &&
-               descriptionInfo.equals(that.descriptionInfo);
+               descriptionInfo.equals(that.descriptionInfo) &&
+               oneOf.equals(that.oneOf) &&
+               Objects.equals(discriminator, that.discriminator);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, alias, fields, descriptionInfo);
+        return Objects.hash(name, alias, fields, descriptionInfo, oneOf, discriminator);
     }
 
     @Override
@@ -185,6 +220,8 @@ public final class StructInfo implements DescriptiveTypeInfo {
                           .add("alias", alias)
                           .add("fields", fields)
                           .add("descriptionInfo", descriptionInfo)
+                          .add("oneOf",oneOf.isEmpty() ? null : oneOf)
+                          .add("discriminator", discriminator)
                           .toString();
     }
 }

--- a/core/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DescriptiveTypeInfoProvider
+++ b/core/src/main/resources/META-INF/services/com.linecorp.armeria.server.docs.DescriptiveTypeInfoProvider
@@ -1,0 +1,1 @@
+com.linecorp.armeria.server.docs.JacksonPolymorphismTypeInfoProvider

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServicePluginTest.java
@@ -19,14 +19,14 @@ package com.linecorp.armeria.internal.server.annotation;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.LONG;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.VOID;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.endpointInfo;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.newDescriptiveTypeInfo;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.toTypeSignature;
 import static com.linecorp.armeria.internal.server.annotation.DefaultDescriptiveTypeInfoProviderTest.REQUEST_STRUCT_INFO_PROVIDER;
 import static com.linecorp.armeria.internal.server.docs.DocServiceUtil.unifyFilter;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.LONG;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.STRING;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.VOID;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
 import static com.linecorp.armeria.server.docs.FieldLocation.HEADER;
 import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
 import static com.linecorp.armeria.server.docs.FieldRequirement.REQUIRED;
@@ -79,6 +79,119 @@ class AnnotatedDocServicePluginTest {
     private static final String BAR_NAME = BarClass.class.getName();
 
     private static final AnnotatedDocServicePlugin plugin = new AnnotatedDocServicePlugin();
+
+    private static Route withMethodAndTypes(RouteBuilder builder) {
+        return builder.methods(HttpMethod.GET)
+                      .consumes(MediaType.PLAIN_TEXT_UTF_8)
+                      .produces(MediaType.JSON_UTF_8)
+                      .build();
+    }
+
+    private static void checkFooService(ServiceInfo fooServiceInfo) {
+        assertThat(fooServiceInfo.exampleHeaders()).isEmpty();
+        final Map<String, MethodInfo> methods =
+                fooServiceInfo.methods().stream()
+                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).containsKeys("fooMethod", "foo2Method");
+
+        final MethodInfo fooMethod = methods.get("fooMethod");
+        assertThat(fooMethod.exampleHeaders()).isEmpty();
+        assertThat(fooMethod.exampleRequests()).isEmpty();
+
+        assertThat(fooMethod.parameters()).hasSize(2);
+        assertThat(fooMethod.parameters()).containsExactlyInAnyOrder(
+                FieldInfo.builder("foo", STRING).requirement(REQUIRED)
+                         .location(QUERY)
+                         .build(),
+                FieldInfo.builder("foo1", LONG).requirement(REQUIRED)
+                         .location(HEADER)
+                         .build());
+
+        assertThat(fooMethod.returnTypeSignature()).isEqualTo(VOID);
+
+        assertThat(fooMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/foo")
+                                                                      .defaultMimeType(MediaType.JSON)
+                                                                      .build());
+    }
+
+    private static void checkBarService(ServiceInfo barServiceInfo) {
+        assertThat(barServiceInfo.exampleHeaders()).isEmpty();
+        final Map<String, MethodInfo> methods =
+                barServiceInfo.methods().stream()
+                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
+        assertThat(methods).containsKeys("barMethod");
+
+        final MethodInfo barMethod = methods.get("barMethod");
+        assertThat(barMethod.exampleHeaders()).isEmpty();
+        assertThat(barMethod.exampleRequests()).isEmpty();
+        assertThat(barMethod.returnTypeSignature()).isEqualTo(VOID);
+
+        assertThat(barMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/bar")
+                                                                      .defaultMimeType(MediaType.JSON)
+                                                                      .build());
+
+        final FieldInfo bar = FieldInfo.builder("bar", STRING).requirement(REQUIRED)
+                                       .location(QUERY)
+                                       .build();
+        final List<FieldInfo> fieldInfos = barMethod.parameters();
+        assertThat(fieldInfos).hasSize(2);
+        assertThat(fieldInfos).contains(bar);
+        final Optional<FieldInfo> compositeBean =
+                fieldInfos.stream()
+                          .filter(fieldInfo -> "compositeBean".equals(fieldInfo.name()))
+                          .findFirst();
+        assertThat(compositeBean).isPresent();
+        final StructInfo expected = new StructInfo(
+                CompositeBean.class.getName(),
+                ImmutableList.of(createBean("bean1", RequestBean1.class),
+                                 createBean("bean2", RequestBean2.class)));
+        final DescriptiveTypeInfo actual = newDescriptiveTypeInfo(
+                (DescriptiveTypeSignature) compositeBean.get().typeSignature(), REQUEST_STRUCT_INFO_PROVIDER,
+                ImmutableSet.of());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static Map<String, ServiceInfo> services(Object... services) {
+        final DocServiceFilter include = (plugin, service, method) -> true;
+        final DocServiceFilter exclude = (plugin, service, method) -> false;
+        return services(include, exclude, services);
+    }
+
+    private static Map<String, ServiceInfo> services(DocServiceFilter include,
+                                                     DocServiceFilter exclude,
+                                                     Object... services) {
+        final ServerBuilder builder = Server.builder();
+        Arrays.stream(services).forEach(builder::annotatedService);
+        final Server server = builder.build();
+        final ServiceSpecification specification =
+                plugin.generateSpecification(ImmutableSet.copyOf(server.serviceConfigs()),
+                                             unifyFilter(include, exclude), typeDescriptor -> null);
+        return specification.services()
+                            .stream()
+                            .collect(toImmutableMap(ServiceInfo::name, Function.identity()));
+    }
+
+    private static List<String> methods(Map<String, ServiceInfo> services) {
+        return services.get(FOO_NAME).methods()
+                       .stream()
+                       .map(MethodInfo::name)
+                       .collect(toImmutableList());
+    }
+
+    static FieldInfo compositeBean() {
+        return FieldInfo.builder("compositeBean",
+                                 new RequestObjectTypeSignature(TypeSignatureType.STRUCT,
+                                                                CompositeBean.class.getName(),
+                                                                CompositeBean.class, ImmutableList.of()))
+                        .requirement(REQUIRED)
+                        .build();
+    }
+
+    private static FieldInfo createBean(String name, Class<?> type) {
+        return FieldInfo.builder(name, TypeSignature.ofStruct(type))
+                        .requirement(REQUIRED)
+                        .build();
+    }
 
     @Test
     void testToTypeSignature() throws Exception {
@@ -224,13 +337,6 @@ class AnnotatedDocServicePluginTest {
                             .build());
     }
 
-    private static Route withMethodAndTypes(RouteBuilder builder) {
-        return builder.methods(HttpMethod.GET)
-                      .consumes(MediaType.PLAIN_TEXT_UTF_8)
-                      .produces(MediaType.JSON_UTF_8)
-                      .build();
-    }
-
     @Test
     void testGenerateSpecification() {
         final Map<String, ServiceInfo> services = services((plugin, service, method) -> true,
@@ -312,112 +418,6 @@ class AnnotatedDocServicePluginTest {
         assertThat(paths).containsOnly("exact:/path1", "exact:/path2");
     }
 
-    private static void checkFooService(ServiceInfo fooServiceInfo) {
-        assertThat(fooServiceInfo.exampleHeaders()).isEmpty();
-        final Map<String, MethodInfo> methods =
-                fooServiceInfo.methods().stream()
-                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
-        assertThat(methods).containsKeys("fooMethod", "foo2Method");
-
-        final MethodInfo fooMethod = methods.get("fooMethod");
-        assertThat(fooMethod.exampleHeaders()).isEmpty();
-        assertThat(fooMethod.exampleRequests()).isEmpty();
-
-        assertThat(fooMethod.parameters()).hasSize(2);
-        assertThat(fooMethod.parameters()).containsExactlyInAnyOrder(
-                FieldInfo.builder("foo", STRING).requirement(REQUIRED)
-                         .location(QUERY)
-                         .build(),
-                FieldInfo.builder("foo1", LONG).requirement(REQUIRED)
-                         .location(HEADER)
-                         .build());
-
-        assertThat(fooMethod.returnTypeSignature()).isEqualTo(VOID);
-
-        assertThat(fooMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/foo")
-                                                                      .defaultMimeType(MediaType.JSON)
-                                                                      .build());
-    }
-
-    private static void checkBarService(ServiceInfo barServiceInfo) {
-        assertThat(barServiceInfo.exampleHeaders()).isEmpty();
-        final Map<String, MethodInfo> methods =
-                barServiceInfo.methods().stream()
-                              .collect(toImmutableMap(MethodInfo::name, Function.identity()));
-        assertThat(methods).containsKeys("barMethod");
-
-        final MethodInfo barMethod = methods.get("barMethod");
-        assertThat(barMethod.exampleHeaders()).isEmpty();
-        assertThat(barMethod.exampleRequests()).isEmpty();
-        assertThat(barMethod.returnTypeSignature()).isEqualTo(VOID);
-
-        assertThat(barMethod.endpoints()).containsExactly(EndpointInfo.builder("*", "exact:/bar")
-                                                                      .defaultMimeType(MediaType.JSON)
-                                                                      .build());
-
-        final FieldInfo bar = FieldInfo.builder("bar", STRING).requirement(REQUIRED)
-                                       .location(QUERY)
-                                       .build();
-        final List<FieldInfo> fieldInfos = barMethod.parameters();
-        assertThat(fieldInfos).hasSize(2);
-        assertThat(fieldInfos).contains(bar);
-        final Optional<FieldInfo> compositeBean =
-                fieldInfos.stream()
-                          .filter(fieldInfo -> "compositeBean".equals(fieldInfo.name()))
-                          .findFirst();
-        assertThat(compositeBean).isPresent();
-        final StructInfo expected = new StructInfo(
-                CompositeBean.class.getName(),
-                ImmutableList.of(createBean("bean1", RequestBean1.class),
-                                 createBean("bean2", RequestBean2.class)));
-        final DescriptiveTypeInfo actual = newDescriptiveTypeInfo(
-                (DescriptiveTypeSignature) compositeBean.get().typeSignature(), REQUEST_STRUCT_INFO_PROVIDER,
-                ImmutableSet.of());
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    private static Map<String, ServiceInfo> services(Object... services) {
-        final DocServiceFilter include = (plugin, service, method) -> true;
-        final DocServiceFilter exclude = (plugin, service, method) -> false;
-        return services(include, exclude, services);
-    }
-
-    private static Map<String, ServiceInfo> services(DocServiceFilter include,
-                                                     DocServiceFilter exclude,
-                                                     Object... services) {
-        final ServerBuilder builder = Server.builder();
-        Arrays.stream(services).forEach(builder::annotatedService);
-        final Server server = builder.build();
-        final ServiceSpecification specification =
-                plugin.generateSpecification(ImmutableSet.copyOf(server.serviceConfigs()),
-                                             unifyFilter(include, exclude), typeDescriptor -> null);
-        return specification.services()
-                            .stream()
-                            .collect(toImmutableMap(ServiceInfo::name, Function.identity()));
-    }
-
-    private static List<String> methods(Map<String, ServiceInfo> services) {
-        return services.get(FOO_NAME).methods()
-                       .stream()
-                       .map(MethodInfo::name)
-                       .collect(toImmutableList());
-    }
-
-    static FieldInfo compositeBean() {
-        return FieldInfo.builder("compositeBean",
-                                 new RequestObjectTypeSignature(TypeSignatureType.STRUCT,
-                                                                CompositeBean.class.getName(),
-                                                                CompositeBean.class, ImmutableList.of()))
-                        .requirement(REQUIRED)
-                        .build();
-    }
-
-    private static FieldInfo createBean(String name, Class<?> type) {
-        return FieldInfo.builder(name, TypeSignature.ofStruct(type))
-                        .requirement(REQUIRED)
-                        .build();
-    }
-
     private static class FieldContainer<T> {
         T typeVariable;
         List<String> list;
@@ -468,7 +468,7 @@ class AnnotatedDocServicePluginTest {
         private Long seqNum;
 
         @JsonProperty
-        private String uid;
+        private final String uid;
 
         @Nullable
         private String notPopulatedStr;

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/AnnotatedDocServiceTest.java
@@ -16,11 +16,11 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.INT;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.LONG;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.toTypeSignature;
 import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePluginTest.compositeBean;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.INT;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.LONG;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.STRING;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.toTypeSignature;
 import static com.linecorp.armeria.server.docs.FieldLocation.PATH;
 import static com.linecorp.armeria.server.docs.FieldLocation.QUERY;
 import static com.linecorp.armeria.server.docs.FieldRequirement.REQUIRED;
@@ -152,47 +152,6 @@ class AnnotatedDocServiceTest {
                                                       .build());
         }
     };
-
-    @Test
-    void jsonSpecification() throws Exception {
-        if (TestUtil.isDocServiceDemoMode()) {
-            Thread.sleep(Long.MAX_VALUE);
-        }
-        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
-        addFooMethodInfo(methodInfos);
-        addAllMethodsMethodInfos(methodInfos);
-        addIntsMethodInfo(methodInfos);
-        addPathParamsMethodInfo(methodInfos);
-        addPathParamsWithQueriesMethodInfo(methodInfos);
-        addRegexMethodInfo(methodInfos);
-        addPrefixMethodInfo(methodInfos);
-        addConsumesMethodInfo(methodInfos);
-        addBeanMethodInfo(methodInfos);
-        addMultiMethodInfo(methodInfos);
-        addJsonMethodInfo(methodInfos);
-        addOverloadMethodInfo(methodInfos);
-        addOverload2MethodInfo(methodInfos);
-        addMarkdownDescriptionMethodInfo(methodInfos);
-        addMermaidDescriptionMethodInfo(methodInfos);
-        addImplicitRequestObjectMethodInfo(methodInfos);
-        addJsonLinesMethodInfo(methodInfos);
-
-        final Map<Class<?>, DescriptionInfo> serviceDescription = ImmutableMap.of(
-                MyService.class, DescriptionInfo.of("My service class"));
-
-        final JsonNode expectedJson = mapper.valueToTree(AnnotatedDocServicePlugin.generate(
-                serviceDescription, methodInfos, typeDescriptor -> null));
-        addExamples(expectedJson);
-
-        final WebClient client = WebClient.of(server.httpUri());
-        final AggregatedHttpResponse res = client.get("/docs/specification.json").aggregate().join();
-        assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
-                .isEqualTo("no-cache, max-age=0, must-revalidate");
-        assertThatJson(res.contentUtf8()).when(IGNORING_ARRAY_ORDER)
-                                         .whenIgnoringPaths("structs", "docServiceRoute")
-                                         .isEqualTo(expectedJson);
-    }
 
     private static void addFooMethodInfo(Map<Class<?>, Set<MethodInfo>> methodInfos) {
         final EndpointInfo endpoint = EndpointInfo.builder("*", "exact:/service/foo")
@@ -499,6 +458,47 @@ class AnnotatedDocServiceTest {
     }
 
     @Test
+    void jsonSpecification() throws Exception {
+        if (TestUtil.isDocServiceDemoMode()) {
+            Thread.sleep(Long.MAX_VALUE);
+        }
+        final Map<Class<?>, Set<MethodInfo>> methodInfos = new HashMap<>();
+        addFooMethodInfo(methodInfos);
+        addAllMethodsMethodInfos(methodInfos);
+        addIntsMethodInfo(methodInfos);
+        addPathParamsMethodInfo(methodInfos);
+        addPathParamsWithQueriesMethodInfo(methodInfos);
+        addRegexMethodInfo(methodInfos);
+        addPrefixMethodInfo(methodInfos);
+        addConsumesMethodInfo(methodInfos);
+        addBeanMethodInfo(methodInfos);
+        addMultiMethodInfo(methodInfos);
+        addJsonMethodInfo(methodInfos);
+        addOverloadMethodInfo(methodInfos);
+        addOverload2MethodInfo(methodInfos);
+        addMarkdownDescriptionMethodInfo(methodInfos);
+        addMermaidDescriptionMethodInfo(methodInfos);
+        addImplicitRequestObjectMethodInfo(methodInfos);
+        addJsonLinesMethodInfo(methodInfos);
+
+        final Map<Class<?>, DescriptionInfo> serviceDescription = ImmutableMap.of(
+                MyService.class, DescriptionInfo.of("My service class"));
+
+        final JsonNode expectedJson = mapper.valueToTree(AnnotatedDocServicePlugin.generate(
+                serviceDescription, methodInfos, typeDescriptor -> null));
+        addExamples(expectedJson);
+
+        final WebClient client = WebClient.of(server.httpUri());
+        final AggregatedHttpResponse res = client.get("/docs/specification.json").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo("no-cache, max-age=0, must-revalidate");
+        assertThatJson(res.contentUtf8()).when(IGNORING_ARRAY_ORDER)
+                                         .whenIgnoringPaths("structs", "docServiceRoute")
+                                         .isEqualTo(expectedJson);
+    }
+
+    @Test
     void excludeAllServices() throws IOException {
         final WebClient client = WebClient.of(server.httpUri());
         final AggregatedHttpResponse res = client.get("/excludeAll/specification.json").aggregate().join();
@@ -524,6 +524,22 @@ class AnnotatedDocServiceTest {
         final JsonNode specificationJson = mapper.readTree(specification);
         assertThatJson(specificationJson).node("docServiceRoute.pathType").isEqualTo("PREFIX");
         assertThatJson(specificationJson).node("docServiceRoute.patternString").isEqualTo("/docs/*");
+    }
+
+    private enum MyEnum {
+        A,
+        B,
+        C
+    }
+
+    @Description("DESCRIPTION ENUM")
+    private enum DescriptionEnum {
+        @Description(value = "MARKDOWN DESCRIPTION `A`", markup = Markup.MARKDOWN)
+        DESCRIPTION_A,
+        @Description("NONE MARKDOWN DESCRIPTION B\nMultiline")
+        DESCRIPTION_B,
+        @Description("NONE MARKDOWN DESCRIPTION C")
+        DESCRIPTION_C
     }
 
     private static final class ProxyService implements HttpService {
@@ -692,22 +708,6 @@ class AnnotatedDocServiceTest {
         public HttpResponse implicitRequestObject(byte[] body) {
             return HttpResponse.of(HttpStatus.OK, MediaType.OCTET_STREAM, body);
         }
-    }
-
-    private enum MyEnum {
-        A,
-        B,
-        C
-    }
-
-    @Description("DESCRIPTION ENUM")
-    private enum DescriptionEnum {
-        @Description(value = "MARKDOWN DESCRIPTION `A`", markup = Markup.MARKDOWN)
-        DESCRIPTION_A,
-        @Description("NONE MARKDOWN DESCRIPTION B\nMultiline")
-        DESCRIPTION_B,
-        @Description("NONE MARKDOWN DESCRIPTION C")
-        DESCRIPTION_C
     }
 
     private static class JsonRequest {

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DefaultDescriptiveTypeInfoProviderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DefaultDescriptiveTypeInfoProviderTest.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.armeria.internal.server.annotation;
 
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.INT;
-import static com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.INT;
+import static com.linecorp.armeria.server.docs.DocServiceTypeUtil.STRING;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DocServiceTestUtil.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/server/annotation/DocServiceTestUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law of an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.internal.server.annotation;
+
+import com.linecorp.armeria.server.docs.DescriptiveTypeInfoProvider;
+
+/**
+ * A test utility class for DocService related tests.
+ * This class resides in the same package as internal classes to provide access for testing purposes.
+ */
+public final class DocServiceTestUtil {
+
+    /**
+     * Creates a new instance of the package-private {@link DefaultDescriptiveTypeInfoProvider}.
+     */
+    public static DescriptiveTypeInfoProvider newDefaultDescriptiveTypeInfoProvider(boolean request) {
+        return new DefaultDescriptiveTypeInfoProvider(request);
+    }
+
+    private DocServiceTestUtil() {}
+}

--- a/core/src/test/java/com/linecorp/armeria/server/docs/JsonSchemaGeneratorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/docs/JsonSchemaGeneratorTest.java
@@ -16,150 +16,268 @@
 
 package com.linecorp.armeria.server.docs;
 
+import static java.util.Objects.requireNonNull;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.jupiter.api.Test;
 
-import net.javacrumbs.jsonunit.core.internal.Node.JsonMap;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.internal.server.annotation.DocServiceTestUtil;
 
 class JsonSchemaGeneratorTest {
-
-    // Common Fixtures
     private static final String methodName = "test-method";
-    private static final DescriptionInfo methodDescription = DescriptionInfo.of("test method");
 
-    // Generate a fake ServiceSpecification that only contains the happy path to parameters
-    private static StructInfo newStructInfo(String name, List<FieldInfo> parameters) {
-        return new StructInfo(name, parameters);
-    }
+    private static ServiceSpecification newServiceSpecificationWithRequestStruct(StructInfo... structInfos) {
 
-    private static FieldInfo newFieldInfo() {
-        return FieldInfo.of("request", TypeSignature.ofStruct(methodName, new Object()));
-    }
+        final MethodInfo methodInfo = new MethodInfo("test-service", methodName, 0, // overloadId
+                                                     TypeSignature.ofBase("void"), // returnType
+                                                     ImmutableList.of(FieldInfo.of("request",
+                                                                                   TypeSignature.ofStruct(
+                                                                                           methodName,
+                                                                                           new Object()))),
+                                                     ImmutableList.of(), // exampleHeaders
+                                                     ImmutableList.of(), // endpoints
+                                                     HttpMethod.POST, DescriptionInfo.empty());
 
-    private static MethodInfo newMethodInfo(FieldInfo... parameters) {
-        return new MethodInfo(
-                "test-service",
-                methodName,
-                TypeSignature.ofBase("void"),
-                Arrays.asList(parameters),
-                true,
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                ImmutableList.of(),
-                HttpMethod.POST,
-                methodDescription
-        );
-    }
-
-    private static ServiceSpecification generateServiceSpecification(StructInfo... structInfos) {
         return new ServiceSpecification(
-                ImmutableList.of(
-                        new ServiceInfo(
-                                "test-service",
-                                ImmutableList.of(newMethodInfo(newFieldInfo())),
-                                DescriptionInfo.empty()
-                        )
-                ),
-                ImmutableList.of(),
-                Arrays.stream(structInfos).collect(Collectors.toList()),
-                ImmutableList.of()
-        );
+                ImmutableList.of(new ServiceInfo("test-service", ImmutableList.of(methodInfo))),
+                ImmutableList.of(), Arrays.stream(structInfos).collect(Collectors.toList()),
+                ImmutableList.of());
     }
 
     @Test
     void testGenerateSimpleMethodWithoutParameters() {
-        final List<FieldInfo> parameters = ImmutableList.of();
-        final StructInfo structInfo = newStructInfo(methodName, parameters);
+        final StructInfo structInfo = new StructInfo(methodName, ImmutableList.of());
+        final ServiceSpecification spec = newServiceSpecificationWithRequestStruct(structInfo);
+        final JsonNode methodSchema = JsonSchemaGenerator.generate(spec).get(0);
 
-        final ServiceSpecification serviceSpecification = generateServiceSpecification(structInfo);
-        final JsonNode jsonSchema = JsonSchemaGenerator.generate(serviceSpecification).get(0);
-
-        // Base properties
-        assertThatJson(jsonSchema).node("title").isEqualTo(methodName);
-        assertThatJson(jsonSchema).node("description").isEqualTo(methodDescription.docString());
-        assertThatJson(jsonSchema).node("type").isEqualTo("object");
-
-        // Method specific properties
-        assertThatJson(jsonSchema).node("properties").matches(
-                new CustomTypeSafeMatcher<JsonMap>("has no key") {
-                    @Override
-                    protected boolean matchesSafely(JsonMap item) {
-                        return item.keySet().size() == 0;
-                    }
-                });
-        assertThatJson(jsonSchema).node("additionalProperties").isEqualTo(false);
+        assertThatJson(methodSchema).node("title").isEqualTo(methodName);
+        assertThatJson(methodSchema).node("properties.request.$ref").isEqualTo("#/definitions/test-method");
+        assertThatJson(methodSchema).node("definitions.test-method.properties").isAbsent();
     }
 
     @Test
     void testGenerateSimpleMethodWithPrimitiveParameters() {
-        final List<FieldInfo> parameters = ImmutableList.of(
-                FieldInfo.of("param1", TypeSignature.ofBase("int"), DescriptionInfo.of("param1 description")),
-                FieldInfo.of("param2", TypeSignature.ofBase("double"),
-                             DescriptionInfo.of("param2 description")),
-                FieldInfo.of("param3", TypeSignature.ofBase("string"),
-                             DescriptionInfo.of("param3 description")),
-                FieldInfo.of("param4", TypeSignature.ofBase("boolean"),
-                             DescriptionInfo.of("param4 description")));
-        final StructInfo structInfo = newStructInfo(methodName, parameters);
+        final List<FieldInfo> parameters = ImmutableList.of(FieldInfo.of("param1", TypeSignature.ofBase("int")),
+                                                            FieldInfo.of("param2",
+                                                                         TypeSignature.ofBase("double")),
+                                                            FieldInfo.of("param3",
+                                                                         TypeSignature.ofBase("string")),
+                                                            FieldInfo.of("param4",
+                                                                         TypeSignature.ofBase("boolean")));
+        final StructInfo structInfo = new StructInfo(methodName, parameters);
+        final ServiceSpecification spec = newServiceSpecificationWithRequestStruct(structInfo);
+        final JsonNode methodSchema = JsonSchemaGenerator.generate(spec).get(0);
 
-        final ServiceSpecification serviceSpecification = generateServiceSpecification(structInfo);
-        final JsonNode jsonSchema = JsonSchemaGenerator.generate(serviceSpecification).get(0);
-
-        // Base properties
-        assertThatJson(jsonSchema).node("title").isEqualTo(methodName);
-        assertThatJson(jsonSchema).node("description").isEqualTo(methodDescription.docString());
-        assertThatJson(jsonSchema).node("type").isEqualTo("object");
-
-        // Method specific properties
-        assertThatJson(jsonSchema).node("properties").matches(
-                new CustomTypeSafeMatcher<JsonMap>("has 4 keys") {
-                    @Override
-                    protected boolean matchesSafely(JsonMap item) {
-                        return item.keySet().size() == 4;
-                    }
-                });
-        assertThatJson(jsonSchema).node("properties.param1.type").isEqualTo("integer");
-        assertThatJson(jsonSchema).node("properties.param2.type").isEqualTo("number");
-        assertThatJson(jsonSchema).node("properties.param3.type").isEqualTo("string");
-        assertThatJson(jsonSchema).node("properties.param4.type").isEqualTo("boolean");
+        assertThatJson(methodSchema).node("properties.request.$ref").isEqualTo("#/definitions/test-method");
+        final JsonNode definition = methodSchema.get("definitions").get(methodName);
+        assertThatJson(definition).node("properties.param1.type").isEqualTo("integer");
+        assertThatJson(definition).node("properties.param2.type").isEqualTo("number");
+        assertThatJson(definition).node("properties.param3.type").isEqualTo("string");
+        assertThatJson(definition).node("properties.param4.type").isEqualTo("boolean");
     }
 
     @Test
     void testMethodWithRecursivePath() {
         final Object commonTypeObjectForRecursion = new Object();
-        final List<FieldInfo> parameters = ImmutableList.of(
-                FieldInfo.of("param1", TypeSignature.ofBase("int"), DescriptionInfo.of("param1 description")),
-                FieldInfo.builder("paramRecursive", TypeSignature.ofStruct("rec", commonTypeObjectForRecursion))
-                         .build()
-        );
 
-        final StructInfo structInfo = newStructInfo(methodName, parameters);
+        final FieldInfo param1 = FieldInfo.of("param1", TypeSignature.ofBase("int"));
+        final FieldInfo paramRecursive = FieldInfo.of("paramRecursive",
+                                                      TypeSignature.ofStruct("rec",
+                                                                             commonTypeObjectForRecursion));
+
+        final List<FieldInfo> parameters = ImmutableList.of(param1, paramRecursive);
+
+        final StructInfo structInfo = new StructInfo(methodName, parameters);
 
         final List<FieldInfo> parametersOfRec = ImmutableList.of(
                 FieldInfo.of("inner-param1", TypeSignature.ofBase("int32")),
-                FieldInfo.of("inner-recurse", TypeSignature.ofStruct("rec", commonTypeObjectForRecursion))
-        );
-        final StructInfo rec = newStructInfo("rec", parametersOfRec);
+                FieldInfo.of("inner-recurse", TypeSignature.ofStruct("rec", commonTypeObjectForRecursion)));
+        final StructInfo rec = new StructInfo("rec", parametersOfRec);
 
-        final ServiceSpecification serviceSpecification = generateServiceSpecification(structInfo, rec);
-        final JsonNode jsonSchema = JsonSchemaGenerator.generate(serviceSpecification).get(0);
+        final ServiceSpecification spec = newServiceSpecificationWithRequestStruct(structInfo, rec);
+        final JsonNode methodSchema = JsonSchemaGenerator.generate(spec).get(0);
 
-        assertThatJson(jsonSchema).node("properties.paramRecursive.properties.inner-param1").isPresent();
-        assertThatJson(jsonSchema).node("properties.paramRecursive.properties.inner-recurse.$ref").isEqualTo(
-                "#/properties/paramRecursive");
+        assertThatJson(methodSchema).node("definitions.rec.properties.inner-param1.type").isEqualTo("integer");
+        assertThatJson(methodSchema).node("definitions.rec.properties.inner-recurse.$ref").isEqualTo(
+                "#/definitions/rec");
+    }
+
+    @Test
+    void shouldGenerateOneOfForPolymorphicType() {
+        // 1. Arrange (Given): Create a provider chain and generate StructInfos by analyzing actual classes.
+        final DescriptiveTypeInfoProvider providerChain = new JacksonPolymorphismTypeInfoProvider().orElse(
+                DocServiceTestUtil.newDefaultDescriptiveTypeInfoProvider(false));
+
+        final StructInfo animalInfo = (StructInfo) providerChain.newDescriptiveTypeInfo(Animal.class);
+        final StructInfo dogInfo = (StructInfo) providerChain.newDescriptiveTypeInfo(Dog.class);
+        final StructInfo catInfo = (StructInfo) providerChain.newDescriptiveTypeInfo(Cat.class);
+        final StructInfo toyInfo = (StructInfo) providerChain.newDescriptiveTypeInfo(Toy.class);
+        final StructInfo mammalInfo = (StructInfo) providerChain.newDescriptiveTypeInfo(Mammal.class);
+
+        assertThat(animalInfo).isNotNull();
+        assertThat(dogInfo).isNotNull();
+        assertThat(catInfo).isNotNull();
+        assertThat(toyInfo).isNotNull();
+        assertThat(mammalInfo).isNotNull();
+
+        final EndpointInfo endpoint = EndpointInfo.builder("*", "/test-polymorphism").defaultMimeType(
+                MediaType.JSON_UTF_8).build();
+
+        final MethodInfo testMethod = new MethodInfo("animal-service", "animalMethod", 0,
+                                                     TypeSignature.ofBase("void"), ImmutableList.of(
+                FieldInfo.of("animal", TypeSignature.ofStruct(Animal.class))), ImmutableList.of(),
+                                                     ImmutableList.of(endpoint), HttpMethod.POST,
+                                                     DescriptionInfo.empty());
+
+        final ServiceSpecification specification = new ServiceSpecification(
+                ImmutableList.of(new ServiceInfo("animal-service", ImmutableList.of(testMethod))),
+                ImmutableList.of(), ImmutableList.of(animalInfo, dogInfo, catInfo, toyInfo, mammalInfo),
+                ImmutableList.of());
+
+        // 2. Act (When): Generate the JSON schema.
+        final JsonNode methodSchema = JsonSchemaGenerator.generate(specification).get(0);
+
+        // 3. Assert (Then): Verify the generated schema.
+        final JsonNode definitions = methodSchema.get("definitions");
+        final JsonNode animalSchema = definitions.get(Animal.class.getName());
+        final JsonNode discriminator = animalSchema.get("discriminator");
+
+        assertThat(animalSchema).isNotNull();
+
+        assertThat(discriminator).isNotNull();
+        assertThatJson(discriminator).node("propertyName").isEqualTo("species");
+
+        assertThatJson(animalSchema).node("oneOf").isArray().ofLength(2);
+        assertThatJson(animalSchema).node("oneOf[0].$ref").isEqualTo("#/definitions/" + Dog.class.getName());
+        assertThatJson(animalSchema).node("oneOf[1].$ref").isEqualTo("#/definitions/" + Cat.class.getName());
+
+        assertThatJson(discriminator).node("mapping.dog")
+                                     .isEqualTo("#/definitions/" + Dog.class.getName());
+        assertThatJson(discriminator).node("mapping.cat")
+                                     .isEqualTo("#/definitions/" + Cat.class.getName());
+    }
+
+    // Test-specific DTOs
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "species")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+            @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    interface Animal {
+        String name();
+    }
+
+    abstract static class Mammal implements Animal {
+        private final String name;
+
+        protected Mammal(String name) {
+            this.name = requireNonNull(name, "name");
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        public abstract String sound();
+    }
+
+    static final class Toy {
+        @JsonProperty
+        private final String toyName;
+        @JsonProperty
+        private final String color;
+
+        @JsonCreator
+        Toy(@JsonProperty("toyName") String toyName, @JsonProperty("color") String color) {
+            this.toyName = requireNonNull(toyName, "toyName");
+            this.color = requireNonNull(color, "color");
+        }
+
+        public String toyName() {
+            return toyName;
+        }
+
+        public String color() {
+            return color;
+        }
+    }
+
+    static final class Dog extends Mammal {
+        @JsonProperty
+        private final int age;
+        @JsonProperty
+        private final String[] favoriteFoods;
+        @JsonProperty
+        private final Toy favoriteToy;
+
+        @JsonCreator
+        Dog(@JsonProperty("name") String name, @JsonProperty("age") int age,
+            @JsonProperty("favoriteFoods") String[] favoriteFoods,
+            @JsonProperty("favoriteToy") Toy favoriteToy) {
+            super(name);
+            this.age = age;
+            this.favoriteFoods = requireNonNull(favoriteFoods, "favoriteFoods");
+            this.favoriteToy = requireNonNull(favoriteToy, "favoriteToy");
+        }
+
+        @Override
+        public String sound() {
+            return "woof woof";
+        }
+
+        public int age() {
+            return age;
+        }
+
+        public String[] favoriteFoods() {
+            return favoriteFoods;
+        }
+
+        public Toy favoriteToy() {
+            return favoriteToy;
+        }
+    }
+
+    static final class Cat extends Mammal {
+        @JsonProperty
+        private final boolean likesTuna;
+        @JsonProperty
+        private final Toy scratchPost;
+
+        @JsonCreator
+        Cat(@JsonProperty("name") String name, @JsonProperty("likesTuna") boolean likesTuna,
+            @JsonProperty("scratchPost") Toy scratchPost) {
+            super(name);
+            this.likesTuna = likesTuna;
+            this.scratchPost = requireNonNull(scratchPost, "scratchPost");
+        }
+
+        @Override
+        public String sound() {
+            return "meow meow";
+        }
+
+        public boolean likesTuna() {
+            return likesTuna;
+        }
+
+        public Toy scratchPost() {
+            return scratchPost;
+        }
     }
 }

--- a/examples/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/animal/PolymorphismDocServiceExample.java
+++ b/examples/tutorials/rest-api-annotated-service/src/main/java/example/armeria/server/animal/PolymorphismDocServiceExample.java
@@ -1,0 +1,159 @@
+package example.armeria.server.animal;
+
+import static java.util.Objects.requireNonNull;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.armeria.server.docs.DocService;
+
+public final class PolymorphismDocServiceExample {
+
+    private static final Logger logger = LoggerFactory.getLogger(PolymorphismDocServiceExample.class);
+
+    // --- Data Transfer Objects (DTOs) from the test case ---
+
+    public static void main(String[] args) throws Exception {
+        final Server server = Server.builder().http(8080).annotatedService("/api", new AnimalService())
+                                    .serviceUnder("/docs", new DocService()) // Add DocService
+                                    .build();
+
+        server.start().join();
+
+        logger.info("Server has been started. You can view the documentation at:");
+        logger.info("UI: http://127.0.0.1:8080/docs/");
+        logger.info("JSON Specification: http://127.0.0.1:8080/docs/specification.json");
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "species")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+            @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    interface Animal {
+        String name();
+    }
+
+    abstract static class Mammal implements Animal {
+        @JsonProperty
+        private final String name;
+
+        protected Mammal(String name) {
+            this.name = requireNonNull(name, "name");
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        public abstract String sound();
+    }
+
+    static final class Toy {
+        @JsonProperty
+        private final String toyName;
+        @JsonProperty
+        private final String color;
+
+        @JsonCreator
+        Toy(@JsonProperty("toyName") String toyName, @JsonProperty("color") String color) {
+            this.toyName = requireNonNull(toyName, "toyName");
+            this.color = requireNonNull(color, "color");
+        }
+
+        public String toyName() {
+            return toyName;
+        }
+
+        public String color() {
+            return color;
+        }
+    }
+
+    static final class Dog extends Mammal {
+        @JsonProperty
+        private final int age;
+        @JsonProperty
+        private final String[] favoriteFoods;
+        @JsonProperty
+        private final Toy favoriteToy;
+
+        @JsonCreator
+        Dog(@JsonProperty("name") String name, @JsonProperty("age") int age,
+            @JsonProperty("favoriteFoods") String[] favoriteFoods,
+            @JsonProperty("favoriteToy") Toy favoriteToy) {
+            super(name);
+            this.age = age;
+            this.favoriteFoods = requireNonNull(favoriteFoods, "favoriteFoods");
+            this.favoriteToy = requireNonNull(favoriteToy, "favoriteToy");
+        }
+
+        @Override
+        public String sound() {
+            return "woof";
+        }
+
+        public int age() {
+            return age;
+        }
+
+        public String[] favoriteFoods() {
+            return favoriteFoods;
+        }
+
+        public Toy favoriteToy() {
+            return favoriteToy;
+        }
+    }
+
+    static final class Cat extends Mammal {
+        @JsonProperty
+        private final boolean likesTuna;
+        @JsonProperty
+        private final Toy scratchPost;
+
+        @JsonCreator
+        Cat(@JsonProperty("name") String name, @JsonProperty("likesTuna") boolean likesTuna,
+            @JsonProperty("scratchPost") Toy scratchPost) {
+            super(name);
+            this.likesTuna = likesTuna;
+            this.scratchPost = requireNonNull(scratchPost, "scratchPost");
+        }
+
+        @Override
+        public String sound() {
+            return "meow";
+        }
+
+        public boolean likesTuna() {
+            return likesTuna;
+        }
+
+        public Toy scratchPost() {
+            return scratchPost;
+        }
+    }
+
+    // --- Annotated Service ---
+    public static class AnimalService {
+        @Post("/animal")
+        public String processAnimal(Animal animal) {
+            // This method uses the polymorphic Animal interface.
+            // DocService will analyze this and generate documentation for the complex types.
+            String response = "Received animal named: " + animal.name();
+            if (animal instanceof Mammal) {
+                response += ". It says: " + ((Mammal) animal).sound();
+            }
+            logger.info(response);
+            return response;
+        }
+    }
+}

--- a/it/grpc/java/src/test/java/com/linecorp/armeria/grpc/java/TestServiceTest.java
+++ b/it/grpc/java/src/test/java/com/linecorp/armeria/grpc/java/TestServiceTest.java
@@ -99,7 +99,7 @@ class TestServiceTest {
                 GrpcClients.newClient(uri(), TestServiceBlockingStub.class);
         final Stopwatch watch = Stopwatch.createStarted();
         assertThat(TestService.blockingHello(HelloRequest.newBuilder().setName("Armeria").build())
-                               .getMessage()).isEqualTo("Hello, Armeria!");
+                              .getMessage()).isEqualTo("Hello, Armeria!");
         assertThat(watch.elapsed(TimeUnit.SECONDS)).isGreaterThanOrEqualTo(3);
     }
 

--- a/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
+++ b/kotlin/src/test/kotlin/com/linecorp/armeria/internal/server/annotation/DataClassDefaultNameTypeInfoProviderTest.kt
@@ -17,9 +17,10 @@
 package com.linecorp.armeria.internal.server.annotation
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING
+
 import com.linecorp.armeria.server.annotation.Description
 import com.linecorp.armeria.server.docs.DescriptionInfo
+import com.linecorp.armeria.server.docs.DocServiceTypeUtil.STRING
 import com.linecorp.armeria.server.docs.EnumInfo
 import com.linecorp.armeria.server.docs.EnumValueInfo
 import com.linecorp.armeria.server.docs.FieldInfo

--- a/scala/scala_2.13/src/test/scala/com/linecorp/armeria/internal/server/annotation/CaseClassDefaultNameTypeInfoProviderTest.scala
+++ b/scala/scala_2.13/src/test/scala/com/linecorp/armeria/internal/server/annotation/CaseClassDefaultNameTypeInfoProviderTest.scala
@@ -15,8 +15,7 @@
  */
 
 package com.linecorp.armeria.internal.server.annotation
-
-import com.linecorp.armeria.internal.server.annotation.AnnotatedDocServicePlugin.STRING
+import com.linecorp.armeria.server.docs.DocServiceTypeUtil.STRING
 import com.linecorp.armeria.internal.testing.GenerateNativeImageTrace
 import com.linecorp.armeria.scala.implicits._
 import com.linecorp.armeria.server.annotation.Description


### PR DESCRIPTION
### Motivation

This pull request implements support for Jackson's polymorphism annotations (`@JsonTypeInfo`, `@JsonSubTypes`) in `DocService`, as requested in the community (issue #6313). Currently, `DocService` does not correctly generate documentation for annotated services that use inheritance in their DTOs, leading to incomplete specifications. This change adds a new `DescriptiveTypeInfoProvider` to resolve these polymorphic types and generate accurate JSON Schemas.

However, this feature has uncovered significant and complex build stability issues when running a full parallel build (`./gradlew clean build --parallel`). This PR serves as both the implementation of the feature and a concrete test case for discussing the build instability it triggers.

### Modifications

* **Added `JacksonPolymorphismTypeInfoProvider`:** A new provider that uses pure Java reflection to safely inspect `@JsonTypeInfo` and `@JsonSubTypes` annotations. It is registered via Java's SPI mechanism to be discoverable by `DocService`.
* **Added `DiscriminatorInfo`:** A new data class to hold polymorphism metadata extracted from the annotations.
* **Consolidated Type Utilities:** General-purpose type conversion logic (e.g., `toTypeSignature`) was moved from a separate `DocServiceTypeUtil` into `AnnotatedDocServicePlugin` for better cohesion.
* **Updated `StructInfo`:** Modified to include `oneOf` and `discriminator` fields to carry polymorphism information.
* **Updated `JsonSchemaGenerator`:** The generator now recognizes the new fields in `StructInfo` and correctly produces JSON Schema with `oneOf` and `discriminator` properties.
* **Added `PolymorphismDocServiceExample`:** A new example service to demonstrate and manually verify the feature.

### Result

-   `DocService` can now correctly generate documentation for annotated services that use polymorphic types with Jackson. The resulting JSON Schema will contain the appropriate `oneOf` and `discriminator` fields.
-   **Known Issue:** This change is known to trigger build instability in the project's CI environment. A detailed summary of the investigation is provided here : #6369

### Example usage
also, you can try this at **PolymorphismDocServiceExample**

``` java
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "species")
@JsonSubTypes({
    @JsonSubTypes.Type(value = Dog.class, name = "dog"),
    @JsonSubTypes.Type(value = Cat.class, name = "cat")
})
interface Animal {
    // ...
}

```


``` json
"structs" : [ {
    "name" : "example.armeria.server.animal.PolymorphismDocServiceExample$Animal",
    "fields" : [ ],
    "descriptionInfo" : {
      "docString" : "",
      "markup" : "NONE"
    },
    "oneOf" : [ "example.armeria.server.animal.PolymorphismDocServiceExample$Dog", "example.armeria.server.animal.PolymorphismDocServiceExample$Cat" ],
    "discriminator" : {
      "propertyName" : "species",
      "mapping" : {
        "dog" : "#/definitions/example.armeria.server.animal.PolymorphismDocServiceExample$Dog",
        "cat" : "#/definitions/example.armeria.server.animal.PolymorphismDocServiceExample$Cat"
      }
    }

```

