### PR TITLE
Try to trigger CI automatically for PRs created by the xDS protobuf update

### DIFF
--- a/.github/workflows/xds-apply-updates.yml
+++ b/.github/workflows/xds-apply-updates.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.ARMERIAN_PAT }}
           branch: update-xds-protobuf
           base: main
           author: Meri Kim <dl_armeria@linecorp.com>

--- a/.github/workflows/xds-sync-apis.yml
+++ b/.github/workflows/xds-sync-apis.yml
@@ -21,5 +21,4 @@ jobs:
     uses: ./.github/workflows/xds-apply-updates.yml
     with:
       target_version: ${{ needs.envoy-versions.outputs.target_version }}
-    secrets:
-      ARMERIAN_PAT: ${{ secrets.ARMERIAN_PAT }}
+    secrets: inherit

--- a/.github/workflows/xds-sync-apis.yml
+++ b/.github/workflows/xds-sync-apis.yml
@@ -21,3 +21,4 @@ jobs:
     uses: ./.github/workflows/xds-apply-updates.yml
     with:
       target_version: ${{ needs.envoy-versions.outputs.target_version }}
+    secrets: inherit

--- a/.github/workflows/xds-sync-apis.yml
+++ b/.github/workflows/xds-sync-apis.yml
@@ -21,4 +21,5 @@ jobs:
     uses: ./.github/workflows/xds-apply-updates.yml
     with:
       target_version: ${{ needs.envoy-versions.outputs.target_version }}
-    secrets: inherit
+    secrets:
+      ARMERIAN_PAT: ${{ secrets.ARMERIAN_PAT }}

--- a/xds-api/tools/update-api.sh
+++ b/xds-api/tools/update-api.sh
@@ -4,7 +4,7 @@
 
 set -o errexit
 set -o pipefail
-set -o xtrace
+#set -o xtrace
 
 __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/xds-api/tools/update-sha.sh
+++ b/xds-api/tools/update-sha.sh
@@ -5,7 +5,7 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -o xtrace
+#set -o xtrace
 
 # Optional: set GITHUB_TOKEN to avoid API rate limits
 # e.g. GITHUB_TOKEN=ghp_xxx ./update-sha.sh v1.36.4

--- a/xds-api/tools/update-sha.sh
+++ b/xds-api/tools/update-sha.sh
@@ -7,6 +7,27 @@ set -o pipefail
 set -o nounset
 set -o xtrace
 
+# Optional: set GITHUB_TOKEN to avoid API rate limits
+# e.g. GITHUB_TOKEN=ghp_xxx ./update-sha.sh v1.36.4
+CURL_AUTH=()
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  CURL_AUTH=(-H "Authorization: token $GITHUB_TOKEN")
+fi
+
+function github_curl() {
+  local HTTP_CODE BODY TMPFILE
+  TMPFILE=$(mktemp)
+  HTTP_CODE=$(curl -s -o "$TMPFILE" -w '%{http_code}' "${CURL_AUTH[@]+"${CURL_AUTH[@]}"}" "$@")
+  BODY=$(cat "$TMPFILE")
+  rm -f "$TMPFILE"
+  if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+    echo "error: HTTP $HTTP_CODE from $*" >&2
+    echo "$BODY" >&2
+    return 1
+  fi
+  echo "$BODY"
+}
+
 function find_sha() {
   local CONTENT=$1
   local DEPENDENCY=$2
@@ -21,13 +42,17 @@ function find_date() {
 
 function find_envoy_sha_from_tag() {
   local TAG=$1
-  curl -s https://api.github.com/repos/envoyproxy/envoy/tags | grep "$TAG" -A 4 | grep sha | awk '{print $2}' | tr -d '"' | tr -d ","
+  github_curl https://api.github.com/repos/envoyproxy/envoy/tags | grep "$TAG" -A 4 | grep sha | awk '{print $2}' | tr -d '"' | tr -d ","
 }
 
 CURRENT_ENVOY_RELEASE=$(cat envoy_release)
 ENVOY_VERSION=$(find_envoy_sha_from_tag "$1")
+if [[ -z "$ENVOY_VERSION" ]]; then
+  echo "error: could not resolve SHA for tag '$1' (tag not found or API rate-limited)" >&2
+  exit 1
+fi
 
-CURL_OUTPUT=$(curl -s "https://raw.githubusercontent.com/envoyproxy/envoy/$ENVOY_VERSION/api/bazel/repository_locations.bzl")
+CURL_OUTPUT=$(github_curl "https://raw.githubusercontent.com/envoyproxy/envoy/$ENVOY_VERSION/api/bazel/repository_locations.bzl")
 
 GOOGLEAPIS_SHA=$(find_sha "$CURL_OUTPUT" com_google_googleapis)
 GOOGLEAPIS_DATE=$(find_date "$CURL_OUTPUT" com_google_googleapis)


### PR DESCRIPTION
Motivation:

The `xds-apply-updates.yml` workflow creates PRs using the default `GITHUB_TOKEN` via `peter-evans/create-pull-request`. Apparently CI is not run for events created with `GITHUB_TOKEN`, so the automatically created xDS protobuf update PRs never get CI runs.

Sample: https://github.com/jrhee17/armeria/pull/45

Modifications:

- Use `ARMERIAN_PAT` instead of the default `GITHUB_TOKEN` in the `peter-evans/create-pull-request` step of `xds-apply-updates.yml`.
- Add `secrets: inherit` to `xds-sync-apis.yml` so that `ARMERIAN_PAT` is available to the called workflow.
- Misc) Calling `update-sha.sh` locally got me rate-limited. Added a way to add auth token headers.

Result:

- PRs created by the xDS protobuf update workflow will now trigger CI automatically.
