### PR TITLE
server: include requested file paths in 404 responses

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/AbstractHttpFile.java
@@ -196,9 +196,14 @@ public abstract class AbstractHttpFile implements HttpFile {
         requireNonNull(fileReadExecutor, "fileReadExecutor");
         requireNonNull(alloc, "alloc");
 
-        return readAttributes(fileReadExecutor)
-                .thenApply(attrs -> read(fileReadExecutor, alloc, attrs))
-                .exceptionally(cause -> HttpResponse.ofFailure(Exceptions.peel(cause)));
+        return readAttributes(fileReadExecutor).thenApply(attrs -> {
+            final HttpResponse res = read(fileReadExecutor, alloc, attrs);
+            if (res != null) {
+                return res;
+            }
+
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        }).exceptionally(cause -> HttpResponse.ofFailure(Exceptions.peel(cause)));
     }
 
     @Nullable

--- a/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/FileService.java
@@ -75,9 +75,6 @@ public final class FileService extends AbstractHttpService {
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',');
 
-    private static final UnmodifiableFuture<HttpFile> NON_EXISTENT_FILE_FUTURE =
-            UnmodifiableFuture.completedFuture(HttpFile.nonExistent());
-
     /**
      * Returns a new {@link FileService} for the specified {@code rootDir} in an O/S file system.
      */
