### PR TITLE
Add OutlierDetectingEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -16,6 +16,12 @@
 
 package com.linecorp.armeria.client.circuitbreaker;
 
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_FAILURE_RATE_THRESHOLD;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_MINIMUM_REQUEST_THRESHOLD;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -34,12 +40,6 @@ import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
  */
 public final class CircuitBreakerBuilder {
 
-    private static final double DEFAULT_FAILURE_RATE_THRESHOLD = 0.5;
-    private static final long DEFAULT_MINIMUM_REQUEST_THRESHOLD = 10;
-    private static final int DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS = 3;
-    private static final int DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS = 10;
-    private static final int DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS = 20;
-    private static final int DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS = 1;
     private static final Ticker DEFAULT_TICKER = Ticker.systemTicker();
 
     @Nullable
@@ -75,7 +75,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the threshold of failure rate to detect a remote service fault.
-     * Defaults to {@value #DEFAULT_FAILURE_RATE_THRESHOLD} if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_FAILURE_RATE_THRESHOLD} if unspecified.
      *
      * @param failureRateThreshold The rate between 0 (exclusive) and 1 (inclusive)
      */
@@ -90,7 +90,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the minimum number of requests within a time window necessary to detect a remote service fault.
-     * Defaults to {@value #DEFAULT_MINIMUM_REQUEST_THRESHOLD} if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_MINIMUM_REQUEST_THRESHOLD} if unspecified.
      */
     public CircuitBreakerBuilder minimumRequestThreshold(long minimumRequestThreshold) {
         if (minimumRequestThreshold < 0) {
@@ -103,7 +103,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the trial request interval in HALF_OPEN state.
-     * Defaults to {@value #DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder trialRequestInterval(Duration trialRequestInterval) {
         requireNonNull(trialRequestInterval, "trialRequestInterval");
@@ -117,7 +117,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the trial request interval in HALF_OPEN state in milliseconds.
-     * Defaults to {@value #DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder trialRequestIntervalMillis(long trialRequestIntervalMillis) {
         trialRequestInterval(Duration.ofMillis(trialRequestIntervalMillis));
@@ -126,7 +126,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the duration of OPEN state.
-     * Defaults to {@value #DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder circuitOpenWindow(Duration circuitOpenWindow) {
         requireNonNull(circuitOpenWindow, "circuitOpenWindow");
@@ -140,7 +140,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the duration of OPEN state in milliseconds.
-     * Defaults to {@value #DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder circuitOpenWindowMillis(long circuitOpenWindowMillis) {
         circuitOpenWindow(Duration.ofMillis(circuitOpenWindowMillis));
@@ -149,7 +149,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the time length of sliding window to accumulate the count of events.
-     * Defaults to {@value #DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder counterSlidingWindow(Duration counterSlidingWindow) {
         requireNonNull(counterSlidingWindow, "counterSlidingWindow");
@@ -163,7 +163,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the time length of sliding window to accumulate the count of events, in milliseconds.
-     * Defaults to {@value #DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS} seconds if unspecified.
      */
     public CircuitBreakerBuilder counterSlidingWindowMillis(long counterSlidingWindowMillis) {
         counterSlidingWindow(Duration.ofMillis(counterSlidingWindowMillis));
@@ -172,7 +172,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the interval that a circuit breaker can see the latest accumulated count of events.
-     * Defaults to {@value #DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
      */
     public CircuitBreakerBuilder counterUpdateInterval(Duration counterUpdateInterval) {
         requireNonNull(counterUpdateInterval, "counterUpdateInterval");
@@ -186,7 +186,7 @@ public final class CircuitBreakerBuilder {
 
     /**
      * Sets the interval that a circuit breaker can see the latest accumulated count of events, in milliseconds.
-     * Defaults to {@value #DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
+     * Defaults to {@value CircuitBreakerConfig#DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS} second if unspecified.
      */
     public CircuitBreakerBuilder counterUpdateIntervalMillis(long counterUpdateIntervalMillis) {
         counterUpdateInterval(Duration.ofMillis(counterUpdateIntervalMillis));

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilder.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Ticker;
+import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
 
 /**
  * Builds a {@link CircuitBreaker} instance using builder pattern.

--- a/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
+++ b/core/src/main/java/com/linecorp/armeria/client/circuitbreaker/NonBlockingCircuitBreaker.java
@@ -34,6 +34,7 @@ import com.linecorp.armeria.common.circuitbreaker.CircuitBreakerCallback;
 import com.linecorp.armeria.common.util.EventCount;
 import com.linecorp.armeria.common.util.EventCounter;
 import com.linecorp.armeria.common.util.Ticker;
+import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
 
 /**
  * A non-blocking implementation of circuit breaker pattern.

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroup.java
@@ -66,7 +66,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
     }
 
     // An empty list of endpoints we also use as a marker that we have not initialized endpoints yet.
-    private static final List<Endpoint> UNINITIALIZED_ENDPOINTS = Collections.unmodifiableList(
+    static final List<Endpoint> UNINITIALIZED_ENDPOINTS = Collections.unmodifiableList(
             new ArrayList<>());
 
     private final EndpointSelectionStrategy selectionStrategy;
@@ -288,7 +288,7 @@ public class DynamicEndpointGroup extends AbstractEndpointGroup implements Liste
         notifyListeners(newEndpoints);
     }
 
-    private static boolean hasChanges(List<Endpoint> oldEndpoints, List<Endpoint> newEndpoints) {
+    static boolean hasChanges(List<Endpoint> oldEndpoints, List<Endpoint> newEndpoints) {
         if (oldEndpoints == UNINITIALIZED_ENDPOINTS) {
             return true;
         }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -181,6 +182,8 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
     };
 
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
+    @Nullable
+    private volatile ScheduledFuture<?> scheduledFuture;
 
     OutlierDetectingEndpointGroup(EndpointGroup delegate,
                                   int maxNumEndpoints,
@@ -261,7 +264,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
         }
 
         final long nextDurationMillis = refreshEndpoints(true);
-        executor.schedule(this::scheduleEndpointUpdateTask, nextDurationMillis, MILLISECONDS);
+        scheduledFuture = executor.schedule(this::scheduleEndpointUpdateTask, nextDurationMillis, MILLISECONDS);
     }
 
     private long newExpirationNanoTime(long currentNanoTime) {
@@ -370,7 +373,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
             final List<Endpoint> newBadEndpoints = newBadEndpointsBuilder.build();
 
             if (!newBadEndpoints.isEmpty()) {
-                logger.info("Evicting endpoints from rotation due to open circuits: {}",
+                logger.warn("Evicting endpoints from rotation due to open circuits: {}",
                             toShortString(newBadEndpoints));
                 for (Endpoint badEndpoint : newBadEndpoints) {
                     badEndpoints.add(badEndpoint);
@@ -627,10 +630,21 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
     }
 
     private void doCloseAsync(CompletableFuture<?> future) {
+        final ScheduledFuture<?> scheduledFuture = this.scheduledFuture;
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(false);
+        }
         if (!initialCompletionFuture.isDone()) {
             initialCompletionFuture.cancel(false);
         }
-        delegate.closeAsync().handle((unused1, unused2) -> future.complete(null));
+        delegate.closeAsync().handle((unused1, cause) -> {
+            if (cause != null) {
+                future.completeExceptionally(cause);
+            } else {
+                future.complete(null);
+            }
+            return null;
+        });
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -1,0 +1,777 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static com.linecorp.armeria.client.endpoint.DynamicEndpointGroup.UNINITIALIZED_ENDPOINTS;
+import static com.linecorp.armeria.internal.client.endpoint.EndpointToStringUtil.toShortString;
+import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.math.LongMath;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.DecoratingHttpClientFunction;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListenerAdapter;
+import com.linecorp.armeria.client.circuitbreaker.CircuitState;
+import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.common.util.AbstractListenable;
+import com.linecorp.armeria.common.util.AsyncCloseableSupport;
+import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
+import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * An {@link EndpointGroup} that detects bad endpoints and rotates them out using a per-endpoint
+ * {@link CircuitBreaker}. It periodically refreshes the endpoints and selects an endpoint based on the
+ * {@link CircuitBreaker} state.
+ *
+ * <ul>
+ *   <li>Keep-Alive: When the underlying {@link EndpointGroup} (such as DNS-based ones) churns its
+ *       {@link Endpoint}s frequently, pooled connections become unusable and have to be re-established,
+ *       hurting performance and response duration. This {@link EndpointGroup} keeps the cached endpoints
+ *       for {@code maxEndpointAge}. If an {@link Endpoint} exceeds its lifespan, it is automatically
+ *       removed from the valid {@link Endpoint}s and a new {@link Endpoint} is added.</li>
+ *   <li>Circuit breaker: This {@link EndpointGroup} uses {@link CircuitBreaker} to avoid sending requests to
+ *       bad {@link Endpoint}s. Each response is classified by the configured {@link SuccessFunction} (by
+ *       default, status codes 2xx-4xx are successful and everything else is a failure), and the per-endpoint
+ *       {@link CircuitBreaker} updates its counts accordingly. If the failure rate exceeds the
+ *       {@linkplain OutlierDetectingEndpointGroupBuilder#failureRateThreshold(double) configured threshold},
+ *       the {@link Endpoint} is removed from the valid {@link Endpoint}s and a new {@link Endpoint} is
+ *       added automatically.</li>
+ * </ul>
+ *
+ * <h2>Registering the HTTP decorator</h2>
+ *
+ * <p><strong>The {@link DecoratingHttpClientFunction} returned by {@link #asDecorator()} MUST be
+ * registered on the client.</strong> The decorator is what observes each response and feeds success/failure
+ * signals into the per-endpoint {@link CircuitBreaker}. Without it, the circuit breakers never trip, bad
+ * endpoints are never evicted, and this {@link EndpointGroup} effectively degrades to a periodic refresher.
+ *
+ * <p>Example:
+ * <pre>{@code
+ * OutlierDetectingEndpointGroup endpointGroup =
+ *         OutlierDetectingEndpointGroup.builder(delegate)
+ *                                      .maxNumEndpoints(20)
+ *                                      .maxEndpointAge(Duration.ofMinutes(5))
+ *                                      .failureRateThreshold(0.3)
+ *                                      .circuitOpenWindow(Duration.ofSeconds(20))
+ *                                      .meterRegistry(meterIdPrefix, meterRegistry)
+ *                                      .build();
+ *
+ * WebClient client =
+ *         WebClient.builder(SessionProtocol.HTTPS, endpointGroup)
+ *                  // Required: report each response to the per-endpoint CircuitBreaker.
+ *                  .decorator(endpointGroup.asDecorator())
+ *                  .build();
+ * }</pre>
+ */
+@UnstableApi
+public final class OutlierDetectingEndpointGroup implements EndpointGroup, ListenableAsyncCloseable {
+
+    // Forked from https://github.com/line/pushsphere/blob/main/client/src/main/kotlin/com/linecorp/pushsphere/client/OutlierDetectingEndpointGroup.kt
+    // and migrated to Java and adapted for Armeria.
+
+    private static final Logger logger = LoggerFactory.getLogger(OutlierDetectingEndpointGroup.class);
+
+    /**
+     * JVM-wide counter shared by every {@link OutlierDetectingEndpointGroup} instance to mint
+     * unique per-endpoint {@link CircuitBreaker} names. The counter is monotonic across instances,
+     * so circuit breaker numbers within a single group are not contiguous.
+     */
+    private static final AtomicLong circuitBreakerCounter = new AtomicLong();
+
+    /**
+     * Returns a newly created {@link OutlierDetectingEndpointGroupBuilder} that wraps the given
+     * {@link EndpointGroup}.
+     *
+     * @param delegate the underlying {@link EndpointGroup} whose endpoints are filtered through
+     *                 per-endpoint {@link CircuitBreaker}s.
+     */
+    public static OutlierDetectingEndpointGroupBuilder builder(EndpointGroup delegate) {
+        return new OutlierDetectingEndpointGroupBuilder(delegate);
+    }
+
+    /**
+     * An executor that schedules endpoint refresh and bad-endpoint cleanup tasks.
+     */
+    private final ScheduledExecutorService executor = CommonPools.workerGroup().next();
+
+    private final EndpointGroup delegate;
+    private final int maxNumEndpoints;
+    private final String namePrefix;
+    private final boolean failFastOnAllCircuitOpen;
+    private final SuccessFunction successFunction;
+    private final CircuitBreakerConfig circuitBreakerConfig;
+
+    private final ReentrantShortLock endpointsLock = new ReentrantShortLock();
+
+    // Guarded by `endpointsLock`.
+    private volatile List<Endpoint> endpoints = UNINITIALIZED_ENDPOINTS;
+
+    private final OutlierEndpointGroupListener endpointGroupListeners;
+    private final CompletableFuture<List<Endpoint>> initialCompletionFuture = new CompletableFuture<>();
+
+    private final Map<Endpoint, EndpointContext> endpointContexts = new ConcurrentHashMap<>();
+    private final EndpointSelectionStrategy selectionStrategy;
+    private final EndpointSelector endpointSelector;
+
+    private final long maxEndpointAgeNanoTime;
+    private final long badEndpointExpirationMillis;
+
+    private final Set<Endpoint> badEndpoints = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    private final CircuitBreakerListener cbListener = new CircuitBreakerListenerAdapter() {
+        @Override
+        public void onStateChanged(String circuitBreakerName, CircuitState state) {
+            handleCircuitBreakerStateChanged(circuitBreakerName);
+        }
+    };
+
+    private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::doCloseAsync);
+
+    OutlierDetectingEndpointGroup(EndpointGroup delegate,
+                                  int maxNumEndpoints,
+                                  long maxEndpointAgeMillis,
+                                  String namePrefix,
+                                  boolean failFastOnAllCircuitOpen,
+                                  SuccessFunction successFunction,
+                                  CircuitBreakerConfig circuitBreakerConfig,
+                                  @Nullable MeterIdPrefix meterIdPrefix,
+                                  @Nullable MeterRegistry meterRegistry) {
+        this.delegate = delegate;
+        this.maxNumEndpoints = maxNumEndpoints;
+        this.namePrefix = namePrefix;
+        this.failFastOnAllCircuitOpen = failFastOnAllCircuitOpen;
+        this.successFunction = successFunction;
+        this.circuitBreakerConfig = circuitBreakerConfig;
+
+        endpointGroupListeners = new OutlierEndpointGroupListener(this::endpoints);
+        selectionStrategy = new CircuitBreakerEndpointSelectionStrategy();
+        endpointSelector = selectionStrategy.newSelector(this);
+
+        maxEndpointAgeNanoTime = maxEndpointAgeMillis > 0
+                                 ? TimeUnit.MILLISECONDS.toNanos(maxEndpointAgeMillis)
+                                 : -1;   // Sentinel: age-based rotation disabled.
+        badEndpointExpirationMillis = circuitBreakerConfig.circuitOpenWindow().toMillis();
+
+        delegate.addListener(unused -> {
+            endpointsLock.lock();
+            try {
+                // Strict mode (age disabled): always refresh so the pool mirrors the delegate.
+                // Keep-alive mode (age enabled): only refresh when there are slots to fill — cached
+                // endpoints stay in the pool until they age out.
+                if (maxEndpointAgeNanoTime <= 0 || endpointContexts.size() < maxNumEndpoints) {
+                    refreshEndpoints(false);
+                }
+            } finally {
+                endpointsLock.unlock();
+            }
+        });
+
+        delegate.whenReady().handle((unused, cause) -> {
+            if (cause != null) {
+                logger.warn("Failed to initialize the delegate: {}", delegate, cause);
+                initialCompletionFuture.completeExceptionally(cause);
+                return null;
+            }
+
+            if (maxEndpointAgeNanoTime > 0) {
+                scheduleEndpointUpdateTask();
+            } else {
+                // Age-based rotation is disabled. Do an initial population only.
+                refreshEndpoints(false);
+            }
+            return null;
+        });
+
+        if (meterIdPrefix != null && meterRegistry != null) {
+            final String name = meterIdPrefix.name("endpoints.count");
+            Gauge.builder(name, this, obj -> obj.endpoints().size())
+                 .tags(meterIdPrefix.tags())
+                 .tag("state", "healthy")
+                 .description("The number of healthy endpoints")
+                 .register(meterRegistry);
+
+            Gauge.builder(name, badEndpoints, Set::size)
+                 .tags(meterIdPrefix.tags())
+                 .tag("state", "unhealthy")
+                 .description("The number of unhealthy endpoints")
+                 .register(meterRegistry);
+        }
+    }
+
+    /**
+     * Schedules a task to update the old endpoints periodically.
+     */
+    private void scheduleEndpointUpdateTask() {
+        if (closeable.isClosing()) {
+            return;
+        }
+
+        final long nextDurationMillis = refreshEndpoints(true);
+        executor.schedule(this::scheduleEndpointUpdateTask, nextDurationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private long newExpirationNanoTime(long currentNanoTime) {
+        if (maxEndpointAgeNanoTime <= 0) {
+            // Age-based rotation disabled. Endpoints never age out.
+            return Long.MAX_VALUE;
+        }
+
+        // Use 20% of max age as jitter to avoid thundering herd problem.
+        final long jitter = Math.max(maxEndpointAgeNanoTime / 5, 1);
+        return LongMath.saturatedAdd(LongMath.saturatedAdd(currentNanoTime, maxEndpointAgeNanoTime),
+                                     ThreadLocalRandom.current().nextLong(jitter));
+    }
+
+    @VisibleForTesting
+    @Nullable
+    EndpointContext endpointContext(Endpoint endpoint) {
+        return endpointContexts.get(endpoint);
+    }
+
+    /**
+     * Updates {@code endpoints} if the sorted input differs from the current value, then offloads
+     * listener notification (and the initial-readiness future) to {@link #executor} so the callbacks
+     * never run while {@code endpointsLock} is held by the calling thread. Sorting stabilizes the
+     * round-robin sequence since {@code endpointContexts} is unordered.
+     */
+    private void setEndpoints(Iterable<Endpoint> endpoints) {
+        final List<Endpoint> newEndpoints = ImmutableList.sortedCopyOf(endpoints);
+        if (!DynamicEndpointGroup.hasChanges(this.endpoints, newEndpoints)) {
+            return;
+        }
+        this.endpoints = newEndpoints;
+        logger.info("New endpoints have been set: {}", toShortString(newEndpoints));
+        executor.execute(() -> {
+            if (closeable.isClosing()) {
+                return;
+            }
+
+            if (!initialCompletionFuture.isDone()) {
+                initialCompletionFuture.complete(newEndpoints);
+            }
+            endpointGroupListeners.notifyListeners0(newEndpoints);
+        });
+    }
+
+    private CircuitBreaker newCircuitBreaker(Endpoint endpoint) {
+        final String name = namePrefix + '-' +
+                            circuitBreakerCounter.incrementAndGet() + ':' + endpoint;
+        return CircuitBreaker.builder(name)
+                             .failureRateThreshold(circuitBreakerConfig.failureRateThreshold())
+                             .minimumRequestThreshold(circuitBreakerConfig.minimumRequestThreshold())
+                             .trialRequestInterval(circuitBreakerConfig.trialRequestInterval())
+                             .circuitOpenWindow(circuitBreakerConfig.circuitOpenWindow())
+                             .counterSlidingWindow(circuitBreakerConfig.counterSlidingWindow())
+                             .counterUpdateInterval(circuitBreakerConfig.counterUpdateInterval())
+                             .listener(cbListener)
+                             .build();
+    }
+
+    /**
+     * Invoked when the {@link CircuitState} of a per-endpoint {@link CircuitBreaker} changes.
+     * If the circuit breaker belongs to one of the tracked endpoints, the rotation is refreshed
+     * to evict the now-bad endpoint.
+     */
+    private void handleCircuitBreakerStateChanged(String circuitBreakerName) {
+        endpointsLock.lock();
+        try {
+            boolean needsUpdate = false;
+            for (EndpointContext context : endpointContexts.values()) {
+                if (context.circuitBreaker().name().equals(circuitBreakerName)) {
+                    needsUpdate = true;
+                    break;
+                }
+            }
+            if (needsUpdate) {
+                refreshEndpoints(false);
+            }
+        } finally {
+            endpointsLock.unlock();
+        }
+    }
+
+    /**
+     * Evicts open-circuit endpoints, drops aged-out ones, and fills the remaining slots with fresh
+     * candidates from the delegate (reusing still-valid old endpoints if needed).
+     *
+     * @param isScheduledJob {@code true} from the periodic scheduler, or {@code false} when triggered
+     *                       reactively (delegate update or circuit state change).
+     * @return the next refresh delay in ms when scheduled (100 when empty, 500 on errors, otherwise
+     *         clamped to ≥500 ms). Returns {@code 0} when not a scheduled job.
+     */
+    private long refreshEndpoints(boolean isScheduledJob) {
+        if (closeable.isClosing()) {
+            return 0;
+        }
+
+        endpointsLock.lock();
+        try {
+            // Remove bad endpoints.
+            final ImmutableList.Builder<Endpoint> newBadEndpointsBuilder = ImmutableList.builder();
+            for (Entry<Endpoint, EndpointContext> entry : endpointContexts.entrySet()) {
+                if (entry.getValue().circuitBreaker().circuitState() != CircuitState.CLOSED) {
+                    newBadEndpointsBuilder.add(entry.getKey());
+                }
+            }
+            final List<Endpoint> newBadEndpoints = newBadEndpointsBuilder.build();
+
+            if (!newBadEndpoints.isEmpty()) {
+                logger.info("Evicting endpoints from rotation due to open circuits: {}",
+                            toShortString(newBadEndpoints));
+                for (Endpoint badEndpoint : newBadEndpoints) {
+                    badEndpoints.add(badEndpoint);
+                    endpointContexts.remove(badEndpoint);
+                }
+
+                // Schedule a task to remove the bad endpoint from the badEndpoints.
+                executor.schedule(() -> {
+                    if (closeable.isClosing()) {
+                        return;
+                    }
+                    newBadEndpoints.forEach(badEndpoints::remove);
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Bad endpoints are eligible to rejoin the rotation: {}",
+                                     toShortString(newBadEndpoints));
+                    }
+                    // Bad endpoints are removed. Make the endpoint available if there are not enough endpoints.
+                    refreshEndpoints(false);
+                }, badEndpointExpirationMillis, TimeUnit.MILLISECONDS);
+            }
+
+            // Remove old endpoints (only meaningful in keep-alive mode — endpoints never age out
+            // when maxEndpointAgeNanoTime is disabled).
+            final long currentNanoTime = System.nanoTime();
+            final ImmutableSet<Endpoint> oldEndpoints;
+            if (maxEndpointAgeNanoTime > 0) {
+                final ImmutableSet.Builder<Endpoint> oldEndpointsBuilder = ImmutableSet.builder();
+                for (Entry<Endpoint, EndpointContext> entry : endpointContexts.entrySet()) {
+                    if (currentNanoTime - entry.getValue().expirationNanoTime() >= 0) {
+                        oldEndpointsBuilder.add(entry.getKey());
+                    }
+                }
+                oldEndpoints = oldEndpointsBuilder.build();
+            } else {
+                oldEndpoints = ImmutableSet.of();
+            }
+
+            // Capture old contexts so they can be reused if there aren't enough new candidates.
+            final List<EndpointContext> oldEndpointContexts;
+            if (!oldEndpoints.isEmpty()) {
+                final ImmutableList.Builder<EndpointContext> oldContextsBuilder = ImmutableList.builder();
+                for (Endpoint oldEndpoint : oldEndpoints) {
+                    final EndpointContext context = endpointContexts.remove(oldEndpoint);
+                    if (context != null) {
+                        oldContextsBuilder.add(context);
+                    }
+                }
+                oldEndpointContexts = oldContextsBuilder.build();
+            } else {
+                oldEndpointContexts = ImmutableList.of();
+            }
+
+            // Fetch new endpoints.
+            final List<Endpoint> candidates = delegate.endpoints();
+
+            // When age-based rotation is disabled, mirror the delegate strictly.
+            if (maxEndpointAgeNanoTime <= 0) {
+                final Set<Endpoint> candidateSet = ImmutableSet.copyOf(candidates);
+                endpointContexts.keySet().removeIf(e -> !candidateSet.contains(e));
+            }
+
+            int remainingSlots = maxNumEndpoints - endpointContexts.size();
+            for (Endpoint candidate : candidates) {
+                if (remainingSlots <= 0) {
+                    break;
+                }
+                // Exclude the existing endpoints.
+                if (endpointContexts.containsKey(candidate)) {
+                    continue;
+                }
+                // Exclude the old endpoints.
+                if (oldEndpoints.contains(candidate)) {
+                    continue;
+                }
+                // Exclude the bad endpoints.
+                if (badEndpoints.contains(candidate)) {
+                    continue;
+                }
+                final long expirationNanoTime = newExpirationNanoTime(currentNanoTime);
+                endpointContexts.put(candidate,
+                                     new EndpointContext(candidate, newCircuitBreaker(candidate),
+                                                         expirationNanoTime));
+                remainingSlots--;
+            }
+
+            // Fill remaining slots by reusing old endpoints (capped so the pool never exceeds the max).
+            if (remainingSlots > 0) {
+                for (EndpointContext context : oldEndpointContexts) {
+                    if (remainingSlots <= 0) {
+                        break;
+                    }
+                    if (!candidates.contains(context.endpoint())) {
+                        continue;
+                    }
+                    final long expirationNanoTime = newExpirationNanoTime(currentNanoTime);
+                    // Extend the expiration. The CircuitBreaker's accumulated state is preserved.
+                    endpointContexts.put(context.endpoint(),
+                                         new EndpointContext(context.endpoint(), context.circuitBreaker(),
+                                                             expirationNanoTime));
+                    remainingSlots--;
+                }
+            }
+
+            setEndpoints(endpointContexts.keySet());
+
+            if (!isScheduledJob) {
+                return 0;
+            }
+
+            // Compute the next update interval.
+            long minRemainingNanoTime = Long.MAX_VALUE;
+            boolean hasContext = false;
+            for (EndpointContext context : endpointContexts.values()) {
+                hasContext = true;
+                final long remaining = context.expirationNanoTime() - currentNanoTime;
+                if (remaining < minRemainingNanoTime) {
+                    minRemainingNanoTime = remaining;
+                }
+            }
+            if (!hasContext) {
+                // No endpoints. Retry after 100 ms to quickly fetch the next endpoints.
+                return 100;
+            }
+            // Clamp the min interval to 500 ms to avoid too frequent updates.
+            return Math.max(TimeUnit.NANOSECONDS.toMillis(minRemainingNanoTime), 500);
+        } catch (Throwable e) {
+            logger.error("Unexpected exception while updating endpoints.", e);
+            return 500;
+        } finally {
+            endpointsLock.unlock();
+        }
+    }
+
+    @Nullable
+    @Override
+    public Endpoint selectNow(ClientRequestContext ctx) {
+        return endpointSelector.selectNow(ctx);
+    }
+
+    @Deprecated
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                              ScheduledExecutorService executor,
+                                              long timeoutMillis) {
+        return select(ctx, executor);
+    }
+
+    @Override
+    public CompletableFuture<Endpoint> select(ClientRequestContext ctx, ScheduledExecutorService executor) {
+        return endpointSelector.select(ctx, executor);
+    }
+
+    /**
+     * Returns a {@link DecoratingHttpClientFunction} that reports each HTTP response to the per-endpoint
+     * {@link CircuitBreaker}.
+     *
+     * <p><strong>Must be registered on the HTTP client</strong> via
+     * {@code WebClientBuilder.decorator(...)}. Without it, circuit breakers never trip and outlier
+     * detection becomes a no-op periodic refresher.
+     */
+    public DecoratingHttpClientFunction asDecorator() {
+        return (delegate, ctx, req) -> {
+            reportResult(ctx);
+            return delegate.execute(ctx, req);
+        };
+    }
+
+    /**
+     * Reports the result of the request to the {@link CircuitBreaker}, classifying the response via the
+     * configured {@link SuccessFunction}.
+     */
+    private void reportResult(ClientRequestContext ctx) {
+        final Endpoint endpoint = ctx.endpoint();
+        if (endpoint == null) {
+            // Nothing to report.
+            return;
+        }
+        final EndpointContext endpointContext = endpointContexts.get(endpoint);
+        if (endpointContext == null) {
+            return;
+        }
+        final CircuitBreaker circuitBreaker = endpointContext.circuitBreaker();
+        ctx.log().whenComplete().thenAccept(log -> {
+            if (successFunction.isSuccess(ctx, log)) {
+                circuitBreaker.onSuccess();
+            } else {
+                circuitBreaker.onFailure();
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        closeable.close();
+    }
+
+    @Override
+    public CompletableFuture<?> closeAsync() {
+        return closeable.closeAsync();
+    }
+
+    @Override
+    public boolean isClosing() {
+        return closeable.isClosing();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closeable.isClosed();
+    }
+
+    @Override
+    public CompletableFuture<?> whenClosed() {
+        return closeable.whenClosed();
+    }
+
+    private void doCloseAsync(CompletableFuture<?> future) {
+        if (!initialCompletionFuture.isDone()) {
+            initialCompletionFuture.cancel(false);
+        }
+        delegate.closeAsync().handle((unused1, unused2) -> future.complete(null));
+    }
+
+    @Override
+    public List<Endpoint> endpoints() {
+        return endpoints;
+    }
+
+    @Override
+    public EndpointSelectionStrategy selectionStrategy() {
+        return selectionStrategy;
+    }
+
+    @Override
+    public long selectionTimeoutMillis() {
+        return delegate.selectionTimeoutMillis();
+    }
+
+    @Override
+    public CompletableFuture<List<Endpoint>> whenReady() {
+        return initialCompletionFuture;
+    }
+
+    @Override
+    public void addListener(Consumer<? super List<Endpoint>> listener, boolean notifyLatestEndpoints) {
+        endpointGroupListeners.addListener(listener, notifyLatestEndpoints);
+    }
+
+    @Override
+    public void removeListener(Consumer<?> listener) {
+        endpointGroupListeners.removeListener(listener);
+    }
+
+    @Override
+    public String toString() {
+        final List<Endpoint> endpoints = this.endpoints;
+        return MoreObjects.toStringHelper(this)
+                          .add("delegate", delegate)
+                          .add("maxNumEndpoints", maxNumEndpoints)
+                          .add("maxEndpointAge",
+                               maxEndpointAgeNanoTime > 0
+                               ? TimeUnit.NANOSECONDS.toMillis(maxEndpointAgeNanoTime) + "ms"
+                               : "disabled")
+                          .add("namePrefix", namePrefix)
+                          .add("failFastOnAllCircuitOpen", failFastOnAllCircuitOpen)
+                          .add("initialized", initialCompletionFuture.isDone())
+                          .add("closing", closeable.isClosing())
+                          .add("numEndpoints", endpoints.size())
+                          .add("numBadEndpoints", badEndpoints.size())
+                          .add("endpoints", truncate(endpoints, 10))
+                          .toString();
+    }
+
+    private static final class OutlierEndpointGroupListener extends AbstractListenable<List<Endpoint>> {
+
+        private final Supplier<List<Endpoint>> latest;
+
+        OutlierEndpointGroupListener(Supplier<List<Endpoint>> latest) {
+            this.latest = latest;
+        }
+
+        @Nullable
+        @Override
+        protected List<Endpoint> latestValue() {
+            final List<Endpoint> latest0 = latest.get();
+            return latest0 == UNINITIALIZED_ENDPOINTS ? null : latest0;
+        }
+
+        void notifyListeners0(List<Endpoint> latestValue) {
+            notifyListeners(latestValue);
+        }
+    }
+
+    private final class CircuitBreakerEndpointSelectionStrategy implements EndpointSelectionStrategy {
+        @Override
+        public EndpointSelector newSelector(EndpointGroup endpointGroup) {
+            final EndpointSelector selector = delegate.selectionStrategy().newSelector(endpointGroup);
+            return new CircuitBreakerEndpointSelector(selector);
+        }
+    }
+
+    private final class CircuitBreakerEndpointSelector implements EndpointSelector {
+
+        private final EndpointSelector selector;
+
+        CircuitBreakerEndpointSelector(EndpointSelector selector) {
+            this.selector = selector;
+        }
+
+        @Nullable
+        @Override
+        public Endpoint selectNow(ClientRequestContext ctx) {
+            Endpoint endpoint = selector.selectNow(ctx);
+            if (endpoint == null) {
+                // No endpoint is available.
+                return null;
+            }
+            final RequestLogAccess parent = ctx.log().parent();
+            if (parent == null || parent.children().isEmpty()) {
+                // No retry or the first attempt.
+                return endpoint;
+            }
+
+            for (int i = 0; i < 3; i++) {
+                RequestLogAccess duplicated = null;
+                for (RequestLogAccess child : parent.children()) {
+                    final ClientRequestContext cctx = (ClientRequestContext) child.context();
+                    if (Objects.equals(cctx.endpoint(), endpoint)) {
+                        duplicated = child;
+                        break;
+                    }
+                }
+                if (duplicated == null) {
+                    return endpoint;
+                }
+                // The endpoint was used in the previous attempt. Try another endpoint.
+                endpoint = selector.selectNow(ctx);
+            }
+
+            // All endpoints are used to send the previous attempts. Use the endpoint anyway.
+            return endpoint;
+        }
+
+        @Deprecated
+        @Override
+        public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                                  ScheduledExecutorService executor,
+                                                  long timeoutMillis) {
+            // Deprecated overload. Delegated as-is to the wrapped selector.
+            return selector.select(ctx, executor, timeoutMillis);
+        }
+
+        @Override
+        public CompletableFuture<Endpoint> select(ClientRequestContext ctx,
+                                                  ScheduledExecutorService executor) {
+            final int numBadEndpoints = badEndpoints.size();
+            if (endpoints.isEmpty() && numBadEndpoints > 0 && !failFastOnAllCircuitOpen) {
+                // All endpoints are bad — likely a local/network issue. Fall back to a bad endpoint
+                // rather than failing until the underlying group refreshes.
+                final CompletableFuture<Endpoint> fallback = selectNowFromBadEndpoints(numBadEndpoints);
+                if (fallback != null) {
+                    return fallback;
+                }
+            }
+            return selector.select(ctx, executor);
+        }
+
+        @Nullable
+        private CompletableFuture<Endpoint> selectNowFromBadEndpoints(int numBadEndpoints) {
+            int target = ThreadLocalRandom.current().nextInt(numBadEndpoints);
+            Endpoint badEndpoint = null;
+            for (Endpoint endpoint : badEndpoints) {
+                if (target-- == 0) {
+                    badEndpoint = endpoint;
+                    break;
+                }
+            }
+            if (badEndpoint != null) {
+                return CompletableFuture.completedFuture(badEndpoint);
+            }
+            // Concurrently emptied. Let the caller fall back to the regular selector.
+            return null;
+        }
+    }
+
+    static final class EndpointContext {
+
+        private final Endpoint endpoint;
+        private final CircuitBreaker circuitBreaker;
+        private final long expirationNanoTime;
+
+        EndpointContext(Endpoint endpoint, CircuitBreaker circuitBreaker, long expirationNanoTime) {
+            this.endpoint = endpoint;
+            this.circuitBreaker = circuitBreaker;
+            this.expirationNanoTime = expirationNanoTime;
+        }
+
+        Endpoint endpoint() {
+            return endpoint;
+        }
+
+        CircuitBreaker circuitBreaker() {
+            return circuitBreaker;
+        }
+
+        long expirationNanoTime() {
+            return expirationNanoTime;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -433,6 +433,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
             if (maxEndpointAgeNanoTime <= 0) {
                 final Set<Endpoint> candidateSet = ImmutableSet.copyOf(candidates);
                 endpointContexts.keySet().removeIf(e -> !candidateSet.contains(e));
+                badEndpoints.removeIf(e -> !candidateSet.contains(e));
             }
 
             int remainingSlots = maxNumEndpoints - endpointContexts.size();

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.client.endpoint;
 import static com.linecorp.armeria.client.endpoint.DynamicEndpointGroup.UNINITIALIZED_ENDPOINTS;
 import static com.linecorp.armeria.internal.client.endpoint.EndpointToStringUtil.toShortString;
 import static com.linecorp.armeria.internal.common.util.CollectionUtil.truncate;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import java.util.Collections;
 import java.util.List;
@@ -31,7 +33,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -64,6 +65,7 @@ import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ListenableAsyncCloseable;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 
@@ -200,9 +202,8 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
         selectionStrategy = new CircuitBreakerEndpointSelectionStrategy();
         endpointSelector = selectionStrategy.newSelector(this);
 
-        maxEndpointAgeNanoTime = maxEndpointAgeMillis > 0
-                                 ? TimeUnit.MILLISECONDS.toNanos(maxEndpointAgeMillis)
-                                 : -1;   // Sentinel: age-based rotation disabled.
+        maxEndpointAgeNanoTime = maxEndpointAgeMillis > 0 ? MILLISECONDS.toNanos(maxEndpointAgeMillis)
+                                                          : -1;
         badEndpointExpirationMillis = circuitBreakerConfig.circuitOpenWindow().toMillis();
 
         delegate.addListener(unused -> {
@@ -260,7 +261,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
         }
 
         final long nextDurationMillis = refreshEndpoints(true);
-        executor.schedule(this::scheduleEndpointUpdateTask, nextDurationMillis, TimeUnit.MILLISECONDS);
+        executor.schedule(this::scheduleEndpointUpdateTask, nextDurationMillis, MILLISECONDS);
     }
 
     private long newExpirationNanoTime(long currentNanoTime) {
@@ -388,7 +389,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                     }
                     // Bad endpoints are removed. Make the endpoint available if there are not enough endpoints.
                     refreshEndpoints(false);
-                }, badEndpointExpirationMillis, TimeUnit.MILLISECONDS);
+                }, badEndpointExpirationMillis, MILLISECONDS);
             }
 
             // Remove old endpoints (only meaningful in keep-alive mode — endpoints never age out
@@ -494,7 +495,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                 return 100;
             }
             // Clamp the min interval to 500 ms to avoid too frequent updates.
-            return Math.max(TimeUnit.NANOSECONDS.toMillis(minRemainingNanoTime), 500);
+            return Math.max(NANOSECONDS.toMillis(minRemainingNanoTime), 500);
         } catch (Throwable e) {
             logger.error("Unexpected exception while updating endpoints.", e);
             return 500;
@@ -669,9 +670,8 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                           .add("delegate", delegate)
                           .add("maxNumEndpoints", maxNumEndpoints)
                           .add("maxEndpointAge",
-                               maxEndpointAgeNanoTime > 0
-                               ? TimeUnit.NANOSECONDS.toMillis(maxEndpointAgeNanoTime) + "ms"
-                               : "disabled")
+                               maxEndpointAgeNanoTime > 0 ? NANOSECONDS.toMillis(maxEndpointAgeNanoTime) + "ms"
+                                                          : "disabled")
                           .add("namePrefix", namePrefix)
                           .add("failFastOnAllCircuitOpen", failFastOnAllCircuitOpen)
                           .add("initialized", initialCompletionFuture.isDone())
@@ -768,16 +768,17 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
             if (endpoints.isEmpty() && numBadEndpoints > 0 && !failFastOnAllCircuitOpen) {
                 // All endpoints are bad — likely a local/network issue. Fall back to a bad endpoint
                 // rather than failing until the underlying group refreshes.
-                final CompletableFuture<Endpoint> fallback = selectNowFromBadEndpoints(numBadEndpoints);
+                final Endpoint fallback = selectNowFromBadEndpoints(numBadEndpoints);
                 if (fallback != null) {
-                    return fallback;
+                    return UnmodifiableFuture.completedFuture(fallback);
                 }
+                // Concurrently emptied. Let the caller fall back to the regular selector.
             }
             return selector.select(ctx, executor);
         }
 
         @Nullable
-        private CompletableFuture<Endpoint> selectNowFromBadEndpoints(int numBadEndpoints) {
+        private Endpoint selectNowFromBadEndpoints(int numBadEndpoints) {
             int target = ThreadLocalRandom.current().nextInt(numBadEndpoints);
             Endpoint badEndpoint = null;
             for (Endpoint endpoint : badEndpoints) {
@@ -786,11 +787,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                     break;
                 }
             }
-            if (badEndpoint != null) {
-                return CompletableFuture.completedFuture(badEndpoint);
-            }
-            // Concurrently emptied. Let the caller fall back to the regular selector.
-            return null;
+            return badEndpoint;
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -746,6 +746,8 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                 return endpoint;
             }
 
+            // The maximum number of attempts is mostly based on a rule of thumb.
+            // Three should be a reasonable default for now, but we can make it configurable later if needed.
             for (int i = 0; i < 3; i++) {
                 RequestLogAccess duplicated = null;
                 for (RequestLogAccess child : parent.children()) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -122,7 +122,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 @UnstableApi
 public final class OutlierDetectingEndpointGroup implements EndpointGroup, ListenableAsyncCloseable {
 
-    // Forked from https://github.com/line/pushsphere/blob/main/client/src/main/kotlin/com/linecorp/pushsphere/client/OutlierDetectingEndpointGroup.kt
+    // Forked from https://github.com/line/pushsphere/blob/b641332f69d2dd4247b7cba4c24957739cdb27c8/client/src/main/kotlin/com/linecorp/pushsphere/client/OutlierDetectingEndpointGroup.kt
     // and migrated to Java and adapted for Armeria.
 
     private static final Logger logger = LoggerFactory.getLogger(OutlierDetectingEndpointGroup.class);

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroup.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
@@ -48,14 +49,17 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerDecision;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener;
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListenerAdapter;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRule;
 import com.linecorp.armeria.client.circuitbreaker.CircuitState;
 import com.linecorp.armeria.common.CommonPools;
-import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.logging.RequestLogAccess;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
@@ -78,9 +82,10 @@ import io.micrometer.core.instrument.MeterRegistry;
  *       for {@code maxEndpointAge}. If an {@link Endpoint} exceeds its lifespan, it is automatically
  *       removed from the valid {@link Endpoint}s and a new {@link Endpoint} is added.</li>
  *   <li>Circuit breaker: This {@link EndpointGroup} uses {@link CircuitBreaker} to avoid sending requests to
- *       bad {@link Endpoint}s. Each response is classified by the configured {@link SuccessFunction} (by
- *       default, status codes 2xx-4xx are successful and everything else is a failure), and the per-endpoint
- *       {@link CircuitBreaker} updates its counts accordingly. If the failure rate exceeds the
+ *       bad {@link Endpoint}s. Each response is classified by the configured {@link CircuitBreakerRule} (by
+ *       default, 5xx responses and exceptions are reported as failures and everything else as a success),
+ *       and the per-endpoint {@link CircuitBreaker} updates its counts accordingly. If the failure rate
+ *       exceeds the
  *       {@linkplain OutlierDetectingEndpointGroupBuilder#failureRateThreshold(double) configured threshold},
  *       the {@link Endpoint} is removed from the valid {@link Endpoint}s and a new {@link Endpoint} is
  *       added automatically.</li>
@@ -146,7 +151,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
     private final int maxNumEndpoints;
     private final String namePrefix;
     private final boolean failFastOnAllCircuitOpen;
-    private final SuccessFunction successFunction;
+    private final CircuitBreakerRule circuitBreakerRule;
     private final CircuitBreakerConfig circuitBreakerConfig;
 
     private final ReentrantShortLock endpointsLock = new ReentrantShortLock();
@@ -180,7 +185,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
                                   long maxEndpointAgeMillis,
                                   String namePrefix,
                                   boolean failFastOnAllCircuitOpen,
-                                  SuccessFunction successFunction,
+                                  CircuitBreakerRule circuitBreakerRule,
                                   CircuitBreakerConfig circuitBreakerConfig,
                                   @Nullable MeterIdPrefix meterIdPrefix,
                                   @Nullable MeterRegistry meterRegistry) {
@@ -188,7 +193,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
         this.maxNumEndpoints = maxNumEndpoints;
         this.namePrefix = namePrefix;
         this.failFastOnAllCircuitOpen = failFastOnAllCircuitOpen;
-        this.successFunction = successFunction;
+        this.circuitBreakerRule = circuitBreakerRule;
         this.circuitBreakerConfig = circuitBreakerConfig;
 
         endpointGroupListeners = new OutlierEndpointGroupListener(this::endpoints);
@@ -519,7 +524,7 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
 
     /**
      * Returns a {@link DecoratingHttpClientFunction} that reports each HTTP response to the per-endpoint
-     * {@link CircuitBreaker}.
+     * {@link CircuitBreaker}, classified by the configured {@link CircuitBreakerRule}.
      *
      * <p><strong>Must be registered on the HTTP client</strong> via
      * {@code WebClientBuilder.decorator(...)}. Without it, circuit breakers never trip and outlier
@@ -527,32 +532,71 @@ public final class OutlierDetectingEndpointGroup implements EndpointGroup, Liste
      */
     public DecoratingHttpClientFunction asDecorator() {
         return (delegate, ctx, req) -> {
-            reportResult(ctx);
-            return delegate.execute(ctx, req);
+            try {
+                final HttpResponse response = delegate.execute(ctx, req);
+                reportResult(ctx);
+                return response;
+            } catch (Throwable cause) {
+                reportException(ctx, cause);
+                throw cause;
+            }
         };
     }
 
-    /**
-     * Reports the result of the request to the {@link CircuitBreaker}, classifying the response via the
-     * configured {@link SuccessFunction}.
-     */
     private void reportResult(ClientRequestContext ctx) {
+        final CircuitBreaker circuitBreaker = circuitBreakerFor(ctx);
+        if (circuitBreaker == null) {
+            return;
+        }
+        final RequestLogProperty logProperty =
+                circuitBreakerRule.requiresResponseTrailers() ? RequestLogProperty.RESPONSE_END_TIME
+                                                              : RequestLogProperty.RESPONSE_HEADERS;
+        ctx.log().whenAvailable(logProperty).thenAccept(log -> {
+            final Throwable cause =
+                    log.isAvailable(RequestLogProperty.RESPONSE_CAUSE) ? log.responseCause() : null;
+            applyDecision(circuitBreaker, circuitBreakerRule.shouldReportAsSuccess(ctx, cause));
+        });
+    }
+
+    private void reportException(ClientRequestContext ctx, Throwable cause) {
+        final CircuitBreaker circuitBreaker = circuitBreakerFor(ctx);
+        if (circuitBreaker == null) {
+            return;
+        }
+        applyDecision(circuitBreaker, circuitBreakerRule.shouldReportAsSuccess(ctx, cause));
+    }
+
+    @Nullable
+    private CircuitBreaker circuitBreakerFor(ClientRequestContext ctx) {
         final Endpoint endpoint = ctx.endpoint();
         if (endpoint == null) {
-            // Nothing to report.
-            return;
+            return null;
         }
         final EndpointContext endpointContext = endpointContexts.get(endpoint);
         if (endpointContext == null) {
-            return;
+            return null;
         }
-        final CircuitBreaker circuitBreaker = endpointContext.circuitBreaker();
-        ctx.log().whenComplete().thenAccept(log -> {
-            if (successFunction.isSuccess(ctx, log)) {
+        return endpointContext.circuitBreaker();
+    }
+
+    private static void applyDecision(CircuitBreaker circuitBreaker,
+                                      CompletionStage<CircuitBreakerDecision> decisionFuture) {
+        decisionFuture.handle((decision, cause) -> {
+            if (cause != null) {
+                logger.warn("Unexpected exception while applying circuit breaker decision.", cause);
+                return null;
+            }
+
+            if (decision == null) {
+                return null;
+            }
+            if (decision == CircuitBreakerDecision.success() || decision == CircuitBreakerDecision.next()) {
                 circuitBreaker.onSuccess();
-            } else {
+            } else if (decision == CircuitBreakerDecision.failure()) {
                 circuitBreaker.onFailure();
             }
+            // CircuitBreakerDecision.ignore() leaves the counters untouched.
+            return null;
         });
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -17,6 +17,12 @@
 package com.linecorp.armeria.client.endpoint;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_FAILURE_RATE_THRESHOLD;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_MINIMUM_REQUEST_THRESHOLD;
+import static com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig.DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
@@ -54,13 +60,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
                               .onException()
                               .thenFailure();
 
-    // CircuitBreaker defaults — kept in sync with CircuitBreakerBuilder.
-    private static final double DEFAULT_FAILURE_RATE_THRESHOLD = 0.5;
-    private static final long DEFAULT_MINIMUM_REQUEST_THRESHOLD = 10;
-    private static final Duration DEFAULT_TRIAL_REQUEST_INTERVAL = Duration.ofSeconds(3);
-    private static final Duration DEFAULT_CIRCUIT_OPEN_WINDOW = Duration.ofSeconds(10);
-    private static final Duration DEFAULT_COUNTER_SLIDING_WINDOW = Duration.ofSeconds(20);
-    private static final Duration DEFAULT_COUNTER_UPDATE_INTERVAL = Duration.ofSeconds(1);
 
     private final EndpointGroup delegate;
 
@@ -75,10 +74,10 @@ public final class OutlierDetectingEndpointGroupBuilder {
     // Per-endpoint CircuitBreaker settings.
     private double failureRateThreshold = DEFAULT_FAILURE_RATE_THRESHOLD;
     private long minimumRequestThreshold = DEFAULT_MINIMUM_REQUEST_THRESHOLD;
-    private Duration trialRequestInterval = DEFAULT_TRIAL_REQUEST_INTERVAL;
-    private Duration circuitOpenWindow = DEFAULT_CIRCUIT_OPEN_WINDOW;
-    private Duration counterSlidingWindow = DEFAULT_COUNTER_SLIDING_WINDOW;
-    private Duration counterUpdateInterval = DEFAULT_COUNTER_UPDATE_INTERVAL;
+    private Duration trialRequestInterval = Duration.ofSeconds(DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS);
+    private Duration circuitOpenWindow = Duration.ofSeconds(DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS);
+    private Duration counterSlidingWindow = Duration.ofSeconds(DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS);
+    private Duration counterUpdateInterval = Duration.ofSeconds(DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS);
 
     @Nullable
     private MeterIdPrefix meterIdPrefix;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -131,7 +131,9 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * {@code "outlier-detecting"}.
      */
     public OutlierDetectingEndpointGroupBuilder namePrefix(String namePrefix) {
-        this.namePrefix = requireNonNull(namePrefix, "namePrefix");
+        requireNonNull(namePrefix, "namePrefix");
+        checkArgument(!namePrefix.isEmpty(), "namePrefix cannot be empty");
+        this.namePrefix = namePrefix;
         return this;
     }
 
@@ -300,6 +302,10 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * Returns a newly created {@link OutlierDetectingEndpointGroup}.
      */
     public OutlierDetectingEndpointGroup build() {
+        if (counterSlidingWindow.compareTo(counterUpdateInterval) <= 0) {
+            throw new IllegalStateException(
+                    "counterSlidingWindow: " + counterSlidingWindow + " (expected: > counterUpdateInterval)");
+        }
         final CircuitBreakerConfig circuitBreakerConfig = new CircuitBreakerConfig(
                 null, failureRateThreshold, minimumRequestThreshold,
                 circuitOpenWindow, trialRequestInterval,

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
-import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRule;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
@@ -46,13 +46,14 @@ public final class OutlierDetectingEndpointGroupBuilder {
     static final String DEFAULT_NAME_PREFIX = "outlier-detecting";
 
     /**
-     * The default {@link SuccessFunction} treats responses with status codes 2xx-4xx as successful and
-     * everything else as a failure.
+     * The default {@link CircuitBreakerRule} reports 5xx responses and exceptions as failures, and treats
+     * everything else as a success.
      */
-    private static final SuccessFunction DEFAULT_SUCCESS_FUNCTION = (ctx, log) -> {
-        final int code = log.responseStatus().code();
-        return code >= 200 && code <= 499;
-    };
+    private static final CircuitBreakerRule DEFAULT_RULE =
+            CircuitBreakerRule.builder()
+                              .onServerErrorStatus()
+                              .onException()
+                              .thenFailure();
 
     // CircuitBreaker defaults — kept in sync with CircuitBreakerBuilder.
     private static final double DEFAULT_FAILURE_RATE_THRESHOLD = 0.5;
@@ -70,7 +71,7 @@ public final class OutlierDetectingEndpointGroupBuilder {
     // Outlier-specific (kept separate from CircuitBreakerConfig).
     private String namePrefix = DEFAULT_NAME_PREFIX;
     private boolean failFastOnAllCircuitOpen;
-    private SuccessFunction successFunction = DEFAULT_SUCCESS_FUNCTION;
+    private CircuitBreakerRule circuitBreakerRule = DEFAULT_RULE;
 
     // Per-endpoint CircuitBreaker settings.
     private double failureRateThreshold = DEFAULT_FAILURE_RATE_THRESHOLD;
@@ -273,12 +274,12 @@ public final class OutlierDetectingEndpointGroupBuilder {
     }
 
     /**
-     * Sets the {@link SuccessFunction} used to classify each response as a {@link CircuitBreaker} success or
-     * failure. By default, responses with status codes 2xx-4xx are treated as successful and everything else
-     * as a failure.
+     * Sets the {@link CircuitBreakerRule} used to classify each request outcome as a {@link CircuitBreaker}
+     * success or failure. By default, 5xx responses and exceptions are reported as failures and everything
+     * else as a success.
      */
-    public OutlierDetectingEndpointGroupBuilder successFunction(SuccessFunction successFunction) {
-        this.successFunction = requireNonNull(successFunction, "successFunction");
+    public OutlierDetectingEndpointGroupBuilder circuitBreakerRule(CircuitBreakerRule circuitBreakerRule) {
+        this.circuitBreakerRule = requireNonNull(circuitBreakerRule, "circuitBreakerRule");
         return this;
     }
 
@@ -304,7 +305,7 @@ public final class OutlierDetectingEndpointGroupBuilder {
                 circuitOpenWindow, trialRequestInterval,
                 counterSlidingWindow, counterUpdateInterval, ImmutableList.of());
         return new OutlierDetectingEndpointGroup(delegate, maxNumEndpoints, maxEndpointAgeMillis,
-                                                 namePrefix, failFastOnAllCircuitOpen, successFunction,
+                                                 namePrefix, failFastOnAllCircuitOpen, circuitBreakerRule,
                                                  circuitBreakerConfig, meterIdPrefix, meterRegistry);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -40,10 +40,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 @UnstableApi
 public final class OutlierDetectingEndpointGroupBuilder {
 
-    static final int DEFAULT_MAX_NUM_ENDPOINTS = 1024;
-    /** Sentinel meaning the periodic age-based rotation is disabled by default. */
-    static final long DEFAULT_MAX_ENDPOINT_AGE_MILLIS = -1;
-    static final String DEFAULT_NAME_PREFIX = "outlier-detecting";
+    private static final int DEFAULT_MAX_NUM_ENDPOINTS = 1024;
+    private static final long DEFAULT_MAX_ENDPOINT_AGE_MILLIS = -1;
+    private static final String DEFAULT_NAME_PREFIX = "outlier-detecting";
 
     /**
      * The default {@link CircuitBreakerRule} reports 5xx responses and exceptions as failures, and treats
@@ -94,7 +93,7 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * Sets the maximum number of endpoints kept in the rotation. Defaults to
      * {@value #DEFAULT_MAX_NUM_ENDPOINTS}, which is large enough for typical large-scale deployments
      * and avoids accidentally truncating the underlying group when this builder is used without
-     * explicit configuration. Increase only when more concurrent endpoints are actually needed.
+     * explicit configuration. Increase when more concurrent endpoints are actually needed.
      */
     public OutlierDetectingEndpointGroupBuilder maxNumEndpoints(int maxNumEndpoints) {
         checkArgument(maxNumEndpoints > 0,
@@ -170,7 +169,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * Sets the interval at which a single trial request is allowed through while the per-endpoint
      * {@link CircuitBreaker} is in the {@code HALF_OPEN} state. Defaults to {@code 3} seconds.
      *
-     * @throws NullPointerException if {@code trialRequestInterval} is {@code null}.
      * @throws IllegalArgumentException if {@code trialRequestInterval} is not positive.
      */
     public OutlierDetectingEndpointGroupBuilder trialRequestInterval(Duration trialRequestInterval) {
@@ -195,7 +193,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * value is also used as the cool-down before a bad endpoint becomes selectable again. Defaults to
      * {@code 10} seconds.
      *
-     * @throws NullPointerException if {@code circuitOpenWindow} is {@code null}.
      * @throws IllegalArgumentException if {@code circuitOpenWindow} is not positive.
      */
     public OutlierDetectingEndpointGroupBuilder circuitOpenWindow(Duration circuitOpenWindow) {
@@ -219,7 +216,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * Sets the size of the rolling window over which the per-endpoint {@link CircuitBreaker} counts
      * successes and failures. Defaults to {@code 20} seconds.
      *
-     * @throws NullPointerException if {@code counterSlidingWindow} is {@code null}.
      * @throws IllegalArgumentException if {@code counterSlidingWindow} is not positive.
      */
     public OutlierDetectingEndpointGroupBuilder counterSlidingWindow(Duration counterSlidingWindow) {
@@ -243,7 +239,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
      * Sets the interval at which the per-endpoint {@link CircuitBreaker} re-evaluates its counters and
      * may trip. Defaults to {@code 1} second.
      *
-     * @throws NullPointerException if {@code counterUpdateInterval} is {@code null}.
      * @throws IllegalArgumentException if {@code counterUpdateInterval} is not positive.
      */
     public OutlierDetectingEndpointGroupBuilder counterUpdateInterval(Duration counterUpdateInterval) {

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -60,7 +60,6 @@ public final class OutlierDetectingEndpointGroupBuilder {
                               .onException()
                               .thenFailure();
 
-
     private final EndpointGroup delegate;
 
     private int maxNumEndpoints = DEFAULT_MAX_NUM_ENDPOINTS;

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupBuilder.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreaker;
+import com.linecorp.armeria.common.SuccessFunction;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Builds an {@link OutlierDetectingEndpointGroup}.
+ *
+ * <p>See {@link OutlierDetectingEndpointGroup} for usage and the required HTTP decorator setup.
+ */
+@UnstableApi
+public final class OutlierDetectingEndpointGroupBuilder {
+
+    static final int DEFAULT_MAX_NUM_ENDPOINTS = 1024;
+    /** Sentinel meaning the periodic age-based rotation is disabled by default. */
+    static final long DEFAULT_MAX_ENDPOINT_AGE_MILLIS = -1;
+    static final String DEFAULT_NAME_PREFIX = "outlier-detecting";
+
+    /**
+     * The default {@link SuccessFunction} treats responses with status codes 2xx-4xx as successful and
+     * everything else as a failure.
+     */
+    private static final SuccessFunction DEFAULT_SUCCESS_FUNCTION = (ctx, log) -> {
+        final int code = log.responseStatus().code();
+        return code >= 200 && code <= 499;
+    };
+
+    // CircuitBreaker defaults — kept in sync with CircuitBreakerBuilder.
+    private static final double DEFAULT_FAILURE_RATE_THRESHOLD = 0.5;
+    private static final long DEFAULT_MINIMUM_REQUEST_THRESHOLD = 10;
+    private static final Duration DEFAULT_TRIAL_REQUEST_INTERVAL = Duration.ofSeconds(3);
+    private static final Duration DEFAULT_CIRCUIT_OPEN_WINDOW = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_COUNTER_SLIDING_WINDOW = Duration.ofSeconds(20);
+    private static final Duration DEFAULT_COUNTER_UPDATE_INTERVAL = Duration.ofSeconds(1);
+
+    private final EndpointGroup delegate;
+
+    private int maxNumEndpoints = DEFAULT_MAX_NUM_ENDPOINTS;
+    private long maxEndpointAgeMillis = DEFAULT_MAX_ENDPOINT_AGE_MILLIS;
+
+    // Outlier-specific (kept separate from CircuitBreakerConfig).
+    private String namePrefix = DEFAULT_NAME_PREFIX;
+    private boolean failFastOnAllCircuitOpen;
+    private SuccessFunction successFunction = DEFAULT_SUCCESS_FUNCTION;
+
+    // Per-endpoint CircuitBreaker settings.
+    private double failureRateThreshold = DEFAULT_FAILURE_RATE_THRESHOLD;
+    private long minimumRequestThreshold = DEFAULT_MINIMUM_REQUEST_THRESHOLD;
+    private Duration trialRequestInterval = DEFAULT_TRIAL_REQUEST_INTERVAL;
+    private Duration circuitOpenWindow = DEFAULT_CIRCUIT_OPEN_WINDOW;
+    private Duration counterSlidingWindow = DEFAULT_COUNTER_SLIDING_WINDOW;
+    private Duration counterUpdateInterval = DEFAULT_COUNTER_UPDATE_INTERVAL;
+
+    @Nullable
+    private MeterIdPrefix meterIdPrefix;
+    @Nullable
+    private MeterRegistry meterRegistry;
+
+    OutlierDetectingEndpointGroupBuilder(EndpointGroup delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    /**
+     * Sets the maximum number of endpoints kept in the rotation. Defaults to
+     * {@value #DEFAULT_MAX_NUM_ENDPOINTS}, which is large enough for typical large-scale deployments
+     * and avoids accidentally truncating the underlying group when this builder is used without
+     * explicit configuration. Increase only when more concurrent endpoints are actually needed.
+     */
+    public OutlierDetectingEndpointGroupBuilder maxNumEndpoints(int maxNumEndpoints) {
+        checkArgument(maxNumEndpoints > 0,
+                      "maxNumEndpoints: %s (expected: > 0)", maxNumEndpoints);
+        this.maxNumEndpoints = maxNumEndpoints;
+        return this;
+    }
+
+    /**
+     * Enables periodic age-based rotation by setting the lifespan of each endpoint. Once an endpoint
+     * has been in the rotation for this duration, it is dropped and replaced by a fresh candidate from
+     * the delegate (or reused from the keep-alive cache to preserve {@link CircuitBreaker} state).
+     *
+     * <p>Disabled by default — endpoints stay in the rotation indefinitely until they are evicted by
+     * the per-endpoint {@link CircuitBreaker} or the delegate stops reporting them.
+     */
+    public OutlierDetectingEndpointGroupBuilder maxEndpointAge(Duration maxEndpointAge) {
+        requireNonNull(maxEndpointAge, "maxEndpointAge");
+        return maxEndpointAgeMillis(maxEndpointAge.toMillis());
+    }
+
+    /**
+     * Enables periodic age-based rotation. See {@link #maxEndpointAge(Duration)}.
+     */
+    public OutlierDetectingEndpointGroupBuilder maxEndpointAgeMillis(long maxEndpointAgeMillis) {
+        checkArgument(maxEndpointAgeMillis > 0,
+                      "maxEndpointAgeMillis: %s (expected: > 0)", maxEndpointAgeMillis);
+        this.maxEndpointAgeMillis = maxEndpointAgeMillis;
+        return this;
+    }
+
+    /**
+     * Sets the name prefix used when creating per-endpoint {@link CircuitBreaker}s. Defaults to
+     * {@code "outlier-detecting"}.
+     */
+    public OutlierDetectingEndpointGroupBuilder namePrefix(String namePrefix) {
+        this.namePrefix = requireNonNull(namePrefix, "namePrefix");
+        return this;
+    }
+
+    /**
+     * Sets the failure rate threshold of the per-endpoint {@link CircuitBreaker}. When the failure rate
+     * over the {@linkplain #counterSlidingWindow(Duration) counter sliding window} reaches this value, the
+     * circuit opens and the endpoint is ejected. Defaults to {@code 0.5}.
+     *
+     * @param failureRateThreshold a rate in {@code (0, 1]}.
+     * @throws IllegalArgumentException if {@code failureRateThreshold} is not in {@code (0, 1]}.
+     */
+    public OutlierDetectingEndpointGroupBuilder failureRateThreshold(double failureRateThreshold) {
+        checkArgument(failureRateThreshold > 0 && failureRateThreshold <= 1,
+                      "failureRateThreshold: %s (expected: > 0 and <= 1)", failureRateThreshold);
+        this.failureRateThreshold = failureRateThreshold;
+        return this;
+    }
+
+    /**
+     * Sets the minimum number of requests within the {@linkplain #counterSlidingWindow(Duration) counter
+     * sliding window} required before the per-endpoint {@link CircuitBreaker} can open. Defaults to
+     * {@code 10}.
+     *
+     * @throws IllegalArgumentException if {@code minimumRequestThreshold} is negative.
+     */
+    public OutlierDetectingEndpointGroupBuilder minimumRequestThreshold(long minimumRequestThreshold) {
+        checkArgument(minimumRequestThreshold >= 0,
+                      "minimumRequestThreshold: %s (expected: >= 0)", minimumRequestThreshold);
+        this.minimumRequestThreshold = minimumRequestThreshold;
+        return this;
+    }
+
+    /**
+     * Sets the interval at which a single trial request is allowed through while the per-endpoint
+     * {@link CircuitBreaker} is in the {@code HALF_OPEN} state. Defaults to {@code 3} seconds.
+     *
+     * @throws NullPointerException if {@code trialRequestInterval} is {@code null}.
+     * @throws IllegalArgumentException if {@code trialRequestInterval} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder trialRequestInterval(Duration trialRequestInterval) {
+        requireNonNull(trialRequestInterval, "trialRequestInterval");
+        return trialRequestIntervalMillis(trialRequestInterval.toMillis());
+    }
+
+    /**
+     * Sets the {@linkplain #trialRequestInterval(Duration) trial request interval} in milliseconds.
+     *
+     * @throws IllegalArgumentException if {@code trialRequestIntervalMillis} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder trialRequestIntervalMillis(long trialRequestIntervalMillis) {
+        checkArgument(trialRequestIntervalMillis > 0,
+                      "trialRequestIntervalMillis: %s (expected: > 0)", trialRequestIntervalMillis);
+        trialRequestInterval = Duration.ofMillis(trialRequestIntervalMillis);
+        return this;
+    }
+
+    /**
+     * Sets how long the per-endpoint {@link CircuitBreaker} stays in the {@code OPEN} state. The same
+     * value is also used as the cool-down before a bad endpoint becomes selectable again. Defaults to
+     * {@code 10} seconds.
+     *
+     * @throws NullPointerException if {@code circuitOpenWindow} is {@code null}.
+     * @throws IllegalArgumentException if {@code circuitOpenWindow} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder circuitOpenWindow(Duration circuitOpenWindow) {
+        requireNonNull(circuitOpenWindow, "circuitOpenWindow");
+        return circuitOpenWindowMillis(circuitOpenWindow.toMillis());
+    }
+
+    /**
+     * Sets the {@linkplain #circuitOpenWindow(Duration) circuit open window} in milliseconds.
+     *
+     * @throws IllegalArgumentException if {@code circuitOpenWindowMillis} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder circuitOpenWindowMillis(long circuitOpenWindowMillis) {
+        checkArgument(circuitOpenWindowMillis > 0,
+                      "circuitOpenWindowMillis: %s (expected: > 0)", circuitOpenWindowMillis);
+        circuitOpenWindow = Duration.ofMillis(circuitOpenWindowMillis);
+        return this;
+    }
+
+    /**
+     * Sets the size of the rolling window over which the per-endpoint {@link CircuitBreaker} counts
+     * successes and failures. Defaults to {@code 20} seconds.
+     *
+     * @throws NullPointerException if {@code counterSlidingWindow} is {@code null}.
+     * @throws IllegalArgumentException if {@code counterSlidingWindow} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder counterSlidingWindow(Duration counterSlidingWindow) {
+        requireNonNull(counterSlidingWindow, "counterSlidingWindow");
+        return counterSlidingWindowMillis(counterSlidingWindow.toMillis());
+    }
+
+    /**
+     * Sets the {@linkplain #counterSlidingWindow(Duration) counter sliding window} in milliseconds.
+     *
+     * @throws IllegalArgumentException if {@code counterSlidingWindowMillis} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder counterSlidingWindowMillis(long counterSlidingWindowMillis) {
+        checkArgument(counterSlidingWindowMillis > 0,
+                      "counterSlidingWindowMillis: %s (expected: > 0)", counterSlidingWindowMillis);
+        counterSlidingWindow = Duration.ofMillis(counterSlidingWindowMillis);
+        return this;
+    }
+
+    /**
+     * Sets the interval at which the per-endpoint {@link CircuitBreaker} re-evaluates its counters and
+     * may trip. Defaults to {@code 1} second.
+     *
+     * @throws NullPointerException if {@code counterUpdateInterval} is {@code null}.
+     * @throws IllegalArgumentException if {@code counterUpdateInterval} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder counterUpdateInterval(Duration counterUpdateInterval) {
+        requireNonNull(counterUpdateInterval, "counterUpdateInterval");
+        return counterUpdateIntervalMillis(counterUpdateInterval.toMillis());
+    }
+
+    /**
+     * Sets the {@linkplain #counterUpdateInterval(Duration) counter update interval} in milliseconds.
+     *
+     * @throws IllegalArgumentException if {@code counterUpdateIntervalMillis} is not positive.
+     */
+    public OutlierDetectingEndpointGroupBuilder counterUpdateIntervalMillis(long counterUpdateIntervalMillis) {
+        checkArgument(counterUpdateIntervalMillis > 0,
+                      "counterUpdateIntervalMillis: %s (expected: > 0)", counterUpdateIntervalMillis);
+        counterUpdateInterval = Duration.ofMillis(counterUpdateIntervalMillis);
+        return this;
+    }
+
+    /**
+     * Controls behavior when every endpoint's circuit is open. By default ({@code false}), one of the
+     * bad endpoints is picked as a last-resort fallback so traffic keeps flowing while the underlying
+     * group recovers. When set to {@code true}, the fallback is disabled — endpoint selection then
+     * waits for a healthy endpoint and fails if none becomes available within the
+     * {@linkplain EndpointGroup#selectionTimeoutMillis() selection timeout}.
+     */
+    public OutlierDetectingEndpointGroupBuilder failFastOnAllCircuitOpen(boolean failFastOnAllCircuitOpen) {
+        this.failFastOnAllCircuitOpen = failFastOnAllCircuitOpen;
+        return this;
+    }
+
+    /**
+     * Sets the {@link SuccessFunction} used to classify each response as a {@link CircuitBreaker} success or
+     * failure. By default, responses with status codes 2xx-4xx are treated as successful and everything else
+     * as a failure.
+     */
+    public OutlierDetectingEndpointGroupBuilder successFunction(SuccessFunction successFunction) {
+        this.successFunction = requireNonNull(successFunction, "successFunction");
+        return this;
+    }
+
+    /**
+     * Registers gauges for the number of healthy and unhealthy endpoints under
+     * {@code <meterIdPrefix>.endpoints.count}, distinguished by the {@code state} tag with values
+     * {@code "healthy"} (endpoints currently in rotation) and {@code "unhealthy"} (endpoints whose
+     * circuits are open and are temporarily ejected).
+     */
+    public OutlierDetectingEndpointGroupBuilder meterRegistry(MeterIdPrefix meterIdPrefix,
+                                                              MeterRegistry meterRegistry) {
+        this.meterIdPrefix = requireNonNull(meterIdPrefix, "meterIdPrefix");
+        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
+        return this;
+    }
+
+    /**
+     * Returns a newly created {@link OutlierDetectingEndpointGroup}.
+     */
+    public OutlierDetectingEndpointGroup build() {
+        final CircuitBreakerConfig circuitBreakerConfig = new CircuitBreakerConfig(
+                null, failureRateThreshold, minimumRequestThreshold,
+                circuitOpenWindow, trialRequestInterval,
+                counterSlidingWindow, counterUpdateInterval, ImmutableList.of());
+        return new OutlierDetectingEndpointGroup(delegate, maxNumEndpoints, maxEndpointAgeMillis,
+                                                 namePrefix, failFastOnAllCircuitOpen, successFunction,
+                                                 circuitBreakerConfig, meterIdPrefix, meterRegistry);
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/CircuitBreakerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/CircuitBreakerConfig.java
@@ -29,6 +29,13 @@ import com.linecorp.armeria.common.annotation.Nullable;
  */
 public final class CircuitBreakerConfig {
 
+    public static final double DEFAULT_FAILURE_RATE_THRESHOLD = 0.5;
+    public static final long DEFAULT_MINIMUM_REQUEST_THRESHOLD = 10;
+    public static final int DEFAULT_TRIAL_REQUEST_INTERVAL_SECONDS = 3;
+    public static final int DEFAULT_CIRCUIT_OPEN_WINDOW_SECONDS = 10;
+    public static final int DEFAULT_COUNTER_SLIDING_WINDOW_SECONDS = 20;
+    public static final int DEFAULT_COUNTER_UPDATE_INTERVAL_SECONDS = 1;
+
     @Nullable
     private final String name;
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/CircuitBreakerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/CircuitBreakerConfig.java
@@ -14,19 +14,20 @@
  * under the License.
  */
 
-package com.linecorp.armeria.client.circuitbreaker;
+package com.linecorp.armeria.internal.client.circuitbreaker;
 
 import java.time.Duration;
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerListener;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
  * Stores configurations of circuit breaker.
  */
-final class CircuitBreakerConfig {
+public final class CircuitBreakerConfig {
 
     @Nullable
     private final String name;
@@ -45,11 +46,11 @@ final class CircuitBreakerConfig {
 
     private final List<CircuitBreakerListener> listeners;
 
-    CircuitBreakerConfig(@Nullable String name,
-                         double failureRateThreshold, long minimumRequestThreshold,
-                         Duration circuitOpenWindow, Duration trialRequestInterval,
-                         Duration counterSlidingWindow, Duration counterUpdateInterval,
-                         List<CircuitBreakerListener> listeners) {
+    public CircuitBreakerConfig(@Nullable String name,
+                                double failureRateThreshold, long minimumRequestThreshold,
+                                Duration circuitOpenWindow, Duration trialRequestInterval,
+                                Duration counterSlidingWindow, Duration counterUpdateInterval,
+                                List<CircuitBreakerListener> listeners) {
         this.name = name;
         this.failureRateThreshold = failureRateThreshold;
         this.minimumRequestThreshold = minimumRequestThreshold;
@@ -61,35 +62,35 @@ final class CircuitBreakerConfig {
     }
 
     @Nullable
-    String name() {
+    public String name() {
         return name;
     }
 
-    double failureRateThreshold() {
+    public double failureRateThreshold() {
         return failureRateThreshold;
     }
 
-    long minimumRequestThreshold() {
+    public long minimumRequestThreshold() {
         return minimumRequestThreshold;
     }
 
-    Duration circuitOpenWindow() {
+    public Duration circuitOpenWindow() {
         return circuitOpenWindow;
     }
 
-    Duration trialRequestInterval() {
+    public Duration trialRequestInterval() {
         return trialRequestInterval;
     }
 
-    Duration counterSlidingWindow() {
+    public Duration counterSlidingWindow() {
         return counterSlidingWindow;
     }
 
-    Duration counterUpdateInterval() {
+    public Duration counterUpdateInterval() {
         return counterUpdateInterval;
     }
 
-    List<CircuitBreakerListener> listeners() {
+    public List<CircuitBreakerListener> listeners() {
         return listeners;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/package-info.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/circuitbreaker/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Various classes used internally. Anything in this package can be changed or removed at any time.
+ */
+@NonNullByDefault
+package com.linecorp.armeria.internal.client.circuitbreaker;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;

--- a/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/circuitbreaker/CircuitBreakerBuilderTest.java
@@ -23,6 +23,8 @@ import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.internal.client.circuitbreaker.CircuitBreakerConfig;
+
 class CircuitBreakerBuilderTest {
 
     private static final String remoteServiceName = "testService";

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class OutlierDetectingEndpointGroupIntegrationTest {
+
+    private static final ConcurrentMap<Integer, AtomicInteger> requestCounter = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Integer, Boolean> badServers = new ConcurrentHashMap<>();
+
+    private static ServerExtension server(int id) {
+        return new ServerExtension() {
+            @Override
+            protected void configure(ServerBuilder sb) {
+                sb.http(0);
+                sb.service("/ping", (HttpService) (ctx, req) -> {
+                    requestCounter.computeIfAbsent(id, k -> new AtomicInteger()).incrementAndGet();
+                    if (Boolean.TRUE.equals(badServers.get(id))) {
+                        return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+                    }
+                    return HttpResponse.of(HttpStatus.OK);
+                });
+            }
+        };
+    }
+
+    @RegisterExtension
+    static final ServerExtension server1 = server(1);
+    @RegisterExtension
+    static final ServerExtension server2 = server(2);
+    @RegisterExtension
+    static final ServerExtension server3 = server(3);
+
+    @AfterEach
+    void clearState() {
+        requestCounter.clear();
+        badServers.clear();
+    }
+
+    private static Endpoint endpoint(ServerExtension server) {
+        return Endpoint.of("127.0.0.1", server.httpPort());
+    }
+
+    @Test
+    void asHttpDecoratorMarksFailingServersAsBad() {
+        badServers.put(1, true);
+
+        final List<Endpoint> endpoints =
+                ImmutableList.of(endpoint(server1), endpoint(server2), endpoint(server3));
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                     OutlierDetectingEndpointGroup.builder(EndpointGroup.of(endpoints))
+                                                  // Trip the breaker on the first failure.
+                                                  .minimumRequestThreshold(1)
+                                                  .counterUpdateIntervalMillis(1)
+                                                  .failureRateThreshold(0.99)
+                                                  // Long enough that the bad endpoint stays bad for
+                                                  // the duration of the test.
+                                                  .circuitOpenWindowMillis(30_000)
+                                                  .build()) {
+
+            endpointGroup.whenReady().join();
+
+            final WebClient client =
+                    WebClient.builder(SessionProtocol.HTTP, endpointGroup)
+                             .decorator(endpointGroup.asDecorator())
+                             .build();
+
+            // Drive enough traffic for the round-robin selector to hit every server, including the bad one.
+            for (int i = 0; i < 60; i++) {
+                client.get("/ping").aggregate().join();
+            }
+
+            // The bad server should have been ejected from the rotation.
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                    assertThat(endpointGroup.endpoints()).doesNotContain(endpoint(server1)));
+
+            // Subsequent traffic should not reach server1 anymore.
+            requestCounter.get(1).set(0);
+            for (int i = 0; i < 30; i++) {
+                client.get("/ping").aggregate().join();
+            }
+            assertThat(requestCounter.get(1).get()).isZero();
+            assertThat(requestCounter.get(2).get()).isPositive();
+            assertThat(requestCounter.get(3).get()).isPositive();
+        }
+    }
+
+    @Test
+    void customSuccessFunctionDrivesCircuitBreakerClassification() {
+        // server1 returns 500, but the custom SuccessFunction treats every response as a success, so the
+        // circuit breaker should never open and server1 should remain in the rotation.
+        badServers.put(1, true);
+
+        final List<Endpoint> endpoints =
+                ImmutableList.of(endpoint(server1), endpoint(server2));
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                     OutlierDetectingEndpointGroup.builder(EndpointGroup.of(endpoints))
+                                                  .successFunction((ctx, log) -> true)
+                                                  .minimumRequestThreshold(1)
+                                                  .counterUpdateIntervalMillis(1)
+                                                  .failureRateThreshold(0.5)
+                                                  .circuitOpenWindowMillis(30_000)
+                                                  .build()) {
+
+            endpointGroup.whenReady().join();
+
+            final WebClient client =
+                    WebClient.builder(SessionProtocol.HTTP, endpointGroup)
+                             .decorator(endpointGroup.asDecorator())
+                             .build();
+
+            for (int i = 0; i < 40; i++) {
+                client.get("/ping").aggregate().join();
+            }
+
+            // Both endpoints should still be alive — the failing server was classified as success.
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(
+                    endpoint(server1), endpoint(server2));
+            assertThat(requestCounter.get(1).get()).isPositive();
+            assertThat(requestCounter.get(2).get()).isPositive();
+        }
+    }
+
+    @Test
+    void recoversAfterBadEndpointWindowExpires() {
+        badServers.put(1, true);
+
+        final List<Endpoint> endpoints =
+                ImmutableList.of(endpoint(server1), endpoint(server2));
+        final long circuitOpenWindowMillis = 1500;
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                     OutlierDetectingEndpointGroup.builder(EndpointGroup.of(endpoints))
+                                                  .minimumRequestThreshold(1)
+                                                  .counterUpdateIntervalMillis(1)
+                                                  .failureRateThreshold(0.99)
+                                                  .circuitOpenWindowMillis(circuitOpenWindowMillis)
+                                                  .build()) {
+
+            endpointGroup.whenReady().join();
+            final WebClient client =
+                    WebClient.builder(SessionProtocol.HTTP, endpointGroup)
+                             .decorator(endpointGroup.asDecorator())
+                             .build();
+
+            for (int i = 0; i < 40; i++) {
+                client.get("/ping").aggregate().join();
+            }
+
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                    assertThat(endpointGroup.endpoints()).doesNotContain(endpoint(server1)));
+
+            // Heal the bad server before the cool-down expires.
+            badServers.remove(1);
+
+            await().atMost(Duration.ofSeconds(circuitOpenWindowMillis * 4 / 1000 + 5))
+                   .untilAsserted(() -> assertThat(endpointGroup.endpoints())
+                           .containsExactlyInAnyOrder(endpoint(server1), endpoint(server2)));
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupIntegrationTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.circuitbreaker.CircuitBreakerRule;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -123,8 +124,8 @@ class OutlierDetectingEndpointGroupIntegrationTest {
     }
 
     @Test
-    void customSuccessFunctionDrivesCircuitBreakerClassification() {
-        // server1 returns 500, but the custom SuccessFunction treats every response as a success, so the
+    void customRuleDrivesCircuitBreakerClassification() {
+        // server1 returns 500, but the custom CircuitBreakerRule reports every response as a success, so the
         // circuit breaker should never open and server1 should remain in the rotation.
         badServers.put(1, true);
 
@@ -132,7 +133,9 @@ class OutlierDetectingEndpointGroupIntegrationTest {
                 ImmutableList.of(endpoint(server1), endpoint(server2));
         try (OutlierDetectingEndpointGroup endpointGroup =
                      OutlierDetectingEndpointGroup.builder(EndpointGroup.of(endpoints))
-                                                  .successFunction((ctx, log) -> true)
+                                                  .circuitBreakerRule(CircuitBreakerRule.builder()
+                                                                                        .onException()
+                                                                                        .thenFailure())
                                                   .minimumRequestThreshold(1)
                                                   .counterUpdateIntervalMillis(1)
                                                   .failureRateThreshold(0.5)

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
@@ -1,0 +1,627 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.endpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.circuitbreaker.CircuitState;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestId;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.internal.client.DefaultClientRequestContext;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class OutlierDetectingEndpointGroupTest {
+
+    @Test
+    void whenReadyCompletesAfterDelegateBecomesReady() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        assertThat(endpointGroup.whenReady()).isNotDone();
+        delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
+        assertThat(endpointGroup.whenReady()).isCompletedWithValueMatching(
+                endpoints -> endpoints.contains(Endpoint.of("foo.com")));
+        assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("foo.com"));
+    }
+
+    @Test
+    void listenerReceivesUpdatedEndpoints() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+        final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
+        endpointGroup.addListener(captor::set);
+
+        delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
+
+        // Listener notification is dispatched asynchronously on the executor.
+        await().untilAsserted(() ->
+                assertThat(captor.get()).containsExactly(Endpoint.of("foo.com")));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────
+    // Spec — strict mode (maxEndpointAge=-1, default):
+    //   pool = delegate.endpoints() − bad endpoints, capped at maxNumEndpoints.
+    // Spec — keep-alive mode (maxEndpointAge>0, opt-in):
+    //   pool tries to fill maxNumEndpoints from delegate.endpoints() − bad first; if it can't, the
+    //   remainder is filled from the cache (still-valid old endpoints).
+    // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void strictMode_poolMirrorsDelegate() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        // Default: maxNumEndpoints=1024, maxEndpointAge=-1 (strict).
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        final Endpoint a = Endpoint.of("a.com");
+        final Endpoint b = Endpoint.of("b.com");
+        final Endpoint c = Endpoint.of("c.com");
+
+        delegate.update(ImmutableList.of(a, b, c));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b, c);
+
+        // Delegate drops B. Strict mode tracks delegate exactly — B must disappear from the pool.
+        delegate.update(ImmutableList.of(a, c));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, c);
+    }
+
+    @Test
+    void strictMode_excludesBadEndpoints() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        final Endpoint a = Endpoint.of("a.com");
+        final Endpoint b = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(a, b));
+
+        endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(endpointGroup.endpoints()).containsExactly(b);
+    }
+
+    @Test
+    void strictMode_capsAtMaxNumEndpoints() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .build();
+
+        final Endpoint a = Endpoint.of("a.com");
+        final Endpoint b = Endpoint.of("b.com");
+        final Endpoint c = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(a, b, c));
+        assertThat(endpointGroup.endpoints()).hasSize(2);
+    }
+
+    @Test
+    void keepAlive_fillsFromCacheWhenDelegateIsInsufficient() {
+        // maxNumEndpoints=2, age=10min. Delegate gives [a, b] then replaces b with c.
+        // The pool was full, so the addListener gate skips the refresh; the cache holds b alive.
+        // When a's circuit opens, the refresh triggers and the cache fills the gap with b (still
+        // not expired) plus c from the delegate.
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofMinutes(10))
+                                             .build();
+
+        final Endpoint a = Endpoint.of("a.com");
+        final Endpoint b = Endpoint.of("b.com");
+        final Endpoint c = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(a, b));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
+
+        delegate.update(ImmutableList.of(a, c));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
+
+        endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(b, c);
+    }
+
+    @Test
+    void keepAlive_capsAtMaxNumEndpoints() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofMinutes(10))
+                                             .build();
+
+        final Endpoint a = Endpoint.of("a.com");
+        final Endpoint b = Endpoint.of("b.com");
+        final Endpoint c = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(a, b, c));
+        assertThat(endpointGroup.endpoints()).hasSize(2);
+    }
+
+    @Test
+    void replacesEndpointWhenItsCircuitOpens() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+
+        // Round-robin selection picks A, then B.
+        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointA);
+        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+
+        // Open the circuit breaker for A.
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+
+        // The next selection should skip A.
+        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+        assertThat(endpointGroup.endpointContext(endpointA)).isNull();
+    }
+
+    @Test
+    void keepsExistingEndpointsWhenAllCircuitsAreClosed() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        // Keep-alive mode: cached endpoints survive delegate churn until they age out.
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofMinutes(10))
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        final Endpoint endpointC = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+
+        assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
+
+        // The pool is full and every circuit is closed: changes from the delegate should be ignored.
+        delegate.update(ImmutableList.of(endpointA, endpointC));
+        assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
+    }
+
+    @Test
+    void refreshesEndpointsWhenMaxAgeElapses() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofSeconds(1))
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        final Endpoint endpointC = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+
+        delegate.update(ImmutableList.of(endpointA, endpointC));
+        // Pool is full, no circuit open: changes should be ignored.
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+
+        // After maxEndpointAge elapses, the scheduler picks up the new endpoints.
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+                assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointC));
+    }
+
+    @Test
+    void refreshNeverExceedsMaxNumEndpointsWhenReusingOldOnes() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofSeconds(1))
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        final Endpoint endpointC = Endpoint.of("c.com");
+        // The pool fills with the first two from the delegate; C is a leftover candidate.
+        delegate.update(ImmutableList.of(endpointA, endpointB, endpointC));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+
+        // After maxEndpointAge elapses both A and B become old endpoints. The new-endpoint loop fills
+        // one slot with C (the only non-old candidate), and the reuse loop must respect the remaining
+        // slot count rather than repopulating both A and B (which would push the pool to size 3).
+        // Wait for C to appear (proving refresh-after-expiration has run), then assert the cap holds.
+        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+                assertThat(endpointGroup.endpoints()).contains(endpointC));
+        assertThat(endpointGroup.endpoints()).hasSize(2);
+    }
+
+    @Test
+    void replacesBadEndpointsAndAddsFreshOnes() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        // Keep-alive mode: a bad endpoint is replaced via the cache (b) plus a fresh candidate (c).
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .maxEndpointAge(Duration.ofMinutes(10))
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        final Endpoint endpointC = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+
+        // Delegate now reports A and C, but the pool is full so we keep A and B.
+        delegate.update(ImmutableList.of(endpointA, endpointC));
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+
+        // Open A's circuit; A becomes a bad endpoint and C fills the gap.
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointB, endpointC);
+    }
+
+    @Test
+    void fallsBackToBadEndpointsWhenAllCircuitsAreOpen() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+
+        // Open both circuits so the pool is empty and the bad set has both endpoints.
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(endpointGroup.endpointContext(endpointA)).isNull();
+        assertThat(endpointGroup.endpointContext(endpointB)).isNull();
+
+        final ClientRequestContext ctx = newCtx();
+        assertThat(endpointGroup.selectNow(ctx)).isNull();
+
+        // The async select() randomly picks a bad endpoint as a fallback. Both must be reachable.
+        await().atMost(Duration.ofSeconds(5)).until(() -> {
+            final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
+            return endpointA.equals(picked);
+        });
+        await().atMost(Duration.ofSeconds(5)).until(() -> {
+            final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
+            return endpointB.equals(picked);
+        });
+
+        // Once the delegate reports a healthy endpoint, that takes precedence over the bad ones.
+        // The inner round-robin selector picks up the new endpoint via an asynchronous listener
+        // notification, so wait until it is observable.
+        final Endpoint endpointC = Endpoint.of("c.com");
+        delegate.update(ImmutableList.of(endpointC));
+        await().untilAsserted(() -> assertThat(endpointGroup.selectNow(ctx)).isEqualTo(endpointC));
+    }
+
+    @Test
+    void failFastOnAllCircuitOpenSkipsBadEndpointFallback() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .failFastOnAllCircuitOpen(true)
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+
+        final ClientRequestContext ctx = newCtx();
+        // Without bad-endpoint fallback, the async selector waits for fresh endpoints; the future
+        // should not complete with a bad endpoint right away.
+        assertThat(endpointGroup.select(ctx, ctx.eventLoop())).isNotDone();
+    }
+
+    @Test
+    void expiredBadEndpointsBecomeAvailableAgain() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final long circuitOpenWindowMillis = 1000;
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .circuitOpenWindowMillis(circuitOpenWindowMillis)
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(endpointGroup.endpoints()).containsExactly(endpointB);
+
+        // After the bad-endpoint expiration window, A should be re-added.
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB));
+    }
+
+    @Test
+    void exportsHealthyAndUnhealthyGauges() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(2)
+                                             .meterRegistry(new MeterIdPrefix("my.test"), registry)
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        final Endpoint endpointB = Endpoint.of("b.com");
+        delegate.update(ImmutableList.of(endpointA, endpointB));
+
+        final Gauge healthy = registry.find("my.test.endpoints.count")
+                                      .tag("state", "healthy")
+                                      .gauge();
+        final Gauge unhealthy = registry.find("my.test.endpoints.count")
+                                        .tag("state", "unhealthy")
+                                        .gauge();
+        assertThat(healthy).isNotNull();
+        assertThat(unhealthy).isNotNull();
+        assertThat(healthy.value()).isEqualTo(2.0);
+        assertThat(unhealthy.value()).isEqualTo(0.0);
+
+        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(healthy.value()).isEqualTo(1.0);
+        assertThat(unhealthy.value()).isEqualTo(1.0);
+
+        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+        assertThat(healthy.value()).isEqualTo(0.0);
+        assertThat(unhealthy.value()).isEqualTo(2.0);
+    }
+
+    @Test
+    void retrySkipsAlreadyAttemptedEndpoints() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .maxNumEndpoints(10)
+                                             .maxEndpointAge(Duration.ofSeconds(1))
+                                             .build();
+
+        final ImmutableList.Builder<Endpoint> candidatesBuilder = ImmutableList.builder();
+        for (int i = 1; i <= 20; i++) {
+            candidatesBuilder.add(Endpoint.of(String.format("%02d.com", i)));
+        }
+        final List<Endpoint> candidates = candidatesBuilder.build();
+        delegate.update(candidates);
+        final List<Endpoint> endpoints = endpointGroup.endpoints();
+        assertThat(endpoints).containsExactlyInAnyOrderElementsOf(candidates.subList(0, 10));
+
+        final DefaultClientRequestContext parent = (DefaultClientRequestContext)
+                ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
+
+        // Attach three child contexts representing previous selections of endpoints[0..2].
+        addChild(parent, endpoints.get(0));
+        addChild(parent, endpoints.get(1));
+        addChild(parent, endpoints.get(2));
+
+        final ClientRequestContext retry = parent.newDerivedContext(
+                RequestId.random(), HttpRequest.of(HttpMethod.GET, "/"), null, null);
+        parent.logBuilder().addChild(retry.log());
+
+        // The selector should skip the three already-attempted endpoints and pick endpoints[3].
+        assertThat(endpointGroup.selectNow(retry)).isEqualTo(endpoints.get(3));
+    }
+
+    @Test
+    void builderRejectsInvalidArguments() {
+        assertThatThrownBy(() -> OutlierDetectingEndpointGroup.builder(null))
+                .isInstanceOf(NullPointerException.class);
+
+        final OutlierDetectingEndpointGroupBuilder builder =
+                OutlierDetectingEndpointGroup.builder(new SettableEndpointGroup());
+
+        assertThatThrownBy(() -> builder.maxNumEndpoints(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.maxEndpointAgeMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.maxEndpointAge(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.namePrefix(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.failureRateThreshold(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.failureRateThreshold(1.1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.minimumRequestThreshold(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.trialRequestIntervalMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.circuitOpenWindowMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.counterSlidingWindowMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.counterUpdateIntervalMillis(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> builder.successFunction(null))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.meterRegistry(null, new SimpleMeterRegistry()))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> builder.meterRegistry(new MeterIdPrefix("x"), null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void closeDelegatesToWrappedGroup() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        endpointGroup.close();
+        assertThat(delegate.closed).isTrue();
+    }
+
+    @Test
+    void closeAsyncDelegatesToWrappedGroup() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        endpointGroup.closeAsync().join();
+        assertThat(delegate.closed).isTrue();
+    }
+
+    @Test
+    void selectionTimeoutMillisDelegatesToWrappedGroup() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+        assertThat(endpointGroup.selectionTimeoutMillis())
+                .isEqualTo(delegate.selectionTimeoutMillis());
+    }
+
+    @Test
+    void selectionStrategyReturnsCustomStrategy() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+        // The strategy is the OutlierDetectingEndpointGroup's circuit-breaker-aware one, not the
+        // delegate's plain round-robin.
+        assertThat(endpointGroup.selectionStrategy())
+                .isNotEqualTo(delegate.selectionStrategy());
+    }
+
+    @Test
+    void namePrefixIsAppliedToCircuitBreakerNames() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .namePrefix("custom-prefix")
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        delegate.update(ImmutableList.of(endpointA));
+
+        final String circuitBreakerName =
+                endpointGroup.endpointContext(endpointA).circuitBreaker().name();
+        assertThat(circuitBreakerName).startsWith("custom-prefix-");
+        assertThat(circuitBreakerName).endsWith(":" + endpointA);
+    }
+
+    @Test
+    void removeListenerStopsNotifications() throws InterruptedException {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        final AtomicInteger callCount = new AtomicInteger();
+        final Consumer<List<Endpoint>> listener = endpoints -> callCount.incrementAndGet();
+        endpointGroup.addListener(listener);
+        endpointGroup.removeListener(listener);
+
+        delegate.update(ImmutableList.of(Endpoint.of("a.com")));
+        // Allow the synchronous and any async refresh tasks to fire before asserting.
+        Thread.sleep(500);
+        assertThat(callCount.get()).isZero();
+    }
+
+    @Test
+    void addListenerWithNotifyLatestEndpointsRepliesCurrentState() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        delegate.update(ImmutableList.of(Endpoint.of("a.com")));
+        // Now subscribe with notifyLatestEndpoints=true; the listener should see the current state
+        // immediately.
+        final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
+        endpointGroup.addListener(captor::set, true);
+        assertThat(captor.get()).containsExactly(Endpoint.of("a.com"));
+    }
+
+    @Test
+    void selectNowReturnsNullWhenGroupIsEmpty() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build();
+
+        // No endpoints have been set yet.
+        assertThat(endpointGroup.selectNow(newCtx())).isNull();
+    }
+
+    @Test
+    void perEndpointCircuitBreakerUsesConfiguredDurations() {
+        final SettableEndpointGroup delegate = new SettableEndpointGroup();
+        final OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate)
+                                             .failureRateThreshold(0.42)
+                                             .minimumRequestThreshold(7)
+                                             .trialRequestIntervalMillis(123)
+                                             .circuitOpenWindowMillis(456)
+                                             .counterSlidingWindowMillis(789)
+                                             .counterUpdateIntervalMillis(50)
+                                             .build();
+
+        final Endpoint endpointA = Endpoint.of("a.com");
+        delegate.update(ImmutableList.of(endpointA));
+
+        // The circuit breaker name proves the per-endpoint instance is wired to the configured prefix
+        // and counter, and the bad-endpoint expiration is sourced from circuitOpenWindow.
+        final String name = endpointGroup.endpointContext(endpointA).circuitBreaker().name();
+        assertThat(name).startsWith("outlier-detecting-");
+        assertThat(name).endsWith(":" + endpointA);
+    }
+
+    private static ClientRequestContext newCtx() {
+        return ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+    }
+
+    private static void addChild(DefaultClientRequestContext parent, Endpoint endpoint) {
+        final ClientRequestContext child = parent.newDerivedContext(
+                RequestId.random(), HttpRequest.of(HttpMethod.GET, "/"), null, endpoint);
+        parent.logBuilder().addChild(child.log());
+    }
+
+    private static final class SettableEndpointGroup extends DynamicEndpointGroup {
+
+        volatile boolean closed;
+
+        SettableEndpointGroup() {
+            super(EndpointSelectionStrategy.roundRobin());
+        }
+
+        void update(Iterable<Endpoint> endpoints) {
+            setEndpoints(endpoints);
+        }
+
+        @Override
+        protected void doCloseAsync(CompletableFuture<?> future) {
+            closed = true;
+            super.doCloseAsync(future);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
@@ -48,29 +48,31 @@ class OutlierDetectingEndpointGroupTest {
     @Test
     void whenReadyCompletesAfterDelegateBecomesReady() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        assertThat(endpointGroup.whenReady()).isNotDone();
-        delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
-        assertThat(endpointGroup.whenReady()).isCompletedWithValueMatching(
-                endpoints -> endpoints.contains(Endpoint.of("foo.com")));
-        assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("foo.com"));
+            assertThat(endpointGroup.whenReady()).isNotDone();
+            delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
+            assertThat(endpointGroup.whenReady()).isCompletedWithValueMatching(
+                    endpoints -> endpoints.contains(Endpoint.of("foo.com")));
+            assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("foo.com"));
+        }
     }
 
     @Test
     void listenerReceivesUpdatedEndpoints() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
-        final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
-        endpointGroup.addListener(captor::set);
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
+            final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
+            endpointGroup.addListener(captor::set);
 
-        delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
+            delegate.update(ImmutableList.of(Endpoint.of("foo.com")));
 
-        // Listener notification is dispatched asynchronously on the executor.
-        await().untilAsserted(() ->
-                assertThat(captor.get()).containsExactly(Endpoint.of("foo.com")));
+            // Listener notification is dispatched asynchronously on the executor.
+            await().untilAsserted(() ->
+                    assertThat(captor.get()).containsExactly(Endpoint.of("foo.com")));
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────────────────────────────
@@ -85,48 +87,51 @@ class OutlierDetectingEndpointGroupTest {
     void strictMode_poolMirrorsDelegate() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
         // Default: maxNumEndpoints=1024, maxEndpointAge=-1 (strict).
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        final Endpoint a = Endpoint.of("a.com");
-        final Endpoint b = Endpoint.of("b.com");
-        final Endpoint c = Endpoint.of("c.com");
+            final Endpoint a = Endpoint.of("a.com");
+            final Endpoint b = Endpoint.of("b.com");
+            final Endpoint c = Endpoint.of("c.com");
 
-        delegate.update(ImmutableList.of(a, b, c));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b, c);
+            delegate.update(ImmutableList.of(a, b, c));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b, c);
 
-        // Delegate drops B. Strict mode tracks delegate exactly — B must disappear from the pool.
-        delegate.update(ImmutableList.of(a, c));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, c);
+            // Delegate drops B. Strict mode tracks delegate exactly — B must disappear from the pool.
+            delegate.update(ImmutableList.of(a, c));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, c);
+        }
     }
 
     @Test
     void strictMode_excludesBadEndpoints() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        final Endpoint a = Endpoint.of("a.com");
-        final Endpoint b = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(a, b));
+            final Endpoint a = Endpoint.of("a.com");
+            final Endpoint b = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(a, b));
 
-        endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(endpointGroup.endpoints()).containsExactly(b);
+            endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(endpointGroup.endpoints()).containsExactly(b);
+        }
     }
 
     @Test
     void strictMode_capsAtMaxNumEndpoints() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
-                                             .build();
+                                             .build()) {
 
-        final Endpoint a = Endpoint.of("a.com");
-        final Endpoint b = Endpoint.of("b.com");
-        final Endpoint c = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(a, b, c));
-        assertThat(endpointGroup.endpoints()).hasSize(2);
+            final Endpoint a = Endpoint.of("a.com");
+            final Endpoint b = Endpoint.of("b.com");
+            final Endpoint c = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(a, b, c));
+            assertThat(endpointGroup.endpoints()).hasSize(2);
+        }
     }
 
     @Test
@@ -136,305 +141,319 @@ class OutlierDetectingEndpointGroupTest {
         // When a's circuit opens, the refresh triggers and the cache fills the gap with b (still
         // not expired) plus c from the delegate.
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .maxEndpointAge(Duration.ofMinutes(10))
-                                             .build();
+                                             .build()) {
 
-        final Endpoint a = Endpoint.of("a.com");
-        final Endpoint b = Endpoint.of("b.com");
-        final Endpoint c = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(a, b));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
+            final Endpoint a = Endpoint.of("a.com");
+            final Endpoint b = Endpoint.of("b.com");
+            final Endpoint c = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(a, b));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
 
-        delegate.update(ImmutableList.of(a, c));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
+            delegate.update(ImmutableList.of(a, c));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(a, b);
 
-        endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(b, c);
+            endpointGroup.endpointContext(a).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(b, c);
+        }
     }
 
     @Test
     void keepAlive_capsAtMaxNumEndpoints() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate)
-                                             .maxNumEndpoints(2)
-                                             .maxEndpointAge(Duration.ofMinutes(10))
-                                             .build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                 OutlierDetectingEndpointGroup.builder(delegate)
+                                              .maxNumEndpoints(2)
+                                              .maxEndpointAge(Duration.ofMinutes(10))
+                                              .build()) {
 
-        final Endpoint a = Endpoint.of("a.com");
-        final Endpoint b = Endpoint.of("b.com");
-        final Endpoint c = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(a, b, c));
-        assertThat(endpointGroup.endpoints()).hasSize(2);
+            final Endpoint a = Endpoint.of("a.com");
+            final Endpoint b = Endpoint.of("b.com");
+            final Endpoint c = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(a, b, c));
+            assertThat(endpointGroup.endpoints()).hasSize(2);
+        }
     }
 
     @Test
     void replacesEndpointWhenItsCircuitOpens() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
 
