### PR TITLE
Trim leading and trailing spaces when parsing `X-Forwarded-For` header

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpHeaderUtil.java
@@ -98,7 +98,7 @@ final class HttpHeaderUtil {
                     });
                 } else {
                     headers.getAll(name).forEach(header -> {
-                        getAllValidAddress(header, Function.identity(), filter, builder);
+                        getAllValidAddress(header, String::trim, filter, builder);
                     });
                 }
 

--- a/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/HttpHeaderUtilTest.java
@@ -176,17 +176,23 @@ class HttpHeaderUtilTest {
         assertThat(xForwardedFor("unknown,[2001:db8:cafe::17]:4711,[2001:db8:cafe::18]:4711"))
                 .containsExactly(new InetSocketAddress("2001:db8:cafe::17", 4711),
                                  new InetSocketAddress("2001:db8:cafe::18", 4711));
+
+        // IPv4 with leading and trailing spaces
+        assertThat(xForwardedFor("192.0.2.60, 192.0.2.61, 192.0.2.62"))
+                .containsExactly(new InetSocketAddress("192.0.2.60", 0),
+                                 new InetSocketAddress("192.0.2.61", 0),
+                                 new InetSocketAddress("192.0.2.62", 0));
     }
 
     @Nullable
     private static List<InetSocketAddress> xForwardedFor(String value) {
-        return getAllValidAddresses(value, Function.identity(), ACCEPT_ANY);
+        return getAllValidAddresses(value, String::trim, ACCEPT_ANY);
     }
 
     @Nullable
     private static List<InetSocketAddress> xForwardedFor(String value,
                                                          Predicate<InetAddress> clientAddressFilter) {
-        return getAllValidAddresses(value, Function.identity(), clientAddressFilter);
+        return getAllValidAddresses(value, String::trim, clientAddressFilter);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The `X-Forwarded-For` header syntax allows spaces after commas as shown in the MDN specification. Armeria currently fails to parse such values.

Modifications:

- Pass `String::trim` instead of `Function.identity()` as the `valueConverter` for non-`Forwarded` headers in `HttpHeaderUtil`

Result:

- `X-Forwarded-For` header values with leading/trailing spaces around comma-separated addresses are now parsed correctly

<!--
Visit this URL to learn more about how to write a pull request description:
https://armeria.dev/community/developer-guide#how-to-write-pull-request-description
-->
