### PR TITLE
Fix BeanPostProcessor warning by making factory method static

### DIFF
--- a/spring/boot4-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaBeanPostProcessorConfiguration.java
+++ b/spring/boot4-autoconfigure/src/main/java/com/linecorp/armeria/spring/ArmeriaBeanPostProcessorConfiguration.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.server.Server;
 @ConditionalOnBean(Server.class)
 @ConditionalOnClass(ArmeriaBeanPostProcessor.class)
 @AutoConfigureAfter(name = "com.linecorp.armeria.spring.ArmeriaAutoConfiguration")
+@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class ArmeriaBeanPostProcessorConfiguration {
 
     /**
@@ -39,7 +40,7 @@ public class ArmeriaBeanPostProcessorConfiguration {
      */
     @Bean
     @ConditionalOnMissingBean(ArmeriaBeanPostProcessor.class)
-    public ArmeriaBeanPostProcessor armeriaBeanPostProcessor(BeanFactory beanFactory) {
+    public static ArmeriaBeanPostProcessor armeriaBeanPostProcessor(BeanFactory beanFactory) {
         return new ArmeriaBeanPostProcessor(beanFactory);
     }
 }


### PR DESCRIPTION
Motivation:
Spring Framework warning was logged:
```
Bean 'com.linecorp.armeria.spring.ArmeriaBeanPostProcessorConfiguration' ... is not eligible for getting processed by all BeanPostProcessors... The currently created BeanPostProcessor [armeriaBeanPostProcessor] is declared through a non-static factory method on that class; consider declaring it as static instead.
```

This warning is raised because `BeanPostProcessor` beans must be initialized very early in the container's lifecycle to ensure they can process all other beans.

Modifications:
- Added the `static` keyword to the method declaration, as recommended by the Spring warning.

Result:
- The Spring startup warning is resolved.