### PR TITLE
Set content preview to null when response fails with exception

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/logging/ContentPreviewingUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/logging/ContentPreviewingUtil.java
@@ -115,6 +115,7 @@ public final class ContentPreviewingUtil {
             this.ctx = ctx;
             whenComplete().handle((unused, cause) -> {
                 if (responseContentPreviewer == null) {
+                    ctx.logBuilder().responseContentPreview(null);
                     return null;
                 }
                 if (!responseContentPreviewer.isDisabled()) {

--- a/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/logging/ContentPreviewingService.java
@@ -176,6 +176,7 @@ public final class ContentPreviewingService extends SimpleDecoratingHttpService 
             final HttpResponse res = unwrap().serve(ctx, req);
             return setUpResponseContentPreviewer(contentPreviewerFactory, ctx, res, responsePreviewSanitizer);
         } catch (Throwable t) {
+            ctx.logBuilder().responseContentPreview(null);
             return HttpResponse.ofFailure(t);
         }
     }


### PR DESCRIPTION
Motivation:

Following the discussion in https://github.com/line/armeria/pull/6570#discussion_r2656720562, content preview was being generated even when a preceding decorator failed with an exception. This behavior was inconsistent with `DefaultRequestLog`, which sets the preview to null when an exception is present:

https://github.com/line/armeria/blob/d068172432163c42908ad5d509262cc4022afb04/core/src/main/java/com/linecorp/armeria/common/logging/DefaultRequestLog.java#L1471-L1473

The content preview should not be recorded when the response flow is interrupted by an exception, as the decorator did not actually process the response content.

Modifications:

- Set `responseContentPreview(null)` in `ContentPreviewingUtil` when `responseContentPreviewer` is null.
- Set `responseContentPreview(null)` in `ContentPreviewingService` when service execution throws an exception.
- Updated tests to verify null content preview for various exception scenarios with and without error handlers.

Result:

- Response content preview is properly set to null when exceptions are raised.
- Consistent behavior between decorator-level exceptions and error handler responses.