### PR TITLE
Fix requestEndTime is set after send response when empty content request

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java
@@ -1119,6 +1119,25 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
     }
 
     @Override
+    public void requestEnd() {
+        requestEnd0(System.nanoTime());
+    }
+
+    @Override
+    public void requestEnd(long requestEndTimeNanos) {
+        requestEnd0(requestEndTimeNanos);
+    }
+
+    private void requestEnd0(long requestEndTimeNanos) {
+        if (isAvailable(REQUEST_END_TIME)) {
+            return;
+        }
+
+        this.requestEndTimeNanos = requestEndTimeNanos;
+        updateFlags(REQUEST_END_TIME);
+    }
+
+    @Override
     public void endRequest() {
         endRequest0(null);
     }
@@ -1183,7 +1202,10 @@ final class DefaultRequestLog implements RequestLog, RequestLogBuilder {
             setNamesIfAbsent();
         }
 
-        this.requestEndTimeNanos = requestEndTimeNanos;
+        // Set requestEndTimeNanos if it is not already set
+        if (!isAvailable(REQUEST_END_TIME)) {
+            this.requestEndTimeNanos = requestEndTimeNanos;
+        }
 
         setRequestCause(requestCause);
         updateFlags(flags);

--- a/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/RequestLogBuilder.java
@@ -190,6 +190,18 @@ public interface RequestLogBuilder extends RequestLogAccess {
     void requestCause(Throwable cause);
 
     /**
+     * Sets the {@link RequestLog#requestEndTimeNanos()}.
+     */
+    @UnstableApi
+    void requestEnd();
+
+    /**
+     * Sets the {@link RequestLog#requestEndTimeNanos()} with the specified timestamp.
+     */
+    @UnstableApi
+    void requestEnd(long requestEndTimeNanos);
+
+    /**
      * Finishes the collection of the {@link Request} information. This method sets the following properties:
      * <ul>
      *   <li>{@link RequestLog#requestEndTimeNanos()}</li>

--- a/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
+++ b/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java
@@ -83,6 +83,9 @@ final class EmptyContentDecodedHttpRequest implements DecodedHttpRequest {
     @Override
     public void init(ServiceRequestContext ctx) {
         this.ctx = ctx;
+
+        // EmptyContentDecodedHttpRequest does not have any additional data to read.
+        ctx.logBuilder().requestEnd();
     }
 
     @Nullable


### PR DESCRIPTION
Motivation:

[requestEndTimeNanos](https://javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/latest/com/linecorp/armeria/common/logging/RequestOnlyLog.html#requestEndTimeNanos()) is set after send response when processing the empty body request (ex. GET).
This led to the inclusion of business logic processing time and response transmission time in the `requestDurationNanos`.

Modifications:

- Immediately end the request for the context if the request is [EmptyContentDecodedHttpRequest](https://github.com/line/armeria/blob/main/core/src/main/java/com/linecorp/armeria/server/EmptyContentDecodedHttpRequest.java)

Result:

- `requestDurationNanos` returns expected durations as documented.

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
