### PR TITLE
docs: fix incorrect filename in BlogPostRequestConverter code block

### DIFF
--- a/site/src/pages/tutorials/rest/blog/implement-create.mdx
+++ b/site/src/pages/tutorials/rest/blog/implement-create.mdx
@@ -59,7 +59,7 @@ We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but
 
 1. Create a `BlogPostRequestConverter.java` file and declare a class, implementing the <type://RequestConverterFunction> interface. For the sake of simplicity, generate impromptu IDs for this tutorial.
 
-  ```java filename=BlogRequestConverter.java
+  ```java filename=BlogPostRequestConverter.java
   package example.armeria.server.blog;
 
   import com.fasterxml.jackson.databind.ObjectMapper;
@@ -74,7 +74,7 @@ We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but
 
 2. Add a method retrieving a value of a given key in a JSON object:
 
-  ```java filename=BlogRequestConverter.java highlight=6-12
+  ```java filename=BlogPostRequestConverter.java highlight=6-12
   import com.fasterxml.jackson.databind.JsonNode;
 
   final class BlogPostRequestConverter implements RequestConverterFunction {
@@ -92,7 +92,7 @@ We can use Armeria's default <type://JacksonRequestConverterFunction> as is, but
 
 3. Customize the default `convertRequest()` method as follows.
 
-  ```java filename=BlogRequestConverter.java highlight=10-22
+  ```java filename=BlogPostRequestConverter.java highlight=10-22
   import com.linecorp.armeria.server.ServiceRequestContext;
   import com.linecorp.armeria.common.AggregatedHttpRequest;
   import com.linecorp.armeria.common.annotation.Nullable;


### PR DESCRIPTION
### Motivation

While following Armeria’s REST tutorial, I was confused when reading this code block because the filename shown in the block was BlogRequestConverter.java, but the actual class inside the snippet was BlogPostRequestConverter.
As a beginner, I initially thought I needed to create an additional class or that I was doing something wrong.

<img width="755" height="255" alt="issue#6509" src="https://github.com/user-attachments/assets/3c0d09f3-d0a0-4bf0-9cfd-94a0a41fe716" />


To reduce such confusion for new users, I would like to fix this typo in the tutorial documentation.

### Modifications

Updated the code block filename in
armeria/site/src/pages/tutorials/rest/blog/implement-create.mdx
from BlogRequestConverter.java to BlogPostRequestConverter.java.

Before
```
java filename=BlogRequestConverter.java highlight=10-22
...
final class BlogPostRequestConverter implements RequestConverterFunction {
```
After
```
java filename="BlogPostRequestConverter.java" highlight=10-22
...
final class BlogPostRequestConverter implements RequestConverterFunction {
```

### Result

- Fixes a documentation typo and prevents confusion for new users following the REST tutorial.
- No behavioral or code changes; documentation-only change
- ---
- - Closes #6509