### PR TITLE
Introduce `ConnectionAcceptor` and `ConnectionContext`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/server/DefaultServiceRequestContext.java
@@ -23,9 +23,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -63,6 +61,7 @@ import com.linecorp.armeria.internal.common.InitiateConnectionShutdown;
 import com.linecorp.armeria.internal.common.NonWrappingRequestContext;
 import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
 import com.linecorp.armeria.internal.server.RouteDecoratingService.InitialDispatcherService;
+import com.linecorp.armeria.server.ConnectionContext;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ProxiedAddresses;
 import com.linecorp.armeria.server.Route;
@@ -75,7 +74,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
-import io.netty.util.AttributeKey;
 
 /**
  * Default {@link ServiceRequestContext} implementation.
@@ -105,8 +103,7 @@ public final class DefaultServiceRequestContext
     private final ProxiedAddresses proxiedAddresses;
 
     private final InetAddress clientAddress;
-    private final InetSocketAddress remoteAddress;
-    private final InetSocketAddress localAddress;
+    private final ConnectionContext connectionContext;
 
     private boolean shouldReportUnloggedExceptions = true;
 
@@ -150,12 +147,12 @@ public final class DefaultServiceRequestContext
             SessionProtocol sessionProtocol, RequestId id, RoutingContext routingContext,
             RoutingResult routingResult, ExchangeType exchangeType,
             HttpRequest req, @Nullable SSLSession sslSession, ProxiedAddresses proxiedAddresses,
-            InetAddress clientAddress, InetSocketAddress remoteAddress, InetSocketAddress localAddress,
+            InetAddress clientAddress, ConnectionContext connectionContext,
             long requestStartTimeNanos, long requestStartTimeMicros,
             Supplier<? extends AutoCloseable> contextHook) {
 
         this(cfg, ch, eventLoop, meterRegistry, sessionProtocol, id, routingContext, routingResult,
-             exchangeType, req, sslSession, proxiedAddresses, clientAddress, remoteAddress, localAddress,
+             exchangeType, req, sslSession, proxiedAddresses, clientAddress, connectionContext,
              null /* requestCancellationScheduler */, requestStartTimeNanos, requestStartTimeMicros,
              HttpHeaders.of(), HttpHeaders.of(), contextHook);
     }
@@ -165,7 +162,7 @@ public final class DefaultServiceRequestContext
             SessionProtocol sessionProtocol, RequestId id, RoutingContext routingContext,
             RoutingResult routingResult, ExchangeType exchangeType,
             HttpRequest req, @Nullable SSLSession sslSession, ProxiedAddresses proxiedAddresses,
-            InetAddress clientAddress, InetSocketAddress remoteAddress, InetSocketAddress localAddress,
+            InetAddress clientAddress, ConnectionContext connectionContext,
             @Nullable CancellationScheduler requestCancellationScheduler,
             long requestStartTimeNanos, long requestStartTimeMicros,
             HttpHeaders additionalResponseHeaders, HttpHeaders additionalResponseTrailers,
@@ -174,7 +171,7 @@ public final class DefaultServiceRequestContext
         super(meterRegistry, id,
               requireNonNull(routingContext, "routingContext").method(),
               routingContext.requestTarget(), exchangeType, cfg.requestAutoAbortDelayMillis(),
-              requireNonNull(req, "req"), null, null, contextHook);
+              requireNonNull(req, "req"), null, connectionContext.attrs(), contextHook);
 
         this.sessionProtocol = requireNonNull(sessionProtocol, "sessionProtocol");
         this.ch = requireNonNull(ch, "ch");
@@ -194,8 +191,7 @@ public final class DefaultServiceRequestContext
         this.sslSession = sslSession;
         this.proxiedAddresses = requireNonNull(proxiedAddresses, "proxiedAddresses");
         this.clientAddress = requireNonNull(clientAddress, "clientAddress");
-        this.remoteAddress = requireNonNull(remoteAddress, "remoteAddress");
-        this.localAddress = requireNonNull(localAddress, "localAddress");
+        this.connectionContext = requireNonNull(connectionContext, "connectionContext");
 
         log = RequestLog.builder(this);
         log.startRequest(requestStartTimeNanos, requestStartTimeMicros);
@@ -220,19 +216,6 @@ public final class DefaultServiceRequestContext
         return RequestTarget.forServer(headers.path());
     }
 