-        // Round-robin selection picks A, then B.
-        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointA);
-        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+            // Round-robin selection picks A, then B.
+            assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointA);
+            assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
 
-        // Open the circuit breaker for A.
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            // Open the circuit breaker for A.
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
 
-        // The next selection should skip A.
-        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
-        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
-        assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
-        assertThat(endpointGroup.endpointContext(endpointA)).isNull();
+            // The next selection should skip A.
+            assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+            assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+            assertThat(endpointGroup.selectNow(newCtx())).isEqualTo(endpointB);
+            assertThat(endpointGroup.endpointContext(endpointA)).isNull();
+        }
     }
 
     @Test
     void keepsExistingEndpointsWhenAllCircuitsAreClosed() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
         // Keep-alive mode: cached endpoints survive delegate churn until they age out.
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .maxEndpointAge(Duration.ofMinutes(10))
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        final Endpoint endpointC = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            final Endpoint endpointC = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
 
-        assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
+            assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
 
-        // The pool is full and every circuit is closed: changes from the delegate should be ignored.
-        delegate.update(ImmutableList.of(endpointA, endpointC));
-        assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
+            // The pool is full and every circuit is closed: changes from the delegate should be ignored.
+            delegate.update(ImmutableList.of(endpointA, endpointC));
+            assertThat(endpointGroup.endpoints()).containsExactly(endpointA, endpointB);
+        }
     }
 
     @Test
     void refreshesEndpointsWhenMaxAgeElapses() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .maxEndpointAge(Duration.ofSeconds(1))
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        final Endpoint endpointC = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            final Endpoint endpointC = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
 
