### PR TITLE
Move `allowUnsafeCiphers` to `TlsSpec`

### DIFF
--- a/athenz/src/main/java/com/linecorp/armeria/server/athenz/MinifiedAuthZpeClient.java
+++ b/athenz/src/main/java/com/linecorp/armeria/server/athenz/MinifiedAuthZpeClient.java
@@ -147,14 +147,14 @@ final class MinifiedAuthZpeClient {
         }
         final ClientFactory clientFactory = ztsBaseClient.clientFactory();
         final TlsProvider tlsProvider = clientFactory.options().tlsProvider();
-        final ClientTlsSpec clientTlsSpec = toTlsSpec(tlsProvider);
         final boolean allowUnsafeCiphers = clientFactory.options().tlsConfig().allowsUnsafeCiphers();
+        final ClientTlsSpec clientTlsSpec = toTlsSpec(tlsProvider, allowUnsafeCiphers);
         final JdkSslContext sslContext =
-                (JdkSslContext) SslContextUtil.toSslContext(clientTlsSpec, allowUnsafeCiphers);
+                (JdkSslContext) SslContextUtil.toSslContext(clientTlsSpec);
         return new JwtsSigningKeyResolver(ztsUri + oauth2KeysPath, sslContext.context(), proxyUriStr);
     }
 
