### PR TITLE
`FileService` responds to `HEAD` range requests

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -197,6 +197,12 @@ public final class FileService extends AbstractHttpService {
         return findFile(ctx, req).asService().serve(ctx, req);
     }
 
+    @Override
+    protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+        // responds to https://datatracker.ietf.org/doc/html/rfc9110#name-range-requests
+        return HttpResponse.of(200);
+    }
+
     private HttpFile findFile(ServiceRequestContext ctx, HttpRequest req) {
         final EnumSet<ContentEncoding> encodings = EnumSet.noneOf(ContentEncoding.class);
 

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -199,8 +199,7 @@ public final class FileService extends AbstractHttpService {
 
     @Override
     protected HttpResponse doHead(ServiceRequestContext ctx, HttpRequest req) throws Exception {
-        // responds to https://datatracker.ietf.org/doc/html/rfc9110#name-range-requests
-        return HttpResponse.of(200);
+        return findFile(ctx, req).asService().serve(ctx, req);
     }
 
     private HttpFile findFile(ServiceRequestContext ctx, HttpRequest req) {

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -58,6 +58,7 @@ import com.google.common.io.Resources;
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -670,6 +671,17 @@ class FileServiceTest {
         response = client.get("/extension/decompress/foo");
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
         assertThat(response.contentUtf8()).isEqualTo("foo");
+    }
+
+    @Test
+    void rangeNotSupported() {
+        // not returning Accept-Ranges implies ranges are not supported
+        AggregatedHttpResponse res = server.blockingWebClient().head("/cached/fs/");
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(res.headers().get(HttpHeaderNames.ACCEPT_RANGES)).isNull();
+        res = server.blockingWebClient().head("/cached/fs/auto_index");
+        assertThat(res.status().code()).isEqualTo(200);
+        assertThat(res.headers().get(HttpHeaderNames.ACCEPT_RANGES)).isNull();
     }
 
     private static void writeFile(Path path, String content) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -58,7 +58,6 @@ import com.google.common.io.Resources;
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -674,14 +674,18 @@ class FileServiceTest {
     }
 
     @Test
-    void rangeNotSupported() {
-        // not returning Accept-Ranges implies ranges are not supported
+    void headTest() throws Exception {
         AggregatedHttpResponse res = server.blockingWebClient().head("/cached/fs/");
         assertThat(res.status().code()).isEqualTo(200);
-        assertThat(res.headers().get(HttpHeaderNames.ACCEPT_RANGES)).isNull();
-        res = server.blockingWebClient().head("/cached/fs/auto_index");
+
+        final Path barFile = tmpDir.resolve("bar.html");
+        final String content = "<html/>";
+        writeFile(barFile, content);
+        res = server.blockingWebClient().head("/cached/fs/bar.html");
         assertThat(res.status().code()).isEqualTo(200);
-        assertThat(res.headers().get(HttpHeaderNames.ACCEPT_RANGES)).isNull();
+
+        res = server.blockingWebClient().head("/cached/fs/missing.html");
+        assertThat(res.status().code()).isEqualTo(404);
     }
 
     private static void writeFile(Path path, String content) throws Exception {


### PR DESCRIPTION
Motivation:

Range requests may be made for services serving data with large content (`FileService`).
ref: https://datatracker.ietf.org/doc/html/rfc9110#name-range-requests
Currently, `FileService` doesn't support ranged requests, but at the same time there is no reason to reject range requests.
Returning normally (with a 200) should gracefully let clients know that range requests are not supported.

Modifications:

- `FileService` responds to `HEAD` requests with a 200 response

Result:

- #6392

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