-        delegate.update(ImmutableList.of(endpointA, endpointC));
-        // Pool is full, no circuit open: changes should be ignored.
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+            delegate.update(ImmutableList.of(endpointA, endpointC));
+            // Pool is full, no circuit open: changes should be ignored.
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
 
-        // After maxEndpointAge elapses, the scheduler picks up the new endpoints.
-        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
-                assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointC));
+            // After maxEndpointAge elapses, the scheduler picks up the new endpoints.
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+                assertThat(endpointGroup.endpoints())
+                        .containsExactlyInAnyOrder(endpointA, endpointC);
+            });
+        }
     }
 
     @Test
     void refreshNeverExceedsMaxNumEndpointsWhenReusingOldOnes() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .maxEndpointAge(Duration.ofSeconds(1))
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        final Endpoint endpointC = Endpoint.of("c.com");
-        // The pool fills with the first two from the delegate; C is a leftover candidate.
-        delegate.update(ImmutableList.of(endpointA, endpointB, endpointC));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            final Endpoint endpointC = Endpoint.of("c.com");
+            // The pool fills with the first two from the delegate; C is a leftover candidate.
+            delegate.update(ImmutableList.of(endpointA, endpointB, endpointC));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
 
-        // After maxEndpointAge elapses both A and B become old endpoints. The new-endpoint loop fills
-        // one slot with C (the only non-old candidate), and the reuse loop must respect the remaining
-        // slot count rather than repopulating both A and B (which would push the pool to size 3).
-        // Wait for C to appear (proving refresh-after-expiration has run), then assert the cap holds.
-        await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
-                assertThat(endpointGroup.endpoints()).contains(endpointC));
-        assertThat(endpointGroup.endpoints()).hasSize(2);
+            // After maxEndpointAge elapses both A and B become old endpoints. The new-endpoint loop fills
+            // one slot with C (the only non-old candidate), and the reuse loop must respect the remaining
+            // slot count rather than repopulating both A and B (which would push the pool to size 3).
+            // Wait for C to appear (proving refresh-after-expiration has run), then assert the cap holds.
+            await().atMost(Duration.ofSeconds(10)).untilAsserted(() ->
+                    assertThat(endpointGroup.endpoints()).contains(endpointC));
+            assertThat(endpointGroup.endpoints()).hasSize(2);
+        }
     }
 
     @Test
     void replacesBadEndpointsAndAddsFreshOnes() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
         // Keep-alive mode: a bad endpoint is replaced via the cache (b) plus a fresh candidate (c).
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .maxEndpointAge(Duration.ofMinutes(10))
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        final Endpoint endpointC = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            final Endpoint endpointC = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
 
