### PR TITLE
Add decorator support for ServiceErrorHandler

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/DecoratingErrorHandlerFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DecoratingErrorHandlerFunction.java
@@ -20,10 +20,15 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
- * A function to decorate a {@link ServerErrorHandler} with additional behavior. It is typically used to inject
- * additional logic before or after the specified {@link ServerErrorHandler} execution.
+ * A function to decorate a {@link ServerErrorHandler} or a {@link ServiceErrorHandler} with additional
+ * behavior. Implementations can wrap error handlers to add pre-processing, post-processing, or
+ * conditional logic around error handling. The decorator receives the delegate error handler and
+ * can decide whether and when to invoke it.
  */
-interface DecoratingServerErrorHandlerFunction {
+interface DecoratingErrorHandlerFunction {
     @Nullable
     HttpResponse onServiceException(ServerErrorHandler delegate, ServiceRequestContext ctx, Throwable cause);
+
+    @Nullable
+    HttpResponse onServiceException(ServiceErrorHandler delegate, ServiceRequestContext ctx, Throwable cause);
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -258,7 +258,7 @@ final class DefaultServerConfig implements ServerConfig {
         this.enableServerHeader = enableServerHeader;
         this.enableDateHeader = enableDateHeader;
 
-        this.errorHandler = requireNonNull(errorHandler, "errorHandler");
+        this.errorHandler = ErrorHandlerDecorators.decorate(requireNonNull(errorHandler, "errorHandler"));
         this.sslContexts = sslContexts;
         this.http1HeaderNaming = requireNonNull(http1HeaderNaming, "http1HeaderNaming");
         this.dependencyInjector = requireNonNull(dependencyInjector, "dependencyInjector");

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -2384,9 +2384,9 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
             shutdownSupports.add(ShutdownSupport.of(tlsProvider));
         }
 
-        final ServerErrorHandler errorHandler = ServerErrorHandlerDecorators.decorate(
+        final ServerErrorHandler errorHandler =
                 this.errorHandler == null ? ServerErrorHandler.ofDefault()
-                                          : this.errorHandler.orElse(ServerErrorHandler.ofDefault()));
+                                          : this.errorHandler.orElse(ServerErrorHandler.ofDefault());
         final MeterIdPrefix meterIdPrefix = tlsConfig != null ? tlsConfig.meterIdPrefix() : null;
         final SslContextFactory sslContextFactory = new SslContextFactory(meterIdPrefix, meterRegistry);
         final VirtualHost defaultVirtualHost =

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceConfigBuilder.java
@@ -353,9 +353,9 @@ final class ServiceConfigBuilder implements ServiceConfigSetters<ServiceConfigBu
                         ServiceErrorHandler defaultServiceErrorHandler,
                         @Nullable UnloggedExceptionsReporter unloggedExceptionsReporter,
                         String baseContextPath, Supplier<AutoCloseable> contextHook) {
-        ServiceErrorHandler errorHandler =
+        ServiceErrorHandler errorHandler = ErrorHandlerDecorators.decorate(
                 serviceErrorHandler != null ? serviceErrorHandler.orElse(defaultServiceErrorHandler)
-                                            : defaultServiceErrorHandler;
+                                            : defaultServiceErrorHandler);
         if (unloggedExceptionsReporter != null) {
             errorHandler = new ExceptionReportingServiceErrorHandler(errorHandler,
                                                                      unloggedExceptionsReporter);


### PR DESCRIPTION
Motivation:

Following #6269, error handler decorators like `CorsServerErrorHandler` and `ContentPreviewServerErrorHandler` were introduced to support decorating `ServerErrorHandler`. However, these decorators only worked with `ServerErrorHandler`s and did not support `ServiceErrorHandler` configured via `ServiceBindingBuilder.errorHandler()`. If a `ServiceErrorHandler` is configured, the `ServerErrorHandler` acts as a fallback, so the error response is returned directly without passing through decorators:

https://github.com/line/armeria/blob/677728475305cf87780f4e2ff5ac3c2c9784b51a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java#L1393-L1395

Modifications:

- Extended `DecoratingErrorHandlerFunction` to support both `ServerErrorHandler` and `ServiceErrorHandler`.
- Updated `ServiceConfigBuilder` to automatically decorate `ServiceErrorHandler` instances.

Result:

- Error response content preview and CORS headers are now available for services configured with `ServiceErrorHandler`.