### PR TITLE
Fix flaky spring heap dump test

### DIFF
--- a/spring/boot4-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
+++ b/spring/boot4-actuator-autoconfigure/src/main/java/com/linecorp/armeria/spring/actuate/WebOperationService.java
@@ -50,7 +50,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
-import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -65,7 +64,6 @@ import com.linecorp.armeria.common.ResponseHeadersBuilder;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.server.RoutingContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.buffer.ByteBuf;
@@ -138,11 +136,6 @@ final class WebOperationService implements HttpService {
         } else {
             return HttpResponse.of(req.aggregate().thenApply(invoke(ctx)));
         }
-    }
-
-    @Override
-    public ExchangeType exchangeType(RoutingContext routingContext) {
-        return ExchangeType.RESPONSE_STREAMING;
     }
 
     private Function<AggregatedHttpRequest, HttpResponse> invoke(ServiceRequestContext ctx) {


### PR DESCRIPTION
Motivation:

Handles flaky test: https://ge.armeria.dev/scans/tests?search.relativeStartTime=P28D&search.tags=main%2CCI&search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfigurationTest&tests.test=testHeapDump()

Heap dumps were being aggregated due to the service being unary.

ref: https://ge.armeria.dev/s/vxcnflkr7gb5w/tests/task/:spring:boot2-actuator-autoconfigure:shadedTest/details/com.linecorp.armeria.spring.actuate.ArmeriaSpringActuatorAutoConfigurationTest/testHeapDump()?top-execution=1

ref: https://github.com/spring-projects/spring-boot/blob/e53d008d07ccb8f452b664e3193d3abb67751bdb/module/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/endpoint/web/annotation/RequestPredicateFactory.java#L121

Modifications:

- If octet-stream is the returned media type, modified to use `ExchangeType.RESPONSE_STREAMING`

Result:

- More stable builds

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