-        // Delegate now reports A and C, but the pool is full so we keep A and B.
-        delegate.update(ImmutableList.of(endpointA, endpointC));
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
+            // Delegate now reports A and C, but the pool is full so we keep A and B.
+            delegate.update(ImmutableList.of(endpointA, endpointC));
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB);
 
-        // Open A's circuit; A becomes a bad endpoint and C fills the gap.
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointB, endpointC);
+            // Open A's circuit; A becomes a bad endpoint and C fills the gap.
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointB, endpointC);
+        }
     }
 
     @Test
     void fallsBackToBadEndpointsWhenAllCircuitsAreOpen() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
 
-        // Open both circuits so the pool is empty and the bad set has both endpoints.
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
-        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(endpointGroup.endpointContext(endpointA)).isNull();
-        assertThat(endpointGroup.endpointContext(endpointB)).isNull();
+            // Open both circuits so the pool is empty and the bad set has both endpoints.
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(endpointGroup.endpointContext(endpointA)).isNull();
+            assertThat(endpointGroup.endpointContext(endpointB)).isNull();
 
-        final ClientRequestContext ctx = newCtx();
-        assertThat(endpointGroup.selectNow(ctx)).isNull();
+            final ClientRequestContext ctx = newCtx();
+            assertThat(endpointGroup.selectNow(ctx)).isNull();
 
