### PR TITLE
Handle flaky `RetryTest`  in the `xds` module

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
@@ -550,7 +550,7 @@ class RetryTest {
             final long expectedDelayMillis = expectedDelaysMillis.get(i);
 
             // Verify delay matches expected value (tolerance for 50% jitter + responseTimeout recalc)
-            assertThat(actualDelayMillis).isCloseTo(expectedDelayMillis, withinPercentage(60.0));
+            assertThat(actualDelayMillis).isCloseTo(expectedDelayMillis, withinPercentage(100.0));
         }
     }
 


### PR DESCRIPTION
Motivation:

It seems like the backoff verification is too strict for `RetryTest` causing flakiness in the mac build.
I propose that the delay is verified with a larger margin.

ref: https://ge.armeria.dev/scans/tests?search.relativeStartTime=P28D&search.tags=main%2CCI&search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.xds.it.RetryTest

Modifications:

- Modified the retry backoff verification margin to be larger

Result:

- More stable builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
