### PR TITLE
Delegate exchangeType() and options() in BraveService and ThrottlingService

### DIFF
--- a/brave/brave6/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
+++ b/brave/brave6/src/main/java/com/linecorp/armeria/server/brave/BraveService.java
@@ -22,11 +22,14 @@ import java.util.function.Function;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.brave.RequestContextCurrentTraceContext;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.RoutingContext;
+import com.linecorp.armeria.server.ServiceOptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import brave.Span;
@@ -117,5 +120,15 @@ public final class BraveService extends AbstractBraveService<HttpServerRequest, 
     @Override
     void handleSend(HttpServerResponse response, Span span) {
         handler.handleSend(response, span);
+    }
+
+    @Override
+    public ExchangeType exchangeType(RoutingContext routingContext) {
+        return ((HttpService) unwrap()).exchangeType(routingContext);
+    }
+
+    @Override
+    public ServiceOptions options() {
+        return ((HttpService) unwrap()).options();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/throttling/ThrottlingService.java
@@ -17,9 +17,12 @@ package com.linecorp.armeria.server.throttling;
 
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.RoutingContext;
+import com.linecorp.armeria.server.ServiceOptions;
 
 /**
  * Decorates an {@link HttpService} to throttle incoming requests.
@@ -63,5 +66,15 @@ public final class ThrottlingService extends AbstractThrottlingService<HttpReque
                       ThrottlingAcceptHandler<HttpRequest, HttpResponse> acceptHandler,
                       ThrottlingRejectHandler<HttpRequest, HttpResponse> rejectHandler) {
         super(delegate, strategy, HttpResponse::of, acceptHandler, rejectHandler);
+    }
+
+    @Override
+    public ExchangeType exchangeType(RoutingContext routingContext) {
+        return ((HttpService) unwrap()).exchangeType(routingContext);
+    }
+
+    @Override
+    public ServiceOptions options() {
+        return ((HttpService) unwrap()).options();
     }
 }


### PR DESCRIPTION
Motivation:

Decorators that implement `HttpService` but extend `SimpleDecoratingService<I, O>` (instead of `SimpleDecoratingHttpService`) inherit the `HttpService` interface default for `exchangeType()`, which always returns `ExchangeType.BIDI_STREAMING`. This means the delegate's actual exchange type is lost, preventing request aggregation optimizations when the inner service declares `UNARY` or `RESPONSE_STREAMING`.

Modifications:

- Override `exchangeType()` and `options()` in `BraveService` to delegate to the wrapped `HttpServic`e, matching the pattern in `SimpleDecoratingHttpService`.
- Override `exchangeType()` and `options()` in `ThrottlingService` with the same delegation logic.
- Add tests in BraveServiceTest and ThrottlingServiceTest to verify all ExchangeType values are correctly delegated.

Result:

- `BraveService` and `ThrottlingService` now correctly propagate the delegate's exchange type and service options.