### PR TITLE
Remove setting `SO_KEEPALIVE` related options by default

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -1084,7 +1084,7 @@ public final class ClientFactoryBuilder implements TlsSetters {
         final ClientFactoryOptions newOptions = ClientFactoryOptions.of(options.values());
         final long maxConnectionAgeMillis = newOptions.maxConnectionAgeMillis();
         long idleTimeoutMillis = newOptions.idleTimeoutMillis();
-        long pingIntervalMillis = newOptions.pingIntervalMillis();
+        final long pingIntervalMillis = newOptions.pingIntervalMillis();
         final ImmutableList.Builder<ClientFactoryOptionValue<?>> adjustedOptionsBuilder =
                 ImmutableList.builderWithExpectedSize(2);
 
@@ -1098,18 +1098,16 @@ public final class ClientFactoryBuilder implements TlsSetters {
             final long clampedPingIntervalMillis = Math.max(pingIntervalMillis, MIN_PING_INTERVAL_MILLIS);
             if (clampedPingIntervalMillis >= idleTimeoutMillis) {
                 adjustedOptionsBuilder.add(ZERO_PING_INTERVAL);
-                pingIntervalMillis = 0;
             } else if (pingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
                 // no-op, clampedPingIntervalMillis is equal to pingIntervalMillis
             } else if (clampedPingIntervalMillis == MIN_PING_INTERVAL_MILLIS) {
                 adjustedOptionsBuilder.add(MIN_PING_INTERVAL);
-                pingIntervalMillis = MIN_PING_INTERVAL_MILLIS;
             }
         }
 
         final Map<ChannelOption<?>, Object> newChannelOptions =
                 ChannelUtil.applyDefaultChannelOptions(
-                        newOptions.channelOptions(), idleTimeoutMillis, pingIntervalMillis);
+                        newOptions.channelOptions(), idleTimeoutMillis);
         adjustedOptionsBuilder.add(ClientFactoryOptions.CHANNEL_OPTIONS.newValue(newChannelOptions));
 
         final List<ClientFactoryOptionValue<?>> adjustedOptions = adjustedOptionsBuilder.build();

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -1498,12 +1498,10 @@ public final class Flags {
 
     /**
      * Returns whether default socket options defined by Armeria are enabled.
-     * If enabled, the following socket options are set automatically when
+     * If enabled, the following socket option is set automatically when
      * {@code /dev/epoll} or {@code io_uring} is in use:
      * <ul>
      *   <li>TCP_USER_TIMEOUT</li>
-     *   <li>TCP_KEEPIDLE</li>
-     *   <li>TCP_KEEPINTVL</li>
      * </ul>
      *
      * <p>This flag is enabled by default.

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -1065,12 +1065,10 @@ public interface FlagsProvider {
 
     /**
      * Returns whether default socket options defined by Armeria are enabled.
-     * If enabled, the following socket options are set automatically when
+     * If enabled, the following socket option is set automatically when
      * {@code /dev/epoll} or {@code io_uring} is in use:
      * <ul>
      *   <li>TCP_USER_TIMEOUT</li>
-     *   <li>TCP_KEEPIDLE</li>
-     *   <li>TCP_KEEPINTVL</li>
      * </ul>
      *
      * <p>This flag is enabled by default.

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -101,24 +101,10 @@ public final class ChannelUtil {
     @Nullable
     private static ChannelOption<Integer> epollTcpUserTimeout;
     @Nullable
-    private static ChannelOption<Integer> epollTcpKeepidle;
-    @Nullable
-    private static ChannelOption<Integer> epollTcpKeepintvl;
-    @Nullable
     private static ChannelOption<Integer> ioUringTcpUserTimeout;
-    @Nullable
-    private static ChannelOption<Integer> ioUringTcpKeepidle;
-    @Nullable
-    private static ChannelOption<Integer> ioUringTcpKeepintvl;
-
-    private static final Set<ChannelOption<?>> tcpOptions;
 
     static {
-        final ImmutableSet.Builder<ChannelOption<?>> tcpOptionsBuilder = ImmutableSet.builder();
-
         ChannelOption<Integer> epollTcpUserTimeout = null;
-        ChannelOption<Integer> epollTcpKeepidle = null;
-        ChannelOption<Integer> epollTcpKeepintvl = null;
 
         try {
             final Class<?> clazz = Class.forName(
@@ -126,32 +112,14 @@ public final class ChannelUtil {
                     ChannelUtil.class.getClassLoader());
             //noinspection unchecked
             epollTcpUserTimeout = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_USER_TIMEOUT");
-            //noinspection unchecked
-            epollTcpKeepidle = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPIDLE");
-            //noinspection unchecked
-            epollTcpKeepintvl = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPINTVL");
-
-            if (epollTcpUserTimeout != null) {
-                tcpOptionsBuilder.add(epollTcpUserTimeout);
-            }
-            if (epollTcpKeepidle != null) {
-                tcpOptionsBuilder.add(epollTcpKeepidle);
-            }
-            if (epollTcpKeepintvl != null) {
-                tcpOptionsBuilder.add(epollTcpKeepintvl);
-            }
         } catch (Throwable ignored) {
             // Ignore
         }
 
         ChannelUtil.epollTcpUserTimeout = epollTcpUserTimeout;
-        ChannelUtil.epollTcpKeepidle = epollTcpKeepidle;
-        ChannelUtil.epollTcpKeepintvl = epollTcpKeepintvl;
 
         if (INCUBATOR_CHANNEL_PACKAGE_NAME != null) {
             ChannelOption<Integer> ioUringTcpUserTimeout = null;
-            ChannelOption<Integer> ioUringTcpKeepidle = null;
-            ChannelOption<Integer> ioUringTcpKeepintvl = null;
 
             try {
                 final Class<?> clazz = Class.forName(
@@ -159,30 +127,12 @@ public final class ChannelUtil {
                         ChannelUtil.class.getClassLoader());
                 //noinspection unchecked
                 ioUringTcpUserTimeout = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_USER_TIMEOUT");
-                //noinspection unchecked
-                ioUringTcpKeepidle = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPIDLE");
-                //noinspection unchecked
-                ioUringTcpKeepintvl = (ChannelOption<Integer>) findChannelOption(clazz, "TCP_KEEPINTVL");
-
-                if (ioUringTcpUserTimeout != null) {
-                    tcpOptionsBuilder.add(ioUringTcpUserTimeout);
-                }
-                if (ioUringTcpKeepidle != null) {
-                    tcpOptionsBuilder.add(ioUringTcpKeepidle);
-                }
-                if (ioUringTcpKeepintvl != null) {
-                    tcpOptionsBuilder.add(ioUringTcpKeepintvl);
-                }
             } catch (Throwable ignored) {
                 // Ignore
             }
 
             ChannelUtil.ioUringTcpUserTimeout = ioUringTcpUserTimeout;
-            ChannelUtil.ioUringTcpKeepidle = ioUringTcpKeepidle;
-            ChannelUtil.ioUringTcpKeepintvl = ioUringTcpKeepintvl;
         }
-
-        tcpOptions = tcpOptionsBuilder.build();
     }
 
     @Nullable
@@ -266,16 +216,16 @@ public final class ChannelUtil {
 
     public static Map<ChannelOption<?>, Object> applyDefaultChannelOptions(
             Map<ChannelOption<?>, Object> channelOptions,
-            long idleTimeoutMillis, long pingIntervalMillis) {
+            long idleTimeoutMillis) {
         return applyDefaultChannelOptions(
                 Flags.useDefaultSocketOptions(), Flags.transportType(), channelOptions,
-                idleTimeoutMillis, pingIntervalMillis);
+                idleTimeoutMillis);
     }
 
     @VisibleForTesting
     static Map<ChannelOption<?>, Object> applyDefaultChannelOptions(
             boolean enabled, TransportType transportType, Map<ChannelOption<?>, Object> channelOptions,
-            long idleTimeoutMillis, long pingIntervalMillis) {
+            long idleTimeoutMillis) {
         if (!enabled) {
             return channelOptions;
         }
@@ -283,40 +233,19 @@ public final class ChannelUtil {
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
         if (idleTimeoutMillis > 0) {
-            final int tcpUserTimeout = Ints.saturatedCast(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+            final int tcpUserTimeoutMillis =
+                    Ints.saturatedCast(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
                 assert epollTcpUserTimeout != null;
-                putChannelOption(newChannelOptionsBuilder, epollTcpUserTimeout, tcpUserTimeout);
+                putChannelOption(newChannelOptionsBuilder, epollTcpUserTimeout, tcpUserTimeoutMillis);
             } else if (transportType == TransportType.IO_URING &&
                        canAddChannelOption(ioUringTcpUserTimeout, channelOptions)) {
                 assert ioUringTcpUserTimeout != null;
-                putChannelOption(newChannelOptionsBuilder, ioUringTcpUserTimeout, tcpUserTimeout);
+                putChannelOption(newChannelOptionsBuilder, ioUringTcpUserTimeout, tcpUserTimeoutMillis);
             }
         }
 
-        if (pingIntervalMillis > 0) {
-            final int intPingIntervalMillis = Ints.saturatedCast(pingIntervalMillis);
-            if (transportType == TransportType.EPOLL &&
-                canAddChannelOption(epollTcpKeepidle, channelOptions) &&
-                canAddChannelOption(epollTcpKeepintvl, channelOptions) &&
-                canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
-                assert epollTcpKeepidle != null;
-                assert epollTcpKeepintvl != null;
-                putChannelOption(newChannelOptionsBuilder, ChannelOption.SO_KEEPALIVE, true);
-                putChannelOption(newChannelOptionsBuilder, epollTcpKeepidle, intPingIntervalMillis);
-                putChannelOption(newChannelOptionsBuilder, epollTcpKeepintvl, intPingIntervalMillis);
-            } else if (transportType == TransportType.IO_URING &&
-                       canAddChannelOption(ioUringTcpKeepidle, channelOptions) &&
-                       canAddChannelOption(ioUringTcpKeepintvl, channelOptions) &&
-                       canAddChannelOption(ChannelOption.SO_KEEPALIVE, channelOptions)) {
-                assert ioUringTcpKeepidle != null;
-                assert ioUringTcpKeepintvl != null;
-                putChannelOption(newChannelOptionsBuilder, ChannelOption.SO_KEEPALIVE, true);
-                putChannelOption(newChannelOptionsBuilder, ioUringTcpKeepidle, intPingIntervalMillis);
-                putChannelOption(newChannelOptionsBuilder, ioUringTcpKeepintvl, intPingIntervalMillis);
-            }
-        }
         newChannelOptionsBuilder.putAll(channelOptions);
         return newChannelOptionsBuilder.build();
     }
@@ -337,7 +266,7 @@ public final class ChannelUtil {
     }
 
     public static boolean isTcpOption(ChannelOption<?> option) {
-        return tcpOptions.contains(option);
+        return option.name().startsWith("TCP_");
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -2525,8 +2525,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         }
 
         final Map<ChannelOption<?>, Object> newChildChannelOptions =
-                ChannelUtil.applyDefaultChannelOptions(
-                        childChannelOptions, idleTimeoutMillis, pingIntervalMillis);
+                ChannelUtil.applyDefaultChannelOptions(childChannelOptions, idleTimeoutMillis);
         final BlockingTaskExecutor blockingTaskExecutor = defaultVirtualHost.blockingTaskExecutor();
 
         return new DefaultServerConfig(

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.ImmutableMap;
@@ -65,11 +64,11 @@ public class ChannelUtilTest {
                 ChannelOption.SO_LINGER, 1000);
 
         Map<ChannelOption<?>, Object> newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, TransportType.EPOLL, options, 3000, 4000);
+                true, TransportType.EPOLL, options, 3000);
         assertThat(options).isNotEqualTo(newOptions);
 
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                false, TransportType.EPOLL, options, 3000, 4000);
+                false, TransportType.EPOLL, options, 3000);
         assertThat(options).containsExactlyEntriesOf(newOptions);
     }
 
@@ -83,18 +82,18 @@ public class ChannelUtilTest {
         // ignore if idle timeout not set
         Map<ChannelOption<?>, Object> newOptions =
                 ChannelUtil.applyDefaultChannelOptions(
-                        true, transportType, options, 0, 0);
+                        true, transportType, options, 0);
         assertThat(options).containsExactlyEntriesOf(newOptions);
 
         // ignore if idle timeout is out of bounds
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, transportType, options, -1, 0);
+                true, transportType, options, -1);
         assertThat(options).containsExactlyEntriesOf(newOptions);
 
         // apply idle timeout if possible
         final int idleTimeoutMillis = 2000;
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, transportType, options, idleTimeoutMillis, 0);
+                true, transportType, options, idleTimeoutMillis);
         assertThat(newOptions).containsOnly(
                 entry(ChannelOption.SO_LINGER, lingerMillis),
                 entry(option, idleTimeoutMillis + ChannelUtil.TCP_USER_TIMEOUT_BUFFER_MILLIS));
@@ -104,7 +103,7 @@ public class ChannelUtilTest {
         final Map<ChannelOption<?>, Object> userDefinedOptions = ImmutableMap.of(
                 ChannelOption.SO_LINGER, lingerMillis, option, userDefinedTcpUserTimeoutMillis);
         newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, transportType, userDefinedOptions, idleTimeoutMillis, 0);
+                true, transportType, userDefinedOptions, idleTimeoutMillis);
         assertThat(newOptions).containsExactlyInAnyOrderEntriesOf(userDefinedOptions);
     }
 
@@ -115,53 +114,7 @@ public class ChannelUtilTest {
 
         final Map<ChannelOption<?>, Object> newOptions =
                 ChannelUtil.applyDefaultChannelOptions(
-                        true, TransportType.NIO, options, 3000, 4000);
+                        true, TransportType.NIO, options, 3000);
         assertThat(options).containsExactlyEntriesOf(newOptions);
-    }
-
-    @ParameterizedTest
-    @EnumSource(TransportType.class)
-    void keepAliveChannelOption(TransportType type) {
-        final int lingerMillis = 1000;
-        final Map<ChannelOption<?>, Object> options = ImmutableMap.of(
-                ChannelOption.SO_LINGER, lingerMillis);
-
-        // ignore if parameters are infinite
-        Map<ChannelOption<?>, Object> newOptions =
-                ChannelUtil.applyDefaultChannelOptions(true, type, options, 0, 0);
-        assertThat(newOptions).containsExactlyEntriesOf(options);
-
-        // ignore if parameters are out of bounds
-        newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, type, options, 0, -1);
-        assertThat(newOptions).containsExactlyEntriesOf(options);
-
-        final int pingIntervalMillis = 3000;
-        newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, type, options, 0, pingIntervalMillis);
-        if (type == TransportType.EPOLL) {
-            assertThat(newOptions).containsOnly(entry(ChannelOption.SO_LINGER, lingerMillis),
-                                                entry(ChannelOption.SO_KEEPALIVE, true),
-                                                entry(EpollChannelOption.TCP_KEEPINTVL, pingIntervalMillis),
-                                                entry(EpollChannelOption.TCP_KEEPIDLE, pingIntervalMillis));
-        } else if (type == TransportType.IO_URING) {
-            if (SystemInfo.javaVersion() >= 9) {
-                assertThat(newOptions).containsOnly(entry(ChannelOption.SO_LINGER, lingerMillis),
-                                                    entry(ChannelOption.SO_KEEPALIVE, true),
-                                                    entry(IoUringChannelOption.TCP_KEEPINTVL,
-                                                          pingIntervalMillis),
-                                                    entry(IoUringChannelOption.TCP_KEEPIDLE,
-                                                          pingIntervalMillis));
-            }
-        } else {
-            assertThat(newOptions).containsExactlyEntriesOf(options);
-        }
-
-        // user defined options are respected
-        final Map<ChannelOption<?>, Object> userDefinedOptions = ImmutableMap.of(
-                ChannelOption.SO_LINGER, lingerMillis, ChannelOption.SO_KEEPALIVE, false);
-        newOptions = ChannelUtil.applyDefaultChannelOptions(
-                true, type, userDefinedOptions, 0, pingIntervalMillis);
-        assertThat(newOptions).containsExactlyInAnyOrderEntriesOf(userDefinedOptions);
     }
 }


### PR DESCRIPTION
 Motivation:

This changeset attempts to fix a bug where ClientFactoryOptions.`PING_INTERVAL_MILLIS` (in milliseconds) was passed directly to `TCP_KEEPIDLE/TCP_KEEPINTVL` (seconds). This mismatch could set values far above the kernel limit (e.g., 60,000) and now throws exceptions during channel option validation (Netty 4.1.131+), whereas earlier versions logged internally.

ref: https://discord.com/channels/1087271586832318494/1087272728177942629/1476019079608402045

In the original PR which introduced this change (https://github.com/line/armeria/issues/2976), I think I didn't fully think through the benefits of introducing the default option for `SO_KEEPALIVE`, `TCP_KEEPIDLE `, `TCP_KEEPINTVL `.

I propose that the TCP keepalive behavior by default is removed. TCP keepalive introduces additional complexity without much benefit.

For more context, `TCP_USER_TIMEOUT` and `TCP_KEEP*` serve different purposes:
- `TCP_USER_TIMEOUT` bounds unacked data time and surfaces "stuck" connections to the app during active
  traffic. This timeout provides additional context which the application can use to detect idle connections.
- `TCP_KEEP*` sends probes at the TCP layer for each specified `pingIntervalMillis`. However, tcp layer pings do not add additional value as application layer ping logic/validation logic is stricter than tcp probes. This means tcp probes add kernel work without improving detection when app-layer pings are already active.

Modifications:

  - Stop deriving `TCP_KEEPIDLE/TCP_KEEPINTVL` (and `SO_KEEPALIVE`) from `pingIntervalMillis`
  - Update `useDefaultSocketOptions` docs to reflect that only `TCP_USER_TIMEOUT` is applied by default.
  - `ChannelUtil#isTcpOption` checks options by name

Result:

  - Default socket options now only apply `TCP_USER_TIMEOUT`; `pingIntervalMillis` no longer auto-configures TCP keepalive.
  - Prevents invalid `TCP_KEEP*` values and the resulting exceptions during channel option validation.
  - Users who need TCP keepalive can configure it explicitly via channel options or OS defaults.
