### PR TITLE
Shade extends from api

### DIFF
--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -38,7 +38,7 @@ configure(relocatedProjects) {
         canBeResolved = true
         canBeConsumed = false
     }
-    project.configurations.implementation.extendsFrom(shadeConfig)
+    project.configurations.api.extendsFrom(shadeConfig)
 
     // Generate the shaded JARs.
     task shadedJar(


### PR DESCRIPTION
Motivation:

Following #6555, it seems like doing a simple `./gradlew assemble` fails.

```
  /Users/user/Projects/upstream-armeria/xds-api/src/main/java/com/linecorp/armeria/xds/api/DefaultXdsValidatorIndex.java:22: error: cannot find symbol
  import io.envoyproxy.pgv.ReflectiveValidatorIndex;
```

where the dependency is defined as follows:

https://github.com/line/armeria/blob/d4811bda9906076e18e0f9da0b2087b0e1191f31/xds-pgv-shaded/build.gradle#L11-L13

The current CI seems to pass since `shadedJar` is always run first, which means each module compiles its source based on the shaded artifact.

In practice, relocated dependencies are excluded from the final pom and the dependency itself is embedded in the jar which makes it act similar to the `api` configuration

https://github.com/line/armeria/blob/d4811bda9906076e18e0f9da0b2087b0e1191f31/gradle/scripts/lib/java-publish.gradle#L50

For this reason, I propose that `shade` extends from the `api` configuration.
Conceptually, this can be thought as: wherever the containing module is imported, the shaded dependency is also included (since it's shaded) which acts identically to the `api` configuration

Modifications:

- Modified so that the `shade` configuration extends from the `api` configuration

Result:

- Running `./gradlew assemble` no longer fails

<!--
Visit this URL to learn more about how to write a pull request description:
https://line.github.io/armeria/community/developer-guide#how-to-write-pull-request-description
-->
