### PR TITLE
Mask access and refresh tokens in `GrantedOAuth2AccessToken.toString()`

### DIFF
--- a/oauth2/src/main/java/com/linecorp/armeria/common/auth/oauth2/GrantedOAuth2AccessToken.java
+++ b/oauth2/src/main/java/com/linecorp/armeria/common/auth/oauth2/GrantedOAuth2AccessToken.java
@@ -92,6 +92,8 @@ public class GrantedOAuth2AccessToken implements Serializable {
     @VisibleForTesting
     static final char AUTHORIZATION_SEPARATOR = ' ';
 
+    private static final String MASKED = "****";
+
     /**
      * {@value OAuth2Constants#ACCESS_TOKEN} Access Token response field,
      * REQUIRED. The access token issued by the authorization server.
@@ -352,9 +354,11 @@ public class GrantedOAuth2AccessToken implements Serializable {
     @Override
     public String toString() {
         if (toString == null) {
+            // Mask the access and refresh tokens so that credentials are not leaked via logs.
+            // Note that the full values are still available through rawResponse().
             // include {@code issuedAt()} to toString()
-            toString = composeRawResponse(accessToken, tokenType, issuedAt, expiresIn,
-                                          refreshToken, scope, extras);
+            toString = composeRawResponse(MASKED, tokenType, issuedAt, expiresIn,
+                                          refreshToken == null ? null : MASKED, scope, extras);
         }
         return toString;
     }

--- a/oauth2/src/test/java/com/linecorp/armeria/common/auth/oauth2/GrantedOAuth2AccessTokenTest.java
+++ b/oauth2/src/test/java/com/linecorp/armeria/common/auth/oauth2/GrantedOAuth2AccessTokenTest.java
@@ -155,12 +155,13 @@ public class GrantedOAuth2AccessTokenTest {
         final String refreshToken = "tGzv3JOkF0XG5Qx2TlKWIA";
         final String[] scope = { "read", "write" };
         final Map<String, String> extras = Collections.singletonMap("example_parameter", "example_value");
+        // The access token and refresh token must be masked to avoid leaking credentials via logs.
         final String toString =
-                "{\"access_token\":\"2YotnFZFEjr1zCsicMWpAA\"," +
+                "{\"access_token\":\"****\"," +
                 "\"token_type\":\"bearer\"," +
                 "\"issued_at\":\"2010-01-01T10:15:30Z\"," +
                 "\"expires_in\":3600," +
-                "\"refresh_token\":\"tGzv3JOkF0XG5Qx2TlKWIA\"," +
+                "\"refresh_token\":\"****\"," +
                 "\"scope\":\"read write\"," +
                 "\"example_parameter\":\"example_value\"}";
 


### PR DESCRIPTION
Motivation:

GrantedOAuth2AccessToken.toString() exposed the real access_token and refresh_token, leaking credentials into logs.

Modifications:

- Mask access_token and refresh_token as "****" in `GrantedOAuth2AccessToken.toString()`.

Result:

- `GrantedOAuth2AccessToken.toString()` no longer leaks OAuth2 tokens.

