### PR TITLE
Fix typo: SeverSentEvent to ServerSentEvent

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/streaming/ServerSentEvents.java
+++ b/core/src/main/java/com/linecorp/armeria/server/streaming/ServerSentEvents.java
@@ -43,7 +43,7 @@ import com.linecorp.armeria.common.sse.ServerSentEvent;
  * <pre>{@code
  * Server server =
  *     Server.builder()
- *           // Emit Server-Sent Events with the SeverSentEvent instances published by a publisher.
+ *           // Emit Server-Sent Events with the ServerSentEvent instances published by a publisher.
  *           .service("/sse1",
  *                    (ctx, req) -> ServerSentEvents.fromPublisher(
  *                            Flux.just(ServerSentEvent.ofData("foo"), ServerSentEvent.ofData("bar"))))

--- a/site-new/src/content/blog/en/2020-07-03-reactive-streams-armeria-2.mdx
+++ b/site-new/src/content/blog/en/2020-07-03-reactive-streams-armeria-2.mdx
@@ -193,7 +193,7 @@ HttpResponse httpResponse = JsonTextSequences.fromPublisher(dataStream);
 // Convert Publisher to Server-sent Events with Armeria HttpResponse
 // with “text/event-stream” MIME type
 HttpResponse httpResponse = ServerSentEvents
-        .fromPublisher(dataStream, SeverSentEvent::ofData);
+        .fromPublisher(dataStream, ServerSentEvent::ofData);
 ```
 
 RxJava consolidation support is available for those looking to use the built-in publisher even more easily.

--- a/site-new/src/content/blog/ja/2020-03-26-reactive-streams-armeria-2.mdx
+++ b/site-new/src/content/blog/ja/2020-03-26-reactive-streams-armeria-2.mdx
@@ -168,7 +168,7 @@ HttpResponse httpResponse = JsonTextSequences.fromPublisher(dataStream);
 // Convert Publisher to Server-sent Events with Armeria HttpResponse
 // with "text/event-stream" MIME type
 HttpResponse httpResponse = ServerSentEvents
-        .fromPublisher(dataStream, SeverSentEvent::ofData);
+        .fromPublisher(dataStream, ServerSentEvent::ofData);
 ```
 
 また、ビルトイン publisher をより簡単に使用できるように RxJava 統合をサポートしています。アノテーションのサービスに@ProducesJsonSequences アノテーションを追加し、Observable をそのまま返すと、Armeria で当該プロトコルで自動的に変換します。

--- a/site-new/src/content/blog/ko/2020-02-19-reactive-streams-armeria-2.mdx
+++ b/site-new/src/content/blog/ko/2020-02-19-reactive-streams-armeria-2.mdx
@@ -176,7 +176,7 @@ HttpResponse httpResponse = JsonTextSequences.fromPublisher(dataStream);
 // Convert Publisher to Server-sent Events with Armeria HttpResponse
 // with “text/event-stream” MIME type
 HttpResponse httpResponse = ServerSentEvents
-        .fromPublisher(dataStream, SeverSentEvent::ofData);
+        .fromPublisher(dataStream, ServerSentEvent::ofData);
 ```
 
 또한 빌트인 publisher를 더욱 쉽게 사용할 수 있도록 RxJava 통합을 지원하고 있습니다. 어노테이션한 서비스에 `@ProduceJsonSequence` 어노테이션을 추가하고, `Observable`을 그대로 반환하면 Armeria에서 해당 프로토콜로 자동으로 변환합니다.

--- a/site-new/src/content/docs/server/sse.mdx
+++ b/site-new/src/content/docs/server/sse.mdx
@@ -22,7 +22,7 @@ import reactor.core.publisher.Flux;
 
 Server server =
         Server.builder()
-              // Emit Server-Sent Events with the SeverSentEvent instances published by a publisher.
+              // Emit Server-Sent Events with the ServerSentEvent instances published by a publisher.
               .service("/sse1",
                        (ctx, req) -> ServerSentEvents.fromPublisher(
                                Flux.just(ServerSentEvent.ofData("foo"), ServerSentEvent.ofData("bar"))))


### PR DESCRIPTION
Fixes typo in Java comment and documentation where 'SeverSentEvent' should be 'ServerSentEvent'. This affects the ServerSentEvents class comment, SSE documentation, and blog posts in English, Japanese, and Korean.