### PR TITLE
Fix kotlin's java-paremeters fragment link

### DIFF
--- a/site/src/pages/docs/advanced-kotlin.mdx
+++ b/site/src/pages/docs/advanced-kotlin.mdx
@@ -32,7 +32,7 @@ class MyAnnotatedService {
 }
 ```
 
-Note that you can omit the value of <type://@Param> if you compiled your Kotlin code with [`java-parameters`](https://kotlinlang.org/docs/reference/compiler-reference.html#-java-parameters) option.
+Note that you can omit the value of <type://@Param> if you compiled your Kotlin code with [`java-parameters`](https://kotlinlang.org/docs/reference/compiler-reference.html#java-parameters) option.
 
 ```kotlin
 class MyAnnotatedService {


### PR DESCRIPTION
Motivation:

In docs, kotlin's `java-parameters` link is like `...html#-java-parameters`, but current correct link is `...html#java-parameters`


Modifications:

- Change fragment

Result:

- When clicked link, correctly scrolled to the `-java-parameters` description
  - TO-BE: https://kotlinlang.org/docs/compiler-reference.html#java-parameters

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
