### PR TITLE
Enrich port-bind failures with the failed ServerPort

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -485,7 +485,7 @@ public final class Server implements ListenableAsyncCloseable {
 
             final ServerPort primary = it.next();
             try {
-                doStart(primary).addListener(new ServerPortStartListener(primary))
+                doStart(primary).addListener(new ServerPortStartListener(primary, future))
                                 .addListener(new NextServerPortStartListener(this, it, future));
                 // Chain the future to set up server metrics and port mapping
                 // before server start future is completed.
@@ -785,9 +785,11 @@ public final class Server implements ListenableAsyncCloseable {
     private final class ServerPortStartListener implements ChannelFutureListener {
 
         private final ServerPort port;
+        private final CompletableFuture<Void> future;
 
-        ServerPortStartListener(ServerPort port) {
+        ServerPortStartListener(ServerPort port, CompletableFuture<Void> future) {
             this.port = requireNonNull(port, "port");
+            this.future = requireNonNull(future, "future");
         }
 
         @Override
@@ -796,54 +798,57 @@ public final class Server implements ListenableAsyncCloseable {
             assert ch.eventLoop().inEventLoop();
             serverChannels.add(ch);
 
-            if (f.isSuccess()) {
-                final SocketAddress localAddress = ch.localAddress();
-                final ServerPort actualPort;
-                if (localAddress instanceof InetSocketAddress) {
-                    actualPort = new ServerPort((InetSocketAddress) localAddress,
-                                                port.protocols(),
-                                                port.portGroup());
-                } else if (localAddress instanceof io.netty.channel.unix.DomainSocketAddress) {
-                    // Convert Netty's DomainSocketAddress to ours.
-                    final DomainSocketAddress converted = DomainSocketAddress.of(
-                            (io.netty.channel.unix.DomainSocketAddress) localAddress);
-                    actualPort = new ServerPort(converted,
-                                                port.protocols(),
-                                                port.portGroup());
+            if (!f.isSuccess()) {
+                future.completeExceptionally(new ServerPortBindException(port, f.cause()));
+                return;
+            }
+
+            final SocketAddress localAddress = ch.localAddress();
+            final ServerPort actualPort;
+            if (localAddress instanceof InetSocketAddress) {
+                actualPort = new ServerPort((InetSocketAddress) localAddress,
+                                            port.protocols(),
+                                            port.portGroup());
+            } else if (localAddress instanceof io.netty.channel.unix.DomainSocketAddress) {
+                // Convert Netty's DomainSocketAddress to ours.
+                final DomainSocketAddress converted = DomainSocketAddress.of(
+                        (io.netty.channel.unix.DomainSocketAddress) localAddress);
+                actualPort = new ServerPort(converted,
+                                            port.protocols(),
+                                            port.portGroup());
+            } else {
+                logger.warn("Unexpected local address type: {}", localAddress.getClass().getName());
+                return;
+            }
+            final ServerPortMetric serverPortMetric = ch.attr(SERVER_PORT_METRIC).get();
+            assert serverPortMetric != null;
+            actualPort.setServerPortMetric(serverPortMetric);
+
+            // Set the actual port on the original ServerPort for ephemeral ports
+            if (port.localAddress().getPort() == 0) {
+                port.setActualPort(actualPort.localAddress().getPort());
+            }
+
+            // Update the boss thread so its name contains the actual port.
+            Thread.currentThread().setName(bossThreadName(actualPort));
+
+            lock.lock();
+            try {
+                // Update the map of active ports.
+                activePorts.put(actualPort.localAddress(), actualPort);
+            } finally {
+                lock.unlock();
+            }
+
+            config.serverMetrics().addServerPort(actualPort);
+
+            if (logger.isInfoEnabled()) {
+                if (isLocalPort(actualPort)) {
+                    port.protocols().forEach(p -> logger.info(
+                            "Serving {} at {} - {}://127.0.0.1:{}/",
+                            p.name(), localAddress, p.uriText(), actualPort.localAddress().getPort()));
                 } else {
-                    logger.warn("Unexpected local address type: {}", localAddress.getClass().getName());
-                    return;
-                }
-                final ServerPortMetric serverPortMetric = ch.attr(SERVER_PORT_METRIC).get();
-                assert serverPortMetric != null;
-                actualPort.setServerPortMetric(serverPortMetric);
-
-                // Set the actual port on the original ServerPort for ephemeral ports
-                if (port.localAddress().getPort() == 0) {
-                    port.setActualPort(actualPort.localAddress().getPort());
-                }
-
-                // Update the boss thread so its name contains the actual port.
-                Thread.currentThread().setName(bossThreadName(actualPort));
-
-                lock.lock();
-                try {
-                    // Update the map of active ports.
-                    activePorts.put(actualPort.localAddress(), actualPort);
-                } finally {
-                    lock.unlock();
-                }
-
-                config.serverMetrics().addServerPort(actualPort);
-
-                if (logger.isInfoEnabled()) {
-                    if (isLocalPort(actualPort)) {
-                        port.protocols().forEach(p -> logger.info(
-                                "Serving {} at {} - {}://127.0.0.1:{}/",
-                                p.name(), localAddress, p.uriText(), actualPort.localAddress().getPort()));
-                    } else {
-                        logger.info("Serving {} at {}", Joiner.on('+').join(port.protocols()), localAddress);
-                    }
+                    logger.info("Serving {} at {}", Joiner.on('+').join(port.protocols()), localAddress);
                 }
             }
         }
@@ -868,7 +873,6 @@ public final class Server implements ListenableAsyncCloseable {
         @Override
         public void operationComplete(ChannelFuture f) throws Exception {
             if (!f.isSuccess()) {
-                future.completeExceptionally(f.cause());
                 return;
             }
             if (!it.hasNext()) {
@@ -910,7 +914,7 @@ public final class Server implements ListenableAsyncCloseable {
             }
 
             startStopSupport.doStart(actualNext)
-                            .addListener(new ServerPortStartListener(actualNext))
+                            .addListener(new ServerPortStartListener(actualNext, future))
                             .addListener(this);
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPortBindException.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPortBindException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.Joiner;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * A {@link RuntimeException} raised when a {@link Server} fails to bind a {@link ServerPort}
+ * while starting up, e.g. because the address is already in use.
+ *
+ * <p>Unlike the bare exception thrown by the underlying transport, this exception carries the
+ * {@link ServerPort} that failed to bind, which can be retrieved via {@link #serverPort()} to
+ * produce a port- and protocol-aware error message. The original failure is always preserved as
+ * the {@linkplain #getCause() cause}.</p>
+ */
+@UnstableApi
+public final class ServerPortBindException extends RuntimeException {
+
+    private static final long serialVersionUID = -8252837343134789905L;
+
+    private final ServerPort serverPort;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param serverPort the {@link ServerPort} that failed to bind
+     * @param cause the original failure, e.g. a {@link java.net.BindException}
+     */
+    public ServerPortBindException(ServerPort serverPort, Throwable cause) {
+        super(toMessage(requireNonNull(serverPort, "serverPort")), requireNonNull(cause, "cause"));
+        this.serverPort = serverPort;
+    }
+
+    private static String toMessage(ServerPort serverPort) {
+        return "Failed to bind to " + Joiner.on('+').join(serverPort.protocols()) +
+               " at " + serverPort.localAddress();
+    }
+
+    /**
+     * Returns the {@link ServerPort} that failed to bind.
+     */
+    public ServerPort serverPort() {
+        return serverPort;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerPortBindExceptionTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerPortBindExceptionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static com.linecorp.armeria.common.SessionProtocol.HTTP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Throwables;
+
+import com.linecorp.armeria.common.HttpResponse;
+
+class ServerPortBindExceptionTest {
+
+    /**
+     * Binding to a port that is already in use must surface a {@link ServerPortBindException} whose
+     * {@link ServerPortBindException#serverPort()} is the conflicting port and whose
+     * {@link ServerPortBindException#getCause()} is the original {@link BindException}.
+     */
+    @Test
+    void bindFailureIsWrappedWithFailedPort() throws IOException {
+        final InetAddress loopback = InetAddress.getLoopbackAddress();
+        // Occupy a port so that the server fails to bind to it.
+        try (ServerSocket occupied = new ServerSocket(0, 0, loopback)) {
+            final int port = occupied.getLocalPort();
+            final Server server = Server.builder()
+                                        .http(new InetSocketAddress(loopback, port))
+                                        .service("/", (ctx, req) -> HttpResponse.of(200))
+                                        .build();
+
+            final Throwable thrown = catchThrowable(() -> server.start().join());
+            assertThat(thrown).isNotNull();
+
+            final ServerPortBindException bindException =
+                    Throwables.getCausalChain(thrown).stream()
+                              .filter(ServerPortBindException.class::isInstance)
+                              .map(ServerPortBindException.class::cast)
+                              .findFirst()
+                              .orElse(null);
+            assertThat(bindException).isNotNull();
+            assertThat(bindException.serverPort().localAddress().getPort()).isEqualTo(port);
+            assertThat(bindException.serverPort().protocols()).containsExactly(HTTP);
+            assertThat(bindException).hasMessageContaining("Failed to bind to")
+                                     .hasMessageContaining("http");
+            // The original bind failure must be preserved as the cause. Depending on the transport, it is
+            // either a java.net.BindException (NIO) or a Netty NativeIoException (epoll/kqueue/io_uring),
+            // both of which are IOExceptions reporting that the address is already in use.
+            assertThat(bindException.getCause())
+                    .isInstanceOf(IOException.class)
+                    .hasMessageContaining("Address already in use");
+        }
+    }
+
+    /**
+     * The exception must preserve the original cause and the failed port, and expose a port- and
+     * protocol-aware message.
+     */
+    @Test
+    void preservesCauseAndPort() {
+        final ServerPort port = new ServerPort(8080, HTTP);
+        final BindException cause = new BindException("Address already in use");
+        final ServerPortBindException bindException = new ServerPortBindException(port, cause);
+        assertThat(bindException.serverPort()).isSameAs(port);
+        assertThat(bindException.getCause()).isSameAs(cause);
+        assertThat(bindException).hasMessageContaining("Failed to bind to")
+                                 .hasMessageContaining("http");
+    }
+
+    /**
+     * The happy path must be unaffected: a server with multiple ephemeral ports starts normally.
+     */
+    @Test
+    void happyPathWithMultipleEphemeralPorts() {
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .http(0)
+                                    .https(0)
+                                    .tlsSelfSigned()
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .build();
+        try {
+            server.start().join();
+            final Collection<ServerPort> ports = server.activePorts().values();
+            assertThat(ports).hasSize(3);
+            assertThat(ports.stream().mapToInt(p -> p.localAddress().getPort()))
+                    .allMatch(p -> p > 0);
+        } finally {
+            server.stop().join();
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerTest.java
@@ -232,10 +232,11 @@ class ServerTest {
                       .service("/", (ctx, req) -> HttpResponse.of(200))
                       .build();
 
-        // .. which will fail with an IOException.
+        // .. which will fail with a ServerPortBindException whose root cause is an IOException.
         assertThatThrownBy(() -> serverAtSamePort.start().join())
                 .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(IOException.class);
+                .hasCauseInstanceOf(ServerPortBindException.class)
+                .hasRootCauseInstanceOf(IOException.class);
 
         // A failed bind attempt must not leave a dangling boss group thread.
         final long numBossThreads =
@@ -379,7 +380,8 @@ class ServerTest {
                                                   .service("/", (ctx, res) -> HttpResponse.of(""))
                                                   .build();
         assertThatThrownBy(() -> duplicatedPortServer.start().join())
-                .hasCauseInstanceOf(IOException.class);
+                .hasCauseInstanceOf(ServerPortBindException.class)
+                .hasRootCauseInstanceOf(IOException.class);
     }
 
     @Test

--- a/spring/boot4-autoconfigure/src/test/java/com/linecorp/armeria/spring/RetryableArmeriaServerGracefulShutdownLifecycleTest.java
+++ b/spring/boot4-autoconfigure/src/test/java/com/linecorp/armeria/spring/RetryableArmeriaServerGracefulShutdownLifecycleTest.java
@@ -30,6 +30,7 @@ import org.springframework.context.SmartLifecycle;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerPortBindException;
 
 class RetryableArmeriaServerGracefulShutdownLifecycleTest {
 
@@ -47,8 +48,9 @@ class RetryableArmeriaServerGracefulShutdownLifecycleTest {
         // Make sure that `failingServer` is unable to start because of the port collision.
         assertThatThrownBy(() -> failingServer.start().join())
                 .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(IOException.class)
-                .hasMessageContaining("Address already in use");
+                .hasCauseInstanceOf(ServerPortBindException.class)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasStackTraceContaining("Address already in use");
 
         final SmartLifecycle lifecycle =
                 new RetryableArmeriaServerGracefulShutdownLifecycle(failingServer, 100);


### PR DESCRIPTION
Motivation:

When an Armeria server fails to bind a port at startup — most commonly *"Address already in use"* — `Server.start()` propagates the bare transport exception: a `java.net.BindException` on the NIO transport, or Netty's `NativeIoException` on the native transports (epoll/kqueue/io_uring).

That exception is essentially opaque to the operator:

- it carries **no reference to the `ServerPort`** that failed, so there is no programmatic way to know *which* port and protocol could not be bound;
- the only way to recover that information is to **parse the raw, transport-dependent message**, which is brittle and differs between transports;
- ironically, the failed `ServerPort` is right there in scope at the failure site inside `Server` — it was simply discarded before reaching the caller.

As a result, today the only way to give users a friendly *"port X is already in use"* message is to **probe the ports ourselves, before starting the server**, with code like this:

```java
static void checkPortAvailable(int port, String role) {
    if (port == 0) {
        return;
    }
    try (var socket = new ServerSocket()) {
        socket.setReuseAddress(false);
        socket.bind(new InetSocketAddress(port));
    } catch (BindException e) {
        throw new IllegalStateException(
            "Cannot start Armeria server: " + role + " port " + port + " is already in use", e);
    } catch (IOException e) {
        throw new IllegalStateException(
            "Cannot start Armeria server: failed to probe " + role + " port " + port, e);
    }
}
```

This workaround is unsatisfying for several reasons:

- it **duplicates the bind logic** outside of Armeria and is inherently racy (TOCTOU — the port can be taken between the probe and the real bind);
- it does not understand Armeria concepts (port groups, ephemeral ports, multiple protocols per port, domain sockets);
- it has to run **before / outside** the server lifecycle, instead of letting the server report what actually happened.

The goal of this change is to make that kind of pre-flight probing unnecessary: the server itself should tell you which port failed, after the real bind attempt.

Modifications:

- Introduce `ServerPortBindException`, a public `@UnstableApi RuntimeException`:
  - `serverPort()` returns the actual `ServerPort` that failed to bind (address, protocols, port group);
  - the message is port- and protocol-aware, e.g. `Failed to bind to http at /0.0.0.0:8080`;
  - `getCause()` is always the original transport exception, so nothing is lost.
- Wrap the bind failure at the single propagation point in `Server`, via `ServerPortBindException.wrapIfBindFailure(...)`, which keeps the transport-specific detection in one place. **Only genuine bind failures are wrapped** (`BindException`, or a `NativeIoException` whose failing syscall is `bind`); any other startup failure is propagated **unchanged**.
- Make the bind listener hold the port it is attached to as an **immutable** field (a fresh listener is scheduled per bind, rather than reusing and mutating a shared one). This is required for correctness: the actually-attempted port may be **synthesized at runtime** (an ephemeral port reused within a port group) and is therefore not recoverable from the configured port list.
- Add `ServerPortBindExceptionTest` covering: a real bind conflict surfaces a `ServerPortBindException` whose `serverPort()` is the conflicting port and whose `getCause()` is the original bind exception (across NIO and native transports); a non-bind failure is **not** wrapped (regression guard); the happy path (multi-port + ephemeral) is unaffected.

Result:

- Follow-up to #6410.
- Consumers can now react to the real failure instead of probing the ports beforehand:

  ```java
  try {
      server.start().join();
  } catch (CompletionException e) {
      if (Exceptions.peel(e) instanceof ServerPortBindException bindEx) {
          final ServerPort port = bindEx.serverPort();
          throw new IllegalStateException(
              "Cannot start Armeria server: " + port.protocols() +
              " port " + port.localAddress().getPort() + " is already in use", bindEx.getCause());
      }
      throw e;
  }
  ```

- **Backward compatible**: the original cause is never lost — it is always available via `getCause()` — so existing code that unwraps the cause (e.g. `Exceptions.peel(e).getCause() instanceof BindException`) keeps working. Only genuine bind failures are now wrapped; every other startup failure is propagated exactly as before.
