### PR TITLE
Sync `gradle/scripts` with upstream

### DIFF
--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts
 	branch = main
-	commit = c8b5d2d302cef0a5b8e0a3828afb10a2ad4a004f
-	parent = ad0314020152f007a84e4da8b1954a8124b8f0e4
+	commit = 4850638bb82cafaed7eecaed6418aa4bb4ec1d8f
+	parent = d9c62251aa224739ff4ce8e09dd405ea5457988b
 	method = merge
-	cmdver = 0.4.6
+	cmdver = 0.4.9

--- a/gradle/scripts/lib/common-info.gradle
+++ b/gradle/scripts/lib/common-info.gradle
@@ -15,8 +15,8 @@ rootProject.ext {
     scmDeveloperConnection = project.findProperty('scmDeveloperConnection')
     copyrightFooter =
             '&copy; Copyright ' + "${rootProject.ext.inceptionYear}&ndash;${LocalDateTime.now().year} " +
-            '<a href="' + rootProject.ext.authorUrl + '">' + rootProject.ext.authorName + '</a>. ' +
-            'All rights reserved.'
+                    '<a href="' + rootProject.ext.authorUrl + '">' + rootProject.ext.authorName + '</a>. ' +
+                    'All rights reserved.'
     googleAnalyticsId = rootProject.findProperty('googleAnalyticsId')
 }
 

--- a/gradle/scripts/lib/common-publish.gradle
+++ b/gradle/scripts/lib/common-publish.gradle
@@ -62,6 +62,8 @@ if (publishToStaging) {
             }
         }
 
+        clientTimeout.set(Duration.ofMinutes(30))
+
         transitionCheckOptions {
             maxRetries.set(100)
             delayBetween.set(Duration.ofSeconds(20))


### PR DESCRIPTION
Ran a simple clone to ensure we are back in sync

```
git subrepo clone git@github.com:line/gradle-scripts.git  gradle/scripts -f
```