### PR TITLE
Use `ETag` when fetching Athenz policies

### DIFF
--- a/athenz/src/main/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoader.java
+++ b/athenz/src/main/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoader.java
@@ -19,21 +19,32 @@ package com.linecorp.armeria.server.athenz;
 import static com.google.common.base.Preconditions.checkState;
 import static com.linecorp.armeria.server.athenz.AthenzPolicyHandler.toAssertions;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.athenz.zpe.pkey.PublicKeyStore;
 import com.yahoo.athenz.zts.DomainSignedPolicyData;
 import com.yahoo.athenz.zts.JWSPolicyData;
 
+import com.linecorp.armeria.client.FutureResponseAs;
+import com.linecorp.armeria.client.InvalidHttpResponseException;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientRequestPreparation;
 import com.linecorp.armeria.client.athenz.ZtsBaseClient;
 import com.linecorp.armeria.common.CommonPools;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncLoader;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.common.JacksonUtil;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -42,39 +53,46 @@ final class AthenzPolicyLoader {
 
     private final WebClient client;
     private final String targetDomain;
-    private final AthenzPolicyConfig updaterConfig;
+    private final boolean jwsPolicySupport;
     @Nullable
     private final Map<String, Object> jwsPolicyParams;
     private final AthenzPolicyHandler policyHandler;
-    private final AsyncLoader<AthenzAssertions> policyLoader;
-    private final CompletableFuture<AthenzAssertions> initialPolicyData;
+    private final AsyncLoader<Etagged<AthenzAssertions>> policyLoader;
+    private final CompletableFuture<Etagged<AthenzAssertions>> initialPolicyData;
     private final Counter successCounter;
+    private final Counter notModifiedCounter;
     private final Counter failureCounter;
+    private final AsAthenzAssertions asAthenzAssertions;
 
     AthenzPolicyLoader(ZtsBaseClient baseClient, String targetDomain,
                        AthenzPolicyConfig updaterConfig, PublicKeyStore publicKeyStore,
                        MeterRegistry meterRegistry, MeterIdPrefix meterIdPrefix) {
         client = baseClient.webClient();
         this.targetDomain = targetDomain;
-        this.updaterConfig = updaterConfig;
-        if (updaterConfig.jwsPolicySupport()) {
+        jwsPolicySupport = updaterConfig.jwsPolicySupport();
+        if (jwsPolicySupport) {
             jwsPolicyParams = ImmutableMap.of(
                     "policyVersions", updaterConfig.policyVersions(),
                     "signatureP1363Format", true);
         } else {
             jwsPolicyParams = null;
         }
+        asAthenzAssertions = new AsAthenzAssertions();
 
         final String dataType = updaterConfig.jwsPolicySupport() ? "jws" : "signed";
         successCounter = meterRegistry.counter(meterIdPrefix.name("policy.loads"),
                                                meterIdPrefix.tags("domain", targetDomain, "result", "success",
                                                                   "type", dataType));
+        notModifiedCounter = meterRegistry.counter(meterIdPrefix.name("policy.loads"),
+                                                   meterIdPrefix.tags("domain", targetDomain,
+                                                                      "result", "not_modified",
+                                                                      "type", dataType));
         failureCounter = meterRegistry.counter(meterIdPrefix.name("policy.loads"),
                                                meterIdPrefix.tags("domain", targetDomain, "result", "failure",
                                                                   "type", dataType));
 
         policyHandler = new AthenzPolicyHandler(publicKeyStore);
-        policyLoader = AsyncLoader.<AthenzAssertions>builder(unused -> loadPolicyData())
+        policyLoader = AsyncLoader.builder(this::loadPolicyData)
                                   .name("athenz-policy-loader/" + targetDomain)
                                   .refreshAfterLoad(updaterConfig.refreshInterval())
                                   .build();
@@ -87,51 +105,139 @@ final class AthenzPolicyLoader {
 
     AthenzAssertions getNow() {
         checkState(initialPolicyData.isDone(), "Policy data is not initialized yet");
-        return policyLoader.load().join();
+        return policyLoader.load().join().value;
     }
 
-    private CompletableFuture<AthenzAssertions> loadPolicyData() {
-        final CompletableFuture<AthenzAssertions> future = loadPolicyData0();
-        future.handle((result, cause) -> {
+    private CompletableFuture<Etagged<AthenzAssertions>> loadPolicyData(
+            @Nullable Etagged<AthenzAssertions> old) {
+        return loadPolicyData0(old == null ? null : old.etag).handle((newValue, cause) -> {
             if (cause != null) {
                 failureCounter.increment();
+                return Exceptions.throwUnsafely(cause);
             } else {
-                successCounter.increment();
+                if (newValue == Etagged.<AthenzAssertions>notModified()) {
+                    assert old != null;
+                    notModifiedCounter.increment();
+                    return old;
+                } else {
+                    successCounter.increment();
+                    return newValue;
+                }
             }
-            return null;
         });
-        return future;
     }
 
-    private CompletableFuture<AthenzAssertions> loadPolicyData0() {
-        if (updaterConfig.jwsPolicySupport()) {
-            return loadJwsPolicyData();
+    private CompletableFuture<Etagged<AthenzAssertions>> loadPolicyData0(@Nullable String etag) {
+        if (jwsPolicySupport) {
+            return loadJwsPolicyData(etag);
         } else {
-            return loadSignedPolicyData();
+            return loadSignedPolicyData(etag);
         }
     }
 
-    private CompletableFuture<AthenzAssertions> loadJwsPolicyData() {
+    private CompletableFuture<Etagged<AthenzAssertions>> loadJwsPolicyData(@Nullable String etag) {
         assert jwsPolicyParams != null;
-        return client.prepare()
-                     .post("/domain/{domain}/policy/signed")
-                     .pathParam("domain", targetDomain)
-                     .contentJson(jwsPolicyParams)
-                     .asJson(JWSPolicyData.class)
-                     .execute()
-                     .thenApplyAsync(entity -> {
-                         return toAssertions(policyHandler.getJWSPolicyData(entity.content()));
-                     }, CommonPools.blockingTaskExecutor());
+        final WebClientRequestPreparation prepare = client.prepare()
+                                                          .post("/domain/{domain}/policy/signed");
+        if (etag != null) {
+            prepare.header(HttpHeaderNames.IF_NONE_MATCH, etag);
+        }
+        return prepare
+                .pathParam("domain", targetDomain)
+                .contentJson(jwsPolicyParams)
+                .as(asAthenzAssertions)
+                .execute();
     }
 
-    private CompletableFuture<AthenzAssertions> loadSignedPolicyData() {
-        return client.prepare()
-                     .get("/domain/{domain}/signed_policy_data")
-                     .pathParam("domain", targetDomain)
-                     .asJson(DomainSignedPolicyData.class)
-                     .execute()
-                     .thenApplyAsync(entity -> {
-                         return toAssertions(policyHandler.getSignedPolicyData(entity.content()));
-                     }, CommonPools.blockingTaskExecutor());
+    private CompletableFuture<Etagged<AthenzAssertions>> loadSignedPolicyData(@Nullable String etag) {
+        final WebClientRequestPreparation prepare = client.prepare()
+                                                          .get("/domain/{domain}/signed_policy_data");
+        if (etag != null) {
+            prepare.header(HttpHeaderNames.IF_NONE_MATCH, etag);
+        }
+        return prepare
+                .pathParam("domain", targetDomain)
+                .as(asAthenzAssertions)
+                .execute();
+    }
+
+    private final class AsAthenzAssertions implements FutureResponseAs<Etagged<AthenzAssertions>> {
+
+        @Override
+        public CompletableFuture<Etagged<AthenzAssertions>> as(HttpResponse response) {
+            return response.aggregate().thenApplyAsync(res -> {
+                if (res.status() == HttpStatus.NOT_MODIFIED) {
+                    return Etagged.notModified();
+                }
+                if (res.status() == HttpStatus.OK) {
+                    final AthenzAssertions assertions;
+                    try {
+                        if (jwsPolicySupport) {
+                            final JWSPolicyData policyData =
+                                    JacksonUtil.readValue(res.content().array(), JWSPolicyData.class);
+                            assertions = toAssertions(policyHandler.getJWSPolicyData(policyData));
+                        } else {
+                            final DomainSignedPolicyData policyData =
+                                    JacksonUtil.readValue(res.content().array(), DomainSignedPolicyData.class);
+                            assertions = toAssertions(policyHandler.getSignedPolicyData(policyData));
+                        }
+                    } catch (IOException e) {
+                        throw new InvalidHttpResponseException(res, "Failed to parse policy data", e);
+                    }
+                    return new Etagged<>(res.headers().get(HttpHeaderNames.ETAG), assertions);
+                }
+
+                throw new InvalidHttpResponseException(
+                        res, "status: " + res.status() +
+                             " (expected: 200 OK or 304 Not Modified), response: " + response);
+            }, CommonPools.blockingTaskExecutor());
+        }
+
+        @Override
+        public boolean requiresAggregation() {
+            return true;
+        }
+    }
+
+    private static final class Etagged<T> {
+
+        private static final Etagged<?> NOT_MODIFIED = new Etagged<>(null, "");
+
+        @SuppressWarnings("unchecked")
+        static <T> Etagged<T> notModified() {
+            return (Etagged<T>) NOT_MODIFIED;
+        }
+
+        @Nullable
+        final String etag;
+        final T value;
+
+        private Etagged(@Nullable String etag, T value) {
+            this.etag = etag;
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Etagged)) {
+                return false;
+            }
+            final Etagged<?> etagged = (Etagged<?>) o;
+            return Objects.equals(etag, etagged.etag) && value.equals(etagged.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(etag, value);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .omitNullValues()
+                              .add("etag", etag)
+                              .add("value", value)
+                              .toString();
+        }
     }
 }

--- a/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoaderTest.java
+++ b/athenz/src/test/java/com/linecorp/armeria/server/athenz/AthenzPolicyLoaderTest.java
@@ -22,9 +22,11 @@ import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_DOMAIN_NAME;
 import static com.linecorp.armeria.server.athenz.AthenzDocker.TEST_SERVICE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,8 +39,11 @@ import com.yahoo.athenz.zpe.pkey.PublicKeyStore;
 import com.yahoo.rdl.Struct;
 
 import com.linecorp.armeria.client.athenz.ZtsBaseClient;
+import com.linecorp.armeria.client.logging.LoggingClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 @EnabledIfDockerAvailable
@@ -50,7 +55,11 @@ class AthenzPolicyLoaderTest {
     @ValueSource(booleans = { true, false })
     @ParameterizedTest
     void loadPolicyFiles(boolean jwsPolicySupport) throws Exception {
-        try (ZtsBaseClient baseClient = athenzExtension.newZtsBaseClient(TEST_SERVICE)) {
+        try (ZtsBaseClient baseClient = athenzExtension.newZtsBaseClient(TEST_SERVICE, builder -> {
+            builder.configureWebClient(client -> {
+                client.decorator(LoggingClient.newDecorator());
+            });
+        })) {
             final PublicKeyStore publicKeyStore = new AthenzPublicKeyProvider(baseClient,
                                                                               Duration.ofSeconds(10),
                                                                               "/oauth2/keys?rfc=true");
@@ -84,6 +93,88 @@ class AthenzPolicyLoaderTest {
                                              "domain", TEST_DOMAIN_NAME,
                                              "result", "failure",
                                              "type", dataType).count()).isZero();
+        }
+    }
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void shouldReuseAssertionsWhenNotModified(boolean jwsPolicySupport) throws Exception {
+        final List<String> ifNoneMatchHeaders = new CopyOnWriteArrayList<>();
+        final String policyPath =
+                jwsPolicySupport ? "/zts/v1/domain/" + TEST_DOMAIN_NAME + "/policy/signed"
+                                 : "/zts/v1/domain/" + TEST_DOMAIN_NAME + "/signed_policy_data";
+
+        try (ZtsBaseClient baseClient = athenzExtension.newZtsBaseClient(TEST_SERVICE, builder -> {
+            builder.configureWebClient(client -> {
+                client.decorator(LoggingClient.newDecorator());
+                client.decorator((delegate, ctx, req) -> {
+                    if (policyPath.equals(ctx.path())) {
+                        ifNoneMatchHeaders.add(req.headers().get(HttpHeaderNames.IF_NONE_MATCH));
+                    }
+                    return delegate.execute(ctx, req);
+                });
+            });
+        })) {
+            final PublicKeyStore publicKeyStore = new AthenzPublicKeyProvider(baseClient,
+                                                                              Duration.ofSeconds(10),
+                                                                              "/oauth2/keys?rfc=true");
+            // Use a short refresh interval so that the next getNow() triggers a background refresh.
+            final AthenzPolicyConfig policyConfig = new AthenzPolicyConfig(ImmutableList.of(TEST_DOMAIN_NAME),
+                                                                           ImmutableMap.of(), jwsPolicySupport,
+                                                                           Duration.ofMillis(100));
+
+            final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+            final MeterIdPrefix meterIdPrefix = new MeterIdPrefix("athenz.test");
+            final AthenzPolicyLoader policyLoader = new AthenzPolicyLoader(baseClient, TEST_DOMAIN_NAME,
+                                                                           policyConfig, publicKeyStore,
+                                                                           meterRegistry, meterIdPrefix);
+            policyLoader.init();
+            final AthenzAssertions initial = policyLoader.getNow();
+
+            final String dataType = jwsPolicySupport ? "jws" : "signed";
+            final Counter successCounter = meterRegistry.counter("athenz.test.policy.loads",
+                                                                 "domain", TEST_DOMAIN_NAME,
+                                                                 "result", "success",
+                                                                 "type", dataType);
+            final Counter notModifiedCounter = meterRegistry.counter("athenz.test.policy.loads",
+                                                                     "domain", TEST_DOMAIN_NAME,
+                                                                     "result", "not_modified",
+                                                                     "type", dataType);
+            final Counter failureCounter = meterRegistry.counter("athenz.test.policy.loads",
+                                                                 "domain", TEST_DOMAIN_NAME,
+                                                                 "result", "failure",
+                                                                 "type", dataType);
+
+            // The initial load should be counted as a single successful load.
+            assertThat(successCounter.count()).isEqualTo(1);
+
+            // Wait until ZTS has returned at least three 304 Not Modified responses while no
+            // additional 200 OK responses have occurred. Each poll calls getNow() to trigger a
+            // background refresh once the refreshInterval has elapsed.
+            await().untilAsserted(() -> {
+                policyLoader.getNow();
+                assertThat(successCounter.count()).isEqualTo(1);
+                assertThat(notModifiedCounter.count()).isGreaterThanOrEqualTo(3);
+            });
+
+            // The cached AthenzAssertions instance should be reused when ZTS returned 304.
+            assertThat(policyLoader.getNow()).isSameAs(initial);
+
+            // No failures should have occurred and only the initial load is counted as a success.
+            assertThat(successCounter.count()).isEqualTo(1);
+            assertThat(failureCounter.count()).isZero();
+
+            // The initial request should not include the If-None-Match header.
+            assertThat(ifNoneMatchHeaders).isNotEmpty();
+            assertThat(ifNoneMatchHeaders.get(0))
+                    .as("Initial request should not send the If-None-Match header")
+                    .isNull();
+            // Subsequent requests should send the If-None-Match header with the ETag from the previous
+            // response so that ZTS can respond with 304 Not Modified.
+            assertThat(ifNoneMatchHeaders.subList(1, ifNoneMatchHeaders.size()))
+                    .as("Subsequent requests should send the If-None-Match header")
+                    .isNotEmpty()
+                    .allSatisfy(etag -> assertThat(etag).isNotNull().isNotEmpty());
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
+++ b/core/src/main/java/com/linecorp/armeria/client/AggregatedResponseAs.java
@@ -83,7 +83,7 @@ final class AggregatedResponseAs {
             AggregatedHttpResponse response) {
         return new InvalidHttpResponseException(
                 response, "status: " + response.status() +
-                          " (expect: the success class (2xx). response: " + response, null);
+                          " (expect: the success class (2xx)). response: " + response, null);
     }
 
     @FunctionalInterface

--- a/core/src/main/java/com/linecorp/armeria/client/InvalidHttpResponseException.java
+++ b/core/src/main/java/com/linecorp/armeria/client/InvalidHttpResponseException.java
@@ -40,7 +40,7 @@ public final class InvalidHttpResponseException extends InvalidResponseException
      * @throws IllegalArgumentException if the {@link AggregatedHttpResponse} has a pooled content.
      */
     public InvalidHttpResponseException(AggregatedHttpResponse response) {
-        this(response, null);
+        this(response, (Throwable) null);
     }
 
     /**
@@ -52,6 +52,15 @@ public final class InvalidHttpResponseException extends InvalidResponseException
         super(requireNonNull(response, "response").toString(), cause);
         ensureNonPooledObject(response);
         this.response = response;
+    }
+
+    /**
+     * Creates a new instance with the specified {@link AggregatedHttpResponse}, {@code message}.
+     *
+     * @throws IllegalArgumentException if the {@link AggregatedHttpResponse} has a pooled content.
+     */
+    public InvalidHttpResponseException(AggregatedHttpResponse response, String message) {
+        this(response, message, null);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Athenz policy APIs include an `ETag` in their responses.

> An ETag is generated for the PolicyList that changes when any item in
> the list changes. If the If-None-Match header is provided, and it
> matches the ETag that would be returned, then a NOT_MODIFIED response
> is returned instead of the list.

https://github.com/AthenZ/athenz/blob/10a19bf9569ea9897c99c5f4a51b5671977f03b9/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java#L225 https://github.com/AthenZ/athenz/blob/10a19bf9569ea9897c99c5f4a51b5671977f03b9/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java#L259

The client can pass the received `Etag` in the  `If-None-Match` header for subsequent requests. If the policy isn't updated, the server returns 304 Not Modified. In that case, the cached policies could be reused, so the policy verification does not need to be performed again.

Modifications:

- Wrap `AthenzAssertions` with `Etagged` to store the returned `ETag`.
  - The cached `Etag` is included in the `If-None-Match` header for subsequent requests.
- If 304 Not Modified is returned, reuse the cached assertions.
- Add `AsAthenzAssertions` to dynamically parse the resposnse depending on the response status.

Result:

Fetching Athenz policies has been optimized by using Etags.