### PR TITLE
Fix flaky IPAddrUtilTest

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/IpAddrUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/IpAddrUtilTest.java
@@ -52,9 +52,5 @@ class IpAddrUtilTest {
         inetAddress = InetAddress.getByAddress("foo.com", new byte[] { 1, 2, 3, 4 });
         inetSocketAddress = new InetSocketAddress(inetAddress, 8080);
         assertThat(IpAddrUtil.isCreatedWithIpAddressOnly(inetSocketAddress)).isFalse();
-
-        inetAddress = InetAddress.getByName("foo.com");
-        inetSocketAddress = new InetSocketAddress(inetAddress, 8080);
-        assertThat(IpAddrUtil.isCreatedWithIpAddressOnly(inetSocketAddress)).isFalse();
     }
 }


### PR DESCRIPTION
Motivation:

`IpAddrUtilTest` tries to resolve `foo.com`,which seems to fail, possibly due to DNS settings in the CI enviroment.
```
IpAddrUtilTest > testIsCreatedWithIpAddressOnly() FAILED
    java.net.UnknownHostException: foo.com
        at java.base/java.net.InetAddress$CachedLookup.get(InetAddress.java:909)
        at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1702)
        at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1582)
        at java.base/java.net.InetAddress.getByName(InetAddress.java:1492)
        at com.linecorp.armeria.internal.common.util.IpAddrUtilTest.testIsCreatedWithIpAddressOnly(IpAddrUtilTest.java:56)
```
https://github.com/line/armeria/blob/fd540d449136f91e9b77b5ceb9d8ba7cf154cfea/core/src/test/java/com/linecorp/armeria/internal/common/util/IpAddrUtilTest.java#L56-L58 It is likely that this assertion is unneccessary because the test branch is already covered by the previous one.

Modification:

- Remove the flaky assertion in `IpAddrUtilTest`

Result:

- Stable CI results
- Closes #6625
