### PR TITLE
Fix flaky `InputStreamStreamMessageTest.emptyInputStream()`

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/stream/InputStreamStreamMessageTest.java
@@ -406,8 +406,9 @@ class InputStreamStreamMessageTest {
 
         StepVerifier.create(byteStreamMessage)
                     .verifyComplete();
+        byteStreamMessage.whenComplete().join();
+        assertThat(byteStreamMessage.isOpen()).isFalse();
         assertThat(byteStreamMessage.isEmpty()).isTrue();
-        await().untilAsserted(() -> assertThat(byteStreamMessage.isOpen()).isFalse());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`Subscriber.onComplete()` is invoked before `completionFuture` is completed, so a happen-before relationship between `byteStreamMessage.isOpen()` and `Subscriber.onComplete()` cannot be guaranteed. https://github.com/line/armeria/blob/0d94d0df85ba9b1184c79ffdd58d3e414b2f0c7d/core/src/main/java/com/linecorp/armeria/common/stream/InputStreamStreamMessage.java#L375-L376

Modifications:

- Use `.whenComplete().join()` to explicitly wait until `InputStreamStreamMessage` completes.

Result:

Closes #6483

