### PR TITLE
HTTP2 cleartext upgrades fallback to use/not use preface

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/BootstrapSslContexts.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BootstrapSslContexts.java
@@ -16,12 +16,6 @@
 
 package com.linecorp.armeria.client;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.common.SslContextFactory;
 
@@ -29,43 +23,37 @@ import io.netty.handler.ssl.SslContext;
 
 final class BootstrapSslContexts {
 
-    private final Map<SessionProtocol, ClientTlsSpec> tlsSpecs;
-    private final Map<SessionProtocol, SslContext> contexts;
+    private final ClientTlsSpec http1OnlyTlsSpec;
+    private final ClientTlsSpec defaultTlsSpec;
+    private final SslContext http1OnlySslCtx;
+    private final SslContext sslCtx;
 
     BootstrapSslContexts(ClientTlsSpec baseClientTlsSpec, ClientFactoryOptions options,
                          SslContextFactory sslContextFactory) {
-        final ImmutableMap.Builder<SessionProtocol, ClientTlsSpec> tlsSpecsBuilder = ImmutableMap.builder();
-        final ImmutableMap.Builder<SessionProtocol, SslContext> sslContextsBuilder = ImmutableMap.builder();
-        for (SessionProtocol sessionProtocol: SessionProtocol.httpsValues()) {
-            final ClientTlsSpec tlsSpec = baseClientTlsSpec.toBuilder()
-                                                           .engineType(options.tlsEngineType())
-                                                           .alpnProtocols(sessionProtocol)
-                                                           .tlsCustomizer(options.tlsCustomizer())
-                                                           .build();
-            tlsSpecsBuilder.put(sessionProtocol, tlsSpec);
-            sslContextsBuilder.put(sessionProtocol, sslContextFactory.getOrCreate(tlsSpec));
-        }
-        tlsSpecs =  tlsSpecsBuilder.build();
-        contexts = sslContextsBuilder.build();
+        http1OnlyTlsSpec = baseClientTlsSpec.toBuilder()
+                                            .engineType(options.tlsEngineType())
+                                            .alpnProtocols(SessionProtocol.H1)
+                                            .tlsCustomizer(options.tlsCustomizer())
+                                            .build();
+        defaultTlsSpec = baseClientTlsSpec.toBuilder()
+                                          .engineType(options.tlsEngineType())
+                                          .alpnProtocols(SessionProtocol.H2)
+                                          .tlsCustomizer(options.tlsCustomizer())
+                                          .build();
+        http1OnlySslCtx = sslContextFactory.getOrCreate(http1OnlyTlsSpec);
+        sslCtx = sslContextFactory.getOrCreate(defaultTlsSpec);
     }
 
     ClientTlsSpec getClientTlsSpec(SessionProtocol sessionProtocol) {
-        final ClientTlsSpec clientTlsSpec = tlsSpecs.get(sessionProtocol);
-        checkArgument(clientTlsSpec != null, "Unsupported protocol '%s'. Only TLS-enabled protocols" +
-                                             " have a default ClientTlsSpec.", sessionProtocol);
-        return clientTlsSpec;
+        return sessionProtocol.isExplicitHttp1() ? http1OnlyTlsSpec : defaultTlsSpec;
     }
 
-    SslContext getSslContext(SessionProtocol sessionProtocol) {
-        final SslContext sslContext = contexts.get(sessionProtocol);
-        checkArgument(sslContext != null, "Unsupported protocol '%s'. Only TLS-enabled protocols" +
-                                          " have a default ClientTlsSpec.", sessionProtocol);
-        return sslContext;
+    SslContext getSslContext(HttpPreference httpPreference) {
+        return httpPreference == HttpPreference.HTTP1_REQUIRED ? http1OnlySslCtx : sslCtx;
     }
 
     void release(SslContextFactory factory) {
-        for (SslContext sslContext: contexts.values()) {
-            factory.release(sslContext);
-        }
+        factory.release(http1OnlySslCtx);
+        factory.release(sslCtx);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Bootstraps.java
@@ -18,10 +18,11 @@ package com.linecorp.armeria.client;
 
 import static com.linecorp.armeria.common.SessionProtocol.httpAndHttpsValues;
 
-import java.lang.reflect.Array;
 import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -45,8 +46,7 @@ final class Bootstraps {
     private final BootstrapSslContexts bootstrapSslContexts;
     @Nullable
     private final Bootstrap unixBaseBootstrap;
-    private final Bootstrap[][] inetBootstraps;
-    private final Bootstrap @Nullable [][] unixBootstraps;
+    private final Map<BootstrapKey, Bootstrap> bootstraps;
 
     Bootstraps(HttpClientFactory clientFactory, EventLoop eventLoop,
                SslContextFactory sslContextFactory, BootstrapSslContexts bootstrapSslContexts) {
@@ -57,51 +57,49 @@ final class Bootstraps {
         inetBaseBootstrap = clientFactory.newInetBootstrap();
         this.bootstrapSslContexts = bootstrapSslContexts;
         inetBaseBootstrap.group(eventLoop);
-        inetBootstraps = staticBootstrapMap(inetBaseBootstrap);
 
         unixBaseBootstrap = clientFactory.newUnixBootstrap();
         if (unixBaseBootstrap != null) {
             unixBaseBootstrap.group(eventLoop);
-            unixBootstraps = staticBootstrapMap(unixBaseBootstrap);
-        } else {
-            unixBootstraps = null;
+        }
+
+        bootstraps = staticBootstrapMap();
+    }
+
+    private Map<BootstrapKey, Bootstrap> staticBootstrapMap() {
+        final Map<BootstrapKey, Bootstrap> map = new HashMap<>();
+        populateBootstraps(map, inetBaseBootstrap, false);
+        if (unixBaseBootstrap != null) {
+            populateBootstraps(map, unixBaseBootstrap, true);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+
+    private void populateBootstraps(Map<BootstrapKey, Bootstrap> map,
+                                    Bootstrap baseBootstrap, boolean domainSocket) {
+        for (HttpPreference p : HttpPreference.values()) {
+            final SslContext sslCtx = bootstrapSslContexts.getSslContext(p);
+            createAndSetBootstrap(baseBootstrap, map, domainSocket, p, null, true);
+            createAndSetBootstrap(baseBootstrap, map, domainSocket, p, null, false);
+            createAndSetBootstrap(baseBootstrap, map, domainSocket, p, sslCtx, true);
+            createAndSetBootstrap(baseBootstrap, map, domainSocket, p, sslCtx, false);
         }
     }
 
-    private Bootstrap[][] staticBootstrapMap(Bootstrap baseBootstrap) {
-        final Set<SessionProtocol> sessionProtocols = httpAndHttpsValues();
-        final Bootstrap[][] maps = (Bootstrap[][]) Array.newInstance(
-                Bootstrap.class, SessionProtocol.values().length, 2);
-        // Attempting to access the array with an unallowed protocol will trigger NPE,
-        // which will help us find a bug.
-        for (SessionProtocol p : sessionProtocols) {
-            final SslContext sslCtx = p.isTls() ? bootstrapSslContexts.getSslContext(p) : null;
-            createAndSetBootstrap(baseBootstrap, maps, p, sslCtx, true);
-            createAndSetBootstrap(baseBootstrap, maps, p, sslCtx, false);
-        }
-        return maps;
+    private Bootstrap select(boolean isDomainSocket, HttpPreference httpPreference,
+                             SessionProtocol sessionProtocol, SerializationFormat serializationFormat) {
+        final BootstrapKey key = BootstrapKey.of(isDomainSocket, httpPreference, sessionProtocol.isTls(),
+                                                 serializationFormat == SerializationFormat.WS);
+        final Bootstrap bootstrap = bootstraps.get(key);
+        assert bootstrap != null : "No bootstrap found for " + key;
+        return bootstrap;
     }
 
-    private Bootstrap select(boolean isDomainSocket, SessionProtocol desiredProtocol,
-                             SerializationFormat serializationFormat) {
-        final Bootstrap[][] bootstraps = isDomainSocket ? unixBootstraps : inetBootstraps;
-        assert bootstraps != null;
-        return bootstraps[desiredProtocol.ordinal()][toIndex(serializationFormat)];
-    }
-
-    private void createAndSetBootstrap(Bootstrap baseBootstrap, Bootstrap[][] maps,
-                                       SessionProtocol desiredProtocol, @Nullable SslContext sslContext,
-                                       boolean webSocket) {
-        maps[desiredProtocol.ordinal()][toIndex(webSocket)] = newBootstrap(baseBootstrap, desiredProtocol,
-                                                                           sslContext, webSocket, false);
-    }
-
-    private static int toIndex(boolean webSocket) {
-        return webSocket ? 1 : 0;
-    }
-
-    private static int toIndex(SerializationFormat serializationFormat) {
-        return toIndex(serializationFormat == SerializationFormat.WS);
+    private void createAndSetBootstrap(Bootstrap baseBootstrap, Map<BootstrapKey, Bootstrap> map,
+                                       boolean domainSocket, HttpPreference httpPreference,
+                                       @Nullable SslContext sslContext, boolean webSocket) {
+        final BootstrapKey key = BootstrapKey.of(domainSocket, httpPreference, sslContext != null, webSocket);
+        map.put(key, newBootstrap(baseBootstrap, httpPreference, sslContext, webSocket, false));
     }
 
     /**
@@ -109,6 +107,7 @@ final class Bootstraps {
      * {@link SessionProtocol} and {@link SerializationFormat}.
      */
     Bootstrap getOrCreate(SocketAddress remoteAddress, SessionProtocol desiredProtocol,
+                          HttpPreference httpPreference,
                           SerializationFormat serializationFormat, ClientTlsSpec tlsSpec) {
         if (!httpAndHttpsValues().contains(desiredProtocol)) {
             throw new IllegalArgumentException("Unsupported session protocol: " + desiredProtocol);
@@ -121,31 +120,31 @@ final class Bootstraps {
         }
 
         if (!desiredProtocol.isTls()) {
-            return select(isDomainSocket, desiredProtocol, serializationFormat);
+            return select(isDomainSocket, httpPreference, desiredProtocol, serializationFormat);
         }
         final ClientTlsSpec defaultTlsSpec = bootstrapSslContexts.getClientTlsSpec(desiredProtocol);
         if (Objects.equals(defaultTlsSpec, tlsSpec)) {
-            return select(isDomainSocket, desiredProtocol, serializationFormat);
+            return select(isDomainSocket, httpPreference, desiredProtocol, serializationFormat);
         }
 
         final Bootstrap baseBootstrap = isDomainSocket ? unixBaseBootstrap : inetBaseBootstrap;
         assert baseBootstrap != null;
-        return newBootstrap(baseBootstrap, desiredProtocol, serializationFormat, tlsSpec);
+        return newBootstrap(baseBootstrap, httpPreference, serializationFormat, tlsSpec);
     }
 
     private Bootstrap newBootstrap(Bootstrap baseBootstrap,
-                                   SessionProtocol desiredProtocol,
+                                   HttpPreference httpPreference,
                                    SerializationFormat serializationFormat, ClientTlsSpec tlsSpec) {
         final boolean webSocket = serializationFormat == SerializationFormat.WS;
         final SslContext sslContext = sslContextFactory.getOrCreate(tlsSpec);
-        return newBootstrap(baseBootstrap, desiredProtocol, sslContext, webSocket, true);
+        return newBootstrap(baseBootstrap, httpPreference, sslContext, webSocket, true);
     }
 
-    private Bootstrap newBootstrap(Bootstrap baseBootstrap, SessionProtocol desiredProtocol,
+    private Bootstrap newBootstrap(Bootstrap baseBootstrap, HttpPreference httpPreference,
                                    @Nullable SslContext sslContext, boolean webSocket,
                                    boolean closeSslContext) {
         final Bootstrap bootstrap = baseBootstrap.clone();
-        bootstrap.handler(clientChannelInitializer(desiredProtocol, sslContext, webSocket, closeSslContext));
+        bootstrap.handler(clientChannelInitializer(httpPreference, sslContext, webSocket, closeSslContext));
         return bootstrap;
     }
 
@@ -157,8 +156,9 @@ final class Bootstraps {
         sslContextFactory.release(sslContext);
     }
 
-    private ChannelInitializer<Channel> clientChannelInitializer(SessionProtocol p, @Nullable SslContext sslCtx,
-                                                                 boolean webSocket, boolean closeSslContext) {
+    private ChannelInitializer<Channel> clientChannelInitializer(
+            HttpPreference httpPreference, @Nullable SslContext sslCtx,
+            boolean webSocket, boolean closeSslContext) {
         return new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
@@ -166,8 +166,88 @@ final class Bootstraps {
                     ch.closeFuture().addListener(unused -> release(sslCtx));
                 }
                 ch.pipeline().addLast(new HttpClientPipelineConfigurator(
-                        clientFactory, webSocket, p, sslCtx));
+                        clientFactory, webSocket, httpPreference, sslCtx));
             }
         };
+    }
+
+    private static final class BootstrapKey {
+
+        // 2 (domainSocket) * 4 (httpPreference) * 2 (tls) * 2 (webSocket) = 32
+        private static final BootstrapKey[] CACHE;
+
+        static {
+            final HttpPreference[] preferences = HttpPreference.values();
+            assert preferences.length <= 4 : "BootstrapKey bit layout assumes at most 4 HttpPreference values";
+            CACHE = new BootstrapKey[preferences.length * 8]; // 8 = 2 (domainSocket) * 2 (tls) * 2 (webSocket)
+            for (HttpPreference p : preferences) {
+                for (int ds = 0; ds <= 1; ds++) {
+                    for (int tls = 0; tls <= 1; tls++) {
+                        for (int ws = 0; ws <= 1; ws++) {
+                            final boolean dsBool = ds == 1;
+                            final boolean tlsBool = tls == 1;
+                            final boolean wsBool = ws == 1;
+                            CACHE[index(dsBool, p, tlsBool, wsBool)] =
+                                    new BootstrapKey(dsBool, p, tlsBool, wsBool);
+                        }
+                    }
+                }
+            }
+        }
+
+        static BootstrapKey of(boolean domainSocket, HttpPreference httpPreference,
+                               boolean tls, boolean webSocket) {
+            return CACHE[index(domainSocket, httpPreference, tls, webSocket)];
+        }
+
+        private static int index(boolean domainSocket, HttpPreference httpPreference,
+                                  boolean tls, boolean webSocket) {
+            //  [domainSocket: 1 bit][httpPreference: 2 bits][tls: 1 bit][webSocket: 1 bit]
+            return ((domainSocket ? 1 : 0) << 4) |
+                   (httpPreference.ordinal() << 2) |
+                   ((tls ? 1 : 0) << 1) |
+                   (webSocket ? 1 : 0);
+        }
+
+        private final boolean domainSocket;
+        private final HttpPreference httpPreference;
+        private final boolean tls;
+        private final boolean webSocket;
+        private final int hashCode;
+
+        private BootstrapKey(boolean domainSocket, HttpPreference httpPreference,
+                             boolean tls, boolean webSocket) {
+            this.domainSocket = domainSocket;
+            this.httpPreference = httpPreference;
+            this.tls = tls;
+            this.webSocket = webSocket;
+            hashCode = Objects.hash(domainSocket, httpPreference, tls, webSocket);
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BootstrapKey)) {
+                return false;
+            }
+            final BootstrapKey that = (BootstrapKey) o;
+            return domainSocket == that.domainSocket &&
+                   httpPreference == that.httpPreference &&
+                   tls == that.tls &&
+                   webSocket == that.webSocket;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
+        @Override
+        public String toString() {
+            return "BootstrapKey(domainSocket=" + domainSocket + ", " + httpPreference +
+                   ", tls=" + tls + ", webSocket=" + webSocket + ')';
+        }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -856,8 +856,10 @@ public final class ClientFactoryBuilder implements TlsSetters {
     }
 
     /**
-     * Sets whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
-     * the protocol version of a cleartext HTTP connection.
+     * Sets whether to try the HTTP/2 connection preface before the HTTP/1.1 upgrade request when
+     * negotiating the protocol version of a cleartext HTTP connection. The client will try both
+     * strategies before falling back to HTTP/1.1; this option only controls which strategy is
+     * attempted first.
      */
     public ClientFactoryBuilder useHttp2Preface(boolean useHttp2Preface) {
         option(ClientFactoryOptions.USE_HTTP2_PREFACE, useHttp2Preface);

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -608,8 +608,10 @@ public final class ClientFactoryOptions
     }
 
     /**
-     * Returns whether to send an HTTP/2 preface string instead of an HTTP/1 upgrade request to negotiate
-     * the protocol version of a cleartext HTTP connection.
+     * Returns whether to try the HTTP/2 connection preface before the HTTP/1.1 upgrade request when
+     * negotiating the protocol version of a cleartext HTTP connection. The client will try both
+     * strategies before falling back to HTTP/1.1; this option only controls which strategy is
+     * attempted first.
      *
      * <p>Note that this option is only effective when the {@link SessionProtocol} of the {@link Endpoint} is
      * {@link SessionProtocol#HTTP}.

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultEventLoopScheduler.java
@@ -226,10 +226,8 @@ final class DefaultEventLoopScheduler implements EventLoopScheduler {
             return SessionProtocolNegotiationCache.isUnsupported(endpointWithPort, SessionProtocol.H2C);
         }
 
-        if (sessionProtocol == SessionProtocol.HTTPS) {
-            return SessionProtocolNegotiationCache.isUnsupported(endpointWithPort, SessionProtocol.H2);
-        }
-
+        // For HTTPS, ALPN handles negotiation per-connection and results are not cached,
+        // so we always assume H2 is possible
         return false;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -349,7 +349,9 @@ final class HttpChannelPool implements AsyncCloseable {
 
         // Fail immediately if it is certain that the remote address doesn't support the desired protocol.
         final SocketAddress remoteAddress = key.toRemoteAddress();
-        if (SessionProtocolNegotiationCache.isUnsupported(remoteAddress, desiredProtocol)) {
+        final HttpPreference pref =
+                HttpPreference.of(desiredProtocol, clientFactory.options().useHttp2Preface(), remoteAddress);
+        if (SessionProtocolNegotiationCache.isUnsupported(remoteAddress, pref)) {
             notifyConnect(desiredProtocol, key,
                           eventLoop.newFailedFuture(
                                   new SessionProtocolNegotiationException(
@@ -362,7 +364,7 @@ final class HttpChannelPool implements AsyncCloseable {
 
         // Create a new connection.
         final Promise<Channel> sessionPromise = eventLoop.newPromise();
-        connect(remoteAddress, desiredProtocol, serializationFormat, key, sessionPromise, timingsBuilder);
+        connect(remoteAddress, desiredProtocol, serializationFormat, key, sessionPromise, timingsBuilder, pref);
 
         if (sessionPromise.isDone()) {
             notifyConnect(desiredProtocol, key, sessionPromise, promise, timingsBuilder);
@@ -384,10 +386,11 @@ final class HttpChannelPool implements AsyncCloseable {
     void connect(SocketAddress remoteAddress, SessionProtocol desiredProtocol,
                  SerializationFormat serializationFormat,
                  PoolKey poolKey, Promise<Channel> sessionPromise,
-                 @Nullable ClientConnectionTimingsBuilder timingsBuilder) {
+                 @Nullable ClientConnectionTimingsBuilder timingsBuilder,
+                 HttpPreference httpPreference) {
         final Bootstrap bootstrap;
         try {
-            bootstrap = bootstraps.getOrCreate(remoteAddress, desiredProtocol,
+            bootstrap = bootstraps.getOrCreate(remoteAddress, desiredProtocol, httpPreference,
                                                serializationFormat, poolKey.tlsSpec);
         } catch (Exception e) {
             sessionPromise.tryFailure(e);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -22,8 +22,6 @@ import static com.linecorp.armeria.common.SessionProtocol.H1;
 import static com.linecorp.armeria.common.SessionProtocol.H1C;
 import static com.linecorp.armeria.common.SessionProtocol.H2;
 import static com.linecorp.armeria.common.SessionProtocol.H2C;
-import static com.linecorp.armeria.common.SessionProtocol.HTTP;
-import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static com.linecorp.armeria.internal.client.PendingExceptionUtil.setPendingException;
 import static io.netty.handler.codec.http.HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE;
@@ -103,6 +101,7 @@ import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2FrameReader;
+import io.netty.handler.codec.http2.Http2FrameTypes;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
@@ -141,12 +140,6 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         REQ_TARGET_ASTERISK = asterisk;
     }
 
-    private enum HttpPreference {
-        HTTP1_REQUIRED,
-        HTTP2_PREFERRED,
-        HTTP2_REQUIRED
-    }
-
     private final HttpClientFactory clientFactory;
     private final boolean webSocket;
     @Nullable
@@ -159,24 +152,13 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
     private final SessionProtocol http2;
 
     HttpClientPipelineConfigurator(HttpClientFactory clientFactory,
-                                   boolean webSocket, SessionProtocol sessionProtocol,
+                                   boolean webSocket, HttpPreference httpPreference,
                                    @Nullable SslContext sslCtx) {
         this.clientFactory = clientFactory;
         this.webSocket = webSocket;
+        this.httpPreference = httpPreference;
 
-        if (sessionProtocol == HTTP || sessionProtocol == HTTPS) {
-            httpPreference = HttpPreference.HTTP2_PREFERRED;
-        } else if (sessionProtocol == H1 || sessionProtocol == H1C) {
-            httpPreference = HttpPreference.HTTP1_REQUIRED;
-        } else if (sessionProtocol == H2 || sessionProtocol == H2C) {
-            httpPreference = HttpPreference.HTTP2_REQUIRED;
-        } else {
-            // Should never reach here.
-            throw new Error();
-        }
-
-        if (sessionProtocol.isTls()) {
-            assert sslCtx != null;
+        if (sslCtx != null) {
             this.sslCtx = sslCtx;
             http1 = H1;
             http2 = H2;
@@ -277,15 +259,11 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
 
                     addBeforeSessionHandler(p, newHttp2ConnectionHandler(ch, H2));
                     protocol = H2;
-                } else if (clientFactory.useHttp2WithoutAlpn() && attemptUpgrade()) {
-                    configureUpgradeCodec(ch, h -> addBeforeSessionHandler(p, h));
+                } else if (clientFactory.useHttp2WithoutAlpn() && attemptHttp2()) {
+                    configureHttp2Codec(ch, h -> addBeforeSessionHandler(p, h));
                     p.remove(this);
                     return;
                 } else {
-                    if (httpPreference != HttpPreference.HTTP1_REQUIRED) {
-                        SessionProtocolNegotiationCache.setUnsupported(remoteAddress(ctx), H2);
-                    }
-
                     if (httpPreference == HttpPreference.HTTP2_REQUIRED) {
                         finishWithNegotiationFailure(ctx, H2, H1, "unexpected protocol negotiation result");
                         return;
@@ -338,13 +316,14 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         return firstNonNull(ctx.channel().remoteAddress(), remoteAddress);
     }
 
-    private boolean attemptUpgrade() {
+    private boolean attemptHttp2() {
         switch (httpPreference) {
             case HTTP1_REQUIRED:
                 return false;
-            case HTTP2_PREFERRED:
+            case PREFACE:
+            case UPGRADE:
                 assert remoteAddress != null;
-                return !SessionProtocolNegotiationCache.isUnsupported(remoteAddress, H2C);
+                return !SessionProtocolNegotiationCache.isUnsupported(remoteAddress, httpPreference);
             case HTTP2_REQUIRED:
                 return true;
             default:
@@ -353,12 +332,9 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
     }
 
-    private void configureUpgradeCodec(Channel ch, Consumer<ChannelHandler> pipelineCustomizer) {
+    private void configureHttp2Codec(Channel ch, Consumer<ChannelHandler> pipelineCustomizer) {
         final Http2ClientConnectionHandler http2Handler = newHttp2ConnectionHandler(ch, http2);
-        // - h2c: HTTP/2 preface is always used.
-        // - http: Either HTTP/1.1 upgrade or HTTP/2 preface is used depending on 'useHttp2Preface()'.
-        final boolean shouldUsePreface = httpPreference == HttpPreference.HTTP2_REQUIRED ||
-                                         clientFactory.useHttp2Preface();
+        final boolean shouldUsePreface = httpPreference.isPreface();
         if (shouldUsePreface) {
             pipelineCustomizer.accept(new DowngradeHandler());
             pipelineCustomizer.accept(http2Handler);
@@ -374,6 +350,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                             http1Codec, http2ClientUpgradeCodec,
                             (int) Math.min(Integer.MAX_VALUE, UPGRADE_RESPONSE_MAX_LENGTH));
 
+            pipelineCustomizer.accept(new UpgradeFailureHandler());
             pipelineCustomizer.accept(http1Codec);
             pipelineCustomizer.accept(new WorkaroundHandler());
             pipelineCustomizer.accept(http2UpgradeHandler);
@@ -386,8 +363,8 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         final ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(TrafficLoggingHandler.CLIENT);
 
-        if (attemptUpgrade()) {
-            configureUpgradeCodec(ch, pipeline::addLast);
+        if (attemptHttp2()) {
+            configureHttp2Codec(ch, pipeline::addLast);
         } else {
             pipeline.addLast(newHttp1Codec(
                     clientFactory.http1MaxInitialLineLength(),
@@ -488,8 +465,8 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         private final Http2ResponseDecoder responseDecoder;
         @Nullable
         private UpgradeEvent upgradeEvt;
-        private String upgradeRejectionCause = "";
         private boolean needsToClose;
+        private boolean upgradeResponseReceived;
 
         UpgradeRequestHandler(Http2ResponseDecoder responseDecoder) {
             this.responseDecoder = responseDecoder;
@@ -598,7 +575,6 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
                 // The server rejected the upgrade request and sent its response in HTTP/1.
                 assert upgradeEvt == UPGRADE_REJECTED;
                 final HttpResponse res = (HttpResponse) msg;
-                upgradeRejectionCause = "Upgrade request rejected with: " + res;
                 // We can persist connection only when:
                 // - The response has 'Connection: keep-alive' header on HTTP/1.0.
                 // - The response has no 'Connection: close' header on HTTP/1.1.
@@ -642,6 +618,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
 
         private void onUpgradeResponse(ChannelHandlerContext ctx, boolean success) {
+            upgradeResponseReceived = true;
             final UpgradeEvent upgradeEvt = this.upgradeEvt;
             assert upgradeEvt != null : "received an upgrade response before an UpgradeEvent";
             final ChannelPipeline p = ctx.pipeline();
@@ -652,29 +629,61 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             if (needsToClose) {
                 // Server wants us to close the connection, which means we cannot use this connection
                 // to send the request that contains the actual invocation.
-                SessionProtocolNegotiationCache.setUnsupported(remoteAddress(ctx), http2);
-
-                if (httpPreference == HttpPreference.HTTP2_REQUIRED) {
-                    finishWithNegotiationFailure(ctx, http2, http1, upgradeRejectionCause);
-                } else {
-                    // We can silently retry with H1C.
-                    retryWith(ctx, http1);
-                }
+                maybeRetryAndCache(ctx);
                 return;
             }
 
             if (success) {
                 finishSuccessfully(p, http2);
             } else {
-                SessionProtocolNegotiationCache.setUnsupported(remoteAddress(ctx), http2);
-
-                if (httpPreference == HttpPreference.HTTP2_REQUIRED) {
-                    finishWithNegotiationFailure(ctx, http2, http1, upgradeRejectionCause);
+                maybeCacheUnsupportedPreference(ctx);
+                final HttpPreference nextPref = httpPreference.nextFallback(clientFactory.useHttp2Preface(),
+                                                                            remoteAddress(ctx));
+                if (nextPref != HttpPreference.HTTP1_REQUIRED) {
+                    // Upgrade failed but preface may still work; retry with a new connection.
+                    maybeRetry(ctx, nextPref);
                     return;
                 }
-
                 finishSuccessfully(p, http1);
             }
+        }
+    }
+
+    /**
+     * A handler placed before {@link HttpClientCodec} in the UPGRADE pipeline that detects if the server
+     * responds with HTTP/2 frames instead of an HTTP/1.1 response. This happens when the server speaks
+     * HTTP/2 but does not support HTTP/1.1 upgrade — it sees the {@code OPTIONS *} request as a protocol
+     * error and sends a GOAWAY. In that case we should retry with PREFACE.
+     */
+    private final class UpgradeFailureHandler extends ByteToMessageDecoder {
+
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+            if (in.readableBytes() < Http2CodecUtil.FRAME_HEADER_LENGTH) {
+                return;
+            }
+
+            if (isHttp2Frame(in)) {
+                // Server responded with an H2 frame to our HTTP/1.1 upgrade request.
+                maybeRetryAndCache(ctx);
+            }
+            ctx.pipeline().remove(this);
+        }
+
+        private boolean isHttp2Frame(ByteBuf in) {
+            //  https://datatracker.ietf.org/doc/html/rfc9113#section-4.1:
+            //  HTTP Frame {
+            //    Length (24),
+            //    Type (8),
+            //    Flags (8),
+            //    Reserved (1),
+            //    Stream Identifier (31),
+            //  }
+            // checks Type, Reserved
+            final int start = in.readerIndex();
+            final int frameType = in.getUnsignedByte(start + 3);
+            return frameType <= Http2FrameTypes.CONTINUATION &&
+                   (in.getInt(start + 5) & 0x80000000) == 0;
         }
     }
 
@@ -699,15 +708,7 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             if (!isSettingsFrame(in)) { // The first frame must be a settings frame.
                 // Http2ConnectionHandler sent the connection preface, but the server responded with
                 // something else, which means the server does not support HTTP/2.
-                SessionProtocolNegotiationCache.setUnsupported(remoteAddress(ctx), http2);
-                if (httpPreference == HttpPreference.HTTP2_REQUIRED) {
-                    finishWithNegotiationFailure(
-                            ctx, http2, http1,
-                            "received a non-HTTP/2 response for the HTTP/2 connection preface");
-                } else {
-                    // We can silently retry with HTTP/1.
-                    retryWith(ctx, http1);
-                }
+                maybeRetryAndCache(ctx);
 
                 // We are going to close the connection really soon, so we don't need the response.
                 in.skipBytes(in.readableBytes());
@@ -731,20 +732,36 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
             if (!handledResponse) {
                 // If the connection has been closed even without receiving anything useful,
                 // it is likely that the server failed to decode the preface string.
-                if (httpPreference == HttpPreference.HTTP2_REQUIRED) {
-                    finishWithNegotiationFailure(ctx, http2, http1,
-                                                 "too little data to determine the HTTP version");
-                } else {
-                    // We can silently retry with HTTP/1.
-                    retryWith(ctx, http1);
-                }
+                // We don't cache as the failure may not be specifically due to not supporting http2
+                maybeRetry(ctx);
             }
         }
     }
 
-    static void retryWith(ChannelHandlerContext ctx, SessionProtocol protocol) {
-        HttpSession.get(ctx.channel()).retryWith(protocol);
+    private void maybeRetryAndCache(ChannelHandlerContext ctx) {
+        maybeCacheUnsupportedPreference(ctx);
+        maybeRetry(ctx);
+    }
+
+    private void maybeRetry(ChannelHandlerContext ctx) {
+        final HttpPreference nextFallback =
+                httpPreference.nextFallback(clientFactory.useHttp2Preface(), remoteAddress(ctx));
+        maybeRetry(ctx, nextFallback);
+    }
+
+    private void maybeRetry(ChannelHandlerContext ctx, @Nullable HttpPreference nextFallback) {
+        if (nextFallback == null) {
+            finishWithNegotiationFailure(ctx, http2, http1, "HTTP/2 not supported by the server");
+            return;
+        }
+        HttpSession.get(ctx.channel()).retryWith(nextFallback);
         ctx.close();
+    }
+
+    private void maybeCacheUnsupportedPreference(ChannelHandlerContext ctx) {
+        if (sslCtx == null) {
+            SessionProtocolNegotiationCache.setUnsupported(remoteAddress(ctx), httpPreference);
+        }
     }
 
     private Http2ClientConnectionHandler newHttp2ConnectionHandler(Channel ch, SessionProtocol protocol) {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientPipelineConfigurator.java
@@ -466,7 +466,6 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         @Nullable
         private UpgradeEvent upgradeEvt;
         private boolean needsToClose;
-        private boolean upgradeResponseReceived;
 
         UpgradeRequestHandler(Http2ResponseDecoder responseDecoder) {
             this.responseDecoder = responseDecoder;
@@ -618,7 +617,6 @@ final class HttpClientPipelineConfigurator extends ChannelDuplexHandler {
         }
 
         private void onUpgradeResponse(ChannelHandlerContext ctx, boolean success) {
-            upgradeResponseReceived = true;
             final UpgradeEvent upgradeEvt = this.upgradeEvt;
             assert upgradeEvt != null : "received an upgrade response before an UpgradeEvent";
             final ChannelPipeline p = ctx.pipeline();

--- a/core/src/main/java/com/linecorp/armeria/client/HttpPreference.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpPreference.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.net.SocketAddress;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Specifies the HTTP/2 connection strategy to use when connecting to a server.
+ */
+@UnstableApi
+public enum HttpPreference {
+    HTTP1_REQUIRED,
+    HTTP2_REQUIRED,
+    /** Send the HTTP/2 connection preface directly. */
+    PREFACE,
+    /** Send an HTTP/1.1 upgrade request. */
+    UPGRADE;
+
+    static HttpPreference of(SessionProtocol desiredProtocol, boolean useHttp2Preface) {
+        if (desiredProtocol.isExplicitHttp1()) {
+            return HTTP1_REQUIRED;
+        } else if (desiredProtocol.isExplicitHttp2()) {
+            return HTTP2_REQUIRED;
+        } else if (useHttp2Preface) {
+            return PREFACE;
+        } else {
+            return UPGRADE;
+        }
+    }
+
+    static HttpPreference of(SessionProtocol desiredProtocol, boolean useHttp2Preface,
+                             SocketAddress remoteAddress) {
+        HttpPreference pref = of(desiredProtocol, useHttp2Preface);
+        while (SessionProtocolNegotiationCache.isUnsupported(remoteAddress, pref)) {
+            final HttpPreference next = pref.nextFallback(useHttp2Preface);
+            if (next == null) {
+                break;
+            }
+            pref = next;
+        }
+        return pref;
+    }
+
+    boolean isPreface() {
+        return this == PREFACE || this == HTTP2_REQUIRED;
+    }
+
+    @Nullable
+    HttpPreference nextFallback(boolean useHttp2Preface, SocketAddress remoteAddress) {
+        HttpPreference next = nextFallback(useHttp2Preface);
+        while (next != null && SessionProtocolNegotiationCache.isUnsupported(remoteAddress, next)) {
+            next = next.nextFallback(useHttp2Preface);
+        }
+        return next;
+    }
+
+    @Nullable
+    private HttpPreference nextFallback(boolean useHttp2Preface) {
+        switch (this) {
+            case PREFACE:
+                return useHttp2Preface ? UPGRADE : HTTP1_REQUIRED;
+            case UPGRADE:
+                return useHttp2Preface ? HTTP1_REQUIRED : PREFACE;
+            case HTTP1_REQUIRED:
+            case HTTP2_REQUIRED:
+                return null;
+            default:
+                throw new Error("Unexpected HttpPreference: " + this);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpSessionHandler.java
@@ -125,11 +125,10 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     private int numRequestsSent;
 
     /**
-     * {@code true} if the protocol upgrade to HTTP/2 has failed.
-     * If set to {@code true}, another connection attempt will follow.
+     * Set when the protocol upgrade to HTTP/2 has failed and another connection attempt will follow.
      */
     @Nullable
-    private SessionProtocol retryProtocol;
+    private HttpPreference nextPref;
 
     /**
      * {@code true} if an {@link Http2Settings} has been received from the remote endpoint.
@@ -328,8 +327,8 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
     }
 
     @Override
-    public void retryWith(SessionProtocol protocol) {
-        retryProtocol = protocol;
+    public void retryWith(HttpPreference httpPreference) {
+        nextPref = httpPreference;
     }
 
     @Override
@@ -537,18 +536,15 @@ final class HttpSessionHandler extends ChannelDuplexHandler implements HttpSessi
         isAcquirable = false;
 
         // Protocol upgrade has failed, but needs to retry.
-        if (retryProtocol != null) {
+        if (nextPref != null) {
             assert responseDecoder == null || !responseDecoder.hasUnfinishedResponses();
             if (sessionTimeoutFuture != null) {
                 sessionTimeoutFuture.cancel(false);
             }
-            if (proxyDestinationAddress != null) {
-                channelPool.connect(proxyDestinationAddress, retryProtocol, serializationFormat,
-                                    poolKey, sessionPromise, null);
-            } else {
-                channelPool.connect(remoteAddress, retryProtocol, serializationFormat, poolKey, sessionPromise,
-                                    null);
-            }
+            final SocketAddress addr = proxyDestinationAddress != null ? proxyDestinationAddress
+                                                                       : remoteAddress;
+            channelPool.connect(addr, desiredProtocol, serializationFormat, poolKey, sessionPromise,
+                                null, nextPref);
         } else {
             // Fail all pending responses.
             final HttpResponseDecoder responseDecoder = this.responseDecoder;

--- a/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
@@ -81,7 +81,41 @@ public final class SessionProtocolNegotiationCache {
         return isUnsupported(key(remoteAddress), protocol);
     }
 
+    /**
+     * Returns {@code true} if the specified {@link HttpPreference} is known to be unsupported for the given
+     * {@code remoteAddress}.
+     */
+    public static boolean isUnsupported(SocketAddress remoteAddress, HttpPreference preference) {
+        requireNonNull(remoteAddress, "remoteAddress");
+        requireNonNull(preference, "preference");
+        final CacheEntry e;
+        final long stamp = lock.readLock();
+        try {
+            e = cache.get(key(remoteAddress));
+        } finally {
+            lock.unlockRead(stamp);
+        }
+
+        if (e == null) {
+            return false;
+        }
+        switch (preference) {
+            case HTTP1_REQUIRED:
+                return false;
+            case HTTP2_REQUIRED:
+                preference = HttpPreference.PREFACE;
+                // fall through
+            case PREFACE:
+            case UPGRADE:
+                return e.isUnsupported(preference);
+        }
+        throw new Error();
+    }
+
     private static boolean isUnsupported(String key, SessionProtocol protocol) {
+        if (!isCacheableProtocol(protocol)) {
+            return false;
+        }
         final CacheEntry e;
         final long stamp = lock.readLock();
         try {
@@ -94,8 +128,13 @@ public final class SessionProtocolNegotiationCache {
             // Can't tell if it's unsupported
             return false;
         }
+        return e.h2cUnsupported();
+    }
 
-        return e.isUnsupported(protocol);
+    private static boolean isCacheableProtocol(SessionProtocol protocol) {
+        // TLS negotiation (ALPN) can differ per connection so caching is unreliable.
+        // HTTP, H1C is always supported
+        return protocol == SessionProtocol.H2C;
     }
 
     /**
@@ -104,10 +143,36 @@ public final class SessionProtocolNegotiationCache {
      */
     public static void setUnsupported(SocketAddress remoteAddress, SessionProtocol protocol) {
         requireNonNull(protocol, "protocol");
+        if (!isCacheableProtocol(protocol)) {
+            return;
+        }
         final String key = key(remoteAddress);
         final CacheEntry e = getOrCreate(key);
 
-        if (e.addUnsupported(protocol)) {
+        if (e.addUnsupported(HttpPreference.PREFACE) |
+            e.addUnsupported(HttpPreference.UPGRADE)) {
+            logger.debug("Updated: '{}' does not support {}", key, e);
+        }
+    }
+
+    /**
+     * Updates the cache with the information that the specified {@link HttpPreference} is not supported
+     * by the given {@code remoteAddress}.
+     */
+    public static void setUnsupported(SocketAddress remoteAddress, HttpPreference preference) {
+        requireNonNull(remoteAddress, "remoteAddress");
+        requireNonNull(preference, "preference");
+        switch (preference) {
+            case HTTP1_REQUIRED:
+                return;
+            case HTTP2_REQUIRED:
+                preference = HttpPreference.PREFACE;
+        }
+
+        final String key = key(remoteAddress);
+        final CacheEntry e = getOrCreate(key);
+
+        if (e.addUnsupported(preference)) {
             logger.debug("Updated: '{}' does not support {}", key, e);
         }
     }
@@ -204,33 +269,37 @@ public final class SessionProtocolNegotiationCache {
     }
 
     private static final class CacheEntry {
-        private volatile Set<SessionProtocol> unsupported = ImmutableSet.of();
+        private volatile Set<HttpPreference> failedPreferences = ImmutableSet.of();
 
         CacheEntry(@SuppressWarnings("unused") String key) {
             // Key is unused. It's just here to simplify the Map.computeIfAbsent() call in getOrCreate().
         }
 
-        boolean addUnsupported(SessionProtocol protocol) {
-            final Set<SessionProtocol> unsupported = this.unsupported;
-            if (unsupported.contains(protocol)) {
+        private boolean addUnsupported(HttpPreference preference) {
+            assert preference == HttpPreference.PREFACE || preference == HttpPreference.UPGRADE;
+            final Set<HttpPreference> current = failedPreferences;
+            if (current.contains(preference)) {
                 return false;
             }
-
-            this.unsupported = ImmutableSet.<SessionProtocol>builder()
-                                           .addAll(unsupported)
-                                           .add(protocol)
-                                           .build();
+            failedPreferences = ImmutableSet.<HttpPreference>builder()
+                                            .addAll(current)
+                                            .add(preference)
+                                            .build();
             return true;
         }
 
-        boolean isUnsupported(SessionProtocol protocol) {
-            requireNonNull(protocol, "protocol");
-            return unsupported.contains(protocol);
+        private boolean isUnsupported(HttpPreference preference) {
+            return failedPreferences.contains(preference);
+        }
+
+        private boolean h2cUnsupported() {
+            return failedPreferences.contains(HttpPreference.PREFACE) &&
+                   failedPreferences.contains(HttpPreference.UPGRADE);
         }
 
         @Override
         public String toString() {
-            return unsupported.toString();
+            return failedPreferences.toString();
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.DomainSocketAddress;
 import com.linecorp.armeria.common.util.LruMap;
 import com.linecorp.armeria.internal.common.util.DomainSocketUtil;
@@ -85,6 +86,7 @@ public final class SessionProtocolNegotiationCache {
      * Returns {@code true} if the specified {@link HttpPreference} is known to be unsupported for the given
      * {@code remoteAddress}.
      */
+    @UnstableApi
     public static boolean isUnsupported(SocketAddress remoteAddress, HttpPreference preference) {
         requireNonNull(remoteAddress, "remoteAddress");
         requireNonNull(preference, "preference");
@@ -159,6 +161,7 @@ public final class SessionProtocolNegotiationCache {
      * Updates the cache with the information that the specified {@link HttpPreference} is not supported
      * by the given {@code remoteAddress}.
      */
+    @UnstableApi
     public static void setUnsupported(SocketAddress remoteAddress, HttpPreference preference) {
         requireNonNull(remoteAddress, "remoteAddress");
         requireNonNull(preference, "preference");

--- a/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
+++ b/core/src/main/java/com/linecorp/armeria/client/SessionProtocolNegotiationCache.java
@@ -91,9 +91,10 @@ public final class SessionProtocolNegotiationCache {
         requireNonNull(remoteAddress, "remoteAddress");
         requireNonNull(preference, "preference");
         final CacheEntry e;
+        final String key = key(remoteAddress);
         final long stamp = lock.readLock();
         try {
-            e = cache.get(key(remoteAddress));
+            e = cache.get(key);
         } finally {
             lock.unlockRead(stamp);
         }

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -896,11 +896,10 @@ public final class Flags {
 
     /**
      * Returns the default value of the {@link ClientFactoryBuilder#useHttp2Preface(boolean)} option.
-     * If enabled, the HTTP/2 connection preface is sent immediately for a cleartext HTTP/2 connection,
+     * If enabled, the HTTP/2 connection preface is tried first for a cleartext HTTP/2 connection,
      * reducing an extra round trip incurred by the {@code OPTIONS * HTTP/1.1} upgrade request.
-     * If disabled, the {@code OPTIONS * HTTP/1.1} request with {@code "Upgrade: h2c"} header is sent for
-     * a cleartext HTTP/2 connection. Consider disabling this flag if your HTTP servers have issues
-     * handling or rejecting the HTTP/2 connection preface without a upgrade request.
+     * If disabled, the {@code OPTIONS * HTTP/1.1} request with {@code "Upgrade: h2c"} header is tried first.
+     * In both cases, the client will try the other strategy before falling back to HTTP/1.1.
      *
      * <p>Note that this option is only effective when the {@link SessionProtocol} of the {@link Endpoint} is
      * {@link SessionProtocol#HTTP}. This option does not affect ciphertext HTTP/2 connections, which use ALPN

--- a/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/common/FlagsProvider.java
@@ -471,11 +471,10 @@ public interface FlagsProvider {
 
     /**
      * Returns the default value of the {@link ClientFactoryBuilder#useHttp2Preface(boolean)} option.
-     * If enabled, the HTTP/2 connection preface is sent immediately for a cleartext HTTP/2 connection,
+     * If enabled, the HTTP/2 connection preface is tried first for a cleartext HTTP/2 connection,
      * reducing an extra round trip incurred by the {@code OPTIONS * HTTP/1.1} upgrade request.
-     * If disabled, the {@code OPTIONS * HTTP/1.1} request with {@code "Upgrade: h2c"} header is sent for
-     * a cleartext HTTP/2 connection. Consider disabling this flag if your HTTP servers have issues
-     * handling or rejecting the HTTP/2 connection preface without a upgrade request.
+     * If disabled, the {@code OPTIONS * HTTP/1.1} request with {@code "Upgrade: h2c"} header is tried first.
+     * In both cases, the client will try the other strategy before falling back to HTTP/1.1.
      * Note that this option does not affect ciphertext HTTP/2 connections, which use ALPN for protocol
      * negotiation, and it has no effect if a user specified the value explicitly via
      * {@link ClientFactoryBuilder#useHttp2Preface(boolean)}.

--- a/core/src/main/java/com/linecorp/armeria/internal/client/HttpSession.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/HttpSession.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.internal.client;
 
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.HttpPreference;
 import com.linecorp.armeria.client.WriteTimeoutException;
 import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpRequest;
@@ -76,7 +77,7 @@ public interface HttpSession {
         }
 
         @Override
-        public void retryWith(SessionProtocol protocol) {
+        public void retryWith(HttpPreference httpPreference) {
             throw new IllegalStateException();
         }
 
@@ -159,7 +160,7 @@ public interface HttpSession {
     void invoke(PooledChannel pooledChannel, ClientRequestContext ctx,
                 HttpRequest req, DecodedHttpResponse res);
 
-    void retryWith(SessionProtocol protocol);
+    void retryWith(HttpPreference httpPreference);
 
     int incrementAndGetNumRequestsSent();
 }

--- a/core/src/test/java/com/linecorp/armeria/client/Http2ClientPrefaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2ClientPrefaceTest.java
@@ -17,14 +17,12 @@
 package com.linecorp.armeria.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.internal.testing.NettyServerExtension;
@@ -63,6 +61,9 @@ class Http2ClientPrefaceTest {
     @ValueSource(booleans = { true, false })
     @ParameterizedTest
     void shouldUseConnectionPrefaceOrUpgradeForHttp(boolean useHttp2Preface) {
+        // With the H2C fallback chain, both cases succeed:
+        // - useHttp2Preface=true: preface succeeds directly
+        // - useHttp2Preface=false: upgrade fails → preface fallback succeeds
         try (ClientFactory factory = ClientFactory.builder()
                                                   .useHttp2Preface(useHttp2Preface)
                                                   .build()) {
@@ -70,15 +71,8 @@ class Http2ClientPrefaceTest {
                                                       .factory(factory)
                                                       .build()
                                                       .blocking();
-            if (useHttp2Preface) {
-                final AggregatedHttpResponse response = client.get("/");
-                assertThat(response.status()).isEqualTo(HttpStatus.OK);
-            } else {
-                // Upgrade HTTP/1.1 to HTTP/2 fails because the server only supports H2C.
-                assertThatThrownBy(() -> client.get("/"))
-                        .isInstanceOf(UnprocessedRequestException.class)
-                        .hasCauseInstanceOf(ClosedSessionException.class);
-            }
+            final AggregatedHttpResponse response = client.get("/");
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/Http2FallbackChainTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/Http2FallbackChainTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.testing.NettyServerExtension;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+
+class Http2FallbackChainTest {
+
+    private static final List<String> connectionAttempts = new CopyOnWriteArrayList<>();
+
+    // HTTP/1-only server that rejects both H2 preface and upgrade.
+    @RegisterExtension
+    static NettyServerExtension server = new NettyServerExtension() {
+        @Override
+        protected void configure(Channel ch) throws Exception {
+            ch.pipeline().addLast(new PrefaceDetector(),
+                                  new HttpServerCodec(),
+                                  new HttpObjectAggregator(65536),
+                                  new SimpleHttp1Handler());
+        }
+    };
+
+    @AfterEach
+    void clearState() {
+        connectionAttempts.clear();
+        SessionProtocolNegotiationCache.clear();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void fallbackChain(boolean useHttp2Preface) {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp2Preface(useHttp2Preface)
+                                                  .build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.endpoint().toUri(SessionProtocol.HTTP))
+                             .factory(factory)
+                             .build()
+                             .blocking();
+            final AggregatedHttpResponse response = client.get("/");
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+            assertThat(response.contentUtf8()).contains("HTTP/1");
+            if (useHttp2Preface) {
+                assertThat(connectionAttempts).containsExactly("preface", "upgrade", "http1");
+            } else {
+                assertThat(connectionAttempts).containsExactly("upgrade", "preface", "http1");
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void fallbackChainCachesPreferences(boolean useHttp2Preface) {
+        // First connection: exercises the full fallback chain (3 attempts).
+        try (ClientFactory factory1 = ClientFactory.builder()
+                                                   .useHttp2Preface(useHttp2Preface)
+                                                   .build()) {
+            final BlockingWebClient client1 =
+                    WebClient.builder(server.endpoint().toUri(SessionProtocol.HTTP))
+                             .factory(factory1)
+                             .build()
+                             .blocking();
+            final AggregatedHttpResponse response1 = client1.get("/");
+            assertThat(response1.status()).isEqualTo(HttpStatus.OK);
+            if (useHttp2Preface) {
+                assertThat(connectionAttempts).containsExactly("preface", "upgrade", "http1");
+            } else {
+                assertThat(connectionAttempts).containsExactly("upgrade", "preface", "http1");
+            }
+        }
+
+        // Clear attempt log but keep the static SessionProtocolNegotiationCache.
+        connectionAttempts.clear();
+
+        // Second connection with a new factory (new pool): should skip directly to HTTP/1.
+        try (ClientFactory factory2 = ClientFactory.builder()
+                                                   .useHttp2Preface(useHttp2Preface)
+                                                   .build()) {
+            final BlockingWebClient client2 =
+                    WebClient.builder(server.endpoint().toUri(SessionProtocol.HTTP))
+                             .factory(factory2)
+                             .build()
+                             .blocking();
+            final AggregatedHttpResponse response2 = client2.get("/");
+            assertThat(response2.status()).isEqualTo(HttpStatus.OK);
+            assertThat(connectionAttempts).containsExactly("http1");
+        }
+    }
+
+    // Detects H2 connection preface by inspecting raw bytes before the HTTP codec.
+    private static final class PrefaceDetector extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof ByteBuf) {
+                final ByteBuf buf = (ByteBuf) msg;
+                if (buf.readableBytes() >= 3 &&
+                    buf.getByte(buf.readerIndex()) == 'P' &&
+                    buf.getByte(buf.readerIndex() + 1) == 'R' &&
+                    buf.getByte(buf.readerIndex() + 2) == 'I') {
+                    connectionAttempts.add("preface");
+                    buf.release();
+                    final ByteBuf content = Unpooled.copiedBuffer("Non http2 settings frame",
+                                                                  CharsetUtil.UTF_8);
+                    ctx.writeAndFlush(content);
+                    return;
+                }
+            }
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    // Tracks upgrade vs plain HTTP/1 requests and responds with HTTP/1.1 200 OK.
+    private static final class SimpleHttp1Handler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (msg instanceof HttpRequest) {
+                try {
+                    final HttpRequest req = (HttpRequest) msg;
+                    if (req.headers().contains(HttpHeaderNames.UPGRADE)) {
+                        connectionAttempts.add("upgrade");
+                    } else {
+                        connectionAttempts.add("http1");
+                    }
+
+                    final ByteBuf content = Unpooled.copiedBuffer("Hello World - via HTTP/1",
+                                                                  CharsetUtil.UTF_8);
+                    final DefaultFullHttpResponse response = new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1, HttpResponseStatus.OK, content);
+                    response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+                    response.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+                    ctx.writeAndFlush(response);
+                } finally {
+                    ReferenceCountUtil.release(msg);
+                }
+                return;
+            }
+            ctx.fireChannelRead(msg);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/SessionProtocolNegotiationCacheTest.java
@@ -50,23 +50,26 @@ class SessionProtocolNegotiationCacheTest {
 
         SessionProtocolNegotiationCache.setUnsupported(aRemoteAddress, H2C);
         assertThat(SessionProtocolNegotiationCache.isUnsupported(a, H2C)).isTrue();
+        // TLS protocols (H2) are never cached because ALPN can differ per connection.
         assertThat(SessionProtocolNegotiationCache.isUnsupported(a, H2)).isFalse();
+    }
 
+    @Test
+    void tlsProtocolsAreNotCached() throws UnknownHostException {
+        // TLS negotiation (ALPN) can differ per connection (e.g. per-request TLS specs),
+        // so TLS protocol failures should not be cached.
         final Endpoint b = Endpoint.of("b", 443).withIpAddr("127.0.0.2");
         final InetSocketAddress bRemoteAddress = toRemoteAddress(b);
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2)).isFalse(); // Do not know yet.
 
         SessionProtocolNegotiationCache.setUnsupported(bRemoteAddress, H2);
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2)).isTrue();
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2C)).isFalse();
+        // setUnsupported is a no-op for TLS protocols.
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(b, H2)).isFalse();
 
         final Endpoint ip = Endpoint.of("127.0.0.3", 443);
         final InetSocketAddress ipRemoteAddress = toRemoteAddress(ip);
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2)).isFalse(); // Do not know yet.
 
         SessionProtocolNegotiationCache.setUnsupported(ipRemoteAddress, H2);
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2)).isTrue();
-        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2C)).isFalse();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(ip, H2)).isFalse();
     }
 
     /**
@@ -137,6 +140,39 @@ class SessionProtocolNegotiationCacheTest {
         assertThat(SessionProtocolNegotiationCache.key(
                 new io.netty.channel.unix.DomainSocketAddress("/var/run/foo.sock")))
                 .isEqualTo(expectedKey);
+    }
+
+    @Test
+    void prefaceAndUpgradeUnsupported() {
+        final InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 8080);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.PREFACE)).isFalse();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.UPGRADE)).isFalse();
+
+        SessionProtocolNegotiationCache.setUnsupported(addr, HttpPreference.PREFACE);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.PREFACE)).isTrue();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.UPGRADE)).isFalse();
+
+        SessionProtocolNegotiationCache.setUnsupported(addr, HttpPreference.UPGRADE);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.PREFACE)).isTrue();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.UPGRADE)).isTrue();
+    }
+
+    @Test
+    void clearAlsoClearsPreferences() {
+        final InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 9090);
+        SessionProtocolNegotiationCache.setUnsupported(addr, HttpPreference.PREFACE);
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.PREFACE)).isTrue();
+
+        SessionProtocolNegotiationCache.clear();
+        assertThat(SessionProtocolNegotiationCache.isUnsupported(
+                addr, HttpPreference.PREFACE)).isFalse();
     }
 
     private static InetSocketAddress toRemoteAddress(Endpoint endpoint) throws UnknownHostException {

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -479,7 +479,8 @@ class ProxyClientIntegrationTest {
             final AggregatedHttpResponse response = responseFuture.join();
             assertThat(response.status()).isEqualTo(HttpStatus.OK);
             assertThat(response.contentUtf8()).isEqualTo(HttpMethod.GET.name());
-            assertThat(numSuccessfulProxyRequests).isEqualTo(2);
+            // upgrade -> preface -> http1
+            assertThat(numSuccessfulProxyRequests).isEqualTo(3);
         }
     }
 

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/ThriftOverHttpClientTServletIntegrationTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.client.HttpPreference;
 import com.linecorp.armeria.client.SessionProtocolNegotiationCache;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
@@ -181,7 +182,8 @@ class ThriftOverHttpClientTServletIntegrationTest {
                     assertThat(cause.expected()).isEqualTo(H2C);
                     assertThat(cause.actual()).isEqualTo(H1C);
                     // .. and if the negotiation cache is updated.
-                    assertThat(SessionProtocolNegotiationCache.isUnsupported(remoteAddress, H2C)).isTrue();
+                    assertThat(SessionProtocolNegotiationCache
+                                       .isUnsupported(remoteAddress, HttpPreference.PREFACE)).isTrue();
                 });
 
         assertThatThrownBy(() -> client.hello("unused"))


### PR DESCRIPTION
Motivation:

When connecting to an HTTP/1-only server over cleartext with `useHttp2Preface=true`, the client
only tried the HTTP/2 connection preface and failed without attempting the HTTP/1.1 upgrade
mechanism (and vice versa when `useHttp2Preface=false`). This meant the `useHttp2Preface` flag
was an exclusive either/or choice rather than a preference for which strategy to try first.

Additionally, on subsequent connections from a new connection pool, the
`SessionProtocolNegotiationCache` only recorded "H2C unsupported" after the entire negotiation
failed — it did not track *which specific strategy* (preface vs upgrade) failed. This caused
every new connection pool to repeat the full negotiation from scratch.

The negotiation cache also previously cached TLS protocol negotiation results (e.g., H2 over
HTTPS). However, TLS protocol support is determined by ALPN during the TLS handshake, which can
differ per connection depending on the `SslContext` and server configuration. Caching ALPN
outcomes is unreliable and was removed.

Modifications:

- Introduced `HttpPreference` enum (`HTTP1_REQUIRED`, `HTTP2_REQUIRED`, `PREFACE`, `UPGRADE`)
  that encapsulates the HTTP/2 connection strategy and its fallback chain:
  - `useHttp2Preface=true`: PREFACE → UPGRADE → HTTP1_REQUIRED
  - `useHttp2Preface=false`: UPGRADE → PREFACE → HTTP1_REQUIRED
- Extended `SessionProtocolNegotiationCache` to track failed `HttpPreference` values (PREFACE
  and/or UPGRADE) independently per remote address, so subsequent connections can skip
  known-failed strategies.
- Removed TLS protocol caching from `SessionProtocolNegotiationCache` — only cleartext (H2C)
  negotiation failures are cached. TLS protocol support is determined by ALPN during the
  handshake, so caching is not meaningful.
- Refactored `HttpClientPipelineConfigurator` to use `HttpPreference` instead of deriving
  behavior from `SessionProtocol`:
  - Added `UpgradeFailureHandler` that detects when a server responds with HTTP/2 frames
    to an HTTP/1.1 upgrade request (e.g., GOAWAY) and retries with PREFACE.
  - `DowngradeHandler` now goes through the fallback chain instead of failing immediately.
  - Centralized retry/cache logic into `maybeRetry()` and `maybeCacheUnsupported()`.
- Simplified `BootstrapSslContexts` from a per-protocol `Map<SessionProtocol, SslContext>` to
  two contexts: `http1OnlySslCtx` and `sslCtx`.
- Refactored `Bootstraps` to key on `BootstrapKey(domainSocket, HttpPreference, tls, webSocket)`
  instead of a 2D array indexed by protocol ordinal.
- Changed `HttpSessionHandler.retryWith()` to accept `HttpPreference` instead of
  `SessionProtocol`, keeping the desired protocol stable while varying the connection strategy.
- Updated `DefaultEventLoopScheduler` to always assume H2 for HTTPS since ALPN results are
  no longer cached.
- Updated Javadoc for `useHttp2Preface` in `Flags`, `FlagsProvider`, `ClientFactoryBuilder`,
  and `ClientFactoryOptions` to reflect that it controls which strategy is tried first.

Result:

- Closes #6731
- The `useHttp2Preface` flag now controls the *order* of HTTP/2 strategies rather than being
  an exclusive choice. Both preface and upgrade are tried before falling back to HTTP/1.1.
- Subsequent connections to the same address skip known-failed strategies via the negotiation
  cache, reducing unnecessary round trips (e.g., from 3 attempts down to 1 for a known
  HTTP/1-only server).
- TLS protocol negotiation results are no longer cached, avoiding stale cache entries from
  interfering with ALPN-based negotiation.
