### PR TITLE
Multiple form data files with same name

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -472,7 +472,8 @@ final class AnnotatedValueResolver {
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
             }
-            if (type == File.class || type == Path.class || type == MultipartFile.class || isListOfFiles(annotatedElement)) {
+            if (type == File.class || type == Path.class || type == MultipartFile.class
+                || isListOfFiles(annotatedElement)) {
                 return ofFileParam(name, annotatedElement, typeElement, type, description);
             }
             if (pathParams.contains(name)) {
@@ -529,11 +530,11 @@ final class AnnotatedValueResolver {
     }
 
     private static boolean isListOfFiles(AnnotatedElement typeElement) {
-        if(!(typeElement instanceof Parameter)) {
+        if( !(typeElement instanceof Parameter)) {
             return false;
         }
         final Type parameter = ((Parameter) typeElement).getParameterizedType();
-        if(! (parameter instanceof ParameterizedType)) {
+        if( !(parameter instanceof ParameterizedType)) {
             return false;
         }
         final ParameterizedType parameterizedType = (ParameterizedType) parameter;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -472,8 +472,8 @@ final class AnnotatedValueResolver {
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
             }
-            if (type == File.class || type == Path.class || type == MultipartFile.class
-                || isListOfFiles(annotatedElement)) {
+            if (type == File.class || type == Path.class || type == MultipartFile.class ||
+                isListOfFiles(annotatedElement)) {
                 return ofFileParam(name, annotatedElement, typeElement, type, description);
             }
             if (pathParams.contains(name)) {
@@ -530,16 +530,16 @@ final class AnnotatedValueResolver {
     }
 
     private static boolean isListOfFiles(AnnotatedElement typeElement) {
-        if( !(typeElement instanceof Parameter)) {
+        if (!(typeElement instanceof Parameter)) {
             return false;
         }
         final Type parameter = ((Parameter) typeElement).getParameterizedType();
-        if( !(parameter instanceof ParameterizedType)) {
+        if (!(parameter instanceof ParameterizedType)) {
             return false;
         }
         final ParameterizedType parameterizedType = (ParameterizedType) parameter;
         final Type raw = parameterizedType.getRawType();
-        if(!(raw instanceof  Class<?>)) {
+        if (!(raw instanceof Class<?>)) {
             return false;
         }
         final Class<?> rawClass =  (Class<?>) raw;

--- a/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java
@@ -472,7 +472,7 @@ final class AnnotatedValueResolver {
                 }
                 return ofQueryParamMap(name, annotatedElement, typeElement, type, description);
             }
-            if (type == File.class || type == Path.class || type == MultipartFile.class) {
+            if (type == File.class || type == Path.class || type == MultipartFile.class || isListOfFiles(annotatedElement)) {
                 return ofFileParam(name, annotatedElement, typeElement, type, description);
             }
             if (pathParams.contains(name)) {
@@ -526,6 +526,31 @@ final class AnnotatedValueResolver {
         }
 
         return null;
+    }
+
+    private static boolean isListOfFiles(AnnotatedElement typeElement) {
+        if(!(typeElement instanceof Parameter)) {
+            return false;
+        }
+        final Type parameter = ((Parameter) typeElement).getParameterizedType();
+        if(! (parameter instanceof ParameterizedType)) {
+            return false;
+        }
+        final ParameterizedType parameterizedType = (ParameterizedType) parameter;
+        final Type raw = parameterizedType.getRawType();
+        if(!(raw instanceof  Class<?>)) {
+            return false;
+        }
+        final Class<?> rawClass =  (Class<?>) raw;
+        if (!List.class.isAssignableFrom(rawClass) && !Set.class.isAssignableFrom(rawClass)) {
+            return false;
+        }
+        final Type[] args = parameterizedType.getActualTypeArguments();
+        if (args.length != 1) {
+            return false;
+        }
+        final Type arg = args[0];
+        return arg == File.class || arg == Path.class || arg == MultipartFile.class;
     }
 
     static List<RequestObjectResolver> addToFirstIfExists(List<RequestObjectResolver> resolvers,


### PR DESCRIPTION
Motivation:

This pr solves the bug where annotated services can't handle multiple files with the same form field name in a multi part form upload.
This would solve this issue: https://github.com/line/armeria/issues/6419

Modifications:

Use reflection in the annotatedValueResolver to allow list/sets of File/Path/MultipartFile.

Result:

- Closes #6419. (If this resolves the issue.)

