### PR TITLE
Allow creating non-CA (leaf) certificates

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateParams.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateParams.java
@@ -41,6 +41,7 @@ final class CertificateParams {
     private final Date notAfter;
     private final String algorithm;
     private final ImmutableList<String> subjectAlternativeNames;
+    private final boolean isCA;
 
     @Nullable
     private final X509Certificate issuerCert;
@@ -48,8 +49,9 @@ final class CertificateParams {
     private final PrivateKey issuerPrivateKey;
     private final X500Name issuerName;
 
+    // For self-signed certificate
     CertificateParams(String fqdn, Random random, int bits, Date notBefore, Date notAfter,
-                      String algorithm, Iterable<String> subjectAlternativeNames) {
+                      String algorithm, Iterable<String> subjectAlternativeNames, boolean isCA) {
         this.fqdn = requireNonNull(fqdn, "fqdn");
         this.random = requireNonNull(random, "random");
         this.bits = bits;
@@ -58,6 +60,7 @@ final class CertificateParams {
         this.algorithm = requireNonNull(algorithm, "algorithm");
         this.subjectAlternativeNames =
                 ImmutableList.copyOf(requireNonNull(subjectAlternativeNames, "subjectAlternativeNames"));
+        this.isCA = isCA;
         issuerCert = null;
         issuerPrivateKey = null;
 
@@ -65,14 +68,9 @@ final class CertificateParams {
         issuerName = ownerName;
     }
 
+    // For signed certificate
     CertificateParams(String fqdn, Random random, int bits, Date notBefore, Date notAfter,
-                      SignedCertificate issuer)
-            throws CertificateException {
-        this(fqdn, random, bits, notBefore, notAfter, issuer, ImmutableList.of());
-    }
-
-    CertificateParams(String fqdn, Random random, int bits, Date notBefore, Date notAfter,
-                      SignedCertificate issuer, Iterable<String> subjectAlternativeNames)
+                      SignedCertificate issuer, Iterable<String> subjectAlternativeNames, boolean isCA)
             throws CertificateException {
         this.fqdn = requireNonNull(fqdn, "fqdn");
         ownerName = new X500Name("CN=" + fqdn);
@@ -83,6 +81,7 @@ final class CertificateParams {
         this.notAfter = requireNonNull(notAfter, "notAfter");
         this.subjectAlternativeNames =
                 ImmutableList.copyOf(requireNonNull(subjectAlternativeNames, "subjectAlternativeNames"));
+        this.isCA = isCA;
         requireNonNull(issuer, "issuer");
         algorithm = issuer.key().getAlgorithm();
         issuerCert = issuer.cert();
@@ -132,5 +131,9 @@ final class CertificateParams {
 
     ImmutableList<String> subjectAlternativeNames() {
         return subjectAlternativeNames;
+    }
+
+    boolean isCA() {
+        return isCA;
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SelfSignedCertificate.java
@@ -217,7 +217,25 @@ public final class SelfSignedCertificate extends SignedCertificate {
     public SelfSignedCertificate(String fqdn, Random random, int bits, Date notBefore, Date notAfter,
                                  String algorithm, Iterable<String> subjectAlternativeNames)
             throws CertificateException {
+        this(fqdn, random, bits, notBefore, notAfter, algorithm, subjectAlternativeNames, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param fqdn                     a fully qualified domain name
+     * @param random                   the {@link Random} to use
+     * @param bits                     the number of bits of the generated private key
+     * @param notBefore                Certificate is not valid before this time
+     * @param notAfter                 Certificate is not valid after this time
+     * @param algorithm                Key pair algorithm
+     * @param subjectAlternativeNames  additional Subject Alternative Names
+     * @param isCA                     whether the certificate should be a CA certificate
+     */
+    public SelfSignedCertificate(String fqdn, Random random, int bits, Date notBefore, Date notAfter,
+                                 String algorithm, Iterable<String> subjectAlternativeNames, boolean isCA)
+            throws CertificateException {
         super(new CertificateParams(fqdn, random, bits, notBefore, notAfter, algorithm,
-                                    subjectAlternativeNames));
+                                    subjectAlternativeNames, isCA));
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SignedCertificate.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SignedCertificate.java
@@ -72,6 +72,8 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.util.Exceptions;
 
 import io.netty.buffer.ByteBuf;
@@ -136,7 +138,7 @@ public class SignedCertificate {
      * <p> Algorithm: RSA </p>
      */
     public SignedCertificate(SignedCertificate parent) throws CertificateException {
-        this("localhost", parent);
+        this("localhost", parent, true);
     }
 
     /**
@@ -146,9 +148,7 @@ public class SignedCertificate {
      * @param fqdn a fully qualified domain name
      */
     public SignedCertificate(String fqdn, SignedCertificate parent) throws CertificateException {
-        this(new CertificateParams(requireNonNull(fqdn, "fqdn"), ThreadLocalRandom.current(),
-                                   DEFAULT_KEY_LENGTH_BITS, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER,
-                                   requireNonNull(parent, "parent")));
+        this(fqdn, parent, true);
     }
 
     /**
@@ -161,10 +161,38 @@ public class SignedCertificate {
      */
     public SignedCertificate(String fqdn, SignedCertificate parent,
                              Iterable<String> subjectAlternativeNames) throws CertificateException {
+        this(fqdn, parent, subjectAlternativeNames, true);
+    }
+
+    /**
+     * Creates a new instance.
+     * <p> Algorithm: RSA </p>
+     *
+     * @param fqdn a fully qualified domain name
+     * @param parent the parent certificate to sign with
+     * @param isCA whether the certificate should be a CA certificate
+     */
+    public SignedCertificate(String fqdn, SignedCertificate parent, boolean isCA)
+            throws CertificateException {
+        this(fqdn, parent, ImmutableList.of(), isCA);
+    }
+
+    /**
+     * Creates a new instance.
+     * <p> Algorithm: RSA </p>
+     *
+     * @param fqdn a fully qualified domain name
+     * @param parent the parent certificate to sign with
+     * @param subjectAlternativeNames additional Subject Alternative Names
+     * @param isCA whether the certificate should be a CA certificate
+     */
+    public SignedCertificate(String fqdn, SignedCertificate parent,
+                             Iterable<String> subjectAlternativeNames, boolean isCA)
+            throws CertificateException {
         this(new CertificateParams(requireNonNull(fqdn, "fqdn"), ThreadLocalRandom.current(),
                                    DEFAULT_KEY_LENGTH_BITS, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER,
                                    requireNonNull(parent, "parent"),
-                                   requireNonNull(subjectAlternativeNames, "subjectAlternativeNames")));
+                                   requireNonNull(subjectAlternativeNames, "subjectAlternativeNames"), isCA));
     }
 
     /**
@@ -298,8 +326,7 @@ public class SignedCertificate {
         builder.addExtension(subjectAlternativeName,
                              false,
                              new GeneralNames(names.toArray(new GeneralName[0])));
-        // certs can sign other certs
-        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(params.isCA()));
         if (params.issuerCert() != null) {
             final JcaX509ExtensionUtils extUtils = new JcaX509ExtensionUtils();
             builder.addExtension(Extension.authorityKeyIdentifier, false,

--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/SelfSignedCertificateExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/SelfSignedCertificateExtension.java
@@ -114,10 +114,27 @@ public final class SelfSignedCertificateExtension extends SignedCertificateExten
     public SelfSignedCertificateExtension(String fqdn, SecureRandom random, int bits,
                                           TemporalAccessor notBefore, TemporalAccessor notAfter,
                                           Iterable<String> subjectAlternativeNames) {
+        this(fqdn, random, bits, notBefore, notAfter, subjectAlternativeNames, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param fqdn a fully qualified domain name
+     * @param random the {@link SecureRandom} to use
+     * @param bits the number of bits of the generated private key
+     * @param notBefore {@link Certificate} is not valid before this time
+     * @param notAfter {@link Certificate} is not valid after this time
+     * @param subjectAlternativeNames additional Subject Alternative Names
+     * @param isCA whether the certificate should be a CA certificate
+     */
+    public SelfSignedCertificateExtension(String fqdn, SecureRandom random, int bits,
+                                          TemporalAccessor notBefore, TemporalAccessor notAfter,
+                                          Iterable<String> subjectAlternativeNames, boolean isCA) {
         super(() -> new SelfSignedCertificate(fqdn, random, bits,
                                               toDate(requireNonNull(notBefore, "notBefore")),
                                               toDate(requireNonNull(notAfter, "notAfter")), "RSA",
-                                              subjectAlternativeNames));
+                                              subjectAlternativeNames, isCA));
     }
 
     @SuppressWarnings("UseOfObsoleteDateTimeApi")

--- a/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/SignedCertificateExtension.java
+++ b/junit5/src/main/java/com/linecorp/armeria/testing/junit5/server/SignedCertificateExtension.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.TlsKeyPair;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -49,9 +51,8 @@ public class SignedCertificateExtension extends AbstractAllOrEachExtension {
     /**
      * Creates a new instance.
      */
-    @SuppressWarnings("CopyConstructorMissesField")
     public SignedCertificateExtension(SignedCertificateExtension parent) {
-        this(() -> new SignedCertificate(requireNonNull(parent, "parent").signedCertificate()));
+        this(parent, true);
     }
 
     /**
@@ -60,7 +61,7 @@ public class SignedCertificateExtension extends AbstractAllOrEachExtension {
      * @param fqdn a fully qualified domain name
      */
     public SignedCertificateExtension(String fqdn, SignedCertificateExtension parent) {
-        this(() -> new SignedCertificate(fqdn, requireNonNull(parent, "parent").signedCertificate()));
+        this(fqdn, parent, ImmutableList.of());
     }
 
     /**
@@ -72,8 +73,42 @@ public class SignedCertificateExtension extends AbstractAllOrEachExtension {
      */
     public SignedCertificateExtension(String fqdn, SignedCertificateExtension parent,
                                       Iterable<String> subjectAlternativeNames) {
+        this(fqdn, parent, subjectAlternativeNames, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param parent the parent extension to sign with
+     * @param isCA   whether the certificate should be a CA certificate
+     */
+    public SignedCertificateExtension(SignedCertificateExtension parent, boolean isCA) {
+        this("localhost", parent, isCA);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param fqdn   a fully qualified domain name
+     * @param parent the parent extension to sign with
+     * @param isCA   whether the certificate should be a CA certificate
+     */
+    public SignedCertificateExtension(String fqdn, SignedCertificateExtension parent, boolean isCA) {
+        this(fqdn, parent, ImmutableList.of(), isCA);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param fqdn                    a fully qualified domain name
+     * @param parent                  the parent extension to sign with
+     * @param subjectAlternativeNames additional Subject Alternative Names
+     * @param isCA                    whether the certificate should be a CA certificate
+     */
+    public SignedCertificateExtension(String fqdn, SignedCertificateExtension parent,
+                                      Iterable<String> subjectAlternativeNames, boolean isCA) {
         this(() -> new SignedCertificate(fqdn, requireNonNull(parent, "parent").signedCertificate(),
-                                         subjectAlternativeNames));
+                                         subjectAlternativeNames, isCA));
     }
 
     SignedCertificateExtension(ThrowingSupplier<SignedCertificate> certificateFactory) {

--- a/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/SignedCertificateExtensionTest.java
+++ b/junit5/src/test/java/com/linecorp/armeria/testing/junit5/server/SignedCertificateExtensionTest.java
@@ -44,8 +44,13 @@ class SignedCertificateExtensionTest {
                     "*.example.com",
                     "192.168.1.1",
                     "spiffe://example.com/service"
-            )
-    );
+            ),
+            false);
+
+    @RegisterExtension
+    @Order(3)
+    static final SignedCertificateExtension intermediateCa = new SignedCertificateExtension(
+            "intermediate.example.com", parent, true);
 
     @Test
     void signedCertificateWithParentAndSans() throws Exception {
@@ -75,6 +80,19 @@ class SignedCertificateExtensionTest {
         assertThat(dnsNames).contains("service.example.com", "api.example.com", "*.example.com");
         assertThat(ipAddresses).contains("192.168.1.1");
         assertThat(uris).contains("spiffe://example.com/service");
+
+        // Leaf cert must not be a CA
+        assertThat(cert.getBasicConstraints()).isEqualTo(-1);
+        // Parent (self-signed root) must be a CA
+        assertThat(parent.certificate().getBasicConstraints()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void intermediateCaIsSignedByParentAndIsCA() throws Exception {
+        final X509Certificate cert = intermediateCa.certificate();
+        cert.verify(parent.certificate().getPublicKey());
+        // isCA=true → getBasicConstraints() >= 0
+        assertThat(cert.getBasicConstraints()).isGreaterThanOrEqualTo(0);
     }
 }
 


### PR DESCRIPTION
Motivation:
Previously, the certificate generation logic for both self-signed and signed certificates was hardcoded to set the `isCA` (is Certificate Authority) basic constraint to `true`. This meant that every generated certificate was effectively a CA certificate. Using a CA certificate where a leaf certificate is expected can lead to TLS validation failures in clients or systems with strict Public Key Infrastructure (PKI) policies.

Modifications:
- Added a new boolean parameter, `isCA`, to the certificate generation methods.

Result:
- You can now generate both CA and non-CA (leaf) certificates.