### PR TITLE
Allow configuring a Maven Central mirror via system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,12 @@ plugins {
 
 allprojects {
     repositories {
-        mavenCentral()
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
 
 allprojects {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         } else {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,8 +3,13 @@ plugins {
 }
 
 repositories {
+	def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+	if (mavenCentralMirror) {
+		maven { url = mavenCentralMirror }
+	} else {
+		mavenCentral()
+	}
 	gradlePluginPortal()
-	mavenCentral()
 }
 
 dependencies {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-	def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+	def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
 	if (mavenCentralMirror) {
 		maven { url = mavenCentralMirror }
 	} else {

--- a/gradle/scripts/README.md
+++ b/gradle/scripts/README.md
@@ -36,6 +36,7 @@ sensible defaults. By applying them, you can:
 - [Setting a Kotlin target version with the `kotlin(\\d+\\.\\d+)` flag](#setting-a-koltin-target-version-with-the-kotlindd-flag)
 - [Automatic module names](#automatic-module-names)
 - [Tagging conveniently with `release` task](#tagging-conveniently-with-release-task)
+- [Using a Maven Central mirror](#using-a-maven-central-mirror)
 
 <!-- /MarkdownTOC -->
 
@@ -759,3 +760,25 @@ instructions after tagging:
 Note the `${tag}`, which is replaced with the tag name.
 See [Groovy `SimpleTemplateEngine`](http://docs.groovy-lang.org/docs/next/html/documentation/template-engines.html#_simpletemplateengine)
 for the syntax.
+
+## Using a Maven Central mirror
+
+If your organization blocks direct access to Maven Central (e.g. for supply chain security), you can
+redirect all Maven Central requests to an internal mirror by setting the `mavenCentralMirror` Gradle
+property.
+
+Add to `~/.gradle/gradle.properties`:
+
+```properties
+mavenCentralMirror=https://your-mirror.example.com/repository/maven-central/
+```
+
+Or pass via the CLI:
+
+```bash
+./gradlew build -PmavenCentralMirror=https://your-mirror.example.com/repository/maven-central/
+```
+
+When set, the mirror URL replaces `mavenCentral()` in all repository declarations including
+`settings.gradle`, `buildSrc`, and `buildscript` blocks of applied scripts. When unset, behavior
+is identical to the default — fully backward compatible.

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -4,7 +4,12 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
-        mavenCentral()
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
         gradlePluginPortal()
     }
 
@@ -36,7 +41,12 @@ configure(dependencyManagementProject) {
         google()
         // Since we manage plugin versions here too.
         gradlePluginPortal()
-        mavenCentral()
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
     }
 
     javaPlatform {

--- a/gradle/scripts/lib/common-dependencies.gradle
+++ b/gradle/scripts/lib/common-dependencies.gradle
@@ -4,7 +4,7 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         } else {
@@ -41,7 +41,7 @@ configure(dependencyManagementProject) {
         google()
         // Since we manage plugin versions here too.
         gradlePluginPortal()
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         } else {

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -2,6 +2,10 @@ import org.gradle.internal.os.OperatingSystem
 
 buildscript {
     repositories {
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        }
         gradlePluginPortal()
     }
     dependencies {

--- a/gradle/scripts/lib/java-rpc-proto.gradle
+++ b/gradle/scripts/lib/java-rpc-proto.gradle
@@ -2,7 +2,7 @@ import org.gradle.internal.os.OperatingSystem
 
 buildscript {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -5,6 +5,10 @@ import java.util.concurrent.atomic.AtomicInteger
 
 buildscript {
     repositories {
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        }
         gradlePluginPortal()
         google()
     }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 buildscript {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         }

--- a/gradle/scripts/version-catalog.gradle
+++ b/gradle/scripts/version-catalog.gradle
@@ -4,7 +4,12 @@ import org.tomlj.TomlArray
 
 buildscript {
     repositories {
-        mavenCentral()
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
     }
 
     dependencies {

--- a/gradle/scripts/version-catalog.gradle
+++ b/gradle/scripts/version-catalog.gradle
@@ -4,7 +4,7 @@ import org.tomlj.TomlArray
 
 buildscript {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         } else {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,15 @@
+// Use -DmavenCentralMirror=<url> or systemProp.mavenCentralMirror=<url> in
+// ~/.gradle/gradle.properties to redirect all Maven Central requests to a mirror.
+pluginManagement {
+    repositories {
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        }
+        gradlePluginPortal()
+    }
+}
+
 plugins {
     // This plugin should be applied in settings.gradle, not build.gradle.
     // https://github.com/gradle/foojay-toolchains/issues/15

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,8 @@
-// Use -DmavenCentralMirror=<url> or systemProp.mavenCentralMirror=<url> in
+// Use -PmavenCentralMirror=<url> or mavenCentralMirror=<url> in
 // ~/.gradle/gradle.properties to redirect all Maven Central requests to a mirror.
 pluginManagement {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         }

--- a/site-new/build.gradle
+++ b/site-new/build.gradle
@@ -9,8 +9,13 @@ import java.util.stream.Collectors
 
 buildscript {
     repositories {
+        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
         gradlePluginPortal()
-        mavenCentral()
     }
     dependencies {
         classpath libs.jsoup

--- a/site-new/build.gradle
+++ b/site-new/build.gradle
@@ -9,7 +9,7 @@ import java.util.stream.Collectors
 
 buildscript {
     repositories {
-        def mavenCentralMirror = System.getProperty('mavenCentralMirror')
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
         if (mavenCentralMirror) {
             maven { url = mavenCentralMirror }
         } else {


### PR DESCRIPTION
## Motivation

Due to recent supply chain security concerns, many organizations block direct access to Maven Central and route artifact downloads through an internal mirror or proxy for auditing and control.

Armeria's build currently hardcodes `mavenCentral()` and `gradlePluginPortal()` across multiple Gradle scripts, including `buildscript {}` blocks in `apply from:` scripts that **cannot** be overridden via Gradle init scripts. This makes it impossible to build Armeria in restricted network environments without modifying project files directly.

## Modifications

- Introduced a `mavenCentralMirror` Java system property recognized by all repository declarations.
- When set, the mirror URL replaces `mavenCentral()` (and supplements it where appropriate).
- When unset, behavior is identical to the current build — fully backward compatible.
- Added a `pluginManagement` block to `settings.gradle` to cover settings-level plugin resolution.

## Usage

Add to `~/.gradle/gradle.properties`:

```properties
systemProp.mavenCentralMirror=https://your-mirror.example.com
```

Or pass via the CLI:

```bash
./gradlew build -DmavenCentralMirror=https://your-mirror.example.com
```

### Why `System.getProperty()` instead of Gradle project properties?

`buildscript {}` blocks in `apply from:` scripts use separate `ScriptHandler` objects that cannot access project-level extensions or properties. `System.getProperty()` is the only mechanism available in **all** evaluation contexts: `settings.gradle`, `buildSrc`, and applied scripts' `buildscript {}` blocks.

## Result

- **`mavenCentralMirror` is set:** all Maven Central traffic is routed through the specified mirror.
- **`mavenCentralMirror` is not set:** no behavior change.