### PR TITLE
Stop producing text content preview for non-text types with charset

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/logging/ContentPreviewingClient.java
@@ -68,7 +68,6 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
      * {@link RequestHeaders} or {@link ResponseHeaders} meets any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>
@@ -86,7 +85,6 @@ public final class ContentPreviewingClient extends SimpleDecoratingHttpClient {
      * {@link RequestHeaders} or {@link ResponseHeaders} meets any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/ContentPreviewerFactory.java
@@ -40,7 +40,6 @@ public interface ContentPreviewerFactory {
      * any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>
@@ -58,7 +57,6 @@ public interface ContentPreviewerFactory {
      * any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>

--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultContentPreviewFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultContentPreviewFactory.java
@@ -75,11 +75,6 @@ final class DefaultContentPreviewFactory implements ContentPreviewerFactory {
 
         final MediaType contentType = headers.contentType();
         if (contentType != null) {
-            final Charset charset = contentType.charset();
-            if (charset != null) {
-                return new TextContentPreviewer(maxLength, charset);
-            }
-
             if ("text".equals(contentType.type()) ||
                 textSubTypes.contains(contentType.subtype()) ||
                 textSubTypeSuffixes.stream().anyMatch(contentType.subtype()::endsWith) ||

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -69,7 +69,6 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
      * {@link RequestHeaders} or {@link ResponseHeaders} meets any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>
@@ -87,7 +86,6 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
      * {@link RequestHeaders} or {@link ResponseHeaders} meets any of the following conditions:
      * <ul>
      *     <li>when it matches {@code text/*} or {@code application/x-www-form-urlencoded}</li>
-     *     <li>when its charset has been specified</li>
      *     <li>when its subtype is {@code "xml"} or {@code "json"}</li>
      *     <li>when its subtype ends with {@code "+xml"} or {@code "+json"}</li>
      * </ul>

--- a/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/ContentPreviewerFactoryTest.java
@@ -77,9 +77,14 @@ class ContentPreviewerFactoryTest {
         contentPreviewer = factory.requestContentPreviewer(
                 ctx, RequestHeaders.of(HttpMethod.POST, "/",
                                        HttpHeaderNames.CONTENT_TYPE, "my/type; charset=UTF-8"));
-        checkProduced(contentPreviewer);
+        assertThat(contentPreviewer.produce()).isNull();
 
         contentPreviewer = factory.requestContentPreviewer(ctx, reqHeaders(MediaType.BASIC_AUDIO));
+        contentPreviewer.onData(HttpData.ofUtf8("hello!"));
+        assertThat(contentPreviewer.produce()).isNull();
+
+        contentPreviewer = factory.requestContentPreviewer(
+                ctx, reqHeaders(MediaType.PNG.withCharset(StandardCharsets.UTF_8)));
         contentPreviewer.onData(HttpData.ofUtf8("hello!"));
         assertThat(contentPreviewer.produce()).isNull();
     }

--- a/site-new/docs/advanced/structured-logging.mdx
+++ b/site-new/docs/advanced/structured-logging.mdx
@@ -295,7 +295,6 @@ cb.decorator(ContentPreviewingClient.newDecorator(100));
 Note that the above decorators enable the previews only for textual content
 which meets one of the following cases:
 - when its type matches `text/*` or `application/x-www-form-urlencoded`.
-- when its charset has been specified. e.g. application/json; charset=utf-8.
 - when its subtype is `xml` or `json`. e.g. application/xml, application/json.
 - when its subtype ends with `+xml` or `+json`. e.g. application/atom+xml, application/hal+json
 

--- a/site/src/pages/docs/advanced-structured-logging.mdx
+++ b/site/src/pages/docs/advanced-structured-logging.mdx
@@ -356,7 +356,6 @@ cb.decorator(ContentPreviewingClient.newDecorator(100));
 Note that the above decorators enable the previews only for textual content
 which meets one of the following cases:
 - when its type matches `text/*` or `application/x-www-form-urlencoded`.
-- when its charset has been specified. e.g. application/json; charset=utf-8.
 - when its subtype is `xml` or `json`. e.g. application/xml, application/json.
 - when its subtype ends with `+xml` or `+json`. e.g. application/atom+xml, application/hal+json
 


### PR DESCRIPTION
Motivation:

When no `ContentPreviewer` is selected to produce a content preview, `TextContentPreviewer` acts as a fallback not only when the content type is textual but also when a charset is specified. For example, a request with a `Content-Type` header of `image/png; charset=utf-8` will still be recorded because the charset is specified.

Modifications:

- Stop producing text content preview for non-text types with charset.

Result:

- **Breaking change**: non-textual content with charset is no longer recorded by the `ContentPreviewer` fallback.