### PR TITLE
Less noisy pull requests for xDS upstream sync

### DIFF
--- a/.github/workflows/xds-apply-updates.yml
+++ b/.github/workflows/xds-apply-updates.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          branch: update-protobuf-to-${{ inputs.target_version }}
+          branch: update-xds-protobuf
           base: main
           author: Meri Kim <dl_armeria@linecorp.com>
           committer: Meri Kim <dl_armeria@linecorp.com>

--- a/.github/workflows/xds-sync-apis.yml
+++ b/.github/workflows/xds-sync-apis.yml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   schedule:
-    # every day at 10
-    - cron:  '0 10 * * *'
+    # every monday at 10:00 am (KST)
+    - cron:  '0 1 * * 1'
 
 jobs:
   envoy-versions:


### PR DESCRIPTION
Modifications:

- Run the version comparison every Monday at 10:00am KST instead of daily
- A single pull request is opened instead of multiple pull requests corresponding to each version


<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
