### PR TITLE
Fix a bug where MDC exporting doesn't work when `warnNettyVersions=false`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -448,7 +448,7 @@ public final class Flags {
 
     private static final long DEFAULT_HTTP1_CONNECTION_CLOSE_DELAY_MILLIS =
             getValue(FlagsProvider::defaultHttp1ConnectionCloseDelayMillis,
-                    "defaultHttp1ConnectionCloseDelayMillis", value -> value >= 0);
+                     "defaultHttp1ConnectionCloseDelayMillis", value -> value >= 0);
 
     private static final ResponseTimeoutMode RESPONSE_TIMEOUT_MODE =
             getValue(FlagsProvider::responseTimeoutMode, "responseTimeoutMode");
@@ -1822,8 +1822,6 @@ public final class Flags {
 
     private Flags() {}
 
-    // This static block is defined at the end of this file deliberately
-    // to ensure that all static variables defined beforehand are initialized.
     static {
         if (warnNettyVersions()) {
             final String howToDisableWarning =
@@ -1857,8 +1855,12 @@ public final class Flags {
                     logger.warn("Inconsistent Netty versions detected: {} {}",
                                 nettyVersions, howToDisableWarning);
             }
-
-            FlagsLoaded.set();
         }
+    }
+
+    // This static block is defined at the end of this file deliberately
+    // to ensure that all static variables defined beforehand are initialized.
+    static {
+        FlagsLoaded.set();
     }
 }

--- a/it/flags-cyclic-dep/build.gradle
+++ b/it/flags-cyclic-dep/build.gradle
@@ -5,3 +5,7 @@
 dependencies {
     implementation project(':logback')
 }
+
+tasks.withType(Test).configureEach {
+    jvmArgs += '-Dcom.linecorp.armeria.warnNettyVersions=false'
+}

--- a/it/flags-cyclic-dep/src/test/java/com/linecorp/armeria/common/FlagsCyclicDependencyTest.java
+++ b/it/flags-cyclic-dep/src/test/java/com/linecorp/armeria/common/FlagsCyclicDependencyTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.CountDownLatch;
@@ -25,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.internal.common.FlagsLoaded;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 
 class FlagsCyclicDependencyTest {
@@ -58,5 +60,8 @@ class FlagsCyclicDependencyTest {
         });
         latch.countDown();
         await().until(() -> counter.get() == 2);
+
+        // Flags should be loaded
+        assertThat(FlagsLoaded.get()).isTrue();
     }
 }


### PR DESCRIPTION
Modifications:

- Updated `FlagsLoaded.set();` to be set regardless of `warnNettyVersions`

Result:

- MDC is exported regardless of `warnNettyVersions`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
