### PR TITLE
Handle flaky `negativeTtl` second try

### DIFF
--- a/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/RefreshingAddressResolverTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.RefreshingAddressResolver.CacheEntry;
@@ -259,7 +260,8 @@ class RefreshingAddressResolverTest {
             final EventLoop eventLoop = eventLoopExtension.get();
             final DnsResolverGroupBuilder builder =
                     builder(false, server).negativeTtl(600)
-                                          .queryTimeoutMillis(1000);
+                                          .queryTimeoutMillis(1000)
+                                          .searchDomains(ImmutableList.of());
             try (RefreshingAddressResolverGroup group = builder.build(eventLoop)) {
                 final AddressResolver<InetSocketAddress> resolver = group.getResolver(eventLoop);
 
@@ -909,8 +911,8 @@ class RefreshingAddressResolverTest {
     void shouldRemoveListenerFromDnsCacheWhenClosed() {
         final EventLoop eventLoop = eventLoopExtension.get();
         final DnsCache dnsCache = DnsCache.builder()
-                .executor(eventLoop)
-                .build();
+                                          .executor(eventLoop)
+                                          .build();
         try (RefreshingAddressResolverGroup group = new DnsResolverGroupBuilder()
                 .dnsCache(dnsCache)
                 .build(eventLoop)) {


### PR DESCRIPTION
Motivation:

`RefreshingAddressResolverTest.negativeTtl()` became flaky after upgrading Netty from 4.2.13 to 4.2.15. The test uses `builder(false, server)` which picks up system search domains. On machines with search domains configured, `SearchDomainDnsResolver` is added to the resolver chain and wraps `CachingDnsResolver`'s future (F1) with `.handle().thenCompose()`, creating a wrapper future (S1). When Armeria's timeout fires, it completes S1 but leaves F1 pending in `CachingDnsResolver.inflightRequests`. The second resolution then reuses the stale F1 via `computeIfAbsent` instead of sending a fresh query, and inherits a timeout error instead of the expected NXDOMAIN.

Modifications:

- Added `.searchDomains(ImmutableList.of())` to the `negativeTtl()` test to avoid environment-dependent search domain behavior.

Result:

- Fixes the flaky `negativeTtl()` test across all CI environments.
