### PR TITLE
Fix NullPointerException in AuthService during Server.reconfigure()

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthService.java
@@ -83,9 +83,9 @@ public final class AuthService extends SimpleDecoratingHttpService {
     private final AuthSuccessHandler defaultSuccessHandler;
     private final AuthFailureHandler defaultFailureHandler;
     @Nullable
-    private Timer successTimer;
+    private volatile Timer successTimer;
     @Nullable
-    private Timer failureTimer;
+    private volatile Timer failureTimer;
     private final MeterIdPrefix meterIdPrefix;
 
     AuthService(HttpService delegate, Authorizer<HttpRequest> authorizer,
@@ -138,8 +138,12 @@ public final class AuthService extends SimpleDecoratingHttpService {
                                        @Nullable AuthSuccessHandler authorizerSuccessHandler,
                                        ServiceRequestContext ctx, HttpRequest req,
                                        long startNanos) throws Exception {
-        assert successTimer != null;
-        successTimer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+        // successTimer may not be set yet if a request is served during Server.reconfigure(), before
+        // serviceAdded() runs on the new service; skip recording rather than fail.
+        final Timer timer = successTimer;
+        if (timer != null) {
+            timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
         final AuthSuccessHandler handler = authorizerSuccessHandler == null ? defaultSuccessHandler
                                                                             : authorizerSuccessHandler;
         return handler.authSucceeded(delegate, ctx, req);
@@ -149,8 +153,12 @@ public final class AuthService extends SimpleDecoratingHttpService {
                                        @Nullable AuthFailureHandler authorizerFailureHandler,
                                        ServiceRequestContext ctx, HttpRequest req,
                                        @Nullable Throwable cause, long startNanos) throws Exception {
-        assert failureTimer != null;
-        failureTimer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+        // failureTimer may not be set yet if a request is served during Server.reconfigure(), before
+        // serviceAdded() runs on the new service; skip recording rather than fail.
+        final Timer timer = failureTimer;
+        if (timer != null) {
+            timer.record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
         final AuthFailureHandler handler = authorizerFailureHandler == null ? defaultFailureHandler
                                                                             : authorizerFailureHandler;
         if (cause != null) {

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceReconfigureTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceReconfigureTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.auth;
+
+import static com.linecorp.armeria.common.util.UnmodifiableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+class AuthServiceReconfigureTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @Test
+    void shouldNotFailWhenServedDuringReconfigure() throws Exception {
+        final CountDownLatch blockerAddedReached = new CountDownLatch(1);
+        final CountDownLatch releaseBlocker = new CountDownLatch(1);
+
+        final HttpService blocker = new HttpService() {
+            @Override
+            public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) {
+                return HttpResponse.of(HttpStatus.OK);
+            }
+
+            @Override
+            public void serviceAdded(ServiceConfig cfg) throws Exception {
+                blockerAddedReached.countDown();
+                releaseBlocker.await();
+            }
+        };
+
+        final HttpService authService =
+                ((HttpService) (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                        .decorate(AuthService.newDecorator((ctx, req) -> completedFuture(true)));
+
+        final Thread reconfigureThread = new Thread(() -> server.server().reconfigure(sb -> {
+            // Registration order matters: "/blocker" blocks reconfigure before "/auth".serviceAdded().
+            sb.service("/blocker", blocker);
+            sb.service("/auth", authService);
+        }));
+        reconfigureThread.start();
+
+        try {
+            assertThat(blockerAddedReached.await(10, TimeUnit.SECONDS)).isTrue();
+
+            final BlockingWebClient client = server.blockingWebClient();
+            assertThat(client.get("/auth").status()).isEqualTo(HttpStatus.OK);
+        } finally {
+            releaseBlocker.countDown();
+            reconfigureThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

`Server.reconfigure()` installs the new server config before invoking `serviceAdded()`
on the new services. So during reconfiguration a request can be routed to a freshly built
`AuthService` before its `serviceAdded()` runs, while the success/failure metric timers
(initialized only in `serviceAdded()`) are still null. The request then fails with a
`NullPointerException` (HTTP 500) instead of being served.

Modifications:

- Skip recording the auth latency when the metric timer has not been initialized yet,
  instead of failing the request, and make the timer fields `volatile` so the
  initialization is visible across the reconfigure and event-loop threads.

Result:

- A request that arrives during the brief reconfigure window is now served normally
  instead of returning 500. The auth latency is simply not recorded for those few
  requests until `serviceAdded()` completes.
