### PR TITLE
Introduce `ServerPlugin`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/Server.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Server.java
@@ -113,17 +113,19 @@ public final class Server implements ListenableAsyncCloseable {
     @GuardedBy("lock")
     private final Map<InetSocketAddress, ServerPort> activePorts = new LinkedHashMap<>();
     private final ConnectionLimitingHandler connectionLimitingHandler;
+    private final List<ServerPlugin> plugins;
     private boolean hasWebSocketService;
 
     @Nullable
     @VisibleForTesting
     ServerBootstrap serverBootstrap;
 
-    Server(DefaultServerConfig serverConfig) {
+    Server(DefaultServerConfig serverConfig, List<ServerPlugin> plugins) {
         serverConfig.setServer(this);
         config = new UpdatableServerConfig(requireNonNull(serverConfig, "serverConfig"));
         startStop = new ServerStartStopSupport(config.startStopExecutor());
         connectionLimitingHandler = new ConnectionLimitingHandler(config.maxNumConnections());
+        this.plugins = requireNonNull(plugins, "plugins");
 
         // Server-wide metrics.
         RequestTargetCache.registerServerMetrics(config.meterRegistry());
@@ -418,6 +420,7 @@ public final class Server implements ListenableAsyncCloseable {
         requireNonNull(serverConfigurator, "serverConfigurator");
         final ServerBuilder sb = builder();
         serverConfigurator.reconfigure(sb);
+        plugins.forEach(plugin -> plugin.install(sb));
         final ImmutableList<ServerPort> serverPorts;
         lock.lock();
         try {
@@ -720,6 +723,9 @@ public final class Server implements ListenableAsyncCloseable {
             serverChannels.clear();
 
             final Builder<ShutdownSupport> builder = ImmutableList.builder();
+            for (ServerPlugin plugin : plugins) {
+                builder.add(ShutdownSupport.of(plugin));
+            }
             builder.addAll(config.delegate().shutdownSupports());
             for (VirtualHost virtualHost : config.virtualHosts()) {
                 builder.addAll(virtualHost.shutdownSupports());

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -556,7 +556,6 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         return this;
     }
 
-
     /**
      * Sets the worker {@link EventLoopGroup} which is responsible for performing socket I/O and running
      * {@link Service#serve(ServiceRequestContext, Request)}.

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -44,10 +44,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -245,6 +247,8 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     private final ServerTlsProviderBuilder serverTlsProviderBuilder = new ServerTlsProviderBuilder();
     private Function<? super String, ? extends EventLoopGroup> bossGroupFactory = DEFAULT_BOSS_GROUP_FACTORY;
     private ConnectionAcceptor connectionAcceptor = ConnectionAcceptor.always();
+    private static final List<ServerPlugin> SPI_PLUGINS =
+            ImmutableList.copyOf(ServiceLoader.load(ServerPlugin.class));
     private final List<ServerPlugin> plugins = new ArrayList<>();
 
     ServerBuilder() {
@@ -551,6 +555,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
         plugins.add(requireNonNull(plugin, "plugin"));
         return this;
     }
+
 
     /**
      * Sets the worker {@link EventLoopGroup} which is responsible for performing socket I/O and running
@@ -2486,11 +2491,22 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
      * Returns a newly-created {@link Server} based on the configuration properties set so far.
      */
     public Server build() {
-        final List<ServerPlugin> plugins = ImmutableList.copyOf(this.plugins);
+        final List<ServerPlugin> plugins = buildPlugins();
         plugins.forEach(plugin -> plugin.install(this));
         final Server server = new Server(buildServerConfig(ports), plugins);
         serverListeners.forEach(server::addListener);
         return server;
+    }
+
+    private List<ServerPlugin> buildPlugins() {
+        // SPI-discovered plugins first, then user-registered plugins
+        return ImmutableList.<ServerPlugin>builder()
+                            .addAll(SPI_PLUGINS)
+                            .addAll(this.plugins)
+                            .build()
+                            .stream()
+                            .sorted(Comparator.comparingInt(ServerPlugin::order))
+                            .collect(toImmutableList());
     }
 
     DefaultServerConfig buildServerConfig(List<ServerPort> serverPorts) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -245,6 +245,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     private final ServerTlsProviderBuilder serverTlsProviderBuilder = new ServerTlsProviderBuilder();
     private Function<? super String, ? extends EventLoopGroup> bossGroupFactory = DEFAULT_BOSS_GROUP_FACTORY;
     private ConnectionAcceptor connectionAcceptor = ConnectionAcceptor.always();
+    private final List<ServerPlugin> plugins = new ArrayList<>();
 
     ServerBuilder() {
         // Set the default host-level properties.
@@ -529,6 +530,25 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     @UnstableApi
     public ServerBuilder connectionAcceptor(ConnectionAcceptor connectionAcceptor) {
         this.connectionAcceptor = requireNonNull(connectionAcceptor, "connectionAcceptor");
+        return this;
+    }
+
+    /**
+     * Adds a {@link ServerPlugin} that will be installed during {@link Server} construction
+     * and during {@link Server#reconfigure(ServerConfigurator)}.
+     *
+     * <p>Plugins are installed in insertion order. Each plugin's
+     * {@link ServerPlugin#install(ServerBuilder)} is called before the server configuration
+     * is built. Plugins are closed when the {@link Server} stops.
+     *
+     * <p>Note: Plugins can only be added at initial build time. Calling
+     * {@link ServerBuilder#plugin(ServerPlugin)} inside a {@link ServerConfigurator} passed to
+     * {@link Server#reconfigure(ServerConfigurator)} has no effect — the server uses the plugins
+     * registered at construction. Existing plugins are re-installed automatically during reconfiguration.
+     */
+    @UnstableApi
+    public ServerBuilder plugin(ServerPlugin plugin) {
+        plugins.add(requireNonNull(plugin, "plugin"));
         return this;
     }
 
@@ -2466,7 +2486,9 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
      * Returns a newly-created {@link Server} based on the configuration properties set so far.
      */
     public Server build() {
-        final Server server = new Server(buildServerConfig(ports));
+        final List<ServerPlugin> plugins = ImmutableList.copyOf(this.plugins);
+        plugins.forEach(plugin -> plugin.install(this));
+        final Server server = new Server(buildServerConfig(ports), plugins);
         serverListeners.forEach(server::addListener);
         return server;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
@@ -16,7 +16,6 @@
 package com.linecorp.armeria.server;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.common.util.SafeCloseable;
 
 /**
  * A plugin that encapsulates multi-concern registration into a single
@@ -26,36 +25,45 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  * and during {@link Server#reconfigure(ServerConfigurator)}, allowing the plugin to register
  * any combination of server-level concerns (e.g., ports, TLS, service decorators).
  *
+ * <p>Plugins are sorted by {@link #order()} before installation. Lower values are installed first.
+ *
  * <p>The {@link #close()} method is called when the {@link Server} stops, allowing the plugin
  * to clean up resources such as subscriptions or background tasks.
  *
  * <h2>Example</h2>
  * <pre>{@code
- * ServerPlugin myPlugin = new ServerPlugin() {
- *     @Override
- *     public void install(ServerBuilder sb) {
- *         sb.decorator(LoggingService.newDecorator());
- *     }
- *
- *     @Override
- *     public void close() {
- *         // Clean up resources
- *     }
- * };
- *
  * Server server = Server.builder()
  *                       .http(8080)
  *                       .service("/", (ctx, req) -> HttpResponse.of(200))
- *                       .plugin(myPlugin)
+ *                       .plugin(sb -> sb.decorator(LoggingService.newDecorator()))
  *                       .build();
  * }</pre>
  */
+@FunctionalInterface
 @UnstableApi
-public interface ServerPlugin extends SafeCloseable {
+public interface ServerPlugin extends AutoCloseable {
 
     /**
      * Installs this plugin into the given {@link ServerBuilder}. Called during
      * {@link Server} construction and during {@link Server#reconfigure(ServerConfigurator)}.
      */
     void install(ServerBuilder sb);
+
+    /**
+     * Returns the order of this plugin. Plugins with lower values are installed first.
+     * Plugins with the same order preserve their insertion order (stable sort).
+     * The default value is {@code 0}.
+     */
+    default int order() {
+        return 0;
+    }
+
+    /**
+     * Called when the {@link Server} stops, allowing the plugin to clean up resources.
+     * Note that if the same plugin instance is registered with multiple servers,
+     * this method will be called once for each server that stops.
+     * The default implementation is a no-op.
+     */
+    @Override
+    default void close() {}
 }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
@@ -24,7 +24,7 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  *
  * <p>The {@link #install(ServerBuilder)} method is called during {@link Server} construction
  * and during {@link Server#reconfigure(ServerConfigurator)}, allowing the plugin to register
- * any combination of server-level concerns (e.g., server listeners, service decorators).
+ * any combination of server-level concerns (e.g., ports, TLS, service decorators).
  *
  * <p>The {@link #close()} method is called when the {@link Server} stops, allowing the plugin
  * to clean up resources such as subscriptions or background tasks.
@@ -35,12 +35,6 @@ import com.linecorp.armeria.common.util.SafeCloseable;
  *     @Override
  *     public void install(ServerBuilder sb) {
  *         sb.decorator(LoggingService.newDecorator());
- *         sb.serverListener(new ServerListenerAdapter() {
- *             @Override
- *             public void serverStarted(Server server) {
- *                 // ...
- *             }
- *         });
  *     }
  *
  *     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerPlugin.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
+/**
+ * A plugin that encapsulates multi-concern registration into a single
+ * {@link ServerBuilder#plugin(ServerPlugin)} call.
+ *
+ * <p>The {@link #install(ServerBuilder)} method is called during {@link Server} construction
+ * and during {@link Server#reconfigure(ServerConfigurator)}, allowing the plugin to register
+ * any combination of server-level concerns (e.g., server listeners, service decorators).
+ *
+ * <p>The {@link #close()} method is called when the {@link Server} stops, allowing the plugin
+ * to clean up resources such as subscriptions or background tasks.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * ServerPlugin myPlugin = new ServerPlugin() {
+ *     @Override
+ *     public void install(ServerBuilder sb) {
+ *         sb.decorator(LoggingService.newDecorator());
+ *         sb.serverListener(new ServerListenerAdapter() {
+ *             @Override
+ *             public void serverStarted(Server server) {
+ *                 // ...
+ *             }
+ *         });
+ *     }
+ *
+ *     @Override
+ *     public void close() {
+ *         // Clean up resources
+ *     }
+ * };
+ *
+ * Server server = Server.builder()
+ *                       .http(8080)
+ *                       .service("/", (ctx, req) -> HttpResponse.of(200))
+ *                       .plugin(myPlugin)
+ *                       .build();
+ * }</pre>
+ */
+@UnstableApi
+public interface ServerPlugin extends SafeCloseable {
+
+    /**
+     * Installs this plugin into the given {@link ServerBuilder}. Called during
+     * {@link Server} construction and during {@link Server#reconfigure(ServerConfigurator)}.
+     */
+    void install(ServerBuilder sb);
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerPluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerPluginTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.HttpResponse;
+
+class ServerPluginTest {
+
+    @Test
+    void installCalledDuringBuild() {
+        final AtomicInteger installCount = new AtomicInteger();
+        final ServerPlugin plugin = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                installCount.incrementAndGet();
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(plugin)
+                                    .build();
+        assertThat(installCount.get()).isEqualTo(1);
+        server.close();
+    }
+
+    @Test
+    void installCalledDuringReconfigure() {
+        final AtomicInteger installCount = new AtomicInteger();
+        final ServerPlugin plugin = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                installCount.incrementAndGet();
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(plugin)
+                                    .build();
+        assertThat(installCount.get()).isEqualTo(1);
+
+        server.reconfigure(sb -> sb.service("/new", (ctx, req) -> HttpResponse.of(200)));
+        assertThat(installCount.get()).isEqualTo(2);
+        server.close();
+    }
+
+    @Test
+    void closeCalledDuringStop() throws Exception {
+        final AtomicBoolean closed = new AtomicBoolean();
+        final ServerPlugin plugin = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {}
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(plugin)
+                                    .build();
+        server.start().join();
+        assertThat(closed.get()).isFalse();
+
+        server.stop().join();
+        assertThat(closed.get()).isTrue();
+    }
+
+    @Test
+    void multiplePluginsInstalledInOrder() {
+        final List<String> order = new ArrayList<>();
+        final ServerPlugin pluginA = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("A");
+            }
+
+            @Override
+            public void close() {}
+        };
+        final ServerPlugin pluginB = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("B");
+            }
+
+            @Override
+            public void close() {}
+        };
+        final ServerPlugin pluginC = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("C");
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(pluginA)
+                                    .plugin(pluginB)
+                                    .plugin(pluginC)
+                                    .build();
+        assertThat(order).containsExactly("A", "B", "C");
+        server.close();
+    }
+
+    @Test
+    void pluginCanModifyServerBuilder() {
+        final ServerPlugin plugin = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                sb.serverListener(new ServerListenerAdapter() {});
+            }
+
+            @Override
+            public void close() {}
+        };
+
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(plugin)
+                                    .build();
+        // Just verify it builds successfully without error
+        server.close();
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/server/ServerPluginTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerPluginTest.java
@@ -36,9 +36,6 @@ class ServerPluginTest {
             public void install(ServerBuilder sb) {
                 installCount.incrementAndGet();
             }
-
-            @Override
-            public void close() {}
         };
 
         final Server server = Server.builder()
@@ -58,9 +55,6 @@ class ServerPluginTest {
             public void install(ServerBuilder sb) {
                 installCount.incrementAndGet();
             }
-
-            @Override
-            public void close() {}
         };
 
         final Server server = Server.builder()
@@ -108,27 +102,18 @@ class ServerPluginTest {
             public void install(ServerBuilder sb) {
                 order.add("A");
             }
-
-            @Override
-            public void close() {}
         };
         final ServerPlugin pluginB = new ServerPlugin() {
             @Override
             public void install(ServerBuilder sb) {
                 order.add("B");
             }
-
-            @Override
-            public void close() {}
         };
         final ServerPlugin pluginC = new ServerPlugin() {
             @Override
             public void install(ServerBuilder sb) {
                 order.add("C");
             }
-
-            @Override
-            public void close() {}
         };
 
         final Server server = Server.builder()
@@ -143,15 +128,95 @@ class ServerPluginTest {
     }
 
     @Test
+    void pluginsSortedByOrder() {
+        final List<String> order = new ArrayList<>();
+        final ServerPlugin pluginA = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("A");
+            }
+
+            @Override
+            public int order() {
+                return 10;
+            }
+        };
+        final ServerPlugin pluginB = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("B");
+            }
+
+            @Override
+            public int order() {
+                return -1;
+            }
+        };
+        final ServerPlugin pluginC = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("C");
+            }
+
+            @Override
+            public int order() {
+                return 5;
+            }
+        };
+
+        // Registered in A, B, C order but B (-1) < C (5) < A (10)
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(pluginA)
+                                    .plugin(pluginB)
+                                    .plugin(pluginC)
+                                    .build();
+        assertThat(order).containsExactly("B", "C", "A");
+        server.close();
+    }
+
+    @Test
+    void pluginsWithSameOrderPreserveInsertionOrder() {
+        final List<String> order = new ArrayList<>();
+        final ServerPlugin pluginA = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("A");
+            }
+        };
+        final ServerPlugin pluginB = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("B");
+            }
+        };
+        final ServerPlugin pluginC = new ServerPlugin() {
+            @Override
+            public void install(ServerBuilder sb) {
+                order.add("C");
+            }
+        };
+
+        // All have default order (0), so insertion order is preserved
+        final Server server = Server.builder()
+                                    .http(0)
+                                    .service("/", (ctx, req) -> HttpResponse.of(200))
+                                    .plugin(pluginC)
+                                    .plugin(pluginA)
+                                    .plugin(pluginB)
+                                    .build();
+        assertThat(order).containsExactly("C", "A", "B");
+        server.close();
+    }
+
+    @Test
     void pluginCanModifyServerBuilder() {
         final ServerPlugin plugin = new ServerPlugin() {
             @Override
             public void install(ServerBuilder sb) {
                 sb.serverListener(new ServerListenerAdapter() {});
             }
-
-            @Override
-            public void close() {}
         };
 
         final Server server = Server.builder()


### PR DESCRIPTION
Motivation:

When integrating cross-cutting server concerns (e.g., xDS-driven TLS, service decorators, server listeners), users currently need to call multiple `ServerBuilder` methods individually. There's no way to bundle these concerns into a reusable unit that also participates in `Server.reconfigure()` and gets cleaned up on server stop.

Modifications:

- Added `ServerPlugin` interface (extends `SafeCloseable`) with a single `install(ServerBuilder)` method.
- Added `ServerBuilder.plugin(ServerPlugin)` to register plugins at build time.
- In `ServerBuilder.build()`, call `plugin.install(this)` for each registered plugin before building the server config.
- In `Server.reconfigure()`, re-install all plugins on the new `ServerBuilder` after the `ServerConfigurator` runs.
- In `Server.finishDoStop()`, close plugins via the existing `ShutdownSupport` machinery.
- Added `ServerPluginTest` covering install-on-build, install-on-reconfigure, close-on-stop, ordering, and builder modification.

Result:

- Users can encapsulate multi-concern server configuration into a single `ServerPlugin` and register it with `ServerBuilder.plugin(plugin)`.
- Plugins are automatically re-installed during `Server.reconfigure()` and closed when the server stops.
