### PR TITLE
Reproduce MaxResetFramesTest.java test failure

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/server/MaxResetFramesTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/MaxResetFramesTest.java
@@ -48,7 +48,7 @@ class MaxResetFramesTest {
         @Override
         protected void configure(ServerBuilder sb) {
             sb.idleTimeoutMillis(0);
-            sb.http2MaxResetFramesPerWindow(10, 60);
+            sb.http2MaxResetFramesPerWindow(2, 60);
             sb.service("/", (ctx, req) -> {
                 return HttpResponse.of(req.aggregate().thenApply(unused -> HttpResponse.of(200)));
             });
@@ -66,7 +66,7 @@ class MaxResetFramesTest {
                                               .factory(factory)
                                               .build();
             final List<CompletableFuture<AggregatedHttpResponse>> futures =
-                    IntStream.range(0, 11)
+                    IntStream.range(0, 6)
                              .mapToObj(unused -> HttpRequest.of(RequestHeaders.of(HttpMethod.POST, "/"),
                                                                 StreamMessage.of(InvalidHttpObject.INSTANCE)))
                              .map(client::execute)
@@ -74,8 +74,8 @@ class MaxResetFramesTest {
                              .collect(toImmutableList());
 
             CompletableFutures.successfulAsList(futures, cause -> null).join();
-            assertThat(listener.opened()).isEqualTo(1);
-            await().untilAsserted(() -> assertThat(listener.closed()).isEqualTo(1));
+            assertThat(listener.opened()).isEqualTo(2);
+            await().untilAsserted(() -> assertThat(listener.closed()).isEqualTo(2));
         }
     }
 


### PR DESCRIPTION
Motivation:

we found that MaxResetFramesTest.java fails under the following conditions:
 
Total number of requests is in the range (0, 6)
http2MaxResetFramesPerWindow is set to 2
Assert connections opened: 2
Assert connections closed: 2

My understanding is that the 3rd request should close the first connection, while the 4th request should create a new connection. This second connection should then be closed by the 6th request. Therefore, the test should conclude with 2 opened and 2 closed connections. Is my understanding correct? But we noticed that only one connection is opened and closed.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
