### PR TITLE
Do not warn for certificates missing both SAN and CN

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
@@ -71,7 +71,8 @@ public final class CertificateUtil {
                                 return commonName;
                             }
 
-                            logger.warn("No common name or subject alternative name found " +
+                            // Public root CA certificates may not have both CN and SAN.
+                            logger.debug("No common name or subject alternative name found " +
                                         "in certificate: {}", cert);
                             return null;
                         } catch (Exception e) {


### PR DESCRIPTION
Motivation:

Both CN and SAN would be absent if a certicate is public root CA. Warning for CA is false positive and noisy.
In addition, since this is related to metrics, strict validation isn’t necessary. If there’s an issue with the certificate, it will fail at the TLS handshake level and the user will notice it.

Discord discussion: https://discord.com/channels/1087271586832318494/1390342361770365020/1433043355566211254

Modifications:

- Change the log level in `CertificateUtil` to debug from warn.

Result:

You no longer see false positive warnings for certificate metrics.
