### PR TITLE
Provide a way to extract a Node IP address from labels or annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ typings/
 
 # Claude
 CLAUDE.md
+.claude/settings.local.json

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.function.Predicate;
+import java.util.function.Function;
 
 import org.jctools.maps.NonBlockingHashMap;
 import org.slf4j.Logger;
@@ -46,7 +46,6 @@ import com.linecorp.armeria.common.util.ShutdownHooks;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 
 import io.fabric8.kubernetes.api.model.Node;
-import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.api.model.NodeList;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -215,7 +214,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
     private final String serviceName;
     @Nullable
     private final String portName;
-    private final Predicate<? super NodeAddress> nodeAddressFilter;
+    private final Function<Node, @Nullable String> nodeIpExtractor;
     private final long maxWatchAgeMillis;
 
     @Nullable
@@ -250,7 +249,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
     private volatile int numPodFailures;
 
     KubernetesEndpointGroup(KubernetesClient client, @Nullable String namespace, String serviceName,
-                            @Nullable String portName, Predicate<? super NodeAddress> nodeAddressFilter,
+                            @Nullable String portName, Function<Node, @Nullable String> nodeIpExtractor,
                             boolean autoClose, EndpointSelectionStrategy selectionStrategy,
                             boolean allowEmptyEndpoints, long selectionTimeoutMillis, long maxWatchAgeMillis) {
         super(selectionStrategy, allowEmptyEndpoints, selectionTimeoutMillis);
@@ -258,7 +257,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         this.namespace = namespace;
         this.serviceName = serviceName;
         this.portName = portName;
-        this.nodeAddressFilter = nodeAddressFilter;
+        this.nodeIpExtractor = nodeIpExtractor;
         this.autoClose = autoClose;
         this.maxWatchAgeMillis = maxWatchAgeMillis == Long.MAX_VALUE ? 0 : maxWatchAgeMillis;
         executeJob(() -> start(true));
@@ -596,10 +595,16 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         switch (action) {
             case ADDED:
             case MODIFIED:
-                final String nodeIp = node.getStatus().getAddresses().stream()
-                                          .filter(nodeAddressFilter)
-                                          .map(NodeAddress::getAddress)
-                                          .findFirst().orElse(null);
+                final String nodeIp;
+                try {
+                    nodeIp = nodeIpExtractor.apply(node);
+                } catch (Throwable ex) {
+                    logger.warn("[{}/{}] Failed to extract the IP address of the node: {}",
+                                namespace, serviceName, nodeName, ex);
+                    nodeToIp.remove(nodeName);
+                    return true;
+                }
+
                 if (nodeIp == null) {
                     logger.debug("[{}/{}] No matching IP address is found in {}. node: {}",
                                  namespace, serviceName, nodeName, node);

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupBuilder.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.google.common.base.Strings;
@@ -32,6 +33,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
+import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeAddress;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
@@ -44,6 +46,16 @@ public final class KubernetesEndpointGroupBuilder
         extends AbstractDynamicEndpointGroupBuilder<KubernetesEndpointGroupBuilder> {
 
     private static final int DEFAULT_MAX_WATCH_AGE_MILLIS = 10 * 60 * 1000; // 10 minutes
+    private static final Predicate<? super NodeAddress> DEFAULT_NODE_ADDRESS_FILTER = nodeAddress ->
+            "InternalIP".equals(nodeAddress.getType()) && !Strings.isNullOrEmpty(nodeAddress.getAddress());
+
+    private static Function<Node, @Nullable String> toNodeIpExtractor(
+            Predicate<? super NodeAddress> addressFilter) {
+        return node -> node.getStatus().getAddresses().stream()
+                           .filter(addressFilter)
+                           .map(NodeAddress::getAddress)
+                           .findFirst().orElse(null);
+    }
 
     private final KubernetesClient kubernetesClient;
     private final boolean autoClose;
@@ -56,8 +68,8 @@ public final class KubernetesEndpointGroupBuilder
     @Nullable
     private String portName;
 
-    private Predicate<? super NodeAddress> nodeAddressFilter = nodeAddress ->
-            "InternalIP".equals(nodeAddress.getType()) && !Strings.isNullOrEmpty(nodeAddress.getAddress());
+    private Function<Node, @Nullable String> nodeIpExtractor = toNodeIpExtractor(DEFAULT_NODE_ADDRESS_FILTER);
+
     private long maxWatchAgeMillis = DEFAULT_MAX_WATCH_AGE_MILLIS;
 
     KubernetesEndpointGroupBuilder(KubernetesClient kubernetesClient, boolean autoClose) {
@@ -103,7 +115,23 @@ public final class KubernetesEndpointGroupBuilder
      */
     public KubernetesEndpointGroupBuilder nodeAddressFilter(Predicate<? super NodeAddress> nodeAddressFilter) {
         requireNonNull(nodeAddressFilter, "nodeAddressFilter");
-        this.nodeAddressFilter = nodeAddressFilter;
+        return nodeIpExtractor(toNodeIpExtractor(nodeAddressFilter));
+    }
+
+    /**
+     * Sets the {@link Function} to extract the IP address of a Kubernetes {@link Node}.
+     * If unspecified, the default is to select an {@code InternalIP} address that is not empty.
+     * This method provides more flexibility than {@link #nodeAddressFilter(Predicate)} as it allows you to
+     * use other properties of the {@link Node} to determine the IP address, such as labels or annotations.
+     *
+     * <p>Note that this method is mutually exclusive with {@link #nodeAddressFilter(Predicate)}. If both
+     * methods are called, the last one will take precedence.
+     */
+    public KubernetesEndpointGroupBuilder nodeIpExtractor(
+            Function<? super Node, @Nullable String> nodeIpExtractor) {
+        requireNonNull(nodeIpExtractor, "nodeIpExtractor");
+        //noinspection unchecked
+        this.nodeIpExtractor = (Function<Node, @Nullable String>) nodeIpExtractor;
         return this;
     }
 
@@ -148,7 +176,7 @@ public final class KubernetesEndpointGroupBuilder
     public KubernetesEndpointGroup build() {
         checkState(serviceName != null, "serviceName not set");
         return new KubernetesEndpointGroup(kubernetesClient, namespace, serviceName, portName,
-                                           nodeAddressFilter, autoClose,
+                                           nodeIpExtractor, autoClose,
                                            selectionStrategy, shouldAllowEmptyEndpoints(),
                                            selectionTimeoutMillis(), maxWatchAgeMillis);
     }

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -320,6 +321,60 @@ class KubernetesEndpointGroupMockServerTest {
             );
         });
         endpointGroup.close();
+    }
+
+    @Test
+    void shouldUseAnnotationsToGetNodeIp() {
+        // Create nodes with annotations containing custom IPs different from InternalIP
+        final String annotationKey = "custom-ip";
+        final Node node1 = newNode("1.1.1.1");
+        node1.getMetadata().setAnnotations(ImmutableMap.of(annotationKey, "10.0.0.1"));
+        final Node node2 = newNode("2.2.2.2");
+        node2.getMetadata().setAnnotations(ImmutableMap.of(annotationKey, "10.0.0.2"));
+        final Node node3 = newNode("3.3.3.3");
+        node3.getMetadata().setAnnotations(ImmutableMap.of(annotationKey, "10.0.0.3"));
+        final List<Node> nodes = ImmutableList.of(node1, node2, node3);
+
+        final Deployment deployment = newDeployment();
+        final int nodePort = 30000;
+        final Service service = newService(nodePort);
+        final List<Pod> pods = nodes.stream()
+                                    .map(node -> node.getMetadata().getName())
+                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
+                                    .collect(toImmutableList());
+
+        // Create Kubernetes resources
+        for (Node node : nodes) {
+            client.nodes().resource(node).create();
+        }
+        for (Pod pod : pods) {
+            client.pods().resource(pod).create();
+        }
+        client.apps().deployments().resource(deployment).create();
+        client.services().resource(service).create();
+
+        // Use nodeIpExtractor to extract the IP from annotations
+        try (KubernetesEndpointGroup endpointGroup =
+                     KubernetesEndpointGroup.builder(client, false)
+                                            .serviceName("nginx-service")
+                                            .nodeIpExtractor(node -> {
+                                                final Map<String, String> annotations =
+                                                        node.getMetadata().getAnnotations();
+                                                if (annotations == null) {
+                                                    return null;
+                                                }
+                                                return annotations.get(annotationKey);
+                                            })
+                                            .build()) {
+            await().untilAsserted(() -> {
+                assertThat(endpointGroup.whenReady()).isDone();
+                // Endpoints should use the annotation IPs, not the InternalIP addresses
+                assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(
+                        Endpoint.of("10.0.0.1", nodePort),
+                        Endpoint.of("10.0.0.2", nodePort),
+                        Endpoint.of("10.0.0.3", nodePort));
+            });
+        }
     }
 
     private static Node newNode(String ip, String type) {


### PR DESCRIPTION
Motivation:

Instead of relying only on the kubelet-provided
`status.addresses[].InternalIP`, we may want to use an IP provided by a CNI (Container Network Interface) such as Calico. In that case, the IP should be obtained from the Node's metadata (e.g., labels or annotations)

Modifications:

- Added `nodeIpExtractor(Function<Node, String)` to `KubernetesEndopintGroupBuilder` as an extension point.
- Make `nodeIpExtrator` and `nodeAddressFilter` mutually exclusive so they cannot be configured at the same time.

Result:

`KubernetesEndpointGroup` can now be configured to extract a Node IP from labels and annotations.