-        // The async select() randomly picks a bad endpoint as a fallback. Both must be reachable.
-        await().atMost(Duration.ofSeconds(5)).until(() -> {
-            final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
-            return endpointA.equals(picked);
-        });
-        await().atMost(Duration.ofSeconds(5)).until(() -> {
-            final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
-            return endpointB.equals(picked);
-        });
+            // The async select() randomly picks a bad endpoint as a fallback. Both must be reachable.
+            await().atMost(Duration.ofSeconds(5)).until(() -> {
+                final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
+                return endpointA.equals(picked);
+            });
+            await().atMost(Duration.ofSeconds(5)).until(() -> {
+                final Endpoint picked = endpointGroup.select(ctx, ctx.eventLoop()).join();
+                return endpointB.equals(picked);
+            });
 
-        // Once the delegate reports a healthy endpoint, that takes precedence over the bad ones.
-        // The inner round-robin selector picks up the new endpoint via an asynchronous listener
-        // notification, so wait until it is observable.
-        final Endpoint endpointC = Endpoint.of("c.com");
-        delegate.update(ImmutableList.of(endpointC));
-        await().untilAsserted(() -> assertThat(endpointGroup.selectNow(ctx)).isEqualTo(endpointC));
+            // Once the delegate reports a healthy endpoint, that takes precedence over the bad ones.
+            // The inner round-robin selector picks up the new endpoint via an asynchronous listener
+            // notification, so wait until it is observable.
+            final Endpoint endpointC = Endpoint.of("c.com");
+            delegate.update(ImmutableList.of(endpointC));
+            await().untilAsserted(() -> assertThat(endpointGroup.selectNow(ctx)).isEqualTo(endpointC));
+        }
     }
 
     @Test
     void failFastOnAllCircuitOpenSkipsBadEndpointFallback() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .failFastOnAllCircuitOpen(true)
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
-        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
 
