### PR TITLE
Fix flaky `ServerSetDiscoveryTest`

### DIFF
--- a/zookeeper3/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperExtension.java
+++ b/zookeeper3/src/test/java/com/linecorp/armeria/common/zookeeper/ZooKeeperExtension.java
@@ -33,7 +33,7 @@ import zookeeperjunit.ZooKeeperAssert;
 
 public class ZooKeeperExtension extends AbstractAllOrEachExtension implements ZooKeeperAssert {
 
-    private static final Duration duration = Duration.ofSeconds(10);
+    private static final Duration duration = Duration.ofSeconds(60);
     private static final TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Nullable


### PR DESCRIPTION
Motivation:

#6451 #6408 
I'm not 100% sure but test failures seem to have decreased after increasing the timeout.

Modifications:

- Wait up to 60 seconds for the zookeeper test server to start.

Result:

- Closes #6451
- Closes #6408 
