### PR TITLE
Suppress `Unexpected exception: ` logs on `ConnectionAcceptor` failure

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -248,7 +248,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                 requireNonNull(config.sslContextMapping(), "config.sslContextMapping() returned null");
 
         p.addLast(new HttpsConnectionAcceptHandler(config.connectionAcceptor(), sslContexts,
-                                                   proxiedAddresses,
+                                                   proxiedAddresses, p,
                                                    Flags.defaultMaxClientHelloLength(),
                                                    config.idleTimeoutMillis()));
         p.addLast(TrafficLoggingHandler.SERVER);

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -153,6 +153,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                   if (accepted) {
                                       resolveSslContext(ctx, connectionCtx, lookupPromise);
                                   } else {
+                                      // connection rejected via connectionacceptor
                                       logger.trace("Connection for '{}' rejected", connectionCtx);
                                       lookupPromise.trySuccess(null);
                                   }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpsConnectionAcceptHandler.java
@@ -28,11 +28,13 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslClientHelloHandler;
@@ -71,16 +73,18 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
     private ScheduledFuture<?> timeoutFuture;
     @Nullable
     private String sniHostname;
+    private final Promise<SslContext> lookupPromise;
 
     HttpsConnectionAcceptHandler(DefaultConnectionAcceptor connectionAcceptor,
                                  Mapping<String, SslContext> sslContextMapping,
                                  @Nullable ProxiedAddresses proxiedAddresses,
-                                 int maxClientHelloLength, long handshakeTimeoutMillis) {
+                                 ChannelPipeline p, int maxClientHelloLength, long handshakeTimeoutMillis) {
         super(maxClientHelloLength);
         this.connectionAcceptor = connectionAcceptor;
         this.sslContextMapping = sslContextMapping;
         this.proxiedAddresses = proxiedAddresses;
         this.handshakeTimeoutMillis = handshakeTimeoutMillis;
+        lookupPromise = p.channel().eventLoop().newPromise();
     }
 
     @Override