-        final ClientRequestContext ctx = newCtx();
-        // Without bad-endpoint fallback, the async selector waits for fresh endpoints; the future
-        // should not complete with a bad endpoint right away.
-        assertThat(endpointGroup.select(ctx, ctx.eventLoop())).isNotDone();
+            final ClientRequestContext ctx = newCtx();
+            // Without bad-endpoint fallback, the async selector waits for fresh endpoints; the future
+            // should not complete with a bad endpoint right away.
+            assertThat(endpointGroup.select(ctx, ctx.eventLoop())).isNotDone();
+        }
     }
 
     @Test
     void expiredBadEndpointsBecomeAvailableAgain() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
         final long circuitOpenWindowMillis = 1000;
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .circuitOpenWindowMillis(circuitOpenWindowMillis)
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
 
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(endpointGroup.endpoints()).containsExactly(endpointB);
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(endpointGroup.endpoints()).containsExactly(endpointB);
 
-        // After the bad-endpoint expiration window, A should be re-added.
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
-                assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB));
+            // After the bad-endpoint expiration window, A should be re-added.
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                    assertThat(endpointGroup.endpoints()).containsExactlyInAnyOrder(endpointA, endpointB));
+        }
     }
 
     @Test
     void exportsHealthyAndUnhealthyGauges() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
         final SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(2)
                                              .meterRegistry(new MeterIdPrefix("my.test"), registry)
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        final Endpoint endpointB = Endpoint.of("b.com");
-        delegate.update(ImmutableList.of(endpointA, endpointB));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            final Endpoint endpointB = Endpoint.of("b.com");
+            delegate.update(ImmutableList.of(endpointA, endpointB));
 
