### PR TITLE
Fix duplicate decorator registration in ZtsBaseClient

### DIFF
--- a/athenz/src/main/java/com/linecorp/armeria/client/athenz/ZtsBaseClient.java
+++ b/athenz/src/main/java/com/linecorp/armeria/client/athenz/ZtsBaseClient.java
@@ -120,11 +120,7 @@ public final class ZtsBaseClient implements SafeCloseable {
         }
         clientFactory = factoryBuilder.build();
         this.webClientConfigurer = webClientConfigurer;
-        defaultWebClient = webClient(builder -> {
-            if (webClientConfigurer != null) {
-                webClientConfigurer.accept(builder);
-            }
-        });
+        defaultWebClient = webClient(builder -> {});
     }
 
     /**


### PR DESCRIPTION
Motivation:
If you register a decorator such as LoggingClient to `ZtsBaseClient` via `configureWebClient`, the same decorator will be registered to the webClient twice. In this case, the same log is displayed twice.

Modifications:
- Remove this setting.
  - https://github.com/line/armeria/blob/armeria-1.33.4/athenz/src/main/java/com/linecorp/armeria/client/athenz/ZtsBaseClient.java#L125
- Because we already set it in `webClient(Consumer<? super WebClientBuilder> configurer)`.
  - https://github.com/line/armeria/blob/armeria-1.33.4/athenz/src/main/java/com/linecorp/armeria/client/athenz/ZtsBaseClient.java#L182

Result:
- The `webClientConfigurer` is registered only once.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