-    @Nullable
-    @Override
-    public <V> V attr(AttributeKey<V> key) {
-        // Don't check the root attributes; root is always null.
-        return ownAttr(key);
-    }
-
-    @Override
-    public Iterator<Entry<AttributeKey<?>, Object>> attrs() {
-        // Don't check the root attributes; root is always null.
-        return ownAttrs();
-    }
-
     @Override
     public SessionProtocol sessionProtocol() {
         return sessionProtocol;
@@ -241,13 +224,13 @@ public final class DefaultServiceRequestContext
     @Nonnull
     @Override
     public InetSocketAddress remoteAddress() {
-        return remoteAddress;
+        return connectionContext.remoteAddress();
     }
 
     @Nonnull
     @Override
     public InetSocketAddress localAddress() {
-        return localAddress;
+        return connectionContext.localAddress();
     }
 
     @Override
@@ -258,6 +241,11 @@ public final class DefaultServiceRequestContext
     @Override
     protected Channel channel() {
         return ch;
+    }
+
+    @Override
+    public ConnectionContext connectionContext() {
+        return connectionContext;
     }
 
     @Override
@@ -580,6 +568,8 @@ public final class DefaultServiceRequestContext
             buf.append("[sreqId=").append(sreqId)
                .append(", chanId=").append(chanId);
 
+            final InetSocketAddress remoteAddress = remoteAddress();
+            final InetSocketAddress localAddress = localAddress();
             if (!Objects.equals(caddr, remoteAddress.getAddress())) {
                 buf.append(", caddr=");
                 TextFormatter.appendInetAddress(buf, caddr);

--- a/core/src/main/java/com/linecorp/armeria/server/ConnectionAcceptor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ConnectionAcceptor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.server.DefaultConnectionAcceptor.AlwaysAcceptConnectionAcceptor;
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+
+/**
+ * A callback that determines whether to accept or reject a newly established connection.
+ * It is invoked once per connection for both TLS and cleartext (plain HTTP) connections.
+ * For TLS connections, it runs <b>before</b> TLS negotiation begins and provides access to
+ * SNI hostname and offered ALPN protocols. For cleartext connections, those TLS-specific
+ * properties will be absent, but connection-level properties such as the remote address
+ * are still available.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * sb.connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+ *     if ("blocked.example.com".equals(ctx.sniHostname())) {
+ *         return false; // reject
+ *     }
+ *     return true;
+ * }));
+ * }</pre>
+ *
+ * @see ConnectionContext
+ * @see ServerBuilder#connectionAcceptor(ConnectionAcceptor)
+ */
+@UnstableApi
+@FunctionalInterface
+public interface ConnectionAcceptor {
+
+    /**
+     * Returns a {@link ConnectionAcceptor} that always accepts connections.
+     */
+    static ConnectionAcceptor always() {
+        return AlwaysAcceptConnectionAcceptor.INSTANCE;
+    }
+
+    /**
+     * Creates a {@link ConnectionAcceptor} from a synchronous {@link Predicate}.
+     *
+     * @param predicate a predicate that returns {@code true} to accept or {@code false} to reject
+     */
+    static ConnectionAcceptor of(Predicate<? super ConnectionContext> predicate) {
+        requireNonNull(predicate, "predicate");
+        return ctx -> UnmodifiableFuture.completedFuture(predicate.test(ctx));
+    }
+
+    /**
+     * Determines whether to accept or reject the connection.
+     *
+     * @param ctx the {@link ConnectionContext} for the new connection
+     * @return a {@link CompletableFuture} resolving to {@code true} to accept or
+     *         {@code false} to reject. Must not resolve to {@code null}.
+     */
+    CompletableFuture<Boolean> accept(ConnectionContext ctx);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ConnectionContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ConnectionContext.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.AttributesGetters;
+import com.linecorp.armeria.common.ConcurrentAttributes;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.internal.common.util.ChannelUtil;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+/**
+ * A read-only context representing a newly accepted connection. Provides connection-level
+ * properties parsed from the TLS ClientHello (for TLS connections) and attribute storage
+ * for passing per-connection state through the server pipeline.
+ *
+ * <p>A {@link ConnectionContext} is created by the server pipeline for each connection and
+ * is accessible from {@link ServiceRequestContext#connectionContext()} so that service
+ * decorators can access connection-level state at request time.
+ */
+@UnstableApi
+public final class ConnectionContext {
+
+    static final AttributeKey<ConnectionContext> ATTR =
+            AttributeKey.valueOf(ConnectionContext.class, "CONNECTION_CONTEXT");
+
+    private static final InetSocketAddress UNKNOWN_ADDR;
+
+    static {
+        InetAddress unknownAddr;
+        try {
+            unknownAddr = InetAddress.getByAddress("<unknown>", new byte[] { 0, 0, 0, 0 });
+        } catch (Exception e1) {
+            try {
+                unknownAddr = InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 });
+            } catch (Exception e2) {
+                final Error err = new Error(e2);
+                err.addSuppressed(e1);
+                throw err;
+            }
+        }
+        UNKNOWN_ADDR = new InetSocketAddress(unknownAddr, 1);
+    }
+
+    private final SessionProtocol sessionProtocol;
+    @Nullable
+    private final String sniHostname;
+    private final List<String> alpnProtocols;
+    @Nullable
+    private final ProxiedAddresses proxiedAddresses;
+    private final Channel channel;
+    private final InetSocketAddress remoteAddress;
+    private final InetSocketAddress localAddress;
+    private final ConcurrentAttributes attrs = ConcurrentAttributes.of();
+
+    @Nullable
+    static ConnectionContext get(Channel channel) {
+        return channel.attr(ATTR).get();
+    }
+
+    ConnectionContext(SessionProtocol sessionProtocol, @Nullable String sniHostname,
+                     List<String> alpnProtocols,
+                     @Nullable ProxiedAddresses proxiedAddresses, Channel channel) {
+        this.sessionProtocol = sessionProtocol;
+        this.sniHostname = sniHostname;
+        this.alpnProtocols = ImmutableList.copyOf(alpnProtocols);
+        this.proxiedAddresses = proxiedAddresses;
+        this.channel = channel;
+        remoteAddress = firstNonNull(ChannelUtil.remoteAddress(channel), UNKNOWN_ADDR);
+        localAddress = firstNonNull(ChannelUtil.localAddress(channel), UNKNOWN_ADDR);
+    }
+
+    /**
+     * Returns the {@link SessionProtocol} of this connection.
+     * Either {@link SessionProtocol#HTTP} or {@link SessionProtocol#HTTPS} will be returned.
+     */
+    public SessionProtocol sessionProtocol() {
+        return sessionProtocol;
+    }
+
+    /**
+     * Returns the SNI hostname from the TLS ClientHello, or {@code null} if
+     * the connection is not TLS or no SNI was provided.
+     */
+    @Nullable
+    public String sniHostname() {
+        return sniHostname;
+    }
+
+    /**
+     * Returns the ALPN protocols offered in the TLS ClientHello, or an empty list
+     * if the connection is not TLS or no ALPN extension was present.
+     */
+    public List<String> alpnProtocols() {
+        return alpnProtocols;
+    }
+
+    /**
+     * Returns the proxied addresses of this connection from the PROXY protocol,
+     * or {@code null} if the connection did not use the PROXY protocol.
+     */
+    @Nullable
+    public ProxiedAddresses proxiedAddresses() {
+        return proxiedAddresses;
+    }
+
+    /**
+     * Returns the local address of this connection.
+     */
+    public InetSocketAddress localAddress() {
+        return localAddress;
+    }
+
+    /**
+     * Returns the remote address of this connection.
+     */
+    public InetSocketAddress remoteAddress() {
+        return remoteAddress;
+    }
+
+    /**
+     * Returns the value associated with the given {@link AttributeKey}, or {@code null} if not set.
+     */
+    @Nullable
+    public <T> T attr(AttributeKey<T> key) {
+        return attrs.attr(requireNonNull(key, "key"));
+    }
+
+    /**
+     * Sets the value associated with the given {@link AttributeKey}.
+     */
+    public <T> void setAttr(AttributeKey<T> key, @Nullable T value) {
+        attrs.set(requireNonNull(key, "key"), value);
+    }
+
+    /**
+     * Returns the {@link AttributesGetters} that contains the attributes of this connection.
+     */
+    public AttributesGetters attrs() {
+        return attrs;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ConnectionContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ConnectionContext.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.List;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.AttributesGetters;
@@ -74,7 +75,6 @@ public final class ConnectionContext {
     private final List<String> alpnProtocols;
     @Nullable
     private final ProxiedAddresses proxiedAddresses;
-    private final Channel channel;
     private final InetSocketAddress remoteAddress;
     private final InetSocketAddress localAddress;
     private final ConcurrentAttributes attrs = ConcurrentAttributes.of();
@@ -91,7 +91,6 @@ public final class ConnectionContext {
         this.sniHostname = sniHostname;
         this.alpnProtocols = ImmutableList.copyOf(alpnProtocols);
         this.proxiedAddresses = proxiedAddresses;
-        this.channel = channel;
         remoteAddress = firstNonNull(ChannelUtil.remoteAddress(channel), UNKNOWN_ADDR);
         localAddress = firstNonNull(ChannelUtil.localAddress(channel), UNKNOWN_ADDR);
     }
@@ -164,5 +163,18 @@ public final class ConnectionContext {
      */
     public AttributesGetters attrs() {
         return attrs;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
+                          .add("sessionProtocol", sessionProtocol)
+                          .add("sniHostname", sniHostname)
+                          .add("alpnProtocols", alpnProtocols)
+                          .add("proxiedAddresses", proxiedAddresses)
+                          .add("remoteAddress", remoteAddress)
+                          .add("localAddress", localAddress)
+                          .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultConnectionAcceptor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultConnectionAcceptor.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
@@ -67,8 +68,7 @@ final class DefaultConnectionAcceptor implements ConnectionAcceptor {
         if (t != null) {
             future.completeExceptionally(t);
         } else {
-            assert v != null;
-            future.complete(v);
+            future.complete(firstNonNull(v, false));
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultConnectionAcceptor.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultConnectionAcceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+
+import io.netty.channel.EventLoop;
+
+final class DefaultConnectionAcceptor implements ConnectionAcceptor {
+
+    private final ConnectionAcceptor delegate;
+
+    DefaultConnectionAcceptor(ConnectionAcceptor delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    boolean isNoop() {
+        return delegate == AlwaysAcceptConnectionAcceptor.INSTANCE;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> accept(ConnectionContext ctx) {
+        try {
+            final CompletableFuture<Boolean> future =
+                    requireNonNull(delegate.accept(ctx), "ConnectionAcceptor.accept()");
+            return future.thenApply(result -> requireNonNull(result, "result"));
+        } catch (Exception e) {
+            return UnmodifiableFuture.exceptionallyCompletedFuture(e);
+        }
+    }
+
+    CompletableFuture<Boolean> accept(ConnectionContext ctx, EventLoop eventLoop) {
+        final CompletableFuture<Boolean> future = accept(ctx);
+        if (future.isDone()) {
+            return future;
+        }
+        final CompletableFuture<Boolean> f = new CompletableFuture<>();
+        future.whenComplete((v, t) -> tryComplete(v, t, f, eventLoop));
+        return f;
+    }
+
+    private static void tryComplete(@Nullable Boolean v, @Nullable Throwable t,
+                                    CompletableFuture<Boolean> future, EventLoop eventLoop) {
+        if (!eventLoop.inEventLoop()) {
+            eventLoop.execute(() -> tryComplete(v, t, future, eventLoop));
+            return;
+        }
+        if (t != null) {
+            future.completeExceptionally(t);
+        } else {
+            assert v != null;
+            future.complete(v);
+        }
+    }
+
+    enum AlwaysAcceptConnectionAcceptor implements ConnectionAcceptor {
+
+        INSTANCE;
+
+        @Override
+        public CompletableFuture<Boolean> accept(ConnectionContext ctx) {
+            return UnmodifiableFuture.completedFuture(true);
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -136,6 +136,7 @@ final class DefaultServerConfig implements ServerConfig {
     private final Mapping<String, SslContext> sslContexts;
     private final ServerMetrics serverMetrics;
     private final Function<? super String, ? extends EventLoopGroup> bossGroupFactory;
+    private final DefaultConnectionAcceptor connectionAcceptor;
 
     @Nullable
     private String strVal;
@@ -169,7 +170,8 @@ final class DefaultServerConfig implements ServerConfig {
             Function<? super String, String> absoluteUriTransformer,
             long unloggedExceptionsReportIntervalMillis,
             List<ShutdownSupport> shutdownSupports,
-            @Nullable Function<? super String, ? extends EventLoopGroup> bossGroupFactory) {
+            @Nullable Function<? super String, ? extends EventLoopGroup> bossGroupFactory,
+            DefaultConnectionAcceptor connectionAcceptor) {
         requireNonNull(ports, "ports");
         requireNonNull(defaultVirtualHost, "defaultVirtualHost");
         requireNonNull(virtualHosts, "virtualHosts");
@@ -286,6 +288,7 @@ final class DefaultServerConfig implements ServerConfig {
         this.unloggedExceptionsReportIntervalMillis = unloggedExceptionsReportIntervalMillis;
         this.shutdownSupports = ImmutableList.copyOf(requireNonNull(shutdownSupports, "shutdownSupports"));
         this.bossGroupFactory = bossGroupFactory == null ? DEFAULT_BOSS_GROUP_FACTORY : bossGroupFactory;
+        this.connectionAcceptor = requireNonNull(connectionAcceptor, "connectionAcceptor");
         serverMetrics = new ServerMetrics(meterRegistry);
     }
 
@@ -737,6 +740,10 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public ServerMetrics serverMetrics() {
         return serverMetrics;
+    }
+
+    DefaultConnectionAcceptor connectionAcceptor() {
+        return connectionAcceptor;
     }
 
     List<ShutdownSupport> shutdownSupports() {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerHandler.java
@@ -71,7 +71,6 @@ import com.linecorp.armeria.internal.common.AbstractHttp2ConnectionHandler;
 import com.linecorp.armeria.internal.common.Http1ObjectEncoder;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 import com.linecorp.armeria.internal.common.RequestTargetCache;
-import com.linecorp.armeria.internal.common.util.ChannelUtil;
 import com.linecorp.armeria.internal.server.DefaultServiceRequestContext;
 
 import io.netty.buffer.Unpooled;
@@ -98,26 +97,6 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
 
     private static final String ALLOWED_METHODS_STRING =
             HttpMethod.knownMethods().stream().map(HttpMethod::name).collect(Collectors.joining(","));
-
-    private static final InetSocketAddress UNKNOWN_ADDR;
-
-    static {
-        InetAddress unknownAddr;
-        try {
-            unknownAddr = InetAddress.getByAddress("<unknown>", new byte[] { 0, 0, 0, 0 });
-        } catch (Exception e1) {
-            // Just in case a certain JRE implementation doesn't accept the hostname '<unknown>'
-            try {
-                unknownAddr = InetAddress.getByAddress(new byte[] { 0, 0, 0, 0 });
-            } catch (Exception e2) {
-                // Should never reach here.
-                final Error err = new Error(e2);
-                err.addSuppressed(e1);
-                throw err;
-            }
-        }
-        UNKNOWN_ADDR = new InetSocketAddress(unknownAddr, 1);
-    }
 
     private static final ChannelFutureListener CLOSE = future -> {
         final Throwable cause = future.cause();
@@ -194,10 +173,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     @Nullable
     private ServerHttpObjectEncoder responseEncoder;
 
-    @Nullable
-    private final ProxiedAddresses proxiedAddresses;
-    private final InetSocketAddress remoteAddress;
-    private final InetSocketAddress localAddress;
+    private final ConnectionContext connectionContext;
 
     private final IdentityHashMap<DecodedHttpRequest, HttpResponse> unfinishedRequests;
     private boolean isReading;
@@ -209,7 +185,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                       Channel channel, GracefulShutdownSupport gracefulShutdownSupport,
                       @Nullable ServerHttpObjectEncoder responseEncoder,
                       SessionProtocol protocol,
-                      @Nullable ProxiedAddresses proxiedAddresses) {
+                      ConnectionContext connectionContext) {
 
         assert protocol == H1 || protocol == H1C || protocol == H2;
 
@@ -217,13 +193,11 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final ServerPortMetric serverPortMetric = channel.attr(SERVER_PORT_METRIC).get();
         assert serverPortMetric != null;
         this.serverPortMetric = serverPortMetric;
-        remoteAddress = firstNonNull(ChannelUtil.remoteAddress(channel), UNKNOWN_ADDR);
-        localAddress = firstNonNull(ChannelUtil.localAddress(channel), UNKNOWN_ADDR);
+        this.connectionContext = requireNonNull(connectionContext, "connectionContext");
         this.gracefulShutdownSupport = requireNonNull(gracefulShutdownSupport, "gracefulShutdownSupport");
 
         this.protocol = requireNonNull(protocol, "protocol");
         this.responseEncoder = responseEncoder;
-        this.proxiedAddresses = proxiedAddresses;
         unfinishedRequests = new IdentityHashMap<>();
     }
 
@@ -413,8 +387,9 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         // `determineProxiedAddresses` could throw IllegalArgumentException if the headers are invalid.
         // If it does, we will return a 400 Bad Request response.
         // We need to get the ServiceConfig before responding, hence, we store the exception first.
-        ProxiedAddresses proxiedAddresses = (this.proxiedAddresses != null) ?
-                this.proxiedAddresses : ProxiedAddresses.of(remoteAddress);
+        final ProxiedAddresses connProxiedAddresses = connectionContext.proxiedAddresses();
+        ProxiedAddresses proxiedAddresses = (connProxiedAddresses != null) ?
+                connProxiedAddresses : ProxiedAddresses.of(connectionContext.remoteAddress());
         IllegalArgumentException invalidProxiedAddressesException = null;
         try {
             proxiedAddresses = determineProxiedAddresses(headers);
@@ -464,7 +439,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
         final DefaultServiceRequestContext reqCtx = new DefaultServiceRequestContext(
                 serviceCfg, channel, serviceEventLoop, config.meterRegistry(), protocol,
                 nextRequestId(routingCtx, serviceCfg), routingCtx, routingResult, req.exchangeType(),
-                req, sslSession, proxiedAddresses, clientAddress, remoteAddress, localAddress,
+                req, sslSession, proxiedAddresses, clientAddress, connectionContext,
                 req.requestStartTimeNanos(), req.requestStartTimeMicros(), serviceCfg.contextHook());
 
         HttpResponse res;
@@ -592,6 +567,8 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
     }
 
     private ProxiedAddresses determineProxiedAddresses(RequestHeaders headers) {
+        final ProxiedAddresses proxiedAddresses = connectionContext.proxiedAddresses();
+        final InetSocketAddress remoteAddress = connectionContext.remoteAddress();
         if (config.clientAddressTrustedProxyFilter().test(remoteAddress.getAddress())) {
             return HttpHeaderUtil.determineProxiedAddresses(
                     headers, config.clientAddressSources(), proxiedAddresses,
@@ -739,7 +716,7 @@ final class HttpServerHandler extends ChannelInboundHandlerAdapter implements Ht
                 serviceConfig,
                 channel, eventLoop, NoopMeterRegistry.get(), protocol(),
                 nextRequestId(routingCtx, serviceConfig), routingCtx, routingResult, req.exchangeType(),
-                req, sslSession, proxiedAddresses, clientAddress, remoteAddress, localAddress,
+                req, sslSession, proxiedAddresses, clientAddress, connectionContext,
                 System.nanoTime(), SystemInfo.currentTimeMicros(), NOOP_CONTEXT_HOOK);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -58,6 +58,7 @@ import com.linecorp.armeria.internal.common.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.common.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.common.util.CertificateUtil;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
+import com.linecorp.armeria.server.HttpsConnectionAcceptHandler.NotAFailureException;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
@@ -335,6 +336,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             if (acceptTimeoutMillis > 0) {
                 timeoutFuture = ch.eventLoop().schedule(() -> {
                     if (ch.isActive()) {
+                        logger.warn("{} ConnectionAcceptor timed out after {}ms",
+                                    ch, acceptTimeoutMillis);
                         ch.close();
                     }
                 }, acceptTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -352,6 +355,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                                   if (accepted) {
                                       ch.pipeline().remove(this);
                                   } else {
+                                      logger.trace("Connection rejected by ConnectionAcceptor: {}",
+                                                   connectionContext);
                                       ch.close();
                                   }
                               });
@@ -673,6 +678,8 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                     loggedHandshakeFailure = true;
                     final SSLHandshakeException handshakeException = (SSLHandshakeException) cause.getCause();
                     recordHandshakeFailure(ctx, handshakeException);
+                    return;
+                } else if (cause.getCause() instanceof NotAFailureException) {
                     return;
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -30,7 +30,6 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -202,7 +201,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
         final Channel ch = p.channel();
         final ConnectionContext connectionContext =
-                new ConnectionContext(HTTP, null, Collections.emptyList(), proxiedAddresses, ch);
+                new ConnectionContext(HTTP, null, ImmutableList.of(), proxiedAddresses, ch);
 
         final DefaultConnectionAcceptor connectionAcceptor = config.connectionAcceptor();
         if (!connectionAcceptor.isNoop()) {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -29,6 +29,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
@@ -96,12 +98,12 @@ import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
-import io.netty.handler.ssl.SniHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AsciiString;
 import io.netty.util.Mapping;
 import io.netty.util.NetUtil;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ScheduledFuture;
 
 /**
@@ -198,6 +200,17 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private void configureHttp(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
+        final Channel ch = p.channel();
+        final ConnectionContext connectionContext =
+                new ConnectionContext(HTTP, null, Collections.emptyList(), proxiedAddresses, ch);
+
+        final DefaultConnectionAcceptor connectionAcceptor = config.connectionAcceptor();
+        if (!connectionAcceptor.isNoop()) {
+            // Install the accept handler to buffer reads while the async accept is pending.
+            p.addLast(new HttpConnectionAcceptHandler(connectionAcceptor, connectionContext,
+                                                      config.idleTimeoutMillis()));
+        }
+
         final long idleTimeoutMillis = config.idleTimeoutMillis();
         final long maxConnectionAgeMillis = config.maxConnectionAgeMillis();
         final int maxNumRequestsPerConnection = config.maxNumRequestsPerConnection();
@@ -208,20 +221,20 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         final KeepAliveHandler keepAliveHandler;
         if (needsKeepAliveHandler) {
             final Timer keepAliveTimer = newKeepAliveTimer(H1C);
-            keepAliveHandler = new Http1ServerKeepAliveHandler(p.channel(), keepAliveTimer, idleTimeoutMillis,
+            keepAliveHandler = new Http1ServerKeepAliveHandler(ch, keepAliveTimer, idleTimeoutMillis,
                                                                maxConnectionAgeMillis,
                                                                maxNumRequestsPerConnection);
         } else {
             keepAliveHandler = new NoopKeepAliveHandler();
         }
         final ServerHttp1ObjectEncoder responseEncoder = new ServerHttp1ObjectEncoder(
-                p.channel(), H1C, keepAliveHandler, config.http1HeaderNaming()
+                ch, H1C, keepAliveHandler, config.http1HeaderNaming()
         );
         p.addLast(TrafficLoggingHandler.SERVER);
-        final HttpServerHandler httpServerHandler = new HttpServerHandler(config, p.channel(),
+        final HttpServerHandler httpServerHandler = new HttpServerHandler(config, ch,
                                                                           gracefulShutdownSupport,
                                                                           responseEncoder,
-                                                                          H1C, proxiedAddresses);
+                                                                          H1C, connectionContext);
         p.addLast(new Http2PrefaceOrHttpHandler(responseEncoder, httpServerHandler));
         p.addLast(httpServerHandler);
     }
@@ -232,25 +245,15 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     }
 
     private void configureHttps(ChannelPipeline p, @Nullable ProxiedAddresses proxiedAddresses) {
-        p.addLast(newSniHandler(p));
-        p.addLast(TrafficLoggingHandler.SERVER);
-        p.addLast(new Http2OrHttpHandler(proxiedAddresses));
-    }
-
-    private SniHandler newSniHandler(ChannelPipeline p) {
         final Mapping<String, SslContext> sslContexts =
                 requireNonNull(config.sslContextMapping(), "config.sslContextMapping() returned null");
-        final SniHandler sniHandler = new SniHandler(sslContexts, Flags.defaultMaxClientHelloLength(),
-                                                     config.idleTimeoutMillis());
-        if (sslContexts instanceof TlsProviderMapping) {
-            p.channel().closeFuture().addListener(future -> {
-                final SslContext sslContext = sniHandler.sslContext();
-                if (sslContext != null) {
-                    ((TlsProviderMapping) sslContexts).release(sslContext);
-                }
-            });
-        }
-        return sniHandler;
+
+        p.addLast(new HttpsConnectionAcceptHandler(config.connectionAcceptor(), sslContexts,
+                                                   proxiedAddresses,
+                                                   Flags.defaultMaxClientHelloLength(),
+                                                   config.idleTimeoutMillis()));
+        p.addLast(TrafficLoggingHandler.SERVER);
+        p.addLast(new Http2OrHttpHandler());
     }
 
     private Http2ConnectionHandler newHttp2ConnectionHandler(ChannelPipeline pipeline, AsciiString scheme) {
@@ -307,6 +310,86 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         }
 
         return settings;
+    }
+
+    private static final class HttpConnectionAcceptHandler extends ChannelInboundHandlerAdapter {
+
+        private final DefaultConnectionAcceptor connectionAcceptor;
+        private final ConnectionContext connectionContext;
+        private final long acceptTimeoutMillis;
+        private final List<Object> buffered = new ArrayList<>();
+        @Nullable
+        private ScheduledFuture<?> timeoutFuture;
+        private boolean removed;
+
+        HttpConnectionAcceptHandler(DefaultConnectionAcceptor connectionAcceptor,
+                                    ConnectionContext connectionContext,
+                                    long acceptTimeoutMillis) {
+            this.connectionAcceptor = connectionAcceptor;
+            this.connectionContext = connectionContext;
+            this.acceptTimeoutMillis = acceptTimeoutMillis;
+        }
+
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+            final Channel ch = ctx.channel();
+            if (acceptTimeoutMillis > 0) {
+                timeoutFuture = ch.eventLoop().schedule(() -> {
+                    if (ch.isActive()) {
+                        ch.close();
+                    }
+                }, acceptTimeoutMillis, TimeUnit.MILLISECONDS);
+            }
+            connectionAcceptor.accept(connectionContext, ch.eventLoop())
+                              .whenComplete((accepted, t) -> {
+                                  if (timeoutFuture != null) {
+                                      timeoutFuture.cancel(false);
+                                  }
+                                  if (t != null) {
+                                      logger.warn("Failed to accept connection for ctx: [{}]", ctx, t);
+                                      ch.close();
+                                      return;
+                                  }
+                                  if (accepted) {
+                                      ch.pipeline().remove(this);
+                                  } else {
+                                      ch.close();
+                                  }
+                              });
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (removed) {
+                logger.warn("{} Unexpected channelRead after handler removal", ctx.channel());
+            }
+            buffered.add(msg);
+        }
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            // Swallow while buffering; replayed in handlerRemoved.
+        }
+
+        @Override
+        public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+            removed = true;
+            if (!ctx.channel().isActive()) {
+                for (Object msg : buffered) {
+                    ReferenceCountUtil.release(msg);
+                }
+                buffered.clear();
+                return;
+            }
+            for (Object msg : buffered) {
+                ctx.fireChannelRead(msg);
+            }
+            buffered.clear();
+            ctx.fireChannelReadComplete();
+        }
     }
 
     private final class ProtocolDetectionHandler extends ByteToMessageDecoder {
@@ -486,14 +569,11 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
          */
         private static final String DUMMY_CIPHER_SUITE = "SSL_NULL_WITH_NULL_NULL";
 
-        @Nullable
-        private final ProxiedAddresses proxiedAddresses;
         private boolean loggedHandshakeFailure;
         private boolean addedExceptionLogger;
 
-        Http2OrHttpHandler(@Nullable ProxiedAddresses proxiedAddresses) {
+        Http2OrHttpHandler() {
             super(ApplicationProtocolNames.HTTP_1_1);
-            this.proxiedAddresses = proxiedAddresses;
         }
 
         @Override
@@ -513,12 +593,18 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             throw new SSLHandshakeException("unsupported application protocol: " + protocol);
         }
 
+        private ConnectionContext connectionContext(Channel ch) {
+            final ConnectionContext connectionContext = ConnectionContext.get(ch);
+            assert connectionContext != null : "ConnectionContext must exist for HTTPS";
+            return connectionContext;
+        }
+
         private void addHttp2Handlers(ChannelHandlerContext ctx) {
             final ChannelPipeline p = ctx.pipeline();
+            final Channel ch = p.channel();
             p.addLast(newHttp2ConnectionHandler(p, SCHEME_HTTPS));
-            p.addLast(new HttpServerHandler(config, p.channel(),
-                                            gracefulShutdownSupport,
-                                            null, H2, proxiedAddresses));
+            p.addLast(new HttpServerHandler(config, ch, gracefulShutdownSupport, null, H2,
+                                            connectionContext(ch)));
         }
 
         private void addHttpHandlers(ChannelHandlerContext ctx) {
@@ -546,9 +632,9 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                     config.http1MaxInitialLineLength(),
                     config.http1MaxHeaderSize(),
                     config.http1MaxChunkSize()));
-            final HttpServerHandler httpServerHandler = new HttpServerHandler(config, ch,
-                                                                              gracefulShutdownSupport,
-                                                                              encoder, H1, proxiedAddresses);
+            final HttpServerHandler httpServerHandler =
+                    new HttpServerHandler(config, ch, gracefulShutdownSupport, encoder, H1,
+                                          connectionContext(ch));
             p.addLast(new Http1RequestDecoder(config, ch, SCHEME_HTTPS, encoder, httpServerHandler));
             p.addLast(httpServerHandler);
         }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -58,7 +58,6 @@ import com.linecorp.armeria.internal.common.ReadSuppressingHandler;
 import com.linecorp.armeria.internal.common.TrafficLoggingHandler;
 import com.linecorp.armeria.internal.common.util.CertificateUtil;
 import com.linecorp.armeria.internal.common.util.ChannelUtil;
-import com.linecorp.armeria.server.HttpsConnectionAcceptHandler.NotAFailureException;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
@@ -678,8 +677,6 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                     loggedHandshakeFailure = true;
                     final SSLHandshakeException handshakeException = (SSLHandshakeException) cause.getCause();
                     recordHandshakeFailure(ctx, handshakeException);
-                    return;
-                } else if (cause.getCause() instanceof NotAFailureException) {
                     return;
                 }
             }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.server;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +25,8 @@ import javax.net.ssl.SSLHandshakeException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -111,7 +112,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
     @Override
     protected Future<SslContext> lookup(ChannelHandlerContext ctx,
                                         @Nullable ByteBuf clientHello) throws Exception {
-        List<String> alpnProtocols = Collections.emptyList();
+        List<String> alpnProtocols = ImmutableList.of();
 
         if (clientHello != null) {
             final ClientHelloInfo info = parseClientHello(clientHello);
@@ -333,7 +334,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
             offset += nameLength;
         }
 
-        return protocols.isEmpty() ? null : Collections.unmodifiableList(protocols);
+        return protocols.isEmpty() ? null : ImmutableList.copyOf(protocols);
     }
 
     static final class ClientHelloInfo {

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -1,7 +1,7 @@
 /*
- * Copyright 2025 LINE Corporation
+ * Copyright 2026 LY Corporation
  *
- * LINE Corporation licenses this file to you under the Apache License,
+ * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
@@ -22,6 +22,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLHandshakeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 
@@ -32,6 +37,7 @@ import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslClientHelloHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslHandshakeTimeoutException;
 import io.netty.util.CharsetUtil;
 import io.netty.util.Mapping;
 import io.netty.util.ReferenceCountUtil;
@@ -44,6 +50,8 @@ import io.netty.util.concurrent.ScheduledFuture;
  * runs the {@link ConnectionAcceptor} during the TLS lookup phase.
  */
 final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContext> {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpsConnectionAcceptHandler.class);
 
     // TLS extension types
     private static final int EXT_SERVER_NAME = 0x0000;
@@ -93,7 +101,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         }
         timeoutFuture = ctx.executor().schedule(() -> {
             if (ctx.channel().isActive()) {
-                ctx.fireExceptionCaught(new DecoderException(
+                ctx.fireExceptionCaught(new SslHandshakeTimeoutException(
                         "handshake timed out after " + handshakeTimeoutMillis + "ms"));
                 ctx.close();
             }
@@ -121,8 +129,8 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         final Promise<SslContext> promise = ctx.executor().newPromise();
 
         ctx.channel().closeFuture().addListener(f -> {
-            promise.tryFailure(new IllegalStateException(
-                    "ConnectionAcceptor.accept(ctx) timed out for: " + connectionCtx));
+            // complete the promise so the clientHello is released
+            promise.tryFailure(NotAFailureException.INSTANCE);
         });
 
         if (connectionAcceptor.isNoop()) {
@@ -137,8 +145,8 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                   if (accepted) {
                                       resolveSslContext(ctx, connectionCtx, promise);
                                   } else {
-                                      promise.tryFailure(new IllegalArgumentException(
-                                              "Connection rejected for: " + connectionCtx));
+                                      logger.trace("Connection for '{}' rejected", connectionCtx);
+                                      promise.tryFailure(NotAFailureException.INSTANCE);
                                   }
                               });
         }
@@ -151,7 +159,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                    Promise<SslContext> promise) {
         final SslContext sslContext = sslContextMapping.map(connectionCtx.sniHostname());
         if (sslContext == null) {
-            promise.tryFailure(new IllegalArgumentException(
+            promise.tryFailure(new SSLHandshakeException(
                     "No SslContext found for hostname: " + connectionCtx.sniHostname()));
             return;
         }
@@ -169,19 +177,18 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
             timeoutFuture.cancel(false);
         }
 
-        try {
-            if (!future.isSuccess()) {
-                throw new DecoderException(future.cause());
+        final Throwable cause = future.cause();
+        if (cause != null) {
+            ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname, cause));
+            if (!(cause instanceof NotAFailureException)) {
+                ctx.fireExceptionCaught(new DecoderException(cause));
             }
-            replaceHandler(ctx, future.getNow());
-        } finally {
-            final Throwable cause = future.cause();
-            if (cause == null) {
-                ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname));
-            } else {
-                ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname, cause));
-            }
+            ctx.pipeline().remove(this);
+            ctx.close();
+            return;
         }
+        replaceHandler(ctx, future.getNow());
+        ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname));
     }
 
     private void replaceHandler(ChannelHandlerContext ctx, SslContext sslContext) {
@@ -339,5 +346,11 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
             this.sniHostname = sniHostname;
             this.alpnProtocols = alpnProtocols;
         }
+    }
+
+    static final class NotAFailureException extends RuntimeException {
+        private static final long serialVersionUID = -1272562527562139704L;
+
+        static final NotAFailureException INSTANCE = new NotAFailureException();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.ssl.SniCompletionEvent;
+import io.netty.handler.ssl.SslClientHelloHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.CharsetUtil;
+import io.netty.util.Mapping;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
+
+/**
+ * An {@link SslClientHelloHandler}-based alternative to Netty's {@code SniHandler} that also
+ * runs the {@link ConnectionAcceptor} during the TLS lookup phase.
+ */
+final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContext> {
+
+    // TLS extension types
+    private static final int EXT_SERVER_NAME = 0x0000;
+    private static final int EXT_ALPN = 0x0010;
+
+    // Server name type for hostname
+    private static final int SERVER_NAME_TYPE_HOSTNAME = 0;
+
+    private final DefaultConnectionAcceptor connectionAcceptor;
+    private final Mapping<String, SslContext> sslContextMapping;
+    @Nullable
+    private final ProxiedAddresses proxiedAddresses;
+    private final long handshakeTimeoutMillis;
+
+    @Nullable
+    private ScheduledFuture<?> timeoutFuture;
+    @Nullable
+    private String sniHostname;
+
+    HttpsConnectionAcceptHandler(DefaultConnectionAcceptor connectionAcceptor,
+                                 Mapping<String, SslContext> sslContextMapping,
+                                 @Nullable ProxiedAddresses proxiedAddresses,
+                                 int maxClientHelloLength, long handshakeTimeoutMillis) {
+        super(maxClientHelloLength);
+        this.connectionAcceptor = connectionAcceptor;
+        this.sslContextMapping = sslContextMapping;
+        this.proxiedAddresses = proxiedAddresses;
+        this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        if (ctx.channel().isActive()) {
+            checkStartTimeout(ctx);
+        }
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelActive();
+        checkStartTimeout(ctx);
+    }
+
+    private void checkStartTimeout(ChannelHandlerContext ctx) {
+        if (handshakeTimeoutMillis <= 0 || timeoutFuture != null) {
+            return;
+        }
+        timeoutFuture = ctx.executor().schedule(() -> {
+            if (ctx.channel().isActive()) {
+                ctx.fireExceptionCaught(new DecoderException(
+                        "handshake timed out after " + handshakeTimeoutMillis + "ms"));
+                ctx.close();
+            }
+        }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected Future<SslContext> lookup(ChannelHandlerContext ctx,
+                                        @Nullable ByteBuf clientHello) throws Exception {
+        List<String> alpnProtocols = Collections.emptyList();
+
+        if (clientHello != null) {
+            final ClientHelloInfo info = parseClientHello(clientHello);
+            sniHostname = info.sniHostname;
+            if (info.alpnProtocols != null) {
+                alpnProtocols = info.alpnProtocols;
+            }
+        }
+
+        final ConnectionContext connectionCtx =
+                new ConnectionContext(SessionProtocol.HTTPS, sniHostname, alpnProtocols,
+                                      proxiedAddresses, ctx.channel());
+        ctx.channel().attr(ConnectionContext.ATTR).set(connectionCtx);
+
+        final Promise<SslContext> promise = ctx.executor().newPromise();
+
+        if (connectionAcceptor.isNoop()) {
+            resolveSslContext(ctx, connectionCtx, promise);
+        } else {
+            connectionAcceptor.accept(connectionCtx, ctx.channel().eventLoop())
+                              .whenComplete((accepted, t) -> {
+                                  if (t != null) {
+                                      promise.setFailure(t);
+                                      return;
+                                  }
+                                  if (accepted) {
+                                      resolveSslContext(ctx, connectionCtx, promise);
+                                  } else {
+                                      promise.setFailure(new IllegalArgumentException(
+                                              "Connection rejected by ConnectionAcceptor: " + connectionCtx));
+                                  }
+                              });
+        }
+
+        return promise;
+    }
+
+    private void resolveSslContext(ChannelHandlerContext ctx,
+                                   ConnectionContext connectionCtx,
+                                   Promise<SslContext> promise) {
+        final SslContext sslContext = sslContextMapping.map(connectionCtx.sniHostname());
+        if (sslContext == null) {
+            promise.setFailure(new IllegalArgumentException(
+                    "No SslContext found for hostname: " + connectionCtx.sniHostname()));
+            return;
+        }
+        if (sslContextMapping instanceof TlsProviderMapping) {
+            ctx.channel().closeFuture().addListener(
+                    f -> ((TlsProviderMapping) sslContextMapping).release(sslContext));
+        }
+        promise.setSuccess(sslContext);
+    }
+
+    @Override
+    protected void onLookupComplete(ChannelHandlerContext ctx,
+                                    Future<SslContext> future) throws Exception {
+        if (timeoutFuture != null) {
+            timeoutFuture.cancel(false);
+        }
+
+        try {
+            if (!future.isSuccess()) {
+                throw new DecoderException(future.cause());
+            }
+            replaceHandler(ctx, future.getNow());
+        } finally {
+            final Throwable cause = future.cause();
+            if (cause == null) {
+                ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname));
+            } else {
+                ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname, cause));
+            }
+        }
+    }
+
+    private void replaceHandler(ChannelHandlerContext ctx, SslContext sslContext) {
+        SslHandler sslHandler = null;
+        try {
+            sslHandler = sslContext.newHandler(ctx.alloc());
+            if (handshakeTimeoutMillis > 0) {
+                sslHandler.setHandshakeTimeoutMillis(handshakeTimeoutMillis);
+            }
+            ctx.pipeline().replace(this, SslHandler.class.getName(), sslHandler);
+            sslHandler = null;
+        } finally {
+            if (sslHandler != null) {
+                ReferenceCountUtil.safeRelease(sslHandler.engine());
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Single-pass ClientHello parsing (SNI + ALPN)
+    // See https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.2
+    //
+    // struct {
+    //    ProtocolVersion client_version;       // 2 bytes
+    //    Random random;                        // 32 bytes
+    //    SessionID session_id;                 // 1 byte length + variable
+    //    CipherSuite cipher_suites;            // 2 bytes length + variable
+    //    CompressionMethod compression_methods;// 1 byte length + variable
+    //    Extension extensions;                 // 2 bytes length + variable
+    // } ClientHello;
+    // ------------------------------------------------------------------
+
+    // Ported from AbstractSniHandler.extractSniHostname, extended to also extract ALPN.
+    static ClientHelloInfo parseClientHello(ByteBuf in) {
+        String sniHostname = null;
+        List<String> alpnProtocols = null;
+
+        int offset = in.readerIndex();
+        final int endOffset = in.writerIndex();
+        offset += 34;
+
+        if (endOffset - offset >= 6) {
+            final int sessionIdLength = in.getUnsignedByte(offset);
+            offset += sessionIdLength + 1;
+
+            final int cipherSuitesLength = in.getUnsignedShort(offset);
+            offset += cipherSuitesLength + 2;
+
+            final int compressionMethodLength = in.getUnsignedByte(offset);
+            offset += compressionMethodLength + 1;
+
+            final int extensionsLength = in.getUnsignedShort(offset);
+            offset += 2;
+            final int extensionsLimit = offset + extensionsLength;
+
+            // Extensions should never exceed the record boundary.
+            if (extensionsLimit <= endOffset) {
+                while (extensionsLimit - offset >= 4) {
+                    final int extensionType = in.getUnsignedShort(offset);
+                    offset += 2;
+
+                    final int extensionLength = in.getUnsignedShort(offset);
+                    offset += 2;
+
+                    if (extensionsLimit - offset < extensionLength) {
+                        break;
+                    }
+
+                    if (extensionType == EXT_SERVER_NAME) {
+                        sniHostname = parseSniExtension(in, offset, offset + extensionLength);
+                    } else if (extensionType == EXT_ALPN) {
+                        alpnProtocols = parseAlpnExtension(in, offset, offset + extensionLength);
+                    }
+
+                    offset += extensionLength;
+
+                    // Early exit if we found both
+                    if (sniHostname != null && alpnProtocols != null) {
+                        break;
+                    }
+                }
+            }
+        }
+        return new ClientHelloInfo(sniHostname, alpnProtocols);
+    }
+
+    // Ported from the inline SNI parsing in AbstractSniHandler.extractSniHostname.
+    // See https://datatracker.ietf.org/doc/html/rfc6066#page-6
+    @Nullable
+    private static String parseSniExtension(ByteBuf in, int offset, int endOffset) {
+        // server_name_list_length (2)
+        if (endOffset - offset < 2) {
+            return null;
+        }
+        offset += 2;
+
+        if (endOffset - offset < 3) {
+            return null;
+        }
+
+        final int serverNameType = in.getUnsignedByte(offset);
+        offset++;
+
+        if (serverNameType != SERVER_NAME_TYPE_HOSTNAME) {
+            return null;
+        }
+
+        final int serverNameLength = in.getUnsignedShort(offset);
+        offset += 2;
+
+        if (endOffset - offset < serverNameLength) {
+            return null;
+        }
+
+        return in.toString(offset, serverNameLength, CharsetUtil.US_ASCII)
+                 .toLowerCase(Locale.US);
+    }
+
+    // See https://datatracker.ietf.org/doc/html/rfc7301#section-3.1
+    @Nullable
+    private static List<String> parseAlpnExtension(ByteBuf in, int offset, int endOffset) {
+        // protocol_name_list_length (2)
+        if (endOffset - offset < 2) {
+            return null;
+        }
+        final int listLength = in.getUnsignedShort(offset);
+        offset += 2;
+
+        if (endOffset - offset < listLength) {
+            return null;
+        }
+        final int listEnd = offset + listLength;
+
+        final List<String> protocols = new ArrayList<>(4);
+        while (listEnd - offset >= 1) {
+            final int nameLength = in.getUnsignedByte(offset);
+            offset++;
+            if (listEnd - offset < nameLength) {
+                break;
+            }
+            protocols.add(in.toString(offset, nameLength, CharsetUtil.US_ASCII));
+            offset += nameLength;
+        }
+
+        return protocols.isEmpty() ? null : Collections.unmodifiableList(protocols);
+    }
+
+    static final class ClientHelloInfo {
+        @Nullable
+        final String sniHostname;
+        @Nullable
+        final List<String> alpnProtocols;
+
+        ClientHelloInfo(@Nullable String sniHostname, @Nullable List<String> alpnProtocols) {
+            this.sniHostname = sniHostname;
+            this.alpnProtocols = alpnProtocols;
+        }
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -348,9 +348,9 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         }
     }
 
-    static final class NotAFailureException extends RuntimeException {
+    private static final class NotAFailureException extends RuntimeException {
         private static final long serialVersionUID = -1272562527562139704L;
 
-        static final NotAFailureException INSTANCE = new NotAFailureException();
+        private static final NotAFailureException INSTANCE = new NotAFailureException();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -120,20 +120,25 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
 
         final Promise<SslContext> promise = ctx.executor().newPromise();
 
+        ctx.channel().closeFuture().addListener(f -> {
+            promise.tryFailure(new IllegalStateException(
+                    "ConnectionAcceptor.accept(ctx) timed out for: " + connectionCtx));
+        });
+
         if (connectionAcceptor.isNoop()) {
             resolveSslContext(ctx, connectionCtx, promise);
         } else {
             connectionAcceptor.accept(connectionCtx, ctx.channel().eventLoop())
                               .whenComplete((accepted, t) -> {
                                   if (t != null) {
-                                      promise.setFailure(t);
+                                      promise.tryFailure(t);
                                       return;
                                   }
                                   if (accepted) {
                                       resolveSslContext(ctx, connectionCtx, promise);
                                   } else {
-                                      promise.setFailure(new IllegalArgumentException(
-                                              "Connection rejected by ConnectionAcceptor: " + connectionCtx));
+                                      promise.tryFailure(new IllegalArgumentException(
+                                              "Connection rejected for: " + connectionCtx));
                                   }
                               });
         }
@@ -146,7 +151,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                    Promise<SslContext> promise) {
         final SslContext sslContext = sslContextMapping.map(connectionCtx.sniHostname());
         if (sslContext == null) {
-            promise.setFailure(new IllegalArgumentException(
+            promise.tryFailure(new IllegalArgumentException(
                     "No SslContext found for hostname: " + connectionCtx.sniHostname()));
             return;
         }
@@ -154,7 +159,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
             ctx.channel().closeFuture().addListener(
                     f -> ((TlsProviderMapping) sslContextMapping).release(sslContext));
         }
-        promise.setSuccess(sslContext);
+        promise.trySuccess(sslContext);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -248,6 +248,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     @Nullable
     private ServerTlsConfig tlsConfig;
     private Function<? super String, ? extends EventLoopGroup> bossGroupFactory = DEFAULT_BOSS_GROUP_FACTORY;
+    private ConnectionAcceptor connectionAcceptor = ConnectionAcceptor.always();
 
     ServerBuilder() {
         // Set the default host-level properties.
@@ -522,6 +523,16 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         requireNonNull(childChannelPipelineCustomizer, "childChannelPipelineCustomizer");
         this.childChannelPipelineCustomizer =
                 this.childChannelPipelineCustomizer.andThen(childChannelPipelineCustomizer);
+        return this;
+    }
+
+    /**
+     * Sets the {@link ConnectionAcceptor} that is called once per connection, before TLS
+     * negotiation, to decide whether to accept the connection.
+     */
+    @UnstableApi
+    public ServerBuilder connectionAcceptor(ConnectionAcceptor connectionAcceptor) {
+        this.connectionAcceptor = requireNonNull(connectionAcceptor, "connectionAcceptor");
         return this;
     }
 
@@ -2603,7 +2614,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
                 enableServerHeader, enableDateHeader, errorHandler, sslContexts,
                 http1HeaderNaming, dependencyInjector, absoluteUriTransformer,
                 unloggedExceptionsReportIntervalMillis, ImmutableList.copyOf(shutdownSupports),
-                bossGroupFactory);
+                bossGroupFactory, new DefaultConnectionAcceptor(connectionAcceptor));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContext.java
@@ -201,6 +201,14 @@ public interface ServiceRequestContext extends RequestContext {
     InetSocketAddress localAddress();
 
     /**
+     * Returns the {@link ConnectionContext} for the connection handling this request.
+     * The connection context provides connection-level properties such as SNI hostname
+     * and ALPN protocols.
+     */
+    @UnstableApi
+    ConnectionContext connectionContext();
+
+    /**
      * Returns the address of the client who initiated this request.
      */
     InetAddress clientAddress();

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextBuilder.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -243,11 +244,13 @@ public final class ServiceRequestContextBuilder extends AbstractRequestContextBu
 
         // Build the context with the properties set by a user and the fake objects.
         final Channel ch = fakeChannel(eventLoop);
+        final ConnectionContext connectionContext =
+                new ConnectionContext(sessionProtocol(), null, Collections.emptyList(),
+                                      proxiedAddresses, ch);
         return new DefaultServiceRequestContext(
                 serviceCfg, ch, eventLoop, meterRegistry(), sessionProtocol(), id(), routingCtx,
                 routingResult, exchangeType, req, sslSession(), proxiedAddresses,
-                clientAddress, remoteAddress(), localAddress(),
-                requestCancellationScheduler,
+                clientAddress, connectionContext, requestCancellationScheduler,
                 isRequestStartTimeSet() ? requestStartTimeNanos() : System.nanoTime(),
                 isRequestStartTimeSet() ? requestStartTimeMicros() : SystemInfo.currentTimeMicros(),
                 HttpHeaders.of(), HttpHeaders.of(), serviceCfg.contextHook());

--- a/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServiceRequestContextWrapper.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestContextWrapper;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.TimeoutMode;
 
 /**
@@ -73,6 +74,12 @@ public class ServiceRequestContextWrapper
     @Override
     public InetSocketAddress localAddress() {
         return unwrap().localAddress();
+    }
+
+    @UnstableApi
+    @Override
+    public ConnectionContext connectionContext() {
+        return unwrap().connectionContext();
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -67,6 +67,10 @@ final class UpdatableServerConfig implements ServerConfig {
         return delegate.sslContextMapping();
     }
 
+    DefaultConnectionAcceptor connectionAcceptor() {
+        return delegate.connectionAcceptor();
+    }
+
     /**
      * Returns the {@link Executor} which will invoke the callbacks of {@link Server#start()},
      * {@link Server#stop()} and {@link ServerListener}.

--- a/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.TlsKeyPair;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.util.AttributeKey;
+
+class ConnectionAcceptorTest {
+
+    private static final AttributeKey<String> TEST_ATTR =
+            AttributeKey.valueOf(ConnectionAcceptorTest.class, "TEST_ATTR");
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0)
+              .https(0)
+              .tls(TlsKeyPair.ofSelfSigned())
+              .connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+                  ctx.setAttr(TEST_ATTR, "from-connection");
+                  return true;
+              }))
+              .service("/", (ctx, req) -> connectionContextJson(ctx))
+              .service("/override", (ctx, req) -> {
+                  ctx.setAttr(TEST_ATTR, "from-request");
+                  return connectionContextJson(ctx);
+              });
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension rejectServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0)
+              .https(0)
+              .tls(TlsKeyPair.ofSelfSigned())
+              .connectionAcceptor(ConnectionAcceptor.of(ctx -> false))
+              .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
+        }
+    };
+
+    private static HttpResponse connectionContextJson(ServiceRequestContext ctx) {
+        final ConnectionContext connCtx = ctx.connectionContext();
+        final Map<String, Object> map = new HashMap<>();
+        map.put("sni", connCtx.sniHostname());
+        map.put("alpn", connCtx.alpnProtocols());
+        map.put("protocol", connCtx.sessionProtocol().toString());
+        map.put("connAttr", connCtx.attr(TEST_ATTR));
+        map.put("ctxAttr", ctx.attr(TEST_ATTR));
+        return HttpResponse.ofJson(map);
+    }
+
+    @Test
+    void httpsAcceptorAcceptsConnection() {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(server.uri(SessionProtocol.HTTPS))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            final String body = client.get("/").contentUtf8();
+            assertThatJson(body).node("protocol").isEqualTo("https");
+            // SNI is null when connecting to an IP address (127.0.0.1)
+            assertThatJson(body).node("sni").isEqualTo(null);
+            assertThatJson(body).node("alpn").isEqualTo("[\"h2\",\"http/1.1\"]");
+            assertThatJson(body).node("connAttr").isEqualTo("from-connection");
+            assertThatJson(body).node("ctxAttr").isEqualTo("from-connection");
+        }
+    }
+
+    @Test
+    void httpsAcceptorRejectsConnection() {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(rejectServer.uri(SessionProtocol.HTTPS))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class);
+        }
+    }
+
+    @Test
+    void httpAcceptorAcceptsConnection() {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            final BlockingWebClient client = WebClient.builder(server.uri(SessionProtocol.HTTP))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            final String body = client.get("/").contentUtf8();
+            assertThatJson(body).node("sni").isEqualTo(null);
+            assertThatJson(body).node("alpn").isEqualTo("[]");
+            assertThatJson(body).node("connAttr").isEqualTo("from-connection");
+            assertThatJson(body).node("ctxAttr").isEqualTo("from-connection");
+        }
+    }
+
+    @Test
+    void httpAcceptorRejectsConnection() {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            final BlockingWebClient client = WebClient.builder(rejectServer.uri(SessionProtocol.HTTP))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class);
+        }
+    }
+
+    @Test
+    void requestContextAttrOverridesConnectionAttr() {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(server.uri(SessionProtocol.HTTPS))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            final String body = client.get("/override").contentUtf8();
+            assertThatJson(body).node("ctxAttr").isEqualTo("from-request");
+            assertThatJson(body).node("connAttr").isEqualTo("from-connection");
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
@@ -21,9 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.ClientFactory;
@@ -72,6 +76,20 @@ class ConnectionAcceptorTest {
         }
     };
 
+    @RegisterExtension
+    static final ServerExtension throwingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0)
+              .https(0)
+              .tls(TlsKeyPair.ofSelfSigned())
+              .connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+                  throw new RuntimeException("acceptor failed");
+              }))
+              .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
+        }
+    };
+
     private static HttpResponse connectionContextJson(ServiceRequestContext ctx) {
         final ConnectionContext connCtx = ctx.connectionContext();
         final Map<String, Object> map = new HashMap<>();
@@ -101,18 +119,6 @@ class ConnectionAcceptorTest {
     }
 
     @Test
-    void httpsAcceptorRejectsConnection() {
-        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
-            final BlockingWebClient client = WebClient.builder(rejectServer.uri(SessionProtocol.HTTPS))
-                                                      .factory(factory)
-                                                      .build()
-                                                      .blocking();
-            assertThatThrownBy(() -> client.get("/"))
-                    .isInstanceOf(UnprocessedRequestException.class);
-        }
-    }
-
-    @Test
     void httpAcceptorAcceptsConnection() {
         try (ClientFactory factory = ClientFactory.builder().build()) {
             final BlockingWebClient client = WebClient.builder(server.uri(SessionProtocol.HTTP))
@@ -128,18 +134,6 @@ class ConnectionAcceptorTest {
     }
 
     @Test
-    void httpAcceptorRejectsConnection() {
-        try (ClientFactory factory = ClientFactory.builder().build()) {
-            final BlockingWebClient client = WebClient.builder(rejectServer.uri(SessionProtocol.HTTP))
-                                                      .factory(factory)
-                                                      .build()
-                                                      .blocking();
-            assertThatThrownBy(() -> client.get("/"))
-                    .isInstanceOf(UnprocessedRequestException.class);
-        }
-    }
-
-    @Test
     void requestContextAttrOverridesConnectionAttr() {
         try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
             final BlockingWebClient client = WebClient.builder(server.uri(SessionProtocol.HTTPS))
@@ -149,6 +143,28 @@ class ConnectionAcceptorTest {
             final String body = client.get("/override").contentUtf8();
             assertThatJson(body).node("ctxAttr").isEqualTo("from-request");
             assertThatJson(body).node("connAttr").isEqualTo("from-connection");
+        }
+    }
+
+    static Stream<Arguments> rejectAndThrowServers() {
+        return Stream.of(
+                Arguments.of(rejectServer, SessionProtocol.HTTP),
+                Arguments.of(rejectServer, SessionProtocol.HTTPS),
+                Arguments.of(throwingServer, SessionProtocol.HTTP),
+                Arguments.of(throwingServer, SessionProtocol.HTTPS)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("rejectAndThrowServers")
+    void acceptorRejectsOrThrows(ServerExtension server, SessionProtocol protocol) {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(server.uri(protocol))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class);
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/DelayedConnectionAcceptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DelayedConnectionAcceptorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.TlsKeyPair;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+/**
+ * Tests that requests succeed when the {@link ConnectionAcceptor} future completes
+ * after a delay, ensuring that inbound bytes are not dropped while the accept is pending.
+ */
+class DelayedConnectionAcceptorTest {
+
+    @RegisterExtension
+    private static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0)
+              .https(0)
+              .tls(TlsKeyPair.ofSelfSigned())
+              .connectionAcceptor(ctx -> {
+                  final CompletableFuture<Boolean> future = new CompletableFuture<>();
+                  eventLoop.get().schedule(() -> future.complete(true), 1, TimeUnit.SECONDS);
+                  return future;
+              })
+              .service("/", (ctx, req) -> HttpResponse.of("OK"));
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension stalledServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0)
+              .https(0)
+              .tls(TlsKeyPair.ofSelfSigned())
+              .idleTimeoutMillis(1000)
+              // Never completes — should be closed by the accept timeout.
+              .connectionAcceptor(ctx -> new CompletableFuture<>())
+              .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
+        }
+    };
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = {"HTTP", "HTTPS"})
+    void delayedAcceptShouldNotDropRequest(SessionProtocol protocol) {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(server.uri(protocol))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            final AggregatedHttpResponse response = client.get("/");
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+            assertThat(response.contentUtf8()).isEqualTo("OK");
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SessionProtocol.class, names = {"HTTP", "HTTPS"})
+    void stalledAcceptShouldTimeout(SessionProtocol protocol) {
+        try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
+            final BlockingWebClient client = WebClient.builder(stalledServer.uri(protocol))
+                                                      .factory(factory)
+                                                      .build()
+                                                      .blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Armeria currently has no mechanism to accept or reject connections at the transport level before request processing begins. This makes it impossible to implement connection-level policies (e.g., blocking by SNI hostname or remote address) or to expose TLS ClientHello metadata (SNI, ALPN) to service handlers.

Additionally, Netty's built-in `SniHandler` doesn't allow running custom logic during the TLS lookup phase, and connection-level state (remote/local address) was previously stored as separate fields rather than as a unified, shareable context object.

## Modifications

### New public API

- **`ConnectionAcceptor`** — A `@FunctionalInterface` invoked once per connection (both TLS and cleartext) that returns `CompletableFuture<Boolean>` to accept or reject. Provides `always()` (no-op singleton) and `of(Predicate)` factory methods.
- **`ConnectionContext`** — A read-only context for each connection exposing `sessionProtocol()`, `sniHostname()`, `alpnProtocols()`, `proxiedAddresses()`, `remoteAddress()`, `localAddress()`, and per-connection attribute storage via `attr()`/`setAttr()`. Accessible from `ServiceRequestContext.connectionContext()`.
- **`ServerBuilder.connectionAcceptor(ConnectionAcceptor)`** — Configures the acceptor for the server.

### HTTPS path: `HttpsConnectionAcceptHandler`

Replaces Netty's `SniHandler` with a custom `SslClientHelloHandler`-based handler that:
- Parses both SNI and ALPN from the TLS ClientHello in a single pass
- Creates a `ConnectionContext` and runs the `ConnectionAcceptor` during the TLS lookup phase
- Resolves the `SslContext` only after the acceptor approves the connection
- Handles `TlsProviderMapping` release on channel close (previously done by `SniHandler` wrapper code)

### HTTP path: `HttpConnectionAcceptHandler`

A `ChannelInboundHandlerAdapter` that:
- Buffers inbound reads while the async `ConnectionAcceptor` future is pending
- Swallows `channelReadComplete` during buffering to prevent premature flushes via `FlushConsolidationHandler`
- Replays buffered messages on handler removal (when accept succeeds)
- Releases buffered messages if the channel becomes inactive
- Enforces an accept timeout (using `idleTimeoutMillis`) to prevent unbounded memory growth from stalled acceptors

### `ConnectionContext` as unified connection state

`DefaultServiceRequestContext` now holds a `ConnectionContext` instead of separate `remoteAddress`/`localAddress` fields. Connection-level attributes set by the acceptor are visible as parent attributes on `ServiceRequestContext`, and per-request attributes can override them.

## Result

- Connections can be accepted or rejected at the transport level before any request processing
- TLS ClientHello metadata (SNI hostname, ALPN protocols) is accessible from service handlers via `ServiceRequestContext.connectionContext()`
- Per-connection attribute storage enables passing state from the acceptor to service handlers
- Zero overhead when no custom acceptor is configured
- The HTTP async accept race condition is fixed by the buffering handler