-        final Gauge healthy = registry.find("my.test.endpoints.count")
-                                      .tag("state", "healthy")
-                                      .gauge();
-        final Gauge unhealthy = registry.find("my.test.endpoints.count")
-                                        .tag("state", "unhealthy")
-                                        .gauge();
-        assertThat(healthy).isNotNull();
-        assertThat(unhealthy).isNotNull();
-        assertThat(healthy.value()).isEqualTo(2.0);
-        assertThat(unhealthy.value()).isEqualTo(0.0);
+            final Gauge healthy = registry.find("my.test.endpoints.count")
+                                          .tag("state", "healthy")
+                                          .gauge();
+            final Gauge unhealthy = registry.find("my.test.endpoints.count")
+                                            .tag("state", "unhealthy")
+                                            .gauge();
+            assertThat(healthy).isNotNull();
+            assertThat(unhealthy).isNotNull();
+            assertThat(healthy.value()).isEqualTo(2.0);
+            assertThat(unhealthy.value()).isEqualTo(0.0);
 
-        endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(healthy.value()).isEqualTo(1.0);
-        assertThat(unhealthy.value()).isEqualTo(1.0);
+            endpointGroup.endpointContext(endpointA).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(healthy.value()).isEqualTo(1.0);
+            assertThat(unhealthy.value()).isEqualTo(1.0);
 
