### PR TITLE
Fix TCP_USER_TIMEOUT overflow

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -233,8 +233,10 @@ public final class ChannelUtil {
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
         if (idleTimeoutMillis > 0) {
-            final int tcpUserTimeoutMillis =
-                    Ints.saturatedCast(idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS);
+            final long safeSumMillis = Math.min(idleTimeoutMillis,
+                                                Long.MAX_VALUE - TCP_USER_TIMEOUT_BUFFER_MILLIS)
+                                       + TCP_USER_TIMEOUT_BUFFER_MILLIS;
+            final int tcpUserTimeoutMillis = Ints.saturatedCast(safeSumMillis);
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
                 assert epollTcpUserTimeout != null;

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/ChannelUtil.java
@@ -33,6 +33,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.math.LongMath;
 import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.common.Flags;
@@ -233,10 +234,9 @@ public final class ChannelUtil {
         final ImmutableMap.Builder<ChannelOption<?>, Object> newChannelOptionsBuilder = ImmutableMap.builder();
 
         if (idleTimeoutMillis > 0) {
-            final long safeSumMillis = Math.min(idleTimeoutMillis,
-                                                Long.MAX_VALUE - TCP_USER_TIMEOUT_BUFFER_MILLIS)
-                                       + TCP_USER_TIMEOUT_BUFFER_MILLIS;
-            final int tcpUserTimeoutMillis = Ints.saturatedCast(safeSumMillis);
+            final int tcpUserTimeoutMillis =
+                    Ints.saturatedCast(LongMath.saturatedAdd(idleTimeoutMillis,
+                                                             TCP_USER_TIMEOUT_BUFFER_MILLIS));
             if (transportType == TransportType.EPOLL &&
                 canAddChannelOption(epollTcpUserTimeout, channelOptions)) {
                 assert epollTcpUserTimeout != null;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -116,7 +116,7 @@ public class ChannelUtilTest {
         // Long.MAX_VALUE should not cause overflow — should clamp to Integer.MAX_VALUE
         final Map<ChannelOption<?>, Object> newOptions =
                 ChannelUtil.applyDefaultChannelOptions(
-                        true, transportType, options, Long.MAX_VALUE, 0);
+                        true, transportType, options, Long.MAX_VALUE);
         assertThat(newOptions).containsEntry(option, Integer.MAX_VALUE);
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -113,7 +113,6 @@ public class ChannelUtilTest {
         final Map<ChannelOption<?>, Object> options = ImmutableMap.of(
                 ChannelOption.SO_LINGER, 1000);
 
-        // Long.MAX_VALUE should not cause overflow — should clamp to Integer.MAX_VALUE
         final Map<ChannelOption<?>, Object> newOptions =
                 ChannelUtil.applyDefaultChannelOptions(
                         true, transportType, options, Long.MAX_VALUE);

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/ChannelUtilTest.java
@@ -107,6 +107,19 @@ public class ChannelUtilTest {
         assertThat(newOptions).containsExactlyInAnyOrderEntriesOf(userDefinedOptions);
     }
 
+    @ParameterizedTest
+    @MethodSource("tcpUserTimeout_arguments")
+    void tcpUserTimeoutWithMaxIdleTimeout(TransportType transportType, ChannelOption<?> option) {
+        final Map<ChannelOption<?>, Object> options = ImmutableMap.of(
+                ChannelOption.SO_LINGER, 1000);
+
+        // Long.MAX_VALUE should not cause overflow — should clamp to Integer.MAX_VALUE
+        final Map<ChannelOption<?>, Object> newOptions =
+                ChannelUtil.applyDefaultChannelOptions(
+                        true, transportType, options, Long.MAX_VALUE, 0);
+        assertThat(newOptions).containsEntry(option, Integer.MAX_VALUE);
+    }
+
     @Test
     void tcpUserTimeoutUnsupportedTransport() {
         final Map<ChannelOption<?>, Object> options = ImmutableMap.of(


### PR DESCRIPTION
 Motivation:

  `ChannelUtil.applyDefaultChannelOptions()` overflows when `idleTimeoutMillis` is near `Long.MAX_VALUE`. The expression `idleTimeoutMillis + TCP_USER_TIMEOUT_BUFFER_MILLIS` (where the buffer is 5,000)
   wraps the `long` type to a large negative number, and `Ints.saturatedCast()` then clamps it to `Integer.MIN_VALUE` (-2,147,483,648).

  Linux rejects this negative value for `TCP_USER_TIMEOUT` via `setsockopt()` with `EINVAL`. Starting with **Netty 4.1.131+**, channel option values are validated at set time and throw exceptions
  instead of being silently logged internally (see https://github.com/netty/netty/pull/15896). This means the overflow now causes a hard failure rather than a silent misconfiguration.

  Modifications:

  - Use `LongMath.saturatedAdd` to prevent the `long` overflow before passing the result to `Ints.saturatedCast`:
    ```java
    final int tcpUserTimeoutMillis =
            Ints.saturatedCast(LongMath.saturatedAdd(idleTimeoutMillis,
                                                     TCP_USER_TIMEOUT_BUFFER_MILLIS));
  - Add a regression test that passes Long.MAX_VALUE as idleTimeoutMillis and asserts the result is Integer.MAX_VALUE.

  Result:

  - Long.MAX_VALUE idle timeout no longer overflows — produces Integer.MAX_VALUE (~24.8 day timeout) instead of Integer.MIN_VALUE (rejected by Linux).
  - For normal values (e.g., 2000), Math.min is a no-op and behavior is unchanged.
