### PR TITLE
Preserve stack trace for `CancelledSubscriptionException`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/CancellableStreamMessage.java
@@ -47,6 +47,8 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
     static final Logger logger = LoggerFactory.getLogger(CancellableStreamMessage.class);
 
     static final CloseEvent SUCCESSFUL_CLOSE = new CloseEvent(null);
+    static final CloseEvent CANCELLED_CLOSE = new CloseEvent(CancelledSubscriptionException.INSTANCE);
+    static final CloseEvent ABORTED_CLOSE = new CloseEvent(AbortedStreamException.INSTANCE);
 
     private final CompletableFuture<Void> completionFuture = new EventLoopCheckingFuture<>();
 
@@ -132,10 +134,17 @@ abstract class CancellableStreamMessage<T> extends AggregationSupport implements
     }
 
     /**
-     * Returns newly created {@link CloseEvent} with the cause.
+     * Returns newly created {@link CloseEvent} if the specified {@link Throwable} is not an instance of
+     * {@link CancelledSubscriptionException#INSTANCE} or {@link AbortedStreamException#INSTANCE}.
      */
     static CloseEvent newCloseEvent(Throwable cause) {
-        return new CloseEvent(cause);
+        if (cause == CancelledSubscriptionException.INSTANCE) {
+            return CANCELLED_CLOSE;
+        } else if (cause == AbortedStreamException.INSTANCE) {
+            return ABORTED_CLOSE;
+        } else {
+            return new CloseEvent(cause);
+        }
     }
 
     static final class SubscriptionImpl implements Subscription {

--- a/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
+++ b/core/src/main/java/com/linecorp/armeria/common/stream/DefaultStreamMessage.java
@@ -293,7 +293,7 @@ public class DefaultStreamMessage<T> extends AbstractStreamWriter<T> {
             // is called. We just ignore the previously pushed event and deal with cancelled close event.
             final SubscriptionImpl subscription = this.subscription;
             assert subscription != null;
-            notifySubscriberOfCloseEvent(subscription, new CloseEvent(CancelledSubscriptionException.get()));
+            notifySubscriberOfCloseEvent(subscription, newCloseEvent(CancelledSubscriptionException.get()));
         }
     }
 


### PR DESCRIPTION
Motivation:
When a `CancelledSubscriptionException` was raised, it was created without a stack trace for performance reasons. This made it difficult for developers to debug the root cause of a subscription cancellation.

Modifications:
- Used `CancelledSubscriptionException.get()` when creating a `CloseEvent`.
  - This method leverages the configured `verboseExceptionSampler` to determine whether a full stack trace should be captured and preserved.

Result:
- Developers can now obtain a full stack trace for `CancelledSubscriptionException` by configuring the `verboseExceptionSampler`.