@@ -102,8 +106,9 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         }
         timeoutFuture = ctx.executor().schedule(() -> {
             if (ctx.channel().isActive()) {
-                ctx.fireExceptionCaught(new SslHandshakeTimeoutException(
-                        "handshake timed out after " + handshakeTimeoutMillis + "ms"));
+                lookupPromise.tryFailure(new DecoderException(new SslHandshakeTimeoutException(
+                        "handshake timed out after " + handshakeTimeoutMillis + "ms")));
+                // also close in case lookup isn't triggered yet
                 ctx.close();
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -112,6 +117,10 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
     @Override
     protected Future<SslContext> lookup(ChannelHandlerContext ctx,
                                         @Nullable ByteBuf clientHello) throws Exception {
+        if (lookupPromise.isDone()) {
+            // channelInactive -> decodeLast can invoke lookup again for a closed connection
+            return lookupPromise;
+        }
         List<String> alpnProtocols = ImmutableList.of();
 
         if (clientHello != null) {
@@ -127,32 +136,30 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                       proxiedAddresses, ctx.channel());
         ctx.channel().attr(ConnectionContext.ATTR).set(connectionCtx);
 
-        final Promise<SslContext> promise = ctx.executor().newPromise();
-
         ctx.channel().closeFuture().addListener(f -> {
             // complete the promise so the clientHello is released
-            promise.tryFailure(NotAFailureException.INSTANCE);
+            lookupPromise.tryFailure(ClosedSessionException.get());
         });
 
         if (connectionAcceptor.isNoop()) {
-            resolveSslContext(ctx, connectionCtx, promise);
+            resolveSslContext(ctx, connectionCtx, lookupPromise);
         } else {
             connectionAcceptor.accept(connectionCtx, ctx.channel().eventLoop())
                               .whenComplete((accepted, t) -> {
                                   if (t != null) {
-                                      promise.tryFailure(t);
+                                      lookupPromise.tryFailure(toSSLException(t));
                                       return;
                                   }
                                   if (accepted) {
-                                      resolveSslContext(ctx, connectionCtx, promise);
+                                      resolveSslContext(ctx, connectionCtx, lookupPromise);
                                   } else {
                                       logger.trace("Connection for '{}' rejected", connectionCtx);
-                                      promise.tryFailure(NotAFailureException.INSTANCE);
+                                      lookupPromise.trySuccess(null);
                                   }
                               });
         }
 
-        return promise;
+        return lookupPromise;
     }
 
     private void resolveSslContext(ChannelHandlerContext ctx,
@@ -160,7 +167,7 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
                                    Promise<SslContext> promise) {
         final SslContext sslContext = sslContextMapping.map(connectionCtx.sniHostname());
         if (sslContext == null) {
-            promise.tryFailure(new SSLHandshakeException(
+            promise.tryFailure(toSSLException(
                     "No SslContext found for hostname: " + connectionCtx.sniHostname()));
             return;
         }
@@ -177,18 +184,25 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         if (timeoutFuture != null) {
             timeoutFuture.cancel(false);
         }
+        if (!ctx.channel().isActive()) {
+            return;
+        }
 
         final Throwable cause = future.cause();
         if (cause != null) {
             ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname, cause));
-            if (!(cause instanceof NotAFailureException)) {
-                ctx.fireExceptionCaught(new DecoderException(cause));
-            }
-            ctx.pipeline().remove(this);
+            ctx.fireExceptionCaught(cause);
             ctx.close();
             return;
         }
-        replaceHandler(ctx, future.getNow());
+
+        final SslContext sslContext = future.getNow();
+        if (sslContext == null) {
+            // connection rejected via connectionacceptor
+            ctx.close();
+            return;
+        }
+        replaceHandler(ctx, sslContext);
         ctx.fireUserEventTriggered(new SniCompletionEvent(sniHostname));
     }
 
@@ -349,9 +363,19 @@ final class HttpsConnectionAcceptHandler extends SslClientHelloHandler<SslContex
         }
     }
 
-    private static final class NotAFailureException extends RuntimeException {
-        private static final long serialVersionUID = -1272562527562139704L;
+    static Throwable toSSLException(String message) {
+        return new DecoderException(new SSLHandshakeException(message));
+    }
 
-        private static final NotAFailureException INSTANCE = new NotAFailureException();
+    static Throwable toSSLException(Throwable e) {
+        Throwable cause = e.getCause();
+        if (e instanceof DecoderException && cause instanceof SSLHandshakeException) {
+            return e;
+        }
+        if (!(cause instanceof SSLHandshakeException)) {
+            cause = new SSLHandshakeException(e.getMessage()).initCause(e);
+        }
+
+        return new DecoderException(cause);
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ConnectionAcceptorTest.java
@@ -17,12 +17,15 @@
 package com.linecorp.armeria.server;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,6 +47,7 @@ class ConnectionAcceptorTest {
 
     private static final AttributeKey<String> TEST_ATTR =
             AttributeKey.valueOf(ConnectionAcceptorTest.class, "TEST_ATTR");
+    private static final AtomicLong acceptCount = new AtomicLong();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
@@ -54,6 +58,7 @@ class ConnectionAcceptorTest {
               .tls(TlsKeyPair.ofSelfSigned())
               .connectionAcceptor(ConnectionAcceptor.of(ctx -> {
                   ctx.setAttr(TEST_ATTR, "from-connection");
+                  acceptCount.incrementAndGet();
                   return true;
               }))
               .service("/", (ctx, req) -> connectionContextJson(ctx))
@@ -71,7 +76,10 @@ class ConnectionAcceptorTest {
             sb.http(0)
               .https(0)
               .tls(TlsKeyPair.ofSelfSigned())
-              .connectionAcceptor(ConnectionAcceptor.of(ctx -> false))
+              .connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+                  acceptCount.incrementAndGet();
+                  return false;
+              }))
               .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
         }
     };
@@ -84,6 +92,7 @@ class ConnectionAcceptorTest {
               .https(0)
               .tls(TlsKeyPair.ofSelfSigned())
               .connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+                  acceptCount.incrementAndGet();
                   throw new RuntimeException("acceptor failed");
               }))
               .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
@@ -101,6 +110,11 @@ class ConnectionAcceptorTest {
         return HttpResponse.ofJson(map);
     }
 
+    @BeforeEach
+    void beforeEach() {
+        acceptCount.set(0);
+    }
+
     @Test
     void httpsAcceptorAcceptsConnection() {
         try (ClientFactory factory = ClientFactory.builder().tlsNoVerify().build()) {
@@ -115,6 +129,7 @@ class ConnectionAcceptorTest {
             assertThatJson(body).node("alpn").isEqualTo("[\"h2\",\"http/1.1\"]");
             assertThatJson(body).node("connAttr").isEqualTo("from-connection");
             assertThatJson(body).node("ctxAttr").isEqualTo("from-connection");
+            assertThat(acceptCount).hasValue(1);
         }
     }
 
@@ -130,6 +145,7 @@ class ConnectionAcceptorTest {
             assertThatJson(body).node("alpn").isEqualTo("[]");
             assertThatJson(body).node("connAttr").isEqualTo("from-connection");
             assertThatJson(body).node("ctxAttr").isEqualTo("from-connection");
+            assertThat(acceptCount).hasValue(1);
         }
     }
 