-    private static ClientTlsSpec toTlsSpec(TlsProvider tlsProvider) {
+    private static ClientTlsSpec toTlsSpec(TlsProvider tlsProvider, boolean allowUnsafeCiphers) {
         final ClientTlsSpecBuilder builder = ClientTlsSpec.builder();
         final TlsKeyPair tlsKeyPair = tlsProvider.keyPair("*");
         if (tlsKeyPair != null) {
@@ -166,6 +166,7 @@ final class MinifiedAuthZpeClient {
         }
         builder.engineType(TlsEngineType.JDK);
         builder.alpnProtocols(SslContextUtil.DEFAULT_ALPN_PROTOCOLS);
+        builder.allowUnsafeCiphers(allowUnsafeCiphers);
         return builder.build();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpec.java
@@ -65,9 +65,11 @@ public final class ClientTlsSpec extends AbstractTlsSpec {
                   List<TlsPeerVerifierFactory> verifierFactories, TlsEngineType engineType,
                   Consumer<? super SslContextBuilder> tlsCustomizer,
                   @Nullable KeyManagerFactory keyManagerFactory,
-                  String endpointIdentificationAlgorithm) {
+                  String endpointIdentificationAlgorithm,
+                  boolean allowUnsafeCiphers) {
         super(tlsVersions, alpnProtocols, ciphers, tlsKeyPair,
-              trustedCertificates, verifierFactories, engineType, tlsCustomizer, keyManagerFactory);
+              trustedCertificates, verifierFactories, engineType, tlsCustomizer, keyManagerFactory,
+              allowUnsafeCiphers);
         this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpec.java
@@ -114,6 +114,7 @@ public final class ClientTlsSpec extends AbstractTlsSpec {
                           .add("tlsCustomizer", tlsCustomizer())
                           .add("keyManagerFactory", keyManagerFactory())
                           .add("endpointIdentificationAlgorithm", endpointIdentificationAlgorithm())
+                          .add("allowUnsafeCiphers", allowUnsafeCiphers())
                           .toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
@@ -51,7 +51,8 @@ public final class ClientTlsSpecBuilder extends AbstractTlsSpecBuilder<ClientTls
 
     ClientTlsSpecBuilder(ClientTlsSpec clientTlsSpec) {
         super(clientTlsSpec.ciphers(), clientTlsSpec.tlsKeyPair(), clientTlsSpec.trustedCertificates(),
-              clientTlsSpec.verifierFactories(), clientTlsSpec.engineType());
+              clientTlsSpec.verifierFactories(), clientTlsSpec.engineType(),
+              clientTlsSpec.allowUnsafeCiphers());
         alpnProtocols = clientTlsSpec.alpnProtocols();
         keyManagerFactory = clientTlsSpec.keyManagerFactory();
         tlsCustomizer = clientTlsSpec.tlsCustomizer();
@@ -108,6 +109,6 @@ public final class ClientTlsSpecBuilder extends AbstractTlsSpecBuilder<ClientTls
         return new ClientTlsSpec(SslContextUtil.supportedTlsVersions(engineType().sslProvider()),
                                  alpnProtocols, ciphers(), tlsKeyPair(),
                                  trustedCertificates(), verifierFactories(), engineType(), tlsCustomizer,
-                                 keyManagerFactory, endpointIdentificationAlgorithm);
+                                 keyManagerFactory, endpointIdentificationAlgorithm, allowUnsafeCiphers());
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -318,6 +318,7 @@ final class HttpClientDelegate implements HttpClient {
                     ClientTlsSpec.builder()
                                  .tlsCustomizer(config.tlsCustomizer())
                                  .engineType(factory.options().tlsEngineType())
+                                 .allowUnsafeCiphers(config.allowsUnsafeCiphers())
                                  .alpnProtocols(sessionProtocol);
             if (keyPair != null) {
                 builder.tlsKeyPair(keyPair);

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -170,9 +170,11 @@ final class HttpClientFactory implements ClientFactory {
             meterIdPrefix = options.tlsConfig().meterIdPrefix();
             allowUnsafeCiphers = options.tlsConfig().allowsUnsafeCiphers();
         }
-        sslContextFactory = new SslContextFactory(meterIdPrefix, options.meterRegistry(),
-                                                  allowUnsafeCiphers);
-        bootstrapSslContexts = new BootstrapSslContexts(baseClientTlsSpec, options, sslContextFactory);
+        final ClientTlsSpec resolvedTlsSpec = baseClientTlsSpec.toBuilder()
+                                                                .allowUnsafeCiphers(allowUnsafeCiphers)
+                                                                .build();
+        sslContextFactory = new SslContextFactory(meterIdPrefix, options.meterRegistry());
+        bootstrapSslContexts = new BootstrapSslContexts(resolvedTlsSpec, options, sslContextFactory);
 
         http2InitialConnectionWindowSize = options.http2InitialConnectionWindowSize();
         http2InitialStreamWindowSize = options.http2InitialStreamWindowSize();

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpec.java
@@ -203,6 +203,7 @@ public abstract class AbstractTlsSpec {
                           .add("engineType", engineType)
                           .add("tlsCustomizer", tlsCustomizer)
                           .add("keyManagerFactory", keyManagerFactory)
+                          .add("allowUnsafeCiphers", allowUnsafeCiphers)
                           .toString();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpec.java
@@ -54,6 +54,7 @@ public abstract class AbstractTlsSpec {
     private final Consumer<? super SslContextBuilder> tlsCustomizer;
     @Nullable
     private final KeyManagerFactory keyManagerFactory;
+    private final boolean allowUnsafeCiphers;
 
     /**
      * Creates a new instance with the specified TLS configuration.
@@ -62,7 +63,8 @@ public abstract class AbstractTlsSpec {
                               @Nullable TlsKeyPair tlsKeyPair, List<X509Certificate> trustedCertificates,
                               List<TlsPeerVerifierFactory> verifierFactories, TlsEngineType engineType,
                               Consumer<? super SslContextBuilder> tlsCustomizer,
-                              @Nullable KeyManagerFactory keyManagerFactory) {
+                              @Nullable KeyManagerFactory keyManagerFactory,
+                              boolean allowUnsafeCiphers) {
         checkArgument(tlsKeyPair == null || keyManagerFactory == null,
                       "'tlsKeyPair' and 'keyManagerFactory' cannot both be set");
         SslContextUtil.checkVersionsSupported(tlsVersions, engineType.sslProvider());
@@ -75,6 +77,7 @@ public abstract class AbstractTlsSpec {
         this.engineType = engineType;
         this.tlsCustomizer = tlsCustomizer;
         this.keyManagerFactory = keyManagerFactory;
+        this.allowUnsafeCiphers = allowUnsafeCiphers;
     }
 
     /**
@@ -147,6 +150,15 @@ public abstract class AbstractTlsSpec {
     }
 
     /**
+     * Returns whether unsafe ciphers are allowed for this TLS configuration.
+     * @deprecated will be removed
+     */
+    @Deprecated
+    public final boolean allowUnsafeCiphers() {
+        return allowUnsafeCiphers;
+    }
+
+    /**
      * Returns {@code true} if this is a server-side TLS specification, {@code false} otherwise.
      */
     public abstract boolean isServer();
@@ -168,13 +180,15 @@ public abstract class AbstractTlsSpec {
                Objects.equal(verifierFactories, tlsSpec.verifierFactories()) &&
                engineType == tlsSpec.engineType() &&
                Objects.equal(tlsCustomizer, tlsSpec.tlsCustomizer()) &&
-               Objects.equal(keyManagerFactory, tlsSpec.keyManagerFactory());
+               Objects.equal(keyManagerFactory, tlsSpec.keyManagerFactory()) &&
+               allowUnsafeCiphers == tlsSpec.allowUnsafeCiphers;
     }
 
     @Override
     public int hashCode() {
         return Objects.hashCode(tlsVersions, alpnProtocols(), ciphers, tlsKeyPair, trustedCertificates,
-                                verifierFactories, engineType, tlsCustomizer, keyManagerFactory);
+                                verifierFactories, engineType, tlsCustomizer, keyManagerFactory,
+                                allowUnsafeCiphers);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpecBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/AbstractTlsSpecBuilder.java
@@ -43,6 +43,7 @@ public abstract class AbstractTlsSpecBuilder<SELF extends AbstractTlsSpecBuilder
     private List<X509Certificate> trustedCertificates = ImmutableList.of();
     private List<TlsPeerVerifierFactory> verifierFactories = ImmutableList.of();
     private TlsEngineType engineType = Flags.tlsEngineType();
+    private boolean allowUnsafeCiphers;
 
     /**
      * Creates a new builder with default settings.
@@ -54,12 +55,15 @@ public abstract class AbstractTlsSpecBuilder<SELF extends AbstractTlsSpecBuilder
      */
     protected AbstractTlsSpecBuilder(Set<String> ciphers, @Nullable TlsKeyPair tlsKeyPair,
                                      List<X509Certificate> trustedCertificates,
-                                     List<TlsPeerVerifierFactory> verifierFactories, TlsEngineType engineType) {
+                                     List<TlsPeerVerifierFactory> verifierFactories,
+                                     TlsEngineType engineType,
+                                     boolean allowUnsafeCiphers) {
         this.ciphers = ciphers;
         this.tlsKeyPair = tlsKeyPair;
         this.trustedCertificates = trustedCertificates;
         this.verifierFactories = verifierFactories;
         this.engineType = engineType;
+        this.allowUnsafeCiphers = allowUnsafeCiphers;
     }
 
     /**
@@ -170,6 +174,23 @@ public abstract class AbstractTlsSpecBuilder<SELF extends AbstractTlsSpecBuilder
      */
     protected final TlsEngineType engineType() {
         return engineType;
+    }
+
+    /**
+     * Sets whether to allow unsafe ciphers.
+     * @deprecated will be removed
+     */
+    @Deprecated
+    public final SELF allowUnsafeCiphers(boolean allowUnsafeCiphers) {
+        this.allowUnsafeCiphers = allowUnsafeCiphers;
+        return self();
+    }
+
+    /**
+     * Returns whether unsafe ciphers are allowed.
+     */
+    protected final boolean allowUnsafeCiphers() {
+        return allowUnsafeCiphers;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/linecorp/armeria/common/Flags.java
+++ b/core/src/main/java/com/linecorp/armeria/common/Flags.java
@@ -658,7 +658,7 @@ public final class Flags {
             final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
                                                        .alpnProtocols(SslContextUtil.DEFAULT_ALPN_PROTOCOLS)
                                                        .build();
-            final SSLEngine engine = SslContextUtil.toSslContext(tlsSpec, false)
+            final SSLEngine engine = SslContextUtil.toSslContext(tlsSpec)
                                                    .newEngine(ByteBufAllocator.DEFAULT);
             logger.info("All available SSL protocols: {}",
                         ImmutableList.copyOf(engine.getSupportedProtocols()));

--- a/core/src/main/java/com/linecorp/armeria/internal/common/SslContextFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SslContextFactory.java
@@ -50,7 +50,6 @@ public final class SslContextFactory {
     private final Map<SslContext, AbstractTlsSpec> reverseCache = new HashMap<>();
 
     private final MeterRegistry meterRegistry;
-    private final boolean allowUnsafeCiphers;
     @Nullable
     private final MeterIdPrefix meterIdPrefix;
 
@@ -61,23 +60,17 @@ public final class SslContextFactory {
     }
 
     public SslContextFactory(@Nullable MeterIdPrefix meterIdPrefix, MeterRegistry meterRegistry) {
-        this(meterIdPrefix, meterRegistry, false);
-    }
-
-    public SslContextFactory(@Nullable MeterIdPrefix meterIdPrefix, MeterRegistry meterRegistry,
-                             boolean allowUnsafeCiphers) {
         this.meterIdPrefix = meterIdPrefix;
         this.meterRegistry = meterRegistry;
-        this.allowUnsafeCiphers = allowUnsafeCiphers;
     }
 
-    public SslContext getOrCreate(ServerTlsSpec serverTlsSpec, boolean allowsUnsafeCiphers) {
+    public SslContext getOrCreate(ServerTlsSpec serverTlsSpec) {
         lock.lock();
         try {
             final SslContextHolder contextHolder =
                     cache.computeIfAbsent(serverTlsSpec, unused -> {
                         final SslContext sslContext =
-                                SslContextUtil.toSslContext(serverTlsSpec, allowsUnsafeCiphers);
+                                SslContextUtil.toSslContext(serverTlsSpec);
                         return toContextHolder(serverTlsSpec, sslContext);
                     });
             contextHolder.retain();
@@ -94,7 +87,7 @@ public final class SslContextFactory {
             final SslContextHolder contextHolder =
                     cache.computeIfAbsent(clientTlsSpec, unused -> {
                         final SslContext sslContext =
-                                SslContextUtil.toSslContext(clientTlsSpec, allowUnsafeCiphers);
+                                SslContextUtil.toSslContext(clientTlsSpec);
                         return toContextHolder(clientTlsSpec, sslContext);
                     });
             contextHolder.retain();

--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/SslContextUtil.java
@@ -95,13 +95,13 @@ public final class SslContextUtil {
     private static boolean warnedMissingEssentialCipherSuite;
     private static boolean warnedBadCipherSuite;
 
-    public static SslContext toSslContext(ClientTlsSpec clientTlsSpec, boolean allowUnsafeCiphers) {
+    public static SslContext toSslContext(ClientTlsSpec clientTlsSpec) {
         checkArgument(!clientTlsSpec.alpnProtocols().isEmpty(), "Specify at least one ALPN protocol.");
         return MinifiedBouncyCastleProvider.call(() -> {
             SslContext sslContext = null;
             try {
                 sslContext = toSslContext0(clientTlsSpec);
-                validateSslContext(allowUnsafeCiphers, sslContext);
+                validateSslContext(clientTlsSpec.allowUnsafeCiphers(), sslContext);
             } catch (Exception e) {
                 ReferenceCountUtil.release(sslContext);
                 return Exceptions.throwUnsafely(e);
@@ -110,13 +110,13 @@ public final class SslContextUtil {
         });
     }
 
-    public static SslContext toSslContext(ServerTlsSpec serverTlsSpec, boolean allowUnsafeCiphers) {
+    public static SslContext toSslContext(ServerTlsSpec serverTlsSpec) {
         checkArgument(!serverTlsSpec.alpnProtocols().isEmpty(), "Specify at least one ALPN protocol.");
         return MinifiedBouncyCastleProvider.call(() -> {
             SslContext sslContext = null;
             try {
                 sslContext = toSslContext0(serverTlsSpec);
-                validateSslContext(allowUnsafeCiphers, sslContext);
+                validateSslContext(serverTlsSpec.allowUnsafeCiphers(), sslContext);
             } catch (Exception e) {
                 ReferenceCountUtil.release(sslContext);
                 return Exceptions.throwUnsafely(e);

--- a/core/src/main/java/com/linecorp/armeria/server/ServerSslContextUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerSslContextUtil.java
@@ -64,7 +64,8 @@ final class ServerSslContextUtil {
                                  .engineType(tlsEngineType)
                                  .alpnProtocols(SslContextUtil.DEFAULT_ALPN_PROTOCOLS)
                                  .build();
-            final SslContext sslContextClient = SslContextUtil.toSslContext(clientTlsSpec, true);
+            final SslContext sslContextClient = SslContextUtil.toSslContext(
+                    clientTlsSpec.toBuilder().allowUnsafeCiphers(true).build());
             clientEngine = sslContextClient.newEngine(ByteBufAllocator.DEFAULT);
             clientEngine.setUseClientMode(true);
             clientEngine.setEnabledProtocols(clientEngine.getSupportedProtocols());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerTlsSpec.java
@@ -116,6 +116,7 @@ public final class ServerTlsSpec extends AbstractTlsSpec {
                           .add("keyManagerFactory", keyManagerFactory())
                           .add("clientAuth", clientAuth)
                           .add("hostnamePattern", hostnamePattern)
+                          .add("allowUnsafeCiphers", allowUnsafeCiphers())
                           .toString();
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/ServerTlsSpec.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerTlsSpec.java
@@ -55,9 +55,10 @@ public final class ServerTlsSpec extends AbstractTlsSpec {
                   List<X509Certificate> trustedCertificates,
                   List<TlsPeerVerifierFactory> verifierFactories, TlsEngineType engineType,
                   Consumer<? super SslContextBuilder> tlsCustomizer, ClientAuth clientAuth,
+                  boolean allowUnsafeCiphers,
                   @Nullable KeyManagerFactory keyManagerFactory, String hostnamePattern) {
         super(protocols, alpnProtocols, ciphers, tlsKeyPair, trustedCertificates, verifierFactories, engineType,
-              tlsCustomizer, keyManagerFactory);
+              tlsCustomizer, keyManagerFactory, allowUnsafeCiphers);
         this.clientAuth = clientAuth;
         this.hostnamePattern = hostnamePattern;
     }
@@ -157,7 +158,7 @@ public final class ServerTlsSpec extends AbstractTlsSpec {
             return new ServerTlsSpec(SslContextUtil.supportedTlsVersions(engineType().sslProvider()),
                                      SslContextUtil.DEFAULT_ALPN_PROTOCOLS, ciphers(), tlsKeyPair(),
                                      trustedCertificates(), verifierFactories(), engineType(), tlsCustomizer,
-                                     clientAuth, keyManagerFactory, hostnamePattern);
+                                     clientAuth, allowUnsafeCiphers(), keyManagerFactory, hostnamePattern);
         }
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/TlsProviderMapping.java
+++ b/core/src/main/java/com/linecorp/armeria/server/TlsProviderMapping.java
@@ -69,11 +69,12 @@ final class TlsProviderMapping implements Mapping<String, SslContext> {
                                                           .tlsKeyPair(keyPair)
                                                           .engineType(tlsEngineType)
                                                           .tlsCustomizer(tlsCustomizer)
-                                                          .clientAuth(clientAuth);
+                                                          .clientAuth(clientAuth)
+                                                          .allowUnsafeCiphers(allowUnsafeCiphers);
         if (trustedCertificates != null) {
             builder.trustedCertificates(trustedCertificates);
         }
-        return sslContextFactory.getOrCreate(builder.build(), allowUnsafeCiphers);
+        return sslContextFactory.getOrCreate(builder.build());
     }
 
     void release(SslContext sslContext) {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostBuilder.java
@@ -1516,7 +1516,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         if (serverTlsSpec != null && tlsProvider != null) {
             throw new IllegalStateException("Cannot configure TLS settings with a TlsProvider");
         }
-        final SslContext sslContext = sslContext(template, sslContextFactory, serverTlsSpec);
+        final SslContext sslContext = sslContext(sslContextFactory, serverTlsSpec);
 
         final VirtualHost virtualHost =
                 new VirtualHost(defaultHostname, hostnamePattern, port, serverPort,
@@ -1553,7 +1553,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
     }
 
     @Nullable
-    private SslContext sslContext(VirtualHostBuilder template, SslContextFactory sslContextFactory,
+    private SslContext sslContext(SslContextFactory sslContextFactory,
                                   @Nullable ServerTlsSpec serverTlsSpec) {
         if (portBased || serverTlsSpec == null) {
             return null;
@@ -1562,12 +1562,7 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
         SslContext sslContext = null;
         boolean releaseSslContextOnFailure = true;
         try {
-            assert template.tlsAllowUnsafeCiphers != null;
-            final boolean tlsAllowUnsafeCiphers =
-                    this.tlsAllowUnsafeCiphers != null ?
-                    this.tlsAllowUnsafeCiphers : template.tlsAllowUnsafeCiphers;
-
-            sslContext = sslContextFactory.getOrCreate(serverTlsSpec, tlsAllowUnsafeCiphers);
+            sslContext = sslContextFactory.getOrCreate(serverTlsSpec);
             validateSslContext(sslContext, serverTlsSpec.engineType());
             checkState(sslContext.isServer(), "sslContextBuilder built a client SSL context.");
 
@@ -1606,7 +1601,12 @@ public final class VirtualHostBuilder implements TlsSetters, ServiceConfigsBuild
             tlsSetter.tlsKeyPair(TlsKeyPair.of(ssc.key(), ssc.cert()));
         }
 
-        return tlsSetter.toServerTlsSpec(tlsEngineType, hostnamePattern);
+        assert template.tlsAllowUnsafeCiphers != null;
+        final boolean allowUnsafeCiphers =
+                this.tlsAllowUnsafeCiphers != null ?
+                this.tlsAllowUnsafeCiphers : template.tlsAllowUnsafeCiphers;
+
+        return tlsSetter.toServerTlsSpec(tlsEngineType, hostnamePattern, allowUnsafeCiphers);
     }
 
     private SelfSignedCertificate selfSignedCertificate() throws CertificateException {

--- a/core/src/main/java/com/linecorp/armeria/server/VirtualHostTlsSetter.java
+++ b/core/src/main/java/com/linecorp/armeria/server/VirtualHostTlsSetter.java
@@ -100,13 +100,15 @@ final class VirtualHostTlsSetter {
         return new VirtualHostTlsSetter(tlsKeyPair, tlsCustomizer, keyManagerFactory, tlsSelfSigned);
     }
 
-    ServerTlsSpec toServerTlsSpec(TlsEngineType tlsEngineType, String hostnamePattern) {
+    ServerTlsSpec toServerTlsSpec(TlsEngineType tlsEngineType, String hostnamePattern,
+                                  boolean allowUnsafeCiphers) {
         if (tlsKeyPair == null && keyManagerFactory == null) {
             throw new IllegalStateException("Cannot call tlsCustomizer() without tls() or tlsSelfSigned()");
         }
         assert keyManagerFactory == null || tlsKeyPair == null;
         final ServerTlsSpecBuilder tlsSpecBuilder = ServerTlsSpec.builder()
-                                                                 .engineType(tlsEngineType);
+                                                                 .engineType(tlsEngineType)
+                                                                 .allowUnsafeCiphers(allowUnsafeCiphers);
         if (tlsKeyPair != null) {
             tlsSpecBuilder.tlsKeyPair(tlsKeyPair);
         } else if (keyManagerFactory != null) {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/util/SslContextUtilTest.java
@@ -89,14 +89,15 @@ class SslContextUtilTest {
             SslContextUtil.toSslContext(ClientTlsSpec.builder()
                                                      .alpnProtocols(SslContextUtil.DEFAULT_ALPN_PROTOCOLS)
                                                      .ciphers(BAD_HTTP2_CIPHERS)
-                                                     .build(), false);
+                                                     .build());
         }).isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("TLS without the TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 cipher suite");
 
         final SslContext sslContext = SslContextUtil.toSslContext(
                 ClientTlsSpec.builder().ciphers(BAD_HTTP2_CIPHERS)
                              .alpnProtocols(SslContextUtil.DEFAULT_ALPN_PROTOCOLS)
-                             .build(), true);
+                             .allowUnsafeCiphers(true)
+                             .build());
         ReferenceCountUtil.release(sslContext);
     }
 


### PR DESCRIPTION
## Motivation:

This is a preparatory refactor for xDS server-side support. Currently, `allowUnsafeCiphers` is passed as a separate boolean through method chains (`SslContextFactory`, `SslContextUtil`, `VirtualHostBuilder.sslContext()`), which means a `ServerTlsSpec` alone doesn't fully describe a virtual host's TLS configuration.

By folding `allowUnsafeCiphers` into the TLS spec objects, each virtual host's TLS configuration can be completely expressed as a single `ServerTlsSpec`. This makes it possible for static TLS configurations to be represented as a `TlsProvider`, which is needed for xDS server-side integration.

## Modifications:

- Added `allowUnsafeCiphers` field, constructor parameter, and getter to `AbstractTlsSpec`.
- Added `allowUnsafeCiphers` field, setter, and copy-constructor parameter to `AbstractTlsSpecBuilder`.
- Removed the `allowUnsafeCiphers` parameter from `SslContextUtil.toSslContext()` — it now reads from the spec directly.
- Removed the `allowUnsafeCiphers` constructor parameter and `getOrCreate()` parameter from `SslContextFactory`.
- Updated `VirtualHostBuilder` to compute `allowUnsafeCiphers` in `buildServerTlsSpec()` and pass it to `VirtualHostTlsSetter.toServerTlsSpec()`, instead of passing it separately to `sslContext()`.
- Updated `TlsProviderMapping` to set `allowUnsafeCiphers` on the spec builder instead of passing it to `SslContextFactory.getOrCreate()`.
- Updated `HttpClientFactory` to set `allowUnsafeCiphers` on the `ClientTlsSpec` via `toBuilder()` instead of on the `SslContextFactory`.
- Updated `HttpClientDelegate`, `ServerSslContextUtil`, and `MinifiedAuthZpeClient` to set `allowUnsafeCiphers` on the spec builder.
- Deprecated `allowUnsafeCiphers` on both `AbstractTlsSpec` and `AbstractTlsSpecBuilder`.

## Result:

- TLS spec objects are now self-contained — a `ServerTlsSpec` or `ClientTlsSpec` fully describes a TLS configuration without needing a separate `allowUnsafeCiphers` flag.
- No behavioral changes for users.
