### PR TITLE
Fix deadlock between Flags and RequestContextUtil static initialization

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1825,8 +1825,6 @@ public final class Flags {
     // This static block is defined at the end of this file deliberately
     // to ensure that all static variables defined beforehand are initialized.
     static {
-        FlagsLoaded.set();
-
         if (warnNettyVersions()) {
             final String howToDisableWarning =
                     "This means 1) you specified Netty versions inconsistently in your build or " +
@@ -1859,6 +1857,8 @@ public final class Flags {
                     logger.warn("Inconsistent Netty versions detected: {} {}",
                                 nettyVersions, howToDisableWarning);
             }
+
+            FlagsLoaded.set();
         }
     }
 }

--- a/it/flags-cyclic-dep/src/test/java/com/linecorp/armeria/common/FlagsCyclicDependencyTest.java
+++ b/it/flags-cyclic-dep/src/test/java/com/linecorp/armeria/common/FlagsCyclicDependencyTest.java
@@ -16,15 +16,47 @@
 
 package com.linecorp.armeria.common;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.internal.common.RequestContextUtil;
 
 class FlagsCyclicDependencyTest {
 
     @Test
-    void testBasicCase() {
-        assertThatCode(Flags::requestContextStorageProvider)
-                .doesNotThrowAnyException();
+    void testRequestContextUtilAndFlagsCycle() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.execute(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            // Calls Flags.requestContextStorageProvider() internally when initializing RequestContextUtil.
+            RequestContextUtil.get();
+            counter.incrementAndGet();
+        });
+
+        executorService.execute(() -> {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            // If RequestContextExportingAppender is enabled, when initializing Flags,
+            // it calls RequestContextUtil.get() internally if FlagsLoaded doesn't work properly.
+            Flags.requestContextStorageProvider();
+            counter.incrementAndGet();
+        });
+        latch.countDown();
+        await().until(() -> counter.get() == 2);
     }
 }

--- a/it/flags-cyclic-dep/src/test/resources/logback-test.xml
+++ b/it/flags-cyclic-dep/src/test/resources/logback-test.xml
@@ -26,9 +26,7 @@
     <export>remote.ip</export>
   </appender>
 
-  <logger name="com.linecorp.armeria" level="DEBUG" />
-
-  <root level="WARN">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="RCEA" />
   </root>


### PR DESCRIPTION
Motivation:
A cyclic dependency existed between the Flags and `RequestContextUtil` classes. `RequestContextUtil`'s static initializer calls `Flags.requestContextStorageProvider()`, and when `RequestContextExportingAppender` is enabled, the `Flags` static initializer could indirectly call `RequestContextUtil.get()`. This created a race condition where two concurrent threads could cause a deadlock while initializing these two classes.

Modification:
- The call to `FlagsLoaded.set()` was moved to the very end of the static initialization block in the `Flags` class.

Result:
The deadlock `Flags` and `RequestContextUtil` static initialization is eliminated.