-        endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
-        assertThat(healthy.value()).isEqualTo(0.0);
-        assertThat(unhealthy.value()).isEqualTo(2.0);
+            endpointGroup.endpointContext(endpointB).circuitBreaker().enterState(CircuitState.OPEN);
+            assertThat(healthy.value()).isEqualTo(0.0);
+            assertThat(unhealthy.value()).isEqualTo(2.0);
+        }
     }
 
     @Test
     void retrySkipsAlreadyAttemptedEndpoints() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .maxNumEndpoints(10)
                                              .maxEndpointAge(Duration.ofSeconds(1))
-                                             .build();
+                                             .build()) {
 
-        final ImmutableList.Builder<Endpoint> candidatesBuilder = ImmutableList.builder();
-        for (int i = 1; i <= 20; i++) {
-            candidatesBuilder.add(Endpoint.of(String.format("%02d.com", i)));
+            final ImmutableList.Builder<Endpoint> candidatesBuilder = ImmutableList.builder();
+            for (int i = 1; i <= 20; i++) {
+                candidatesBuilder.add(Endpoint.of(String.format("%02d.com", i)));
+            }
+            final List<Endpoint> candidates = candidatesBuilder.build();
+            delegate.update(candidates);
+            final List<Endpoint> endpoints = endpointGroup.endpoints();
+            assertThat(endpoints).containsExactlyInAnyOrderElementsOf(candidates.subList(0, 10));
+
+            final DefaultClientRequestContext parent = (DefaultClientRequestContext)
+                    ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
+
+            // Attach three child contexts representing previous selections of endpoints[0..2].
+            addChild(parent, endpoints.get(0));
+            addChild(parent, endpoints.get(1));
+            addChild(parent, endpoints.get(2));
+
+            final ClientRequestContext retry = parent.newDerivedContext(
+                    RequestId.random(), HttpRequest.of(HttpMethod.GET, "/"), null, null);
+            parent.logBuilder().addChild(retry.log());
+
+            // The selector should skip the three already-attempted endpoints and pick endpoints[3].
+            assertThat(endpointGroup.selectNow(retry)).isEqualTo(endpoints.get(3));
         }
-        final List<Endpoint> candidates = candidatesBuilder.build();
-        delegate.update(candidates);
-        final List<Endpoint> endpoints = endpointGroup.endpoints();
-        assertThat(endpoints).containsExactlyInAnyOrderElementsOf(candidates.subList(0, 10));
-
-        final DefaultClientRequestContext parent = (DefaultClientRequestContext)
-                ClientRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
-
-        // Attach three child contexts representing previous selections of endpoints[0..2].
-        addChild(parent, endpoints.get(0));
-        addChild(parent, endpoints.get(1));
-        addChild(parent, endpoints.get(2));
-
-        final ClientRequestContext retry = parent.newDerivedContext(
-                RequestId.random(), HttpRequest.of(HttpMethod.GET, "/"), null, null);
-        parent.logBuilder().addChild(retry.log());
-
-        // The selector should skip the three already-attempted endpoints and pick endpoints[3].
-        assertThat(endpointGroup.selectNow(retry)).isEqualTo(endpoints.get(3));
     }
 
     @Test
@@ -498,85 +517,91 @@ class OutlierDetectingEndpointGroupTest {
     @Test
     void selectionTimeoutMillisDelegatesToWrappedGroup() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
-        assertThat(endpointGroup.selectionTimeoutMillis())
-                .isEqualTo(delegate.selectionTimeoutMillis());
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
+            assertThat(endpointGroup.selectionTimeoutMillis())
+                    .isEqualTo(delegate.selectionTimeoutMillis());
+        }
     }
 
     @Test
     void selectionStrategyReturnsCustomStrategy() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
-        // The strategy is the OutlierDetectingEndpointGroup's circuit-breaker-aware one, not the
-        // delegate's plain round-robin.
-        assertThat(endpointGroup.selectionStrategy())
-                .isNotEqualTo(delegate.selectionStrategy());
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
+            // The strategy is the OutlierDetectingEndpointGroup's circuit-breaker-aware one, not the
+            // delegate's plain round-robin.
+            assertThat(endpointGroup.selectionStrategy())
+                    .isNotEqualTo(delegate.selectionStrategy());
+        }
     }
 
     @Test
     void namePrefixIsAppliedToCircuitBreakerNames() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .namePrefix("custom-prefix")
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        delegate.update(ImmutableList.of(endpointA));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            delegate.update(ImmutableList.of(endpointA));
 
-        final String circuitBreakerName =
-                endpointGroup.endpointContext(endpointA).circuitBreaker().name();
-        assertThat(circuitBreakerName).startsWith("custom-prefix-");
-        assertThat(circuitBreakerName).endsWith(":" + endpointA);
+            final String circuitBreakerName =
+                    endpointGroup.endpointContext(endpointA).circuitBreaker().name();
+            assertThat(circuitBreakerName).startsWith("custom-prefix-");
+            assertThat(circuitBreakerName).endsWith(":" + endpointA);
+        }
     }
 
     @Test
     void removeListenerStopsNotifications() throws InterruptedException {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        final AtomicInteger callCount = new AtomicInteger();
-        final Consumer<List<Endpoint>> listener = endpoints -> callCount.incrementAndGet();
-        endpointGroup.addListener(listener);
-        endpointGroup.removeListener(listener);
+            final AtomicInteger callCount = new AtomicInteger();
+            final Consumer<List<Endpoint>> listener = endpoints -> callCount.incrementAndGet();
+            endpointGroup.addListener(listener);
+            endpointGroup.removeListener(listener);
 
-        delegate.update(ImmutableList.of(Endpoint.of("a.com")));
-        // Allow the synchronous and any async refresh tasks to fire before asserting.
-        Thread.sleep(500);
-        assertThat(callCount.get()).isZero();
+            delegate.update(ImmutableList.of(Endpoint.of("a.com")));
+            // Allow the synchronous and any async refresh tasks to fire before asserting.
+            Thread.sleep(500);
+            assertThat(callCount.get()).isZero();
+        }
     }
 
     @Test
     void addListenerWithNotifyLatestEndpointsRepliesCurrentState() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        delegate.update(ImmutableList.of(Endpoint.of("a.com")));
-        // Now subscribe with notifyLatestEndpoints=true; the listener should see the current state
-        // immediately.
-        final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
-        endpointGroup.addListener(captor::set, true);
-        assertThat(captor.get()).containsExactly(Endpoint.of("a.com"));
+            delegate.update(ImmutableList.of(Endpoint.of("a.com")));
+            // Now subscribe with notifyLatestEndpoints=true; the listener should see the current state
+            // immediately.
+            final AtomicReference<List<Endpoint>> captor = new AtomicReference<>();
+            endpointGroup.addListener(captor::set, true);
+            assertThat(captor.get()).containsExactly(Endpoint.of("a.com"));
+        }
     }
 
     @Test
     void selectNowReturnsNullWhenGroupIsEmpty() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
-                OutlierDetectingEndpointGroup.builder(delegate).build();
+        try (OutlierDetectingEndpointGroup endpointGroup =
+                OutlierDetectingEndpointGroup.builder(delegate).build()) {
 
-        // No endpoints have been set yet.
-        assertThat(endpointGroup.selectNow(newCtx())).isNull();
+            // No endpoints have been set yet.
+            assertThat(endpointGroup.selectNow(newCtx())).isNull();
+        }
     }
 
     @Test
     void perEndpointCircuitBreakerUsesConfiguredDurations() {
         final SettableEndpointGroup delegate = new SettableEndpointGroup();
-        final OutlierDetectingEndpointGroup endpointGroup =
+        try (OutlierDetectingEndpointGroup endpointGroup =
                 OutlierDetectingEndpointGroup.builder(delegate)
                                              .failureRateThreshold(0.42)
                                              .minimumRequestThreshold(7)
@@ -584,16 +609,17 @@ class OutlierDetectingEndpointGroupTest {
                                              .circuitOpenWindowMillis(456)
                                              .counterSlidingWindowMillis(789)
                                              .counterUpdateIntervalMillis(50)
-                                             .build();
+                                             .build()) {
 
-        final Endpoint endpointA = Endpoint.of("a.com");
-        delegate.update(ImmutableList.of(endpointA));
+            final Endpoint endpointA = Endpoint.of("a.com");
+            delegate.update(ImmutableList.of(endpointA));
 
-        // The circuit breaker name proves the per-endpoint instance is wired to the configured prefix
-        // and counter, and the bad-endpoint expiration is sourced from circuitOpenWindow.
-        final String name = endpointGroup.endpointContext(endpointA).circuitBreaker().name();
-        assertThat(name).startsWith("outlier-detecting-");
-        assertThat(name).endsWith(":" + endpointA);
+            // The circuit breaker name proves the per-endpoint instance is wired to the configured prefix
+            // and counter, and the bad-endpoint expiration is sourced from circuitOpenWindow.
+            final String name = endpointGroup.endpointContext(endpointA).circuitBreaker().name();
+            assertThat(name).startsWith("outlier-detecting-");
+            assertThat(name).endsWith(":" + endpointA);
+        }
     }
 
     private static ClientRequestContext newCtx() {

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/OutlierDetectingEndpointGroupTest.java
@@ -467,7 +467,7 @@ class OutlierDetectingEndpointGroupTest {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> builder.counterUpdateIntervalMillis(0))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> builder.successFunction(null))
+        assertThatThrownBy(() -> builder.circuitBreakerRule(null))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> builder.meterRegistry(null, new SimpleMeterRegistry()))
                 .isInstanceOf(NullPointerException.class);


### PR DESCRIPTION
Motivation:

Armeria has no built-in way to eject misbehaving endpoints from a rotation. Clients have to either fail fast on dead backends or build custom selectors to skip them.

Modifications:

- Add `OutlierDetectingEndpointGroup`, an `EndpointGroup` decorator that attaches a per-endpoint circuit breaker. When an endpoint's circuit opens, it is removed from the visible pool. When the circuit closes again, the endpoint is restored.
- The client reports request outcomes into the per-endpoint circuit breaker through `asDecorator()`. A custom `SuccessFunction` can be supplied to classify responses.
- Two operating modes:
  - Strict (default): the visible pool mirrors `delegate.endpoints()` minus endpoints with an open circuit, capped at `maxNumEndpoints`.
  - Keep-alive (opt-in via `maxEndpointAge`): when the delegate does not provide enough healthy endpoints, recently seen ones are reused until their TTL expires.
- Add `OutlierDetectingEndpointGroupBuilder` for configuration, including circuit-breaker knobs and a `SuccessFunction`.
- Move `CircuitBreakerConfig` to the internal package so the new endpoint group can build circuit breakers without exposing internals.

Result:

- Closes #6224.
- Users can wrap any `EndpointGroup` with `OutlierDetectingEndpointGroup` and register its decorator on a client to automatically eject failing endpoints from rotation.