### PR TITLE
Attach `Pod` and `Node` to `Endpoint` attributes in `KubernetesEndpointGroup`

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroup.java
@@ -17,6 +17,8 @@
 package com.linecorp.armeria.client.kubernetes.endpoints;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesResourceAccess.NODE_KEY;
+import static com.linecorp.armeria.client.kubernetes.endpoints.KubernetesResourceAccess.POD_KEY;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -129,6 +131,11 @@ import io.fabric8.kubernetes.client.WatcherException;
  *   .portName("http")
  *   .build();
  * }</pre>
+ *
+ * <p>Each {@link Endpoint} created by a {@link KubernetesEndpointGroup} carries the {@link Pod} it was
+ * derived from as an attribute, and additionally the {@link Node} the {@link Pod} is running on in
+ * {@link KubernetesEndpointMode#NODE_PORT} mode. Use {@link KubernetesResourceAccess#pod(Endpoint)} and
+ * {@link KubernetesResourceAccess#node(Endpoint)} to retrieve them.
  */
 @UnstableApi
 public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
@@ -249,8 +256,8 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
     private final KubernetesEndpointMode mode;
 
     // NODE_PORT mode maps
-    private final Map<String, String> podToNode = new NonBlockingHashMap<>();
-    private final Map<String, String> nodeToIp = new NonBlockingHashMap<>();
+    private final Map<String, Pod> podMap = new NonBlockingHashMap<>();
+    private final Map<String, NodeAndIp> nodeMap = new NonBlockingHashMap<>();
     @Nullable
     private volatile Integer nodePort;
 
@@ -323,8 +330,8 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         try {
             // Change the updateId to ensure that outdated watchers do not update endpoints.
             updateId++;
-            nodeToIp.clear();
-            podToNode.clear();
+            nodeMap.clear();
+            podMap.clear();
             podToEndpoint.clear();
         } finally {
             updateLock.unlock();
@@ -579,7 +586,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         if (action == Action.ERROR || action == Action.BOOKMARK) {
             return false;
         }
-        final String podName = resource.getMetadata().getName();
+        final String podName = getPodName(resource);
         if (podName == null) {
             logger.debug("[{}/{}] Pod name is null.", namespace, serviceName);
             return false;
@@ -595,8 +602,16 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         }
     }
 
+    private static String getPodName(Pod pod) {
+        return pod.getMetadata().getName();
+    }
+
+    private static String getNodeName(Pod pod) {
+        return pod.getSpec().getNodeName();
+    }
+
     private boolean updatePodForNodePortMode(Action action, String podName, Pod resource) {
-        final String nodeName = resource.getSpec().getNodeName();
+        final String nodeName = getNodeName(resource);
         logger.debug("[{}/{}] Pod event received. action: {}, pod: {}, node: {}, resource version: {}",
                      namespace, serviceName, action, podName, nodeName,
                      resource.getMetadata().getResourceVersion());
@@ -609,10 +624,10 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         switch (action) {
             case ADDED:
             case MODIFIED:
-                podToNode.put(podName, nodeName);
+                podMap.put(podName, resource);
                 break;
             case DELETED:
-                podToNode.remove(podName);
+                podMap.remove(podName);
                 break;
             default:
         }
@@ -652,10 +667,10 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         final Integer containerPort = findContainerPort(pod);
         if (containerPort == null) {
             logger.warn("[{}/{}] No matching container port found in pod: {}",
-                        namespace, serviceName, pod.getMetadata().getName());
+                        namespace, serviceName, getPodName(pod));
             return null;
         }
-        return Endpoint.of(podIp, containerPort);
+        return Endpoint.of(podIp, containerPort).withAttr(POD_KEY, pod);
     }
 
     @Nullable
@@ -691,7 +706,7 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
      * Fetches the internal IPs of the node.
      */
     private Watch doWatchNode(long updateId, String resourceVersion) {
-        final Watcher<Node> watcher = new Watcher<Node>() {
+        final Watcher<Node> watcher = new Watcher<>() {
             @Override
             public void eventReceived(Action action, Node node) {
                 if (closed) {
@@ -742,20 +757,20 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
                 } catch (Throwable ex) {
                     logger.warn("[{}/{}] Failed to extract the IP address of the node: {}",
                                 namespace, serviceName, nodeName, ex);
-                    nodeToIp.remove(nodeName);
+                    nodeMap.remove(nodeName);
                     return true;
                 }
 
                 if (nodeIp == null) {
                     logger.debug("[{}/{}] No matching IP address is found in {}. node: {}",
                                  namespace, serviceName, nodeName, node);
-                    nodeToIp.remove(nodeName);
+                    nodeMap.remove(nodeName);
                 } else {
-                    nodeToIp.put(nodeName, nodeIp);
+                    nodeMap.put(nodeName, new NodeAndIp(nodeIp, node));
                 }
                 break;
             case DELETED:
-                nodeToIp.remove(nodeName);
+                nodeMap.remove(nodeName);
                 break;
         }
         return true;
@@ -828,12 +843,12 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
         final List<Endpoint> endpoints;
         switch (mode) {
             case NODE_PORT:
-                if (nodeToIp.isEmpty()) {
+                if (nodeMap.isEmpty()) {
                     // No event received for the nodes yet.
                     return;
                 }
 
-                if (podToNode.isEmpty()) {
+                if (podMap.isEmpty()) {
                     // No event received for the pods yet.
                     return;
                 }
@@ -841,16 +856,19 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
                 final Integer nodePort = this.nodePort;
                 assert nodePort != null;
                 endpoints =
-                        podToNode.values().stream()
-                                 .map(nodeName -> {
-                                     final String nodeIp = nodeToIp.get(nodeName);
-                                     if (nodeIp == null) {
+                        podMap.values().stream()
+                              .map(pod -> {
+                                     final String nodeName = getNodeName(pod);
+                                     final NodeAndIp nodeAndIp = nodeMap.get(nodeName);
+                                     if (nodeAndIp == null) {
                                          return null;
                                      }
-                                     return Endpoint.of(nodeIp, nodePort);
+                                     return Endpoint.of(nodeAndIp.nodeIp, nodePort)
+                                                    .withAttr(POD_KEY, pod)
+                                                    .withAttr(NODE_KEY, nodeAndIp.node);
                                  })
-                                 .filter(Objects::nonNull)
-                                 .collect(toImmutableList());
+                              .filter(Objects::nonNull)
+                              .collect(toImmutableList());
                 break;
             case POD:
                 endpoints = ImmutableList.copyOf(podToEndpoint.values());
@@ -906,6 +924,30 @@ public final class KubernetesEndpointGroup extends DynamicEndpointGroup {
             task.run();
         } finally {
             updateLock.unlock();
+        }
+    }
+
+    private static final class NodeAndIp {
+        final String nodeIp;
+        final Node node;
+
+        NodeAndIp(String nodeIp, Node node) {
+            this.nodeIp = nodeIp;
+            this.node = node;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof NodeAndIp)) {
+                return false;
+            }
+            final NodeAndIp nodeAndIp = (NodeAndIp) o;
+            return nodeIp.equals(nodeAndIp.nodeIp) && node.equals(nodeAndIp.node);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeIp, node);
         }
     }
 }

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesResourceAccess.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesResourceAccess.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.kubernetes.endpoints;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.netty.util.AttributeKey;
+
+/**
+ * Provides access to the Kubernetes resources that a {@link KubernetesEndpointGroup} attaches to each
+ * {@link Endpoint} it creates.
+ *
+ * <p>A {@link KubernetesEndpointGroup} stores the {@link Pod} an {@link Endpoint} was derived from, and
+ * additionally the {@link Node} the {@link Pod} is running on in {@link KubernetesEndpointMode#NODE_PORT}
+ * mode, as {@linkplain Endpoint#attrs() endpoint attributes}. This class exposes them so that, for example,
+ * load balancing or logging logic can inspect pod labels, annotations or node metadata:
+ * <pre>{@code
+ * KubernetesEndpointGroup endpointGroup = ...;
+ * for (Endpoint endpoint : endpointGroup.endpoints()) {
+ *     Pod pod = KubernetesResourceAccess.pod(endpoint);
+ *     if (pod != null) {
+ *         String zone = pod.getMetadata().getLabels().get("topology.kubernetes.io/zone");
+ *         ...
+ *     }
+ * }
+ * }</pre>
+ */
+@UnstableApi
+public final class KubernetesResourceAccess {
+
+    static final AttributeKey<Node> NODE_KEY =
+            AttributeKey.valueOf(KubernetesResourceAccess.class, "NODE");
+
+    static final AttributeKey<Pod> POD_KEY =
+            AttributeKey.valueOf(KubernetesResourceAccess.class, "POD");
+
+    /**
+     * Returns the {@link Node} the specified {@link Endpoint} was derived from, or {@code null} if the
+     * {@link Endpoint} has no associated {@link Node}.
+     *
+     * <p>A {@link Node} is attached only to {@link Endpoint}s created by a {@link KubernetesEndpointGroup} in
+     * {@link KubernetesEndpointMode#NODE_PORT} mode. {@code null} is returned for {@link Endpoint}s created in
+     * {@link KubernetesEndpointMode#POD} mode, and for {@link Endpoint}s that did not originate from a
+     * {@link KubernetesEndpointGroup}.
+     */
+    @Nullable
+    public static Node node(Endpoint endpoint) {
+        requireNonNull(endpoint, "endpoint");
+        return endpoint.attr(NODE_KEY);
+    }
+
+    /**
+     * Returns the {@link Pod} the specified {@link Endpoint} was derived from, or {@code null} if the
+     * {@link Endpoint} has no associated {@link Pod}.
+     *
+     * <p>A {@link Pod} is attached to every {@link Endpoint} created by a {@link KubernetesEndpointGroup},
+     * regardless of its {@link KubernetesEndpointMode}. {@code null} is returned only for {@link Endpoint}s
+     * that did not originate from a {@link KubernetesEndpointGroup}.
+     */
+    @Nullable
+    public static Pod pod(Endpoint endpoint) {
+        requireNonNull(endpoint, "endpoint");
+        return endpoint.attr(POD_KEY);
+    }
+
+    private KubernetesResourceAccess() {}
+}

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesResourceAccess.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesResourceAccess.java
@@ -49,10 +49,10 @@ import io.netty.util.AttributeKey;
 public final class KubernetesResourceAccess {
 
     static final AttributeKey<Node> NODE_KEY =
-            AttributeKey.valueOf(KubernetesResourceAccess.class, "NODE");
+            AttributeKey.valueOf(KubernetesResourceAccess.class, "NODE_KEY");
 
     static final AttributeKey<Pod> POD_KEY =
-            AttributeKey.valueOf(KubernetesResourceAccess.class, "POD");
+            AttributeKey.valueOf(KubernetesResourceAccess.class, "POD_KEY");
 
     /**
      * Returns the {@link Node} the specified {@link Endpoint} was derived from, or {@code null} if the

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/endpoints/KubernetesEndpointGroupMockServerTest.java
@@ -502,6 +502,97 @@ class KubernetesEndpointGroupMockServerTest {
         }
     }
 
+    @Test
+    void nodePortModeAttachesPodAndNode() {
+        // In NODE_PORT mode, each endpoint should carry both the Pod and the Node it was derived from.
+        final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"));
+        final Deployment deployment = newDeployment();
+        final int nodePort = 30000;
+        final Service service = newService(nodePort);
+        final List<Pod> pods = nodes.stream()
+                                    .map(node -> node.getMetadata().getName())
+                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
+                                    .collect(toImmutableList());
+
+        for (Node node : nodes) {
+            client.nodes().resource(node).create();
+        }
+        for (Pod pod : pods) {
+            client.pods().resource(pod).create();
+        }
+        client.apps().deployments().resource(deployment).create();
+        client.services().resource(service).create();
+
+        try (KubernetesEndpointGroup endpointGroup =
+                     KubernetesEndpointGroup.builder(client, false)
+                                            .serviceName("nginx-service")
+                                            .build()) {
+            final List<Endpoint> endpoints = endpointGroup.whenReady().join();
+            assertThat(endpoints).containsExactlyInAnyOrder(
+                    Endpoint.of("1.1.1.1", nodePort),
+                    Endpoint.of("2.2.2.2", nodePort));
+
+            for (Endpoint endpoint : endpoints) {
+                // newNode(ip) names the node "node-<ip>", and the endpoint host is the node IP.
+                final String nodeName = "node-" + endpoint.host();
+
+                final Node node = KubernetesResourceAccess.node(endpoint);
+                assertThat(node).isNotNull();
+                assertThat(node.getMetadata().getName()).isEqualTo(nodeName);
+
+                // The attached pod must be the one scheduled on the node behind this endpoint.
+                final Pod pod = KubernetesResourceAccess.pod(endpoint);
+                assertThat(pod).isNotNull();
+                assertThat(pod.getSpec().getNodeName()).isEqualTo(nodeName);
+            }
+        }
+    }
+
+    @Test
+    void podModeAttachesPodButNotNode() {
+        // In POD mode, each endpoint should carry the Pod, but no Node is involved.
+        final Deployment deployment = newDeployment();
+        final Service service = newService(null, "nginx", false);
+        service.getSpec().setType("ClusterIP");
+
+        final Pod pod1 = newPodWithIp(deployment.getSpec().getTemplate(), "pod-1", "10.0.0.1");
+        final Pod pod2 = newPodWithIp(deployment.getSpec().getTemplate(), "pod-2", "10.0.0.2");
+
+        client.pods().resource(pod1).create();
+        client.pods().resource(pod2).create();
+        client.apps().deployments().resource(deployment).create();
+        client.services().resource(service).create();
+
+        try (KubernetesEndpointGroup endpointGroup =
+                     KubernetesEndpointGroup.builder(client, false)
+                                            .serviceName("nginx-service")
+                                            .mode(KubernetesEndpointMode.POD)
+                                            .build()) {
+            final List<Endpoint> endpoints = endpointGroup.whenReady().join();
+            assertThat(endpoints).containsExactlyInAnyOrder(
+                    Endpoint.of("10.0.0.1", 8080),
+                    Endpoint.of("10.0.0.2", 8080));
+
+            for (Endpoint endpoint : endpoints) {
+                // The attached pod must be the one whose podIP backs this endpoint.
+                final Pod pod = KubernetesResourceAccess.pod(endpoint);
+                assertThat(pod).isNotNull();
+                assertThat(pod.getStatus().getPodIP()).isEqualTo(endpoint.host());
+
+                // No Node is attached in POD mode.
+                assertThat(KubernetesResourceAccess.node(endpoint)).isNull();
+            }
+        }
+    }
+
+    @Test
+    void returnsNullWhenEndpointHasNoAttachedResource() {
+        // An endpoint that did not originate from a KubernetesEndpointGroup has no attached resources.
+        final Endpoint endpoint = Endpoint.of("1.1.1.1", 8080);
+        assertThat(KubernetesResourceAccess.pod(endpoint)).isNull();
+        assertThat(KubernetesResourceAccess.node(endpoint)).isNull();
+    }
+
     private static Pod newPodWithIp(PodTemplateSpec template, String podName, String podIp) {
         final PodSpec spec = template.getSpec()
                                      .toBuilder()


### PR DESCRIPTION
Motivation:

Endpoints discovered by `KubernetesEndpointGroup` previously exposed only host:port. Users had no way to reach the underlying Kubernetes Pod or Node metadata (labels, annotations, topology/zone, etc.) behind a selected endpoint, which is useful for zone-aware load balancing, request logging, and debugging.

Modifications:

- Add a public `KubernetesResourceAccess` class exposing static `pod(Endpoint)` and `node(Endpoint)` accessors, backed by `POD_KEY`/`NODE_KEY` endpoint attributes.
- `KubernetesEndpointGroup` now attaches the source `Pod` to every endpoint (both `POD` and `NODE_PORT` modes) and the `Node` in `NODE_PORT` mode.

Result:

- Endpoints from a `KubernetesEndpointGroup` now carry their originating `Pod` (and `Node` in `NODE_PORT` mode), retrievable via `KubernetesResourceAccess.pod(endpoint)` and `KubernetesResourceAccess.node(endpoint)`.