@@ -165,6 +181,11 @@ class ConnectionAcceptorTest {
                                                       .blocking();
             assertThatThrownBy(() -> client.get("/"))
                     .isInstanceOf(UnprocessedRequestException.class);
+            if (protocol.isHttp()) {
+                assertThat(acceptCount).hasValue(2);
+            } else {
+                assertThat(acceptCount).hasValue(1);
+            }
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/DelayedConnectionAcceptorTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/DelayedConnectionAcceptorTest.java
@@ -21,7 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -44,6 +46,8 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
  */
 class DelayedConnectionAcceptorTest {
 
+    private static final AtomicLong acceptCount = new AtomicLong();
+
     @RegisterExtension
     private static final EventLoopExtension eventLoop = new EventLoopExtension();
 
@@ -55,6 +59,7 @@ class DelayedConnectionAcceptorTest {
               .https(0)
               .tls(TlsKeyPair.ofSelfSigned())
               .connectionAcceptor(ctx -> {
+                  acceptCount.incrementAndGet();
                   final CompletableFuture<Boolean> future = new CompletableFuture<>();
                   eventLoop.get().schedule(() -> future.complete(true), 1, TimeUnit.SECONDS);
                   return future;
@@ -72,10 +77,18 @@ class DelayedConnectionAcceptorTest {
               .tls(TlsKeyPair.ofSelfSigned())
               .idleTimeoutMillis(1000)
               // Never completes — should be closed by the accept timeout.
-              .connectionAcceptor(ctx -> new CompletableFuture<>())
+              .connectionAcceptor(ctx -> {
+                  acceptCount.incrementAndGet();
+                  return new CompletableFuture<>();
+              })
               .service("/", (ctx, req) -> HttpResponse.of("should not reach"));
         }
     };
+
+    @BeforeEach
+    void beforeEach() {
+        acceptCount.set(0);
+    }
 
     @ParameterizedTest
     @EnumSource(value = SessionProtocol.class, names = {"HTTP", "HTTPS"})
@@ -88,6 +101,7 @@ class DelayedConnectionAcceptorTest {
             final AggregatedHttpResponse response = client.get("/");
             assertThat(response.status()).isEqualTo(HttpStatus.OK);
             assertThat(response.contentUtf8()).isEqualTo("OK");
+            assertThat(acceptCount).hasValue(1);
         }
     }
 
@@ -101,6 +115,11 @@ class DelayedConnectionAcceptorTest {
                                                       .blocking();
             assertThatThrownBy(() -> client.get("/"))
                     .isInstanceOf(UnprocessedRequestException.class);
+            if (protocol.isHttp()) {
+                assertThat(acceptCount).hasValue(2);
+            } else {
+                assertThat(acceptCount).hasValue(1);
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

The `HttpsConnectionAcceptHandler` had several issues with its error handling:
- `NotAFailureException` was a workaround to suppress logging, but it leaked into `onLookupComplete` where it required special-casing and could still produce unexpected log noise.
- The timeout path fired exceptions directly via `ctx.fireExceptionCaught()` instead of flowing through the promise, bypassing the normal `onLookupComplete` lifecycle.
- Some error paths (e.g. "No SslContext found") produced bare `SSLHandshakeException` without wrapping in `DecoderException`, causing them to hit the "Unexpected exception" log path in `logIfUnexpected` instead of the clean `loggedHandshakeFailure` path.

Modifications:

- Moved `lookupPromise` to a field created at construction time, ensuring a single promise per connection and consistent completion semantics across all paths.
- Removed `NotAFailureException` and replaced it with proper semantics:
  - Channel close: `ClosedSessionException` (recognized as expected by `Exceptions.logIfUnexpected`)
  - Connection rejected: `lookupPromise.trySuccess(null)` (silent close, no exception)
- Changed the timeout path to complete the promise with `DecoderException(SslHandshakeTimeoutException)` instead of firing exceptions directly.
- Added `toSSLException(Throwable)` and `toSSLException(String)` helpers to ensure all error paths produce `DecoderException(SSLHandshakeException(...))`, which routes to the clean `loggedHandshakeFailure` log path.
- Added `ctx.pipeline().remove(this)` to both the error and rejection paths in `onLookupComplete`.
- Added `acceptCount` validation to `ConnectionAcceptorTest` and `DelayedConnectionAcceptorTest` to verify the acceptor is invoked exactly once per connection.

Result:

- All TLS error paths now log cleanly as "TLS handshake failed" instead of "Unexpected exception".
- The connection acceptor is guaranteed to be invoked at most once per connection.
- No functional behavior changes for users.
