### PR TITLE
Fix flaky `ConnectionPoolKeepAliveTest.maxAgeEventRecorded` test

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolKeepAliveTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ConnectionPoolKeepAliveTest.java
@@ -118,6 +118,7 @@ class ConnectionPoolKeepAliveTest {
         final RecordingConnectionPoolListener listener = new RecordingConnectionPoolListener();
         try (ClientFactory factory = ClientFactory.builder()
                                                   .connectionPoolListener(listener)
+                                                  .idleTimeoutMillis(0)
                                                   .maxConnectionAgeMillis(1000)
                                                   .build()) {
             final AggregatedHttpResponse res = WebClient.builder(protocol, server.httpEndpoint())


### PR DESCRIPTION
Motivation:

I'm not sure why, but `idleTimeout` is clamped to `maxConnectionAge`. Since both `idleTimeout == maxConnectionAge == 1 second`, the test was flaky.

https://github.com/line/armeria/blob/7705a683a7dcade3c6662b0eca97aa2a22662d2a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java#L1091-L1095

ref: https://ge.armeria.dev/scans/tests?search.relativeStartTime=P28D&search.tags=main%2CCI&search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.client.ConnectionPoolKeepAliveTest&tests.test=maxAgeEventRecorded(SessionProtocol)%5B1%5D

Modifications:

- Modified `idleTimeout` to be disabled for the `maxConnectionAge` test

Result:

- `ConnectionPoolKeepAliveTest.maxAgeEventRecorded' passes reliably`

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
