### PR TITLE
Fix flaky ResponseTimeoutFromStartTest by adding buffer time

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/retry/ResponseTimeoutFromStartTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/ResponseTimeoutFromStartTest.java
@@ -18,12 +18,12 @@ package com.linecorp.armeria.client.retry;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.within;
 
 import java.time.Duration;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
-import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -89,9 +89,8 @@ class ResponseTimeoutFromStartTest {
             assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - prev))
                     .isLessThan(TimeUnit.SECONDS.toMillis(timeoutSeconds));
         } else {
-
             assertThat(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - prev))
-                    .isCloseTo(TimeUnit.SECONDS.toMillis(timeoutSeconds), Percentage.withPercentage(10));
+                    .isCloseTo(TimeUnit.SECONDS.toMillis(timeoutSeconds), within(1000L));
         }
     }
 }


### PR DESCRIPTION
Motivation:
`ResponseTimeoutFromStartTest` has been flaky, particularly in high-load environments. The test failure is caused by the fixed overhead of handling exceptions twice (once by the client and once by the timeout scheduler) and context switching delays. As discussed in #6582, this is not a logic bug but an inevitable overhead in certain environments. To prevent false positives in CI and local tests, we need to relax the assertion window.

Modifications:
- Updated `ResponseTimeoutFromStartTest` to allow a sufficient buffer for system overhead.
- Changed the assertion to use `isCloseTo` with a fixed buffer of 1000ms (`within(1000L)`), ensuring the timeout is respected while tolerating execution delays.

Result:

- Closes #6582.
- The test is now stable and resilient to high CPU load or thread scheduling delays, preventing flaky failures in CI.