### PR TITLE
Don't set `content-type` for methods without a body in DocService

### DIFF
--- a/docs-client/src/containers/App/index.tsx
+++ b/docs-client/src/containers/App/index.tsx
@@ -490,6 +490,7 @@ const App: React.FunctionComponent<Props> = (props) => {
         });
         setSpecification(initialSpecification);
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.log(e);
         setSpecLoadingStatus(SpecLoadingStatus.FAILED);
         return;

--- a/docs-client/src/lib/transports/annotated-http.ts
+++ b/docs-client/src/lib/transports/annotated-http.ts
@@ -98,7 +98,15 @@ export default class AnnotatedHttpTransport extends Transport {
     const endpoint = this.getDebugMimeTypeEndpoint(method);
 
     const hdrs = new Headers();
-    hdrs.set('content-type', ANNOTATED_HTTP_MIME_TYPE);
+    if (
+      method.httpMethod === 'POST' ||
+      method.httpMethod === 'PUT' ||
+      method.httpMethod === 'PATCH'
+    ) {
+      // Set content-type only for methods that usually have a body.
+      hdrs.set('content-type', ANNOTATED_HTTP_MIME_TYPE);
+    }
+
     for (const [name, value] of Object.entries(headers)) {
       hdrs.set(name, value);
     }


### PR DESCRIPTION
Motivation:

DocService debug console sets `content-type: application/json` for all HTTP methods. `content-type` is unnecessary for methods without a method. Additionally, the fall-through logic may not work in `RequestConverterFunction` if `content-type` exists.

Modifications:

- Set `content-type: application/json` to request headers for `POST`, `PUT` and `PATCH` methods in `AnnotatedHttpTransport` by default

Result:

DocService no longer sets the `Content-Type` header for methods without a body.