### PR TITLE
xDS retry now correctly re-selects endpoints on each retry attempt.

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/PreprocessorErrorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/PreprocessorErrorTest.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.internal.client.DefaultClientRequestContext;
 import com.linecorp.armeria.xds.XdsBootstrap;
@@ -133,8 +134,8 @@ class PreprocessorErrorTest {
                               endpoints:
                               - lb_endpoints:
                         """,
-                        TimeoutException.class,
-                        "Failed to select an endpoint"
+                        EmptyEndpointGroupException.class,
+                        "Unable to select endpoints from"
                 )
         );
     }

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/RetryTest.java
@@ -22,9 +22,12 @@ import static org.assertj.core.api.Assertions.withinPercentage;
 
 import java.util.ArrayDeque;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -32,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientRequestContextCaptor;
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RefusedStreamException;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
@@ -772,6 +776,94 @@ class RetryTest {
                 ctx = captor.get();
             }
             assertThat(ctx.log().children()).hasSize(expectedRetries + 1);
+        }
+    }
+
+    //language=YAML
+    private static final String multiEndpointBootstrap =
+            """
+                static_resources:
+                  listeners:
+                  - name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.\
+                http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  cluster: my-cluster
+                                  retry_policy:
+                                    retry_on: "5xx"
+                                    num_retries: 3
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  clusters:
+                  - name: my-cluster
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: my-cluster
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8080
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8081
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8082
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: 8083
+                """;
+
+    @Test
+    void retrySelectsDifferentEndpoints() {
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(XdsResourceReader.fromYaml(multiEndpointBootstrap));
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+            final ArrayDeque<Endpoint> selectedEndpoints = new ArrayDeque<>();
+            final ClientRequestContext ctx;
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse res =
+                        WebClient.builder(preprocessor)
+                                 .decorator((delegate, ctx0, req) -> {
+                                     selectedEndpoints.add(ctx0.endpoint());
+                                     return HttpResponse.of(ResponseHeaders.of(503));
+                                 })
+                                 .build()
+                                 .blocking()
+                                 .execute(HttpRequest.of(HttpMethod.GET, "/"));
+                assertThat(res.status().code()).isEqualTo(503);
+                ctx = captor.get();
+            }
+            // 1 original + 3 retries = 4 total attempts
+            assertThat(ctx.log().children()).hasSize(4);
+            assertThat(selectedEndpoints).hasSize(4);
+
+            // Verify that not all attempts used the same endpoint
+            final Set<Integer> uniquePorts = selectedEndpoints.stream()
+                                                              .map(Endpoint::port)
+                                                              .collect(Collectors.toSet());
+            assertThat(uniquePorts).hasSizeGreaterThan(1);
         }
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.util.Set;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreprocessor;
+import com.linecorp.armeria.client.PreClient;
+import com.linecorp.armeria.client.PreClientRequestContext;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreprocessor;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.Request;
+import com.linecorp.armeria.common.Response;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.client.ClientRequestContextExtension;
+import com.linecorp.armeria.xds.client.endpoint.XdsEndpointGroup;
+import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
+import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
+import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
+import com.linecorp.armeria.xds.internal.XdsCommonUtil;
+
+/**
+ * A factory which injects cluster-related filters.
+ * <pre>{@code
+ * [downstream preprocessors]
+ *     -> [router preprocessor]
+ *         -> [cluster preprocessor]
+ *             -> [endpoint selection]
+ *                 -> [retry decorator]
+ *                     -> [cluster decorator]
+ *                         -> [upstream decorators]
+ * }</pre>
+ */
+final class ClusterFilterFactory {
+
+    static final ClientDecoration DECORATION =
+            ClientDecoration.builder()
+                            .add(ClusterFilterFactory::applyHttpClusterSettings)
+                            .addRpc(ClusterFilterFactory::applyRpcClusterSettings)
+                            .build();
+
+    private static final HttpClient CLUSTER_ONLY_HTTP_CLIENT =
+            DECORATION.decorate(DelegatingHttpClient.of());
+    private static final RpcClient CLUSTER_ONLY_RPC_CLIENT =
+            DECORATION.rpcDecorate(DelegatingRpcClient.of());
+
+    private final String clusterName;
+    @Nullable
+    private final XdsEndpointGroup endpointGroup;
+    private final SessionProtocol sessionProtocol;
+
+    ClusterFilterFactory(ClusterXdsResource clusterXdsResource,
+                         @Nullable XdsLoadBalancer loadBalancer,
+                         TransportSocketSnapshot transportSocket) {
+        clusterName = clusterXdsResource.name();
+        endpointGroup = loadBalancer != null ? XdsEndpointGroup.of(loadBalancer) : null;
+        sessionProtocol = transportSocket.clientTlsSpec() != null ?
+                          SessionProtocol.HTTPS : SessionProtocol.HTTP;
+    }
+
+    HttpPreprocessor httpPreprocessor() {
+        return this::execute;
+    }
+
+    RpcPreprocessor rpcPreprocessor() {
+        return this::execute;
+    }
+
+    private <I extends Request, O extends Response> O execute(
+            PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception {
+        if (endpointGroup == null) {
+            throw UnprocessedRequestException.of(new IllegalStateException(
+                    "The target cluster '" + clusterName +
+                    "' does not specify ClusterLoadAssignments."));
+        }
+        ctx.setEndpointGroup(endpointGroup);
+        ctx.setSessionProtocol(sessionProtocol);
+
+        final RouteEntry route = ctx.attr(XdsCommonUtil.SELECTED_ROUTE);
+        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
+        if (ctxExt != null) {
+            final HttpClient httpClient = route != null ?
+                                          route.httpClient() : CLUSTER_ONLY_HTTP_CLIENT;
+            final RpcClient rpcClient = route != null ?
+                                        route.rpcClient() : CLUSTER_ONLY_RPC_CLIENT;
+            ctxExt.httpClientCustomizer(actualClient -> {
+                DelegatingHttpClient.setDelegate(ctx, actualClient);
+                return httpClient;
+            });
+            ctxExt.rpcClientCustomizer(actualClient -> {
+                DelegatingRpcClient.setDelegate(ctx, actualClient);
+                return rpcClient;
+            });
+        }
+        return delegate.execute(ctx, req);
+    }
+
+    // Decorator logic — applies per-endpoint cluster settings (TLS)
+
+    private static HttpResponse applyHttpClusterSettings(
+            HttpClient delegate, ClientRequestContext ctx, HttpRequest req) throws Exception {
+        applyClusterSettings(ctx);
+        return delegate.execute(ctx, req);
+    }
+
+    private static RpcResponse applyRpcClusterSettings(
+            RpcClient delegate, ClientRequestContext ctx, RpcRequest req) throws Exception {
+        applyClusterSettings(ctx);
+        return delegate.execute(ctx, req);
+    }
+
+    private static void applyClusterSettings(ClientRequestContext ctx) {
+        final Endpoint endpoint = ctx.endpoint();
+        if (endpoint == null) {
+            return;
+        }
+        final TransportSocketSnapshot transportSocket =
+                endpoint.attr(XdsCommonUtil.TRANSPORT_SOCKET_SNAPSHOT_KEY);
+        if (transportSocket == null) {
+            return;
+        }
+        @Nullable
+        ClientTlsSpec clientTlsSpec = transportSocket.clientTlsSpec();
+        if (clientTlsSpec == null) {
+            return;
+        }
+        final Set<String> alpnOverride = ctx.attr(XdsCommonUtil.ALPN_OVERRIDE_KEY);
+        if (alpnOverride != null && !alpnOverride.isEmpty()) {
+            clientTlsSpec = clientTlsSpec.toBuilder().alpnProtocols(alpnOverride).build();
+        }
+        ctx.setClientTlsSpec(clientTlsSpec);
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.RpcPreprocessor;
-import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.Request;
@@ -69,16 +68,12 @@ final class ClusterFilterFactory {
     private static final RpcClient CLUSTER_ONLY_RPC_CLIENT =
             DECORATION.rpcDecorate(DelegatingRpcClient.of());
 
-    private final String clusterName;
-    @Nullable
     private final XdsEndpointGroup endpointGroup;
     private final SessionProtocol sessionProtocol;
 
-    ClusterFilterFactory(ClusterXdsResource clusterXdsResource,
-                         @Nullable XdsLoadBalancer loadBalancer,
+    ClusterFilterFactory(XdsLoadBalancer loadBalancer,
                          TransportSocketSnapshot transportSocket) {
-        clusterName = clusterXdsResource.name();
-        endpointGroup = loadBalancer != null ? XdsEndpointGroup.of(loadBalancer) : null;
+        endpointGroup = XdsEndpointGroup.of(loadBalancer);
         sessionProtocol = transportSocket.clientTlsSpec() != null ?
                           SessionProtocol.HTTPS : SessionProtocol.HTTP;
     }
@@ -93,11 +88,6 @@ final class ClusterFilterFactory {
 
     private <I extends Request, O extends Response> O execute(
             PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception {
-        if (endpointGroup == null) {
-            throw UnprocessedRequestException.of(new IllegalStateException(
-                    "The target cluster '" + clusterName +
-                    "' does not specify ClusterLoadAssignments."));
-        }
         ctx.setEndpointGroup(endpointGroup);
         ctx.setSessionProtocol(sessionProtocol);
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
@@ -24,6 +24,8 @@ import com.google.common.base.Objects;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpPreprocessor;
+import com.linecorp.armeria.client.RpcPreprocessor;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
@@ -43,6 +45,8 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     private final List<TransportSocketMatchSnapshot> transportSocketMatches;
     @Nullable
     private final XdsLoadBalancer loadBalancer;
+    private final HttpPreprocessor httpPreprocessor;
+    private final RpcPreprocessor rpcPreprocessor;
 
     ClusterSnapshot(ClusterXdsResource clusterXdsResource,
                     Optional<XdsLoadBalancer> loadBalancer,
@@ -53,6 +57,10 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
         this.loadBalancer = loadBalancer.orElse(null);
         endpointSnapshot = loadBalancer.map(XdsLoadBalancer::endpointSnapshot).orElse(null);
         this.transportSocketMatches = transportSocketMatches;
+        final ClusterFilterFactory factory = new ClusterFilterFactory(
+                clusterXdsResource, this.loadBalancer, transportSocket);
+        httpPreprocessor = factory.httpPreprocessor();
+        rpcPreprocessor = factory.rpcPreprocessor();
     }
 
     @Override
@@ -102,6 +110,24 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     @Nullable
     public XdsLoadBalancer loadBalancer() {
         return loadBalancer;
+    }
+
+    /**
+     * Returns an {@link HttpPreprocessor} that sets the endpoint group, session protocol,
+     * and installs cluster-level decoration (retry + per-endpoint TLS) on the context.
+     */
+    @UnstableApi
+    public HttpPreprocessor preprocessor() {
+        return httpPreprocessor;
+    }
+
+    /**
+     * Returns an {@link RpcPreprocessor} that sets the endpoint group, session protocol,
+     * and installs cluster-level decoration (retry + per-endpoint TLS) on the context.
+     */
+    @UnstableApi
+    public RpcPreprocessor rpcPreprocessor() {
+        return rpcPreprocessor;
     }
 
     /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
@@ -86,22 +86,6 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
         return transportSocketMatches;
     }
 
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        final ClusterSnapshot that = (ClusterSnapshot) object;
-        return Objects.equal(clusterXdsResource, that.clusterXdsResource) &&
-               Objects.equal(endpointSnapshot, that.endpointSnapshot) &&
-               Objects.equal(loadBalancer, that.loadBalancer) &&
-               Objects.equal(transportSocket, that.transportSocket) &&
-               Objects.equal(transportSocketMatches, that.transportSocketMatches);
-    }
-
     /**
      * The {@link XdsLoadBalancer} which allows users to select an upstream {@link Endpoint} for a given
      * {@link ClientRequestContext}. Note that the lifecycle of {@link XdsLoadBalancer} is not bound to
@@ -139,6 +123,22 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     }
 
     @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        final ClusterSnapshot that = (ClusterSnapshot) object;
+        return Objects.equal(clusterXdsResource, that.clusterXdsResource) &&
+               Objects.equal(endpointSnapshot, that.endpointSnapshot) &&
+               Objects.equal(loadBalancer, that.loadBalancer) &&
+               Objects.equal(transportSocket, that.transportSocket) &&
+               Objects.equal(transportSocketMatches, that.transportSocketMatches);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hashCode(clusterXdsResource, endpointSnapshot, loadBalancer,
                                 transportSocket, transportSocketMatches);
@@ -168,6 +168,8 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
                           .add("transportSocketMatches",
                                SnapshotUtil.debugStrings(transportSocketMatches,
                                                          TransportSocketMatchSnapshot::toDebugString))
+                          .add("httpPreprocessor", httpPreprocessor)
+                          .add("rpcPreprocessor", rpcPreprocessor)
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
@@ -17,7 +17,6 @@
 package com.linecorp.armeria.xds;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -26,7 +25,6 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.RpcPreprocessor;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
 
@@ -40,25 +38,22 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
 
     private final ClusterXdsResource clusterXdsResource;
     private final TransportSocketSnapshot transportSocket;
-    @Nullable
     private final EndpointSnapshot endpointSnapshot;
     private final List<TransportSocketMatchSnapshot> transportSocketMatches;
-    @Nullable
     private final XdsLoadBalancer loadBalancer;
     private final HttpPreprocessor httpPreprocessor;
     private final RpcPreprocessor rpcPreprocessor;
 
     ClusterSnapshot(ClusterXdsResource clusterXdsResource,
-                    Optional<XdsLoadBalancer> loadBalancer,
+                    XdsLoadBalancer loadBalancer,
                     TransportSocketSnapshot transportSocket,
                     List<TransportSocketMatchSnapshot> transportSocketMatches) {
         this.clusterXdsResource = clusterXdsResource;
         this.transportSocket = transportSocket;
-        this.loadBalancer = loadBalancer.orElse(null);
-        endpointSnapshot = loadBalancer.map(XdsLoadBalancer::endpointSnapshot).orElse(null);
+        this.loadBalancer = loadBalancer;
+        endpointSnapshot = loadBalancer.endpointSnapshot();
         this.transportSocketMatches = transportSocketMatches;
-        final ClusterFilterFactory factory = new ClusterFilterFactory(
-                clusterXdsResource, this.loadBalancer, transportSocket);
+        final ClusterFilterFactory factory = new ClusterFilterFactory(loadBalancer, transportSocket);
         httpPreprocessor = factory.httpPreprocessor();
         rpcPreprocessor = factory.rpcPreprocessor();
     }
@@ -71,7 +66,6 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     /**
      * A {@link EndpointSnapshot} which belong to this {@link Cluster}.
      */
-    @Nullable
     public EndpointSnapshot endpointSnapshot() {
         return endpointSnapshot;
     }
@@ -91,7 +85,6 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
      * {@link ClientRequestContext}. Note that the lifecycle of {@link XdsLoadBalancer} is not bound to
      * the current {@link ClusterSnapshot}, and may be updated if the cluster is updated.
      */
-    @Nullable
     public XdsLoadBalancer loadBalancer() {
         return loadBalancer;
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
@@ -92,33 +92,28 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
         final List<TransportSocketMatch> matches = resource.resource().getTransportSocketMatchesList();
         final TransportSocketMatchesStream socketMatchesStream =
                 new TransportSocketMatchesStream(context, configSource, matches);
-        final SnapshotStream<Optional<EndpointSnapshot>> endpointSnapshotStream =
+        final SnapshotStream<EndpointSnapshot> endpointSnapshotStream =
                 new EndpointSnapshotNode(resource, context, configSource);
-        final SnapshotStream<Optional<XdsLoadBalancer>> lbStream =
+        final SnapshotStream<XdsLoadBalancer> lbStream =
                 SnapshotStream.combineLatest(endpointSnapshotStream, transportSocket, socketMatchesStream,
                                              LoadBalancerInput::new)
                               .switchMapEager(input -> {
-                                  if (!input.endpointSnapshot.isPresent()) {
-                                      return SnapshotStream.empty();
-                                  }
-                                  final EndpointSnapshot endpointSnapshot = input.endpointSnapshot.get();
                                   if (context.clusterManager().hasLocalCluster() &&
                                       !resourceName.equals(context.clusterManager().localClusterName())) {
                                       return new LocalClusterStream(context.clusterManager())
                                               .switchMapEager(localCluster -> {
                                                   return new LoadBalancerStream(
-                                                          resource, endpointSnapshot,
+                                                          resource, input.endpointSnapshot,
                                                           input.transportSocket,
                                                           input.transportSocketMatches,
                                                           loadBalancerFactory, localCluster);
-                                              }).map(Optional::of);
+                                              });
                                   } else {
                                       return new LoadBalancerStream(
-                                              resource, endpointSnapshot,
+                                              resource, input.endpointSnapshot,
                                               input.transportSocket,
                                               input.transportSocketMatches,
-                                              loadBalancerFactory, Optional.empty())
-                                              .map(Optional::of);
+                                              loadBalancerFactory, Optional.empty());
                                   }
                               });
         return SnapshotStream.combineLatest(
@@ -174,11 +169,11 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
 
     private static final class LoadBalancerInput {
 
-        private final Optional<EndpointSnapshot> endpointSnapshot;
+        private final EndpointSnapshot endpointSnapshot;
         private final TransportSocketSnapshot transportSocket;
         private final List<TransportSocketMatchSnapshot> transportSocketMatches;
 
-        LoadBalancerInput(Optional<EndpointSnapshot> endpointSnapshot,
+        LoadBalancerInput(EndpointSnapshot endpointSnapshot,
                           TransportSocketSnapshot transportSocket,
                           List<TransportSocketMatchSnapshot> transportSocketMatches) {
             this.endpointSnapshot = endpointSnapshot;
@@ -220,7 +215,7 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
         }
     }
 
-    private static class EndpointSnapshotNode extends RefCountedStream<Optional<EndpointSnapshot>> {
+    private static class EndpointSnapshotNode extends RefCountedStream<EndpointSnapshot> {
 
         private final ClusterXdsResource resource;
         private final SubscriptionContext context;
@@ -235,12 +230,12 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
         }
 
         @Override
-        protected Subscription onStart(SnapshotWatcher<Optional<EndpointSnapshot>> watcher) {
+        protected Subscription onStart(SnapshotWatcher<EndpointSnapshot> watcher) {
             final Cluster cluster = resource.resource();
-            final SnapshotStream<Optional<EndpointSnapshot>> node;
+            final SnapshotStream<EndpointSnapshot> node;
             if (cluster.hasLoadAssignment()) {
                 final ClusterLoadAssignment loadAssignment = cluster.getLoadAssignment();
-                node = new EndpointStream(new EndpointXdsResource(loadAssignment), context).map(Optional::of);
+                node = new EndpointStream(new EndpointXdsResource(loadAssignment), context);
             } else if (cluster.hasEdsClusterConfig()) {
                 final EdsClusterConfig edsClusterConfig = cluster.getEdsClusterConfig();
                 final String serviceName = edsClusterConfig.getServiceName();
@@ -250,14 +245,15 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
                                .configSource(cluster.getEdsClusterConfig().getEdsConfig(),
                                              parentConfigSource);
                 if (configSource == null) {
-                    final SnapshotStream<Optional<EndpointSnapshot>> stream =
+                    final SnapshotStream<EndpointSnapshot> stream =
                             SnapshotStream.error(new XdsResourceException(CLUSTER, clusterName,
                                                                           "config source not found"));
                     return stream.subscribe(watcher);
                 }
-                node = new EndpointStream(configSource, clusterName, context).map(Optional::of);
+                node = new EndpointStream(configSource, clusterName, context);
             } else {
-                node = SnapshotStream.empty();
+                node = SnapshotStream.error(new XdsResourceException(CLUSTER, cluster.getName(),
+                        "neither load_assignment nor eds_cluster_config is specified"));
             }
             return node.subscribe(watcher);
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
@@ -82,8 +82,10 @@ final class FilterUtil {
 
     static SnapshotStream<ClientDecoration> buildUpstreamFilter(
             XdsExtensionRegistry extensionRegistry, FactoryContext factoryContext,
-            List<HttpFilter> httpFilters, Map<String, Any> filterConfigs,
-            @Nullable RetryPolicy retryPolicy) {
+            List<HttpFilter> httpFilters, Map<String, Any> filterConfigs) {
+        if (httpFilters.isEmpty()) {
+            return SnapshotStream.just(ClientDecoration.of());
+        }
         final ImmutableList.Builder<SnapshotStream<XdsHttpFilter>> streams = ImmutableList.builder();
         for (int i = httpFilters.size() - 1; i >= 0; i--) {
             final HttpFilter httpFilter = httpFilters.get(i);
@@ -96,26 +98,26 @@ final class FilterUtil {
         }
         final ImmutableList<SnapshotStream<XdsHttpFilter>> streamList = streams.build();
         if (streamList.isEmpty()) {
-            return SnapshotStream.just(buildDecoration(null, retryPolicy));
+            return SnapshotStream.just(ClientDecoration.of());
         }
         return SnapshotStream.combineNLatest(streamList).map(filters -> {
-            return buildDecoration(filters, retryPolicy);
-        });
-    }
-
-    private static ClientDecoration buildDecoration(@Nullable List<XdsHttpFilter> filters,
-                                                    @Nullable RetryPolicy retryPolicy) {
-        final ClientDecorationBuilder builder = ClientDecoration.builder();
-        if (filters != null) {
+            final ClientDecorationBuilder builder = ClientDecoration.builder();
             for (XdsHttpFilter f : filters) {
                 builder.add(f.httpDecorator());
                 builder.addRpc(f.rpcDecorator());
             }
+            return builder.build();
+        });
+    }
+
+    @Nullable
+    static ClientDecoration buildRetryDecoration(@Nullable RetryPolicy retryPolicy) {
+        if (retryPolicy == null) {
+            return null;
         }
-        if (retryPolicy != null) {
-            builder.add(new RetryStateFactory(retryPolicy).retryingDecorator());
-        }
-        return builder.build();
+        return ClientDecoration.builder()
+                               .add(new RetryStateFactory(retryPolicy).retryingDecorator())
+                               .build();
     }
 
     @Nullable

--- a/xds/src/main/java/com/linecorp/armeria/xds/GrpcServicesPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/GrpcServicesPreprocessor.java
@@ -22,15 +22,12 @@ import static com.google.common.base.Preconditions.checkState;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
-import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 import io.envoyproxy.envoy.config.core.v3.GrpcService;
 import io.envoyproxy.envoy.config.core.v3.GrpcService.EnvoyGrpc;
@@ -67,14 +64,8 @@ final class GrpcServicesPreprocessor implements HttpPreprocessor {
                 bootstrapClusters.snapshotFuture(clusterName);
         checkArgument(snapshotFuture != null, "No cluster found for name: %s", clusterName);
         return HttpResponse.of(snapshotFuture.thenApply(snapshot -> {
-            final XdsLoadBalancer loadBalancer = snapshot.loadBalancer();
-            checkArgument(loadBalancer != null, "No endpoints found for name: %s", clusterName);
-            final Endpoint endpoint = loadBalancer.selectNow(ctx);
-            checkArgument(endpoint != null, "Endpoint not selected found for name: %s", clusterName);
-            XdsCommonUtil.setTlsParams(ctx, endpoint);
-            ctx.setEndpointGroup(endpoint);
             try {
-                return delegate.execute(ctx, req);
+                return snapshot.preprocessor().execute(delegate, ctx, req);
             } catch (Exception e) {
                 return Exceptions.throwUnsafely(e);
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -145,6 +147,7 @@ public final class RouteEntry {
      * Returns whether this route matches the specified {@link ClientRequestContext}.
      */
     public boolean matches(ClientRequestContext ctx) {
+        requireNonNull(ctx, "ctx");
         return matcher.matches(ctx);
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
@@ -31,7 +31,6 @@ import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.RpcPreClient;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.internal.client.ClientRequestContextExtension;
 import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
 import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
 
@@ -58,15 +57,25 @@ public final class RouteEntry {
 
     RouteEntry(Route route, @Nullable ClusterSnapshot clusterSnapshot, int index,
                Map<String, Any> filterConfigs,
-               ClientPreprocessors downstreamPreprocessors, ClientDecoration upstreamDecoration) {
+               ClientPreprocessors downstreamPreprocessors,
+               @Nullable ClientDecoration retryDecoration,
+               ClientDecoration upstreamDecoration) {
         this.route = route;
         this.clusterSnapshot = clusterSnapshot;
         this.index = index;
         this.filterConfigs = filterConfigs;
         matcher = new RouteEntryMatcher(route.getMatch());
 
-        httpClient = upstreamDecoration.decorate(DelegatingHttpClient.of());
-        rpcClient = upstreamDecoration.rpcDecorate(DelegatingRpcClient.of());
+        // Pre-build the full cluster chain: retry → ClusterFilter → upstream filters → delegate
+        HttpClient clusterHttp = ClusterFilterFactory.DECORATION.decorate(
+                upstreamDecoration.decorate(DelegatingHttpClient.of()));
+        if (retryDecoration != null) {
+            clusterHttp = retryDecoration.decorate(clusterHttp);
+        }
+        httpClient = clusterHttp;
+        rpcClient = ClusterFilterFactory.DECORATION.rpcDecorate(
+                upstreamDecoration.rpcDecorate(DelegatingRpcClient.of()));
+
         httpPreClient = downstreamPreprocessors.decorate(DelegatingHttpClient.of());
         rpcPreClient = downstreamPreprocessors.rpcDecorate(DelegatingRpcClient.of());
     }
@@ -115,29 +124,28 @@ public final class RouteEntry {
     }
 
     /**
+     * Returns the pre-built {@link HttpClient} chain for this route. This chain includes
+     * retry, cluster filter, and upstream HTTP filters ending with a {@link DelegatingHttpClient}.
+     */
+    @UnstableApi
+    public HttpClient httpClient() {
+        return httpClient;
+    }
+
+    /**
+     * Returns the pre-built {@link RpcClient} chain for this route. This chain includes
+     * cluster filter and upstream RPC filters ending with a {@link DelegatingRpcClient}.
+     */
+    @UnstableApi
+    public RpcClient rpcClient() {
+        return rpcClient;
+    }
+
+    /**
      * Returns whether this route matches the specified {@link ClientRequestContext}.
      */
     public boolean matches(ClientRequestContext ctx) {
         return matcher.matches(ctx);
-    }
-
-    /**
-     * Applies upstream filters to a request corresponding to the supplied {@link ClientRequestContext}.
-     */
-    @UnstableApi
-    public void applyUpstreamFilter(ClientRequestContext ctx) {
-        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
-        if (ctxExt == null) {
-            return;
-        }
-        ctxExt.httpClientCustomizer(actualClient -> {
-            DelegatingHttpClient.setDelegate(ctx, actualClient);
-            return httpClient;
-        });
-        ctxExt.rpcClientCustomizer(actualClient -> {
-            DelegatingRpcClient.setDelegate(ctx, actualClient);
-            return rpcClient;
-        });
     }
 
     /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
@@ -208,20 +208,23 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             final RetryPolicy effectiveRetryPolicy =
                     retryPolicy == RetryPolicy.getDefaultInstance() ? null : retryPolicy;
 
+            final ClientDecoration retryDecoration =
+                    FilterUtil.buildRetryDecoration(effectiveRetryPolicy);
+
             // Build filter streams
             final SnapshotStream<ClientPreprocessors> downstreamStream =
                     FilterUtil.buildDownstreamFilter(extensionRegistry, context,
                                                      hcmHttpFilters, filterConfigs);
             final SnapshotStream<ClientDecoration> upstreamStream =
                     FilterUtil.buildUpstreamFilter(extensionRegistry, context,
-                                                   upstreamFilters, filterConfigs,
-                                                   effectiveRetryPolicy);
+                                                        upstreamFilters, filterConfigs);
 
             if (!route.getRoute().hasCluster()) {
                 return SnapshotStream.combineLatest(
                         downstreamStream, upstreamStream,
                         (down, up) -> new RouteEntry(
-                                route, null, index, filterConfigs, down, up))
+                                route, null, index, filterConfigs, down,
+                                retryDecoration, up))
                                      .subscribe(watcher);
             }
 
@@ -232,7 +235,8 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             return SnapshotStream.combineLatest(
                     clusterStream, downstreamStream, upstreamStream,
                     (cluster, down, up) -> new RouteEntry(
-                            route, cluster, index, filterConfigs, down, up))
+                            route, cluster, index, filterConfigs, down,
+                            retryDecoration, up))
                                  .subscribe(watcher);
         }
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
@@ -16,22 +16,29 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
-import static com.linecorp.armeria.xds.client.endpoint.XdsAttributeKeys.SELECTED_ROUTE;
+import java.util.function.Function;
 
-import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.client.Preprocessor;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
-import com.linecorp.armeria.common.TimeoutException;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
+import io.netty.util.AttributeKey;
+
 final class RouterFilter<I extends Request, O extends Response> implements Preprocessor<I, O> {
+
+    private static final AttributeKey<RouteEntry> SELECTED_ROUTE = XdsCommonUtil.SELECTED_ROUTE;
+
+    private final Function<ClusterSnapshot, Preprocessor<I, O>> preprocessorMapper;
+
+    RouterFilter(Function<ClusterSnapshot, Preprocessor<I, O>> preprocessorMapper) {
+        this.preprocessorMapper = preprocessorMapper;
+    }
 
     @Override
     public O execute(PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception {
@@ -52,7 +59,6 @@ final class RouterFilter<I extends Request, O extends Response> implements Prepr
             ctx.cancel(e);
             throw e;
         }
-        selectedRoute.applyUpstreamFilter(ctx);
 
         final long responseTimeoutMillis =
                 XdsCommonUtil.durationToMillis(selectedRoute.route().getRoute().getTimeout(), -1);
@@ -60,30 +66,6 @@ final class RouterFilter<I extends Request, O extends Response> implements Prepr
             ctx.setResponseTimeoutMillis(responseTimeoutMillis);
         }
 
-        final XdsLoadBalancer loadBalancer = clusterSnapshot.loadBalancer();
-        if (loadBalancer == null) {
-            final UnprocessedRequestException e = UnprocessedRequestException.of(
-                    new IllegalArgumentException("The target cluster '" + clusterSnapshot +
-                                                 "' does not specify ClusterLoadAssignments."));
-            ctx.cancel(e);
-            throw e;
-        }
-
-        final Endpoint endpoint = loadBalancer.selectNow(ctx);
-        return execute0(delegate, ctx, req, endpoint);
-    }
-
-    private O execute0(PreClient<I, O> delegate, PreClientRequestContext ctx, I req,
-                       @Nullable Endpoint endpoint) throws Exception {
-        if (endpoint == null) {
-            final Throwable cancellationCause = ctx.cancellationCause();
-            if (cancellationCause != null) {
-                throw UnprocessedRequestException.of(cancellationCause);
-            }
-            throw UnprocessedRequestException.of(new TimeoutException("Failed to select an endpoint."));
-        }
-        XdsCommonUtil.setTlsParams(ctx, endpoint);
-        ctx.setEndpointGroup(endpoint);
-        return delegate.execute(ctx, req);
+        return preprocessorMapper.apply(clusterSnapshot).execute(delegate, ctx, req);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
-import java.util.function.Function;
-
 import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.client.Preprocessor;
@@ -28,21 +26,17 @@ import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
-import io.netty.util.AttributeKey;
-
 final class RouterFilter<I extends Request, O extends Response> implements Preprocessor<I, O> {
 
-    private static final AttributeKey<RouteEntry> SELECTED_ROUTE = XdsCommonUtil.SELECTED_ROUTE;
+    private final boolean isRpc;
 
-    private final Function<ClusterSnapshot, Preprocessor<I, O>> preprocessorMapper;
-
-    RouterFilter(Function<ClusterSnapshot, Preprocessor<I, O>> preprocessorMapper) {
-        this.preprocessorMapper = preprocessorMapper;
+    RouterFilter(boolean isRpc) {
+        this.isRpc = isRpc;
     }
 
     @Override
     public O execute(PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception {
-        final RouteEntry selectedRoute = ctx.attr(SELECTED_ROUTE);
+        final RouteEntry selectedRoute = ctx.attr(XdsCommonUtil.SELECTED_ROUTE);
         if (selectedRoute == null) {
             final UnprocessedRequestException e = UnprocessedRequestException.of(
                     new IllegalArgumentException(
@@ -66,6 +60,9 @@ final class RouterFilter<I extends Request, O extends Response> implements Prepr
             ctx.setResponseTimeoutMillis(responseTimeoutMillis);
         }
 
-        return preprocessorMapper.apply(clusterSnapshot).execute(delegate, ctx, req);
+        @SuppressWarnings("unchecked")
+        final Preprocessor<I, O> preprocessor = (Preprocessor<I, O>) (isRpc ?
+                clusterSnapshot.rpcPreprocessor() : clusterSnapshot.preprocessor());
+        return preprocessor.execute(delegate, ctx, req);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
@@ -45,8 +46,10 @@ public final class RouterFilterFactory implements HttpFilterFactory {
     private static final String TYPE_URL =
             "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router";
     private static final List<String> TYPE_URLS = ImmutableList.of(TYPE_URL);
-    private static final RouterFilter<RpcRequest, RpcResponse> rpcFilter = new RouterFilter<>();
-    private static final RouterFilter<HttpRequest, HttpResponse> httpFilter = new RouterFilter<>();
+    private static final RouterFilter<RpcRequest, RpcResponse> rpcFilter =
+            new RouterFilter<>(ClusterSnapshot::rpcPreprocessor);
+    private static final RouterFilter<HttpRequest, HttpResponse> httpFilter =
+            new RouterFilter<>(ClusterSnapshot::preprocessor);
 
     @Override
     public String name() {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
@@ -28,7 +28,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
@@ -47,9 +46,9 @@ public final class RouterFilterFactory implements HttpFilterFactory {
             "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router";
     private static final List<String> TYPE_URLS = ImmutableList.of(TYPE_URL);
     private static final RouterFilter<RpcRequest, RpcResponse> rpcFilter =
-            new RouterFilter<>(ClusterSnapshot::rpcPreprocessor);
+            new RouterFilter<>(true);
     private static final RouterFilter<HttpRequest, HttpResponse> httpFilter =
-            new RouterFilter<>(ClusterSnapshot::preprocessor);
+            new RouterFilter<>(false);
 
     @Override
     public String name() {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributeKeys.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsAttributeKeys.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
-import com.linecorp.armeria.xds.RouteEntry;
-
 import io.envoyproxy.envoy.config.core.v3.Metadata;
 import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
@@ -31,8 +29,6 @@ final class XdsAttributeKeys {
             AttributeKey.valueOf(XdsAttributeKeys.class, "LOCALITY_LB_ENDPOINTS_KEY");
     static final AttributeKey<XdsRandom> XDS_RANDOM =
             AttributeKey.valueOf(XdsAttributeKeys.class, "XDS_RANDOM");
-    static final AttributeKey<RouteEntry> SELECTED_ROUTE =
-            AttributeKey.valueOf(XdsAttributeKeys.class, "SELECTED_ROUTE");
     static final AttributeKey<Metadata> ROUTE_METADATA_MATCH =
             AttributeKey.valueOf(XdsAttributeKeys.class, "ROUTE_METADATA_MATCH");
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,6 +90,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
      */
     @UnstableApi
     public static XdsEndpointGroup of(XdsLoadBalancer loadBalancer) {
+        requireNonNull(loadBalancer, "loadBalancer");
         return new XdsEndpointGroup(loadBalancer);
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -44,7 +44,6 @@ import com.linecorp.armeria.xds.SnapshotWatcher;
 import com.linecorp.armeria.xds.VirtualHostSnapshot;
 import com.linecorp.armeria.xds.XdsBootstrap;
 
-import io.envoyproxy.envoy.config.core.v3.GrpcService;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
 
@@ -85,13 +84,11 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
     }
 
     /**
-     * Creates a {@link XdsEndpointGroup} based on the specified {@link ClusterSnapshot}.
-     * This may be useful if one would like to create an {@link EndpointGroup} based on
-     * a {@link GrpcService}.
+     * Creates a {@link XdsEndpointGroup} based on the specified {@link XdsLoadBalancer}.
      */
     @UnstableApi
-    public static XdsEndpointGroup of(ClusterSnapshot clusterSnapshot) {
-        throw new UnsupportedOperationException("Use ClusterSnapshot.loadBalancer() to select endpoints.");
+    public static XdsEndpointGroup of(XdsLoadBalancer loadBalancer) {
+        return new XdsEndpointGroup(loadBalancer);
     }
 
     private static final List<Endpoint> UNINITIALIZED_ENDPOINTS = Collections.unmodifiableList(
@@ -104,7 +101,9 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
     private final EndpointSelector selector;
     @Nullable
     private volatile XdsLoadBalancer loadBalancer;
+    @Nullable
     private final ListenerRoot listenerRoot;
+    private final long selectionTimeoutMillis;
     private List<Endpoint> endpoints = UNINITIALIZED_ENDPOINTS;
 
     XdsEndpointGroup(String listenerName, XdsBootstrap xdsBootstrap, boolean allowEmptyEndpoints) {
@@ -113,6 +112,18 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
         selector = selectionStrategy.newSelector(this);
         listenerRoot = xdsBootstrap.listenerRoot(listenerName);
         listenerRoot.addSnapshotWatcher(this);
+        selectionTimeoutMillis = Flags.defaultConnectTimeoutMillis();
+    }
+
+    private XdsEndpointGroup(XdsLoadBalancer loadBalancer) {
+        allowEmptyEndpoints = false;
+        selectionStrategy = new XdsEndpointSelectionStrategy();
+        selector = selectionStrategy.newSelector(this);
+        listenerRoot = null;
+        this.loadBalancer = loadBalancer;
+        endpoints = loadBalancer.allEndpoints();
+        initialEndpointsFuture.complete(endpoints);
+        selectionTimeoutMillis = 0;
     }
 
     @Override
@@ -194,7 +205,7 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
 
     @Override
     public long selectionTimeoutMillis() {
-        return Flags.defaultConnectTimeoutMillis();
+        return selectionTimeoutMillis;
     }
 
     @Override
@@ -204,7 +215,9 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
 
     @Override
     public CompletableFuture<?> closeAsync() {
-        listenerRoot.close();
+        if (listenerRoot != null) {
+            listenerRoot.close();
+        }
         return UnmodifiableFuture.completedFuture(null);
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -151,9 +151,6 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
             return;
         }
         final XdsLoadBalancer loadBalancer = clusterSnapshot.loadBalancer();
-        if (loadBalancer == null) {
-            return;
-        }
 
         this.loadBalancer = loadBalancer;
         endpoints = loadBalancer.allEndpoints();

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHttpPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHttpPreprocessor.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.XdsBootstrap;
 import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
+import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 /**
  * An {@link HttpPreprocessor} implementation which allows clients to execute requests based on
@@ -68,7 +69,7 @@ public final class XdsHttpPreprocessor extends XdsPreprocessor<HttpRequest, Http
                     new IllegalArgumentException("No route for listener '" +
                                                  routeConfig.listenerSnapshot() + "'."));
         }
-        ctx.setAttr(XdsAttributeKeys.SELECTED_ROUTE, selectedRoute);
+        ctx.setAttr(XdsCommonUtil.SELECTED_ROUTE, selectedRoute);
         DelegatingHttpClient.setDelegate(ctx, delegate);
         return selectedRoute.httpPreClient().execute(ctx, req);
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsRpcPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsRpcPreprocessor.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.XdsBootstrap;
 import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
+import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 /**
  * An {@link RpcPreprocessor} implementation which allows clients to execute requests based on
@@ -68,7 +69,7 @@ public final class XdsRpcPreprocessor extends XdsPreprocessor<RpcRequest, RpcRes
                     new IllegalArgumentException("No route for listener '" +
                                                  routeConfig.listenerSnapshot() + "'."));
         }
-        ctx.setAttr(XdsAttributeKeys.SELECTED_ROUTE, selectedRoute);
+        ctx.setAttr(XdsCommonUtil.SELECTED_ROUTE, selectedRoute);
         DelegatingRpcClient.setDelegate(ctx, delegate);
         return selectedRoute.rpcPreClient().execute(ctx, req);
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsCommonUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsCommonUtil.java
@@ -16,26 +16,24 @@
 
 package com.linecorp.armeria.xds.internal;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Set;
 
 import com.google.common.primitives.Ints;
 import com.google.protobuf.Duration;
 import com.google.protobuf.UInt32Value;
 
-import com.linecorp.armeria.client.ClientTlsSpec;
-import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.TransportSocketSnapshot;
 
 import io.netty.util.AttributeKey;
 
 public final class XdsCommonUtil {
+
+    public static final AttributeKey<RouteEntry> SELECTED_ROUTE =
+            AttributeKey.valueOf(XdsCommonUtil.class, "SELECTED_ROUTE");
 
     public static final AttributeKey<TransportSocketSnapshot> TRANSPORT_SOCKET_SNAPSHOT_KEY =
             AttributeKey.valueOf(XdsCommonUtil.class, "TRANSPORT_SOCKET_SNAPSHOT_KEY");
@@ -98,24 +96,6 @@ public final class XdsCommonUtil {
         }
         final String subtype = contentType.subtype();
         return "grpc".equals(subtype) || subtype.startsWith("grpc+");
-    }
-
-    public static void setTlsParams(PreClientRequestContext ctx, Endpoint endpoint) {
-        final TransportSocketSnapshot transportSocket =
-                endpoint.attr(TRANSPORT_SOCKET_SNAPSHOT_KEY);
-        checkArgument(transportSocket != null,
-                      "TransportSocket not set for selected endpoint: %s", endpoint);
-        ClientTlsSpec clientTlsSpec = transportSocket.clientTlsSpec();
-        if (clientTlsSpec == null) {
-            ctx.setSessionProtocol(SessionProtocol.HTTP);
-            return;
-        }
-        final Set<String> alpnOverride = ctx.attr(ALPN_OVERRIDE_KEY);
-        if (alpnOverride != null && !alpnOverride.isEmpty()) {
-            clientTlsSpec = clientTlsSpec.toBuilder().alpnProtocols(alpnOverride).build();
-        }
-        ctx.setSessionProtocol(SessionProtocol.HTTPS);
-        ctx.setClientTlsSpec(clientTlsSpec);
     }
 
     private XdsCommonUtil() {}

--- a/xds/src/test/java/com/linecorp/armeria/xds/XdsTestUtil.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/XdsTestUtil.java
@@ -37,9 +37,7 @@ public final class XdsTestUtil {
         });
         final ClusterSnapshot clusterSnapshot = findByName(root, clusterName);
         assertThat(clusterSnapshot).isNotNull();
-        final XdsLoadBalancer selector = clusterSnapshot.loadBalancer();
-        assertThat(selector).isNotNull();
-        return selector;
+        return clusterSnapshot.loadBalancer();
     }
 
     public static XdsLoadBalancer pollLoadBalancer(
@@ -47,15 +45,11 @@ public final class XdsTestUtil {
         await().untilAsserted(() -> {
             final ClusterSnapshot clusterSnapshot = findByName(root, clusterName);
             assertThat(clusterSnapshot).isNotNull();
-            final EndpointSnapshot endpointSnapshot = clusterSnapshot.endpointSnapshot();
-            assertThat(endpointSnapshot).isNotNull();
-            assertThat(endpointSnapshot.xdsResource().resource()).isEqualTo(expected);
+            assertThat(clusterSnapshot.endpointSnapshot().xdsResource().resource()).isEqualTo(expected);
         });
         final ClusterSnapshot clusterSnapshot = findByName(root, clusterName);
         assertThat(clusterSnapshot).isNotNull();
-        final XdsLoadBalancer selector = clusterSnapshot.loadBalancer();
-        assertThat(selector).isNotNull();
-        return selector;
+        return clusterSnapshot.loadBalancer();
     }
 
     @Nullable

--- a/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteMetadataSubsetTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/client/endpoint/RouteMetadataSubsetTest.java
@@ -44,10 +44,10 @@ import com.linecorp.armeria.client.DecoratingHttpClientFunction;
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.endpoint.EmptyEndpointGroupException;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -78,7 +78,12 @@ class RouteMetadataSubsetTest {
     private static final String GROUP_KEY = "key";
     static final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP_KEY);
     private static final DecoratingHttpClientFunction selectedPortDecorator =
-            (delegate, ctx, req) -> HttpResponse.of(String.valueOf(ctx.endpoint().port()));
+            (delegate, ctx, req) -> {
+                if (ctx.endpoint() != null) {
+                    return HttpResponse.of(String.valueOf(ctx.endpoint().port()));
+                }
+                return delegate.execute(ctx, req);
+            };
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -192,8 +197,8 @@ class RouteMetadataSubsetTest {
                 assertThatThrownBy(() -> client.get("/"))
                         .isInstanceOf(UnprocessedRequestException.class)
                         .cause()
-                        .isInstanceOf(TimeoutException.class)
-                        .hasMessageContaining("Failed to select an endpoint");
+                        .isInstanceOf(EmptyEndpointGroupException.class)
+                        .hasMessageContaining("Unable to select endpoints");
             } else {
                 assertThat(client.get("/").contentUtf8()).isEqualTo("8080");
                 assertThat(client.get("/").contentUtf8()).isEqualTo("8081");


### PR DESCRIPTION
Motivation:

xDS retry was broken because `RetryingClient` was built as part of the upstream `ClientDecoration` inside `FilterUtil.buildUpstreamFilter()`. This placed the retry decorator **after** endpoint selection, so retries always reused the same endpoint instead of re-selecting. The fix separates retry from upstream filters and places it **before** the cluster decorator chain, so each retry attempt goes through endpoint selection again.

Additionally, the cluster-level preprocessor, decorator, and retry logic were scattered across `ClusterFilter`, `RouteEntry`, and `RouterFilter`, making the execution order hard to follow.

Modifications:

- Separated retry decoration from upstream filter building into `FilterUtil.buildRetryDecoration()` so retry wraps the full cluster chain in `RouteEntry`:
  `[retry] -> [cluster decorator] -> [upstream decorators] -> [delegate]`
- Added `ClusterFilterFactory` which consolidates cluster-level preprocessor and decorator logic into a single class with a clear execution order.
- Replaced `ClusterSnapshot.hasPreprocessor()` / `executePreprocessor()` with typed, non-null `preprocessor()` → `HttpPreprocessor` and `rpcPreprocessor()` → `RpcPreprocessor`.
- Refactored `RouterFilter` to accept a `Function<ClusterSnapshot, Preprocessor>` mapping, wired via `ClusterSnapshot::preprocessor` / `ClusterSnapshot::rpcPreprocessor` in `RouterFilterFactory`.
- Updated `GrpcServicesPreprocessor` to use `snapshot.preprocessor()` instead of manual endpoint selection and TLS setup.
- Moved `SELECTED_ROUTE` attribute key to `XdsCommonUtil` for cross-package accessibility.
- Removed `ClusterFilter`, `XdsCommonUtil.setTlsParams()`, `ClusterSnapshot.endpointGroup()`, and `ClusterSnapshot.sessionProtocol()`.

Result:

- xDS retry now correctly re-selects endpoints on each retry attempt.
- Cluster-level filter pipeline is consolidated in `ClusterFilterFactory`:
  ```
  [downstream preprocessors]
      -> [router preprocessor]
          -> [cluster preprocessor]
              -> [endpoint selection]
                  -> [retry decorator]
                      -> [cluster decorator]
                          -> [upstream decorators]
  ```
- `ClusterSnapshot.preprocessor()` and `ClusterSnapshot.rpcPreprocessor()` provide typed, non-null accessors enabling direct use like `WebClient.of(clusterSnapshot.preprocessor())`.
