### PR TITLE
Automatically initialize `AbstractEndpointSelector`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelector.java
@@ -95,6 +95,18 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         return asyncSelector.select(ctx, executor, endpointGroup.selectionTimeoutMillis());
     }
 
+    @Override
+    public final @Nullable Endpoint selectNow(ClientRequestContext ctx) {
+        tryInitialize();
+        return doSelectNow(ctx);
+    }
+
+    /**
+     * Selects an {@link Endpoint} from this {@link EndpointGroup} immediately.
+     */
+    @Nullable
+    protected abstract Endpoint doSelectNow(ClientRequestContext ctx);
+
     private void refreshEndpoints(List<Endpoint> endpoints) {
         // Allow subclasses to update the endpoints first.
         updateNewEndpoints(endpoints);
@@ -130,7 +142,6 @@ public abstract class AbstractEndpointSelector implements EndpointSelector {
         @Nullable
         @Override
         protected Endpoint selectNow(ClientRequestContext ctx) {
-            tryInitialize();
             return AbstractEndpointSelector.this.selectNow(ctx);
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DefaultEndpointSelector.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DefaultEndpointSelector.java
@@ -69,7 +69,7 @@ final class DefaultEndpointSelector<T extends LoadBalancer<Endpoint, ClientReque
 
     @Nullable
     @Override
-    public Endpoint selectNow(ClientRequestContext ctx) {
+    public Endpoint doSelectNow(ClientRequestContext ctx) {
         final T loadBalancer = this.loadBalancer;
         if (loadBalancer == null) {
             return null;

--- a/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientRequestContextDelayedInitTest.java
@@ -93,7 +93,7 @@ class ClientRequestContextDelayedInitTest {
 
                 @Nullable
                 @Override
-                public Endpoint selectNow(ClientRequestContext ctx) {
+                public Endpoint doSelectNow(ClientRequestContext ctx) {
                     if (counter.getAndIncrement() >= failAfter) {
                         throw cause;
                     }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/AbstractEndpointSelectorTest.java
@@ -138,7 +138,7 @@ class AbstractEndpointSelectorTest {
 
             @Nullable
             @Override
-            public Endpoint selectNow(ClientRequestContext ctx) {
+            public Endpoint doSelectNow(ClientRequestContext ctx) {
                 final List<Endpoint> endpoints = endpointGroup.endpoints();
                 return endpoints.isEmpty() ? null : endpoints.get(0);
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -253,7 +253,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
 
         @Override
         @Nullable
-        public Endpoint selectNow(ClientRequestContext ctx) {
+        public Endpoint doSelectNow(ClientRequestContext ctx) {
             final XdsLoadBalancer loadBalancer = XdsEndpointGroup.this.loadBalancer;
             if (loadBalancer == null) {
                 return null;


### PR DESCRIPTION
Motivation:

As the `initialize()` method of `AbstractEndpointSelector` may access member fields of subclasses, `initialize()` couldn't be called in the constructor of `AbstractEndpointSelector`.

Although the requirement is stated in the Javadoc, many users overlooked calling `initialize()` in their implementations.

I propose adding a fallback logic that automatically initializes `AbstractEndpointSelector` if it hasn't been initialized by the time the first endpoint selection occurs, so users are protected from implementation mistakes.

Modifications:

- Try to initialize `AbstractEndpointSelector` if it hasn't been initialized when `select(...)` method is called.
- Breaking) A subclass of `AbstractEndpointSelector` should implement `doSelectNow(ctx)` instead of `selectNow(ctx)`, which is now a final method. 

Result:

Make `AbstractEndpointSelector` auto-initialize to avoid user-side implementation errors.
