### PR TITLE
Fix race condition causing incomplete client logs on abort

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/RequestLogCompleteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RequestLogCompleteTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class RequestLogCompleteTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/delay", (ctx, req) -> HttpResponse.of(ResponseHeaders.builder(200)
+                                                                              .endOfStream(true)
+                                                                              .build()));
+        }
+    };
+
+    @Test
+    void logCompleteWithAbortedException() throws InterruptedException {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final HttpResponse httpResponse = server.webClient().get("/delay");
+            httpResponse.subscribe(new Subscriber<HttpObject>() {
+                @Override
+                public void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE);
+                }
+
+                @Override
+                public void onNext(HttpObject httpObject) {
+                    final CountDownLatch latch = new CountDownLatch(1);
+                    executor.submit(() -> {
+                        httpResponse.abort();
+                        latch.countDown();
+                    });
+                    try {
+                        latch.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {}
+
+                @Override
+                public void onComplete() {}
+            });
+            final ClientRequestContext ctx = captor.get();
+            // The log should be completed.
+            ctx.log().whenComplete().join();
+            assertThat(ctx.log().ensureComplete().responseCause()).isInstanceOf(AbortedStreamException.class);
+        }
+        executor.shutdown();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/RequestLogCompleteTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RequestLogCompleteTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -80,6 +81,9 @@ class RequestLogCompleteTest {
             final ClientRequestContext ctx = captor.get();
             // The log should be completed.
             ctx.log().whenComplete().join();
+            assertThatThrownBy(() -> httpResponse.whenComplete().join())
+                    .hasCauseInstanceOf(AbortedStreamException.class);
+            // The log is completed with the same exception as the response.
             assertThat(ctx.log().ensureComplete().responseCause()).isInstanceOf(AbortedStreamException.class);
         }
         executor.shutdown();


### PR DESCRIPTION
Motivation:
A race condition existed in the client-side response decoder.  Consider this situation:
- A client receives a response header and the response is open:
  - https://github.com/line/armeria/blob/e94aceef3266283075fcb5da680f9e29e31f49b7/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java#L203
- The client call `res.close()` if `endOfStream` is true:
  - https://github.com/line/armeria/blob/e94aceef3266283075fcb5da680f9e29e31f49b7/core/src/main/java/com/linecorp/armeria/client/Http2ResponseDecoder.java#L237
- Let's say another thread aborts the response at this point.
- The client sets the `closed` to true:
  - https://github.com/line/armeria/blob/9bb52da34cf9121fed1efa7af7599ab4aacdf752/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java#L219
- Because the response is not open, the client doesn't call `log.endResponse()`.
  - https://github.com/line/armeria/blob/9bb52da34cf9121fed1efa7af7599ab4aacdf752/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java#L273
- Because the `closed` is set to true, the following cancel call cannot complete the log:
  - https://github.com/line/armeria/blob/9bb52da34cf9121fed1efa7af7599ab4aacdf752/core/src/main/java/com/linecorp/armeria/client/HttpResponseWrapper.java#L215

Modifications:
- Updated the response handling logic in the `HttpResponseWrapper`.
  - The logic now ensures `logBuilder.endResponse()` is called with the specific exception that caused the abort.

Result:
- All client-side request logs, including those that are aborted concurrently, will now be completed correctly.