### PR TITLE
Handle flaky `RefreshingAddressResolverTest#negativeTtl`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
+++ b/core/src/main/java/com/linecorp/armeria/common/CoreBlockHoundIntegration.java
@@ -67,7 +67,9 @@ public final class CoreBlockHoundIntegration implements BlockHoundIntegration {
         // Thread.yield can be called
         builder.allowBlockingCallsInside(
                 "java.util.concurrent.FutureTask", "handlePossibleCancellationInterrupt");
-        // SecureRandom.nextBytes() can be called
+        // SecureRandom may read from /dev/urandom which can block briefly, especially on first use.
+        builder.allowBlockingCallsInside("java.security.SecureRandom", "nextBytes");
+
         builder.allowBlockingCallsInside("io.netty.handler.ssl.SslContext", "buildKeyStore");
         // StampedLock.writeLock() can be called
         builder.allowBlockingCallsInside("io.netty.buffer.AdaptivePoolingAllocator", "allocate");

--- a/core/src/test/java/com/linecorp/armeria/common/CoreBlockHoundIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/CoreBlockHoundIntegrationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.security.SecureRandom;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import io.netty.util.concurrent.Future;
+
+class CoreBlockHoundIntegrationTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void secureRandomShouldNotBeBlockedOnEventLoop() {
+        final Future<?> future = eventLoop.get().submit(() -> {
+            final SecureRandom random = new SecureRandom();
+            random.nextInt();
+            random.nextBoolean();
+            random.nextBytes(new byte[16]);
+        });
+        await().until(future::isDone);
+        assertThat(future.cause()).isNull();
+    }
+}


### PR DESCRIPTION
Motivation:

`RefreshingAddressResolverTest.negativeTtl()` started flaking after the Netty 4.2.13 → 4.2.15 upgrade, only on BlockHound-enabled CI runs ([test history](https://ge.armeria.dev/scans/tests?search.relativeStartTime=P28D&search.timeZoneId=Asia%2FSeoul&tests.container=com.linecorp.armeria.client.RefreshingAddressResolverTest&tests.test=negativeTtl())).

While this is only a guess, from 4.2.13 to 4.2.15, Netty replaced `ThreadLocalRandom` with `SecureRandom` for DNS query ID generation. `SecureRandom.nextBytes()` can block briefly when reading from `/dev/urandom`, which may be a cause.

Modifications:

- Added a BlockHound allowance for `SecureRandom.nextBytes()` in `CoreBlockHoundIntegration`. All `SecureRandom` methods (`nextInt()`, `nextBoolean()`, etc.) delegate to `nextBytes()` internally, so this single allowance covers all usage.
- Added `CoreBlockHoundIntegrationTest` to verify that `SecureRandom` can be used on a Netty event loop thread without being flagged by BlockHound.

Result:

- `RefreshingAddressResolverTest.negativeTtl()` should no longer flake under BlockHound-enabled CI runs.