@@ -244,12 +241,12 @@ public final class FileService extends AbstractHttpService {
                     // Auto-generate directory listing if enabled.
                     final Executor readExecutor = ctx.blockingTaskExecutor();
                     if (!config.autoIndex()) {
-                        return NON_EXISTENT_FILE_FUTURE;
+                        return UnmodifiableFuture.completedFuture(HttpFile.nonExistent(decodedMappedPath));
                     }
 
                     return config.vfs().canList(readExecutor, decodedMappedPath).thenCompose(canList -> {
                         if (!canList) {
-                            return NON_EXISTENT_FILE_FUTURE;
+                            return UnmodifiableFuture.completedFuture(HttpFile.nonExistent(decodedMappedPath));
                         }
 
                         return config.vfs().list(readExecutor, decodedMappedPath).thenApply(listing -> {
@@ -404,7 +401,7 @@ public final class FileService extends AbstractHttpService {
                     return HttpFile.ofRedirect(locationBuilder.toString());
                 }
             } else {
-                return HttpFile.nonExistent();
+                return HttpFile.nonExistent(decodedMappedPath);
             }
         });
     }

--- a/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/HttpFile.java
@@ -125,6 +125,15 @@ public interface HttpFile {
     }
 
     /**
+     * Returns an {@link HttpFile} which represents a non-existent file with the specified
+     * {@code decodedMappedPath}.
+     */
+    @UnstableApi
+    static HttpFile nonExistent(String decodedMappedPath) {
+        return new NonExistentHttpFile(null, decodedMappedPath);
+    }
+
+    /**
      * Returns an {@link HttpFile} redirected to the specified {@code location}.
      */
     static HttpFile ofRedirect(String location) {

--- a/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
+++ b/core/src/main/java/com/linecorp/armeria/server/file/NonExistentHttpFile.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Executor;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
@@ -29,7 +30,7 @@ import io.netty.buffer.ByteBufAllocator;
 
 final class NonExistentHttpFile implements HttpFile {
 
-    static final NonExistentHttpFile INSTANCE = new NonExistentHttpFile(null);
+    static final NonExistentHttpFile INSTANCE = new NonExistentHttpFile(null, null);
 
     private static final CompletableFuture<AggregatedHttpFile> AGGREGATED_FUTURE =
             UnmodifiableFuture.completedFuture(NonExistentAggregatedHttpFile.INSTANCE);
@@ -37,8 +38,17 @@ final class NonExistentHttpFile implements HttpFile {
     @Nullable
     private final String location;
 
+    @Nullable
+    private final String pathHint;
+
     NonExistentHttpFile(@Nullable String location) {
         this.location = location;
+        this.pathHint = null;
+    }
+
+    NonExistentHttpFile(@Nullable String location, @Nullable String pathHint) {
+        this.location = location;
+        this.pathHint = pathHint;
     }
 
     @Override
@@ -61,12 +71,20 @@ final class NonExistentHttpFile implements HttpFile {
         return (ctx, req) -> {
             switch (req.method()) {
                 case HEAD:
-                case GET:
-                    if (location == null) {
-                        return HttpResponse.of(HttpStatus.NOT_FOUND);
-                    } else {
+                    if (location != null) {
                         return HttpResponse.ofRedirect(location);
                     }
+                    return HttpResponse.of(HttpStatus.NOT_FOUND);
+                case GET:
+                    if (location != null) {
+                        return HttpResponse.ofRedirect(location);
+                    }
+                    if (pathHint != null) {
+                        return HttpResponse.of(HttpStatus.NOT_FOUND,
+                                               MediaType.PLAIN_TEXT_UTF_8,
+                                               "File not found: " + pathHint);
+                    }
+                    return HttpResponse.of(HttpStatus.NOT_FOUND);
                 default:
                     return HttpResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
             }
@@ -86,6 +104,7 @@ final class NonExistentHttpFile implements HttpFile {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName();
+        return getClass().getSimpleName() +
+               "(location: " + location + ", pathHint: " + pathHint + ")";
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/FileServiceTest.java
@@ -104,6 +104,12 @@ class FileServiceTest {
                                .build());
 
             sb.serviceUnder(
+                    "/cached/no-autoindex/fs/",
+                    FileService.builder(tmpDir)
+                               .autoIndex(false)
+                               .build());
+
+            sb.serviceUnder(
                     "/cached/compressed/",
                     FileService.builder(classLoader, baseResourceDir + "foo")
                                .serveCompressedFiles(true)
@@ -685,6 +691,35 @@ class FileServiceTest {
 
         res = server.blockingWebClient().head("/cached/fs/missing.html");
         assertThat(res.status().code()).isEqualTo(404);
+    }
+
+    @Test
+    void missingFileResponseContainsDecodedMappedPath() {
+        final AggregatedHttpResponse res = server.blockingWebClient().get("/cached/fs/missing.html");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).contains("/missing.html").doesNotContain(tmpDir.toString());
+    }
+
+    @Test
+    void missingDirectoryResponseContainsDecodedMappedPath() {
+        final AggregatedHttpResponse res = server.blockingWebClient().get("/cached/fs/missing-dir/");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).contains("/missing-dir/").doesNotContain(tmpDir.toString());
+    }
+
+    @Test
+    void missingDirectoryResponseContainsDecodedMappedPathWhenAutoIndexDisabled() {
+        final AggregatedHttpResponse res = server.blockingWebClient()
+                                                 .get("/cached/no-autoindex/fs/missing-dir/");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).contains("/missing-dir/").doesNotContain(tmpDir.toString());
+    }
+
+    @Test
+    void missingFileResponseContainsDecodedMappedPathWhenFallbackExtensionConfigured() {
+        final AggregatedHttpResponse res = server.blockingWebClient().get("/extension/missing");
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(res.contentUtf8()).contains("/missing").doesNotContain(tmpDir.toString());
     }
 
     private static void writeFile(Path path, String content) throws Exception {

--- a/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/file/HttpFileTest.java
@@ -18,10 +18,14 @@ package com.linecorp.armeria.server.file;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.file.Path;
+import java.time.Clock;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnJre;
@@ -30,6 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
@@ -37,8 +42,15 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.ServerCacheControl;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.file.HttpFileBuilder.ClassPathHttpFileBuilder;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
 
 class HttpFileTest {
 
@@ -78,10 +90,114 @@ class HttpFileTest {
     @Test
     void redirect() throws Exception {
         final HttpFile file = HttpFile.ofRedirect("/foo/bar?a=b");
-        final HttpResponse response = file.asService().serve(null, HttpRequest.of(HttpMethod.GET, "/foo"));
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/foo");
+        final HttpResponse response = file.asService().serve(ServiceRequestContext.of(request), request);
         final AggregatedHttpResponse agg = response.aggregate().join();
         assertThat(agg.status()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
         assertThat(agg.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/foo/bar?a=b");
+    }
+
+    @Test
+    void nonExistentWithPathHintContainsDecodedMappedPath() throws Exception {
+        final HttpFile file = HttpFile.nonExistent("/missing.txt");
+        final HttpRequest request = HttpRequest.of(HttpMethod.GET, "/missing.txt");
+        final AggregatedHttpResponse agg =
+                file.asService().serve(ServiceRequestContext.of(request), request)
+                    .aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(agg.contentUtf8()).contains("/missing.txt");
+    }
+
+    @Test
+    void nonExistentWithPathHintForHead() throws Exception {
+        final HttpFile file = HttpFile.nonExistent("/missing.txt");
+        final HttpRequest request = HttpRequest.of(HttpMethod.HEAD, "/missing.txt");
+        final AggregatedHttpResponse agg =
+                file.asService().serve(ServiceRequestContext.of(request), request)
+                    .aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void nonExistentWithUnsupportedMethod() throws Exception {
+        final HttpFile file = HttpFile.nonExistent("/missing.txt");
+        final HttpRequest request = HttpRequest.of(HttpMethod.POST, "/missing.txt");
+        final AggregatedHttpResponse agg =
+                file.asService().serve(ServiceRequestContext.of(request), request)
+                    .aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Test
+    void redirectWithHead() throws Exception {
+        final HttpFile file = HttpFile.ofRedirect("/foo/bar?a=b");
+        final HttpRequest request = HttpRequest.of(HttpMethod.HEAD, "/foo");
+        final HttpResponse response = file.asService().serve(ServiceRequestContext.of(request), request);
+        final AggregatedHttpResponse agg = response.aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(agg.headers().get(HttpHeaderNames.LOCATION)).isEqualTo("/foo/bar?a=b");
+    }
+
+    @Test
+    void toStringIncludesPathHint() {
+        final HttpFile file = HttpFile.nonExistent("/missing.txt");
+        assertThat(file.toString()).contains("pathHint: /missing.txt");
+    }
+
+    @Test
+    void read() {
+        final HttpFile file = HttpFile.of(HttpData.ofUtf8("hello"));
+        final HttpResponse res = file.read(CommonPools.blockingTaskExecutor(),
+                                           UnpooledByteBufAllocator.DEFAULT).join();
+        assertThat(res).isNotNull();
+        final AggregatedHttpResponse agg = res.aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.OK);
+        assertThat(agg.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void readWhenDoReadReturnsNull() {
+        // A custom AbstractHttpFile subclass where readAttributes returns non-null
+        // but doRead returns null, simulating a file disappearing between attribute
+        // read and content read.
+        final AbstractHttpFile file = new AbstractHttpFile(
+                null, Clock.systemUTC(), false, false, null, HttpHeaders.of()) {
+            @Override
+            protected String pathOrUri() {
+                return "/vanishing-file";
+            }
+
+            @Override
+            public CompletableFuture<HttpFileAttributes> readAttributes(Executor fileReadExecutor) {
+                return UnmodifiableFuture.completedFuture(new HttpFileAttributes(10, 0));
+            }
+
+            @Nullable
+            @Override
+            protected HttpResponse doRead(ResponseHeaders headers, long length,
+                                          Executor fileReadExecutor,
+                                          ByteBufAllocator alloc) throws IOException {
+                // Simulate the file disappearing after attributes were read.
+                return null;
+            }
+
+            @Override
+            public CompletableFuture<AggregatedHttpFile> aggregate(Executor fileReadExecutor) {
+                return UnmodifiableFuture.completedFuture(null);
+            }
+
+            @Override
+            public CompletableFuture<AggregatedHttpFile> aggregateWithPooledObjects(
+                    Executor fileReadExecutor, ByteBufAllocator alloc) {
+                return UnmodifiableFuture.completedFuture(null);
+            }
+        };
+
+        final HttpResponse res = file.read(CommonPools.blockingTaskExecutor(),
+                                           UnpooledByteBufAllocator.DEFAULT).join();
+        assertThat(res).isNotNull();
+        final AggregatedHttpResponse agg = res.aggregate().join();
+        assertThat(agg.status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test


### PR DESCRIPTION
Fixes #4797
Motivation and Context

Currently, when a file is not found by FileService, it simply returns a plain 404 Not Found response with an empty body. This makes debugging difficult for users who want to know exactly which mapped path failed to resolve. The goal of this PR is to include the requested path (decodedMappedPath) in the 404 response body, while strictly avoiding the exposure of internal server file system paths for security reasons.
Modifications

Based on the implementation, the following changes were made:

    FileService (Core Resolution):

        Updated the final resolution paths to use HttpFile.nonExistent(decodedMappedPath) instead of the generic HttpFile.nonExistent().

        Applied this path hint injection only when directory auto-indexing is disabled, when the directory cannot be listed, or at the absolute end of the file lookup chain. By doing this at the final stage, we ensure that internal fallback mechanisms (like searching for .gz or alternative extensions) are not broken by a premature 404 response.

    HttpFile & NonExistentHttpFile:

        Added a new static method HttpFile.nonExistent(String decodedMappedPath) to allow passing a path hint.

        Updated NonExistentHttpFile to store the pathHint.

        Modified asService() to return a 404 Not Found with the PLAIN_TEXT_UTF_8 body "File not found: " + pathHint only for HttpMethod.GET requests.

        Ensured that HEAD requests (and other methods) continue to return a standard body-less 404 response to comply with HTTP semantics.

    AbstractHttpFile:

        Fixed a potential NullPointerException in the read() method. The .thenApply block now explicitly checks if the underlying read(...) implementation returns null and safely returns HttpResponse.of(HttpStatus.NOT_FOUND) instead of throwing an exception.

How to test / Verification Environment

Comprehensive tests were added for FileServiceTest and HttpFileTest covering GET, HEAD, auto-indexing, and fallback extensions.

Note on Testing Environment (JDK 21):
During local verification on Ubuntu with JDK 21, the build failed initially because -XDaddTypeAnnotationsToSymbol=true is required by Error Prone on JDK 21. To successfully verify the target components in an isolated environment, we bypassed Error Prone temporarily using an initialization script.

If reviewers are testing this branch locally on JDK 21, you can verify it using the following steps:

Create a temporary init script (/tmp/fix-javac.gradle):
```groovy
allprojects {
  afterEvaluate {
    tasks.withType(JavaCompile).configureEach {
      if (options.hasProperty('errorprone')) {
        options.errorprone.enabled = false
      }
    }
  }
}
```
Run the targeted tests:


Bash

      env JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 \
      ./gradlew --no-daemon --init-script /tmp/fix-javac.gradle :core:test \
        --tests 'com.linecorp.armeria.server.file.HttpFileTest.*' \
        --tests 'com.linecorp.armeria.server.file.FileServiceTest.*'

(All tests passed successfully under standard profile).