### PR TITLE
Introduce `XdsServerPlugin`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/server/ConnectionLevelSetters.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ConnectionLevelSetters.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+@UnstableApi
+interface ConnectionLevelSetters {
+
+    @Nullable
+    ConnectionAcceptor connectionAcceptor();
+
+    ConnectionLevelSetters connectionAcceptor(ConnectionAcceptor connectionAcceptor);
+
+    @Nullable
+    ServerTlsProvider tlsProvider();
+
+    ConnectionLevelSetters tlsProvider(ServerTlsProvider serverTlsProvider);
+}

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -172,7 +172,8 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
  *
  * @see VirtualHostBuilder
  */
-public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<ServerBuilder> {
+public final class ServerBuilder implements ConnectionLevelSetters, TlsSetters,
+        ServiceConfigsBuilder<ServerBuilder> {
     private static final Logger logger = LoggerFactory.getLogger(ServerBuilder.class);
 
     // Defaults to no graceful shutdown.
@@ -531,10 +532,20 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
      * Sets the {@link ConnectionAcceptor} that is called once per connection, before TLS
      * negotiation, to decide whether to accept the connection.
      */
+    @Override
     @UnstableApi
     public ServerBuilder connectionAcceptor(ConnectionAcceptor connectionAcceptor) {
         this.connectionAcceptor = requireNonNull(connectionAcceptor, "connectionAcceptor");
         return this;
+    }
+
+    /**
+     * Returns the {@link ConnectionAcceptor} configured so far.
+     */
+    @Override
+    @UnstableApi
+    public ConnectionAcceptor connectionAcceptor() {
+        return connectionAcceptor;
     }
 
     /**
@@ -1244,6 +1255,16 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
     }
 
     /**
+     * Returns the {@link ServerTlsProvider} configured so far, or {@code null} if not set.
+     */
+    @Override
+    @UnstableApi
+    @Nullable
+    public ServerTlsProvider tlsProvider() {
+        return serverTlsProviderBuilder.serverTlsProvider;
+    }
+
+    /**
      * Sets the specified {@link TlsProvider} which will be used for building an {@link SslContext} of
      * a hostname.
      *
@@ -1322,6 +1343,7 @@ public final class ServerBuilder implements TlsSetters, ServiceConfigsBuilder<Se
      * the {@code tlsProvider} takes priority. The static TLS settings are used as a fallback
      * when the provider returns {@code null}.
      */
+    @Override
     @UnstableApi
     public ServerBuilder tlsProvider(ServerTlsProvider serverTlsProvider) {
         requireNonNull(serverTlsProvider, "serverTlsProvider");

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsCertificateExtension.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsCertificateExtension.java
@@ -52,14 +52,14 @@ import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension
  *         new XdsCertificateExtension(new SelfSignedCertificateExtension("localhost"));
  * }</pre>
  */
-final class XdsCertificateExtension extends AbstractAllOrEachExtension {
+public final class XdsCertificateExtension extends AbstractAllOrEachExtension {
 
     private final SelfSignedCertificateExtension delegate;
     private Path tempDir;
     private File certificateFile;
     private File privateKeyFile;
 
-    XdsCertificateExtension(SelfSignedCertificateExtension delegate) {
+    public XdsCertificateExtension(SelfSignedCertificateExtension delegate) {
         this.delegate = delegate;
     }
 
@@ -79,23 +79,23 @@ final class XdsCertificateExtension extends AbstractAllOrEachExtension {
         }
     }
 
-    File certificateFile() {
+    public File certificateFile() {
         return certificateFile;
     }
 
-    File privateKeyFile() {
+    public File privateKeyFile() {
         return privateKeyFile;
     }
 
-    X509Certificate certificate() {
+    public X509Certificate certificate() {
         return delegate.certificate();
     }
 
-    PrivateKey privateKey() {
+    public PrivateKey privateKey() {
         return delegate.privateKey();
     }
 
-    TlsKeyPair tlsKeyPair() {
+    public TlsKeyPair tlsKeyPair() {
         return delegate.tlsKeyPair();
     }
 

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsControlPlaneExtension.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsControlPlaneExtension.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.common.AbstractAllOrEachExtension;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.XdsBootstrapBuilder;
+
+import io.envoyproxy.controlplane.cache.v3.SimpleCache;
+import io.envoyproxy.controlplane.cache.v3.Snapshot;
+import io.envoyproxy.controlplane.server.V3DiscoveryServer;
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.Secret;
+
+/**
+ * A JUnit 5 extension that manages an xDS control plane server, an internal
+ * {@link XdsBootstrap}, and a mutable resource map. All standard discovery services
+ * (ADS, LDS, RDS, CDS, EDS, SDS) are registered on a single ephemeral HTTP port.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * @RegisterExtension
+ * @Order(0)
+ * static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+ *
+ * @RegisterExtension
+ * @Order(1)
+ * static final ServerExtension server = new ServerExtension() {
+ *     protected void configure(ServerBuilder sb) {
+ *         controlPlane.set(myListener);
+ *         sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), "my-listener"));
+ *         sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+ *     }
+ * };
+ *
+ * @Test
+ * void test() {
+ *     String ver = controlPlane.set(updatedListener);
+ *     controlPlane.awaitListener("my-listener", ver);
+ *     // make assertions...
+ * }
+ * }</pre>
+ */
+public final class XdsControlPlaneExtension extends AbstractAllOrEachExtension {
+
+    private static final String GROUP = "key";
+
+    private final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
+    private final AtomicLong version = new AtomicLong();
+    private final Consumer<XdsBootstrapBuilder> bootstrapCustomizer;
+
+    private List<Listener> listeners = ImmutableList.of();
+    private List<Cluster> clusters = ImmutableList.of();
+    private List<ClusterLoadAssignment> endpoints = ImmutableList.of();
+    private List<RouteConfiguration> routes = ImmutableList.of();
+    private List<Secret> secrets = ImmutableList.of();
+
+    private Server server;
+    private XdsBootstrap xdsBootstrap;
+
+    public XdsControlPlaneExtension() {
+        this(builder -> {});
+    }
+
+    public XdsControlPlaneExtension(Consumer<XdsBootstrapBuilder> bootstrapCustomizer) {
+        this.bootstrapCustomizer = bootstrapCustomizer;
+    }
+
+    @Override
+    protected void before(ExtensionContext context) throws Exception {
+        final V3DiscoveryServer ds = new V3DiscoveryServer(cache);
+        server = Server.builder()
+                       .service(GrpcService.builder()
+                                           .addService(ds.getAggregatedDiscoveryServiceImpl())
+                                           .addService(ds.getListenerDiscoveryServiceImpl())
+                                           .addService(ds.getRouteDiscoveryServiceImpl())
+                                           .addService(ds.getClusterDiscoveryServiceImpl())
+                                           .addService(ds.getEndpointDiscoveryServiceImpl())
+                                           .addService(ds.getSecretDiscoveryServiceImpl())
+                                           .build())
+                       .http(0)
+                       .build();
+        server.start().join();
+
+        final int port = server.activePort(SessionProtocol.HTTP).localAddress().getPort();
+        //language=YAML
+        final String yaml =
+                """
+                dynamic_resources:
+                  lds_config:
+                    api_config_source:
+                      api_type: GRPC
+                      grpc_services:
+                        - envoy_grpc:
+                            cluster_name: xds-cluster
+                  cds_config:
+                    api_config_source:
+                      api_type: GRPC
+                      grpc_services:
+                        - envoy_grpc:
+                            cluster_name: xds-cluster
+                static_resources:
+                  clusters:
+                    - name: xds-cluster
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: xds-cluster
+                        endpoints:
+                          - lb_endpoints:
+                              - endpoint:
+                                  address:
+                                    socket_address:
+                                      address: 127.0.0.1
+                                      port_value: %d
+                """.formatted(port);
+        final XdsBootstrapBuilder builder =
+                XdsBootstrap.builder(XdsResourceReader.fromYaml(yaml, Bootstrap.class));
+        bootstrapCustomizer.accept(builder);
+        xdsBootstrap = builder.build();
+    }
+
+    @Override
+    protected void after(ExtensionContext context) throws Exception {
+        if (xdsBootstrap != null) {
+            xdsBootstrap.close();
+        }
+        if (server != null) {
+            server.stop().join();
+        }
+    }
+
+    public XdsBootstrap bootstrap() {
+        return xdsBootstrap;
+    }
+
+    public SimpleCache<String> cache() {
+        return cache;
+    }
+
+    public int httpPort() {
+        return server.activePort(SessionProtocol.HTTP).localAddress().getPort();
+    }
+
+    public String set(Listener... listeners) {
+        this.listeners = ImmutableList.copyOf(listeners);
+        return pushSnapshot();
+    }
+
+    public String set(Cluster... clusters) {
+        this.clusters = ImmutableList.copyOf(clusters);
+        return pushSnapshot();
+    }
+
+    public String set(ClusterLoadAssignment... endpoints) {
+        this.endpoints = ImmutableList.copyOf(endpoints);
+        return pushSnapshot();
+    }
+
+    public String set(RouteConfiguration... routes) {
+        this.routes = ImmutableList.copyOf(routes);
+        return pushSnapshot();
+    }
+
+    public String set(Secret... secrets) {
+        this.secrets = ImmutableList.copyOf(secrets);
+        return pushSnapshot();
+    }
+
+    /**
+     * Waits until the internal {@link XdsBootstrap} has received the specified version
+     * for the given listener name.
+     */
+    public void awaitListener(String listenerName, String version) {
+        try (ListenerRoot root = xdsBootstrap.listenerRoot(listenerName)) {
+            final AtomicReference<ListenerSnapshot> ref = new AtomicReference<>();
+            root.addSnapshotWatcher((snapshot, error) -> {
+                if (snapshot != null) {
+                    ref.set(snapshot);
+                }
+            });
+            await().untilAsserted(() -> {
+                final ListenerSnapshot snapshot = ref.get();
+                assertThat(snapshot).isNotNull();
+                assertThat(snapshot.xdsResource().version()).isEqualTo(version);
+            });
+        }
+    }
+
+    private String pushSnapshot() {
+        final String ver = String.valueOf(version.incrementAndGet());
+        cache.setSnapshot(GROUP, Snapshot.create(clusters, endpoints, listeners,
+                                                 routes, secrets, ver));
+        return ver;
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
@@ -155,7 +155,7 @@ class ServerDecoratorTest {
         final Path certPath = cert2.certificateFile().toPath();
         final Path keyPath = cert2.privateKeyFile().toPath();
 
-        // Route only matches "/other" — request to "/hello" should get 503.
+        // Route only matches "/other" — request to "/hello" should get 404.
         //language=YAML
         final String yaml =
                 """
@@ -200,7 +200,7 @@ class ServerDecoratorTest {
         final AggregatedHttpResponse res = client.execute(
                 HttpRequest.of(HttpMethod.GET, "/hello"),
                 RequestOptions.builder().clientTlsSpec(tlsSpec).build());
-        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.StringValue;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.filter.FactoryContext;
+import com.linecorp.armeria.xds.filter.HttpFilterFactory;
+import com.linecorp.armeria.xds.filter.XdsHttpFilter;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
+
+class ServerDecoratorTest {
+
+    private static final String LISTENER_NAME = "decorator-listener";
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension cert1 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsCertificateExtension cert2 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(2)
+    static final XdsCertificateExtension cert3 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(3)
+    static final XdsCertificateExtension cert4 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(4)
+    static final XdsControlPlaneExtension controlPlane =
+            new XdsControlPlaneExtension(b -> b.extensionFactories(new TestHeaderFilter()));
+
+    @RegisterExtension
+    @Order(5)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            controlPlane.set(Listener.newBuilder().setName(LISTENER_NAME).build());
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME));
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+            sb.service("/route-a", (ctx, req) -> HttpResponse.of("route-a"));
+            sb.service("/route-b", (ctx, req) -> HttpResponse.of("route-b"));
+        }
+    };
+
+    @Test
+    void xdsDecoratorAddsResponseHeader() {
+        final Path certPath = cert1.certificateFile().toPath();
+        final Path keyPath = cert1.privateKeyFile().toPath();
+
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: test.header_filter
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(LISTENER_NAME, certPath, keyPath);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(cert1.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+        assertThat(res.headers().get("x-xds-decorator")).isEqualTo("applied");
+    }
+
+    @Test
+    void noMatchingRoute() {
+        final Path certPath = cert2.certificateFile().toPath();
+        final Path keyPath = cert2.privateKeyFile().toPath();
+
+        // Route only matches "/other" — request to "/hello" should get 503.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/other"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(LISTENER_NAME, certPath, keyPath);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(cert2.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void noRouterFilter() {
+        final Path certPath = cert3.certificateFile().toPath();
+        final Path keyPath = cert3.privateKeyFile().toPath();
+
+        // HCM with routes but no envoy.filters.http.router → 503.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: test.header_filter
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(LISTENER_NAME, certPath, keyPath);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(cert3.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void perRouteFilterConfig() {
+        final Path certPath = cert4.certificateFile().toPath();
+        final Path keyPath = cert4.privateKeyFile().toPath();
+
+        // Two routes with different typed_per_filter_config for test.header_filter.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/route-a"
+                                  non_forwarding_action: {}
+                                  typed_per_filter_config:
+                                    test.header_filter:
+                                      "@type": type.googleapis.com/google.protobuf.StringValue
+                                      value: "from-route-a"
+                                - match:
+                                    prefix: "/route-b"
+                                  non_forwarding_action: {}
+                                  typed_per_filter_config:
+                                    test.header_filter:
+                                      "@type": type.googleapis.com/google.protobuf.StringValue
+                                      value: "from-route-b"
+                        http_filters:
+                          - name: test.header_filter
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(LISTENER_NAME, certPath, keyPath);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(cert4.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+
+        // Route A should have header value "from-route-a".
+        final AggregatedHttpResponse resA = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/route-a"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(resA.status()).isEqualTo(HttpStatus.OK);
+        assertThat(resA.contentUtf8()).isEqualTo("route-a");
+        assertThat(resA.headers().get("x-xds-decorator")).isEqualTo("from-route-a");
+
+        // Route B should have header value "from-route-b".
+        final AggregatedHttpResponse resB = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/route-b"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(resB.status()).isEqualTo(HttpStatus.OK);
+        assertThat(resB.contentUtf8()).isEqualTo("route-b");
+        assertThat(resB.headers().get("x-xds-decorator")).isEqualTo("from-route-b");
+    }
+
+    private static final class TestHeaderFilter implements HttpFilterFactory {
+
+        @Override
+        public String name() {
+            return "test.header_filter";
+        }
+
+        @Override
+        public XdsHttpFilter create(HttpFilter httpFilter, Any config, FactoryContext context) {
+            final String headerValue;
+            if (config.getTypeUrl().contains("google.protobuf.StringValue")) {
+                headerValue = context.validator().unpack(config, StringValue.class).getValue();
+            } else {
+                headerValue = "applied";
+            }
+            return new XdsHttpFilter() {
+                @Override
+                public DecoratingHttpServiceFunction serviceDecorator() {
+                    return (delegate, ctx, req) ->
+                            delegate.serve(ctx, req)
+                                    .mapHeaders(headers -> headers.toBuilder()
+                                                                  .add(HttpHeaderNames.of("x-xds-decorator"),
+                                                                       headerValue)
+                                                                  .build());
+                }
+            };
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
@@ -61,6 +61,8 @@ class ServerFallbackTest {
     private static final String LISTENER_NAME = "fallback-listener";
     private static final ServerPort xdsPort =
             new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
+    private static final ServerPort unmanagedPort =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
 
     private static final AtomicInteger acceptorCallCount = new AtomicInteger();
 
@@ -134,8 +136,8 @@ class ServerFallbackTest {
                                                            .build();
             sb.tlsProvider(ServerTlsProvider.of(ctx -> userTlsSpec));
 
-            // Add an explicit unmanaged HTTPS port (not controlled by xDS).
-            sb.https(0);
+            // Explicit unmanaged HTTPS port (not controlled by xDS).
+            sb.port(unmanagedPort);
 
             sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
                                      .port(xdsPort)
@@ -161,52 +163,32 @@ class ServerFallbackTest {
     }
 
     @Test
-    void connectionAcceptorCalledOnUnmanagedPort() {
+    void tlsProviderFallbackOnUnmanagedPort() {
+        // The unmanaged HTTPS port should use the user-configured TLS provider (userCert),
+        // not the xDS certificate. Also verify the user-configured ConnectionAcceptor is called.
         acceptorCallCount.set(0);
-        final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri()).blocking().get("/hello");
+        final ClientTlsSpec userTlsSpec = ClientTlsSpec.builder()
+                                                       .trustedCertificates(userCert.certificate())
+                                                       .build();
+        final BlockingWebClient client =
+                WebClient.of("https://127.0.0.1:" + unmanagedPort.actualPort()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(userTlsSpec).build());
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("hello");
         assertThat(acceptorCallCount.get()).isGreaterThanOrEqualTo(1);
     }
 
     @Test
-    void tlsProviderFallbackOnUnmanagedPort() {
-        // The unmanaged HTTPS port should use the user-configured TLS provider (userCert),
-        // not the xDS certificate.
-        final int unmanagedHttpsPort = server.server().activePorts().values().stream()
-                                             .filter(ServerPort::hasHttps)
-                                             .map(p -> p.localAddress().getPort())
-                                             .filter(p -> p != xdsPort.actualPort())
-                                             .findFirst()
-                                             .orElseThrow();
-        final ClientTlsSpec userTlsSpec = ClientTlsSpec.builder()
-                                                       .trustedCertificates(userCert.certificate())
-                                                       .build();
-        final BlockingWebClient client =
-                WebClient.of("https://127.0.0.1:" + unmanagedHttpsPort).blocking();
-        final AggregatedHttpResponse res = client.execute(
-                HttpRequest.of(HttpMethod.GET, "/hello"),
-                RequestOptions.builder().clientTlsSpec(userTlsSpec).build());
-        assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThat(res.contentUtf8()).isEqualTo("hello");
-    }
-
-    @Test
     void xdsCertNotTrustedOnUnmanagedPort() {
         // The xDS certificate should NOT work on the unmanaged port — that port uses
         // userCert, so trusting xdsCert should fail the TLS handshake.
-        final int unmanagedHttpsPort = server.server().activePorts().values().stream()
-                                             .filter(ServerPort::hasHttps)
-                                             .map(p -> p.localAddress().getPort())
-                                             .filter(p -> p != xdsPort.actualPort())
-                                             .findFirst()
-                                             .orElseThrow();
         final ClientTlsSpec xdsTlsSpec = ClientTlsSpec.builder()
                                                       .trustedCertificates(xdsCert.certificate())
                                                       .build();
         final BlockingWebClient client =
-                WebClient.of("https://127.0.0.1:" + unmanagedHttpsPort).blocking();
+                WebClient.of("https://127.0.0.1:" + unmanagedPort.actualPort()).blocking();
         assertThatThrownBy(() -> client.execute(
                 HttpRequest.of(HttpMethod.GET, "/hello"),
                 RequestOptions.builder().clientTlsSpec(xdsTlsSpec).build()))

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ConnectionAcceptor;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.ServerTlsProvider;
+import com.linecorp.armeria.server.ServerTlsSpec;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+/**
+ * Verifies that {@link XdsServerPlugin} correctly composes with user-configured
+ * {@link ConnectionAcceptor} and {@link ServerTlsProvider} on both xDS-managed
+ * and unmanaged ports.
+ */
+class ServerFallbackTest {
+
+    private static final String LISTENER_NAME = "fallback-listener";
+    private static final ServerPort xdsPort =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
+
+    private static final AtomicInteger acceptorCallCount = new AtomicInteger();
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension xdsCert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final SelfSignedCertificateExtension userCert =
+            new SelfSignedCertificateExtension("127.0.0.1");
+
+    @RegisterExtension
+    @Order(2)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(3)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final Path certPath = xdsCert.certificateFile().toPath();
+            final Path keyPath = xdsCert.privateKeyFile().toPath();
+
+            //language=YAML
+            final String yaml =
+                    """
+                    name: %s
+                    default_filter_chain:
+                      filters:
+                        - name: envoy.filters.network.http_connection_manager
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters\
+                    .network.http_connection_manager.v3.HttpConnectionManager
+                            stat_prefix: ingress_http
+                            route_config:
+                              name: local_route
+                              virtual_hosts:
+                                - name: local_service
+                                  domains: ["*"]
+                                  routes:
+                                    - match:
+                                        prefix: "/"
+                                      non_forwarding_action: {}
+                            http_filters:
+                              - name: envoy.filters.http.router
+                      transport_socket:
+                        name: envoy.transport_sockets.downstream_tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                    .tls.v3.DownstreamTlsContext
+                          common_tls_context:
+                            tls_certificates:
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
+                    """.formatted(LISTENER_NAME, certPath, keyPath);
+            controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+
+            // User-configured ConnectionAcceptor — should be called on all ports.
+            sb.connectionAcceptor(ConnectionAcceptor.of(ctx -> {
+                acceptorCallCount.incrementAndGet();
+                return true;
+            }));
+
+            // User-configured ServerTlsProvider for the unmanaged HTTPS port.
+            final ServerTlsSpec userTlsSpec = ServerTlsSpec.builder()
+                                                           .tlsKeyPair(userCert.tlsKeyPair())
+                                                           .build();
+            sb.tlsProvider(ServerTlsProvider.of(ctx -> userTlsSpec));
+
+            // Add an explicit unmanaged HTTPS port (not controlled by xDS).
+            sb.https(0);
+
+            sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
+                                     .port(xdsPort)
+                                     .build());
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    @Test
+    void connectionAcceptorCalledOnManagedPort() {
+        acceptorCallCount.set(0);
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(xdsCert.certificate())
+                                                   .build();
+        final BlockingWebClient client =
+                WebClient.of("https://127.0.0.1:" + xdsPort.actualPort()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+        assertThat(acceptorCallCount.get()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void connectionAcceptorCalledOnUnmanagedPort() {
+        acceptorCallCount.set(0);
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri()).blocking().get("/hello");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+        assertThat(acceptorCallCount.get()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void tlsProviderFallbackOnUnmanagedPort() {
+        // The unmanaged HTTPS port should use the user-configured TLS provider (userCert),
+        // not the xDS certificate.
+        final int unmanagedHttpsPort = server.server().activePorts().values().stream()
+                                             .filter(ServerPort::hasHttps)
+                                             .map(p -> p.localAddress().getPort())
+                                             .filter(p -> p != xdsPort.actualPort())
+                                             .findFirst()
+                                             .orElseThrow();
+        final ClientTlsSpec userTlsSpec = ClientTlsSpec.builder()
+                                                       .trustedCertificates(userCert.certificate())
+                                                       .build();
+        final BlockingWebClient client =
+                WebClient.of("https://127.0.0.1:" + unmanagedHttpsPort).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(userTlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void xdsCertNotTrustedOnUnmanagedPort() {
+        // The xDS certificate should NOT work on the unmanaged port — that port uses
+        // userCert, so trusting xdsCert should fail the TLS handshake.
+        final int unmanagedHttpsPort = server.server().activePorts().values().stream()
+                                             .filter(ServerPort::hasHttps)
+                                             .map(p -> p.localAddress().getPort())
+                                             .filter(p -> p != xdsPort.actualPort())
+                                             .findFirst()
+                                             .orElseThrow();
+        final ClientTlsSpec xdsTlsSpec = ClientTlsSpec.builder()
+                                                      .trustedCertificates(xdsCert.certificate())
+                                                      .build();
+        final BlockingWebClient client =
+                WebClient.of("https://127.0.0.1:" + unmanagedHttpsPort).blocking();
+        assertThatThrownBy(() -> client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(xdsTlsSpec).build()))
+                .hasCauseInstanceOf(SSLHandshakeException.class);
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiPortTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiPortTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class ServerMultiPortTest {
+
+    private static final String LISTENER_NAME = "multi-port-listener";
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension cert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(2)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final Path certPath = cert.certificateFile().toPath();
+            final Path keyPath = cert.privateKeyFile().toPath();
+
+            //language=YAML
+            final String yaml =
+                    """
+                    name: %s
+                    default_filter_chain:
+                      filters:
+                        - name: envoy.filters.network.http_connection_manager
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters\
+                    .network.http_connection_manager.v3.HttpConnectionManager
+                            stat_prefix: ingress_http
+                            route_config:
+                              name: local_route
+                              virtual_hosts:
+                                - name: local_service
+                                  domains: ["*"]
+                                  routes:
+                                    - match:
+                                        prefix: "/"
+                                      non_forwarding_action: {}
+                            http_filters:
+                              - name: envoy.filters.http.router
+                      transport_socket:
+                        name: envoy.transport_sockets.downstream_tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                    .tls.v3.DownstreamTlsContext
+                          common_tls_context:
+                            tls_certificates:
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
+                    """.formatted(LISTENER_NAME, certPath, keyPath);
+            controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME, 0, 0));
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    @Test
+    void multiplePortsSinglePlugin() {
+        final List<Integer> httpsPorts = server.server().activePorts().values().stream()
+                                              .filter(ServerPort::hasHttps)
+                                              .map(p -> p.localAddress().getPort())
+                                              .collect(Collectors.toList());
+        assertThat(httpsPorts).hasSize(2);
+
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(cert.certificate())
+                                                   .build();
+        for (int port : httpsPorts) {
+            final BlockingWebClient client =
+                    WebClient.of("https://127.0.0.1:" + port).blocking();
+            final AggregatedHttpResponse res = client.execute(
+                    HttpRequest.of(HttpMethod.GET, "/hello"),
+                    RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(res.contentUtf8()).isEqualTo("hello");
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
 import java.security.SignatureException;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -38,6 +36,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
@@ -50,6 +49,11 @@ import com.linecorp.armeria.xds.server.XdsServerPlugin;
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 
 class ServerMultiplePluginTest {
+
+    private static final ServerPort port1 =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
+    private static final ServerPort port2 =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
 
     @RegisterExtension
     @Order(0)
@@ -72,8 +76,12 @@ class ServerMultiplePluginTest {
         protected void configure(ServerBuilder sb) {
             controlPlane.set(buildListener("listener-1", cert1),
                              buildListener("listener-2", cert2));
-            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), "listener-1"));
-            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), "listener-2"));
+            sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), "listener-1")
+                                     .port(port1)
+                                     .build());
+            sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), "listener-2")
+                                     .port(port2)
+                                     .build());
             sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
         }
     };
@@ -122,11 +130,6 @@ class ServerMultiplePluginTest {
 
     @Test
     void multiplePluginsOnDifferentPorts() {
-        final List<Integer> httpsPorts = server.server().activePorts().values().stream()
-                                              .filter(ServerPort::hasHttps)
-                                              .map(p -> p.localAddress().getPort())
-                                              .collect(Collectors.toList());
-        assertThat(httpsPorts).hasSize(2);
         final ClientTlsSpec tlsSpec1 = ClientTlsSpec.builder()
                                                     .trustedCertificates(cert1.certificate())
                                                     .build();
@@ -134,8 +137,9 @@ class ServerMultiplePluginTest {
                                                     .trustedCertificates(cert2.certificate())
                                                     .build();
 
-        // Port 0 = listener-1 = cert1
-        final BlockingWebClient client1 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(0)).blocking();
+        // port1 = listener-1 = cert1
+        final BlockingWebClient client1 =
+                WebClient.of("https://127.0.0.1:" + port1.actualPort()).blocking();
         final AggregatedHttpResponse res1 = client1.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
                                                             RequestOptions.builder()
                                                                           .clientTlsSpec(tlsSpec1)
@@ -143,8 +147,9 @@ class ServerMultiplePluginTest {
         assertThat(res1.status()).isEqualTo(HttpStatus.OK);
         assertThat(res1.contentUtf8()).isEqualTo("hello");
 
-        // Port 1 = listener-2 = cert2
-        final BlockingWebClient client2 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(1)).blocking();
+        // port2 = listener-2 = cert2
+        final BlockingWebClient client2 =
+                WebClient.of("https://127.0.0.1:" + port2.actualPort()).blocking();
         final AggregatedHttpResponse res2 = client2.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
                                                             RequestOptions.builder()
                                                                           .clientTlsSpec(tlsSpec2)
@@ -152,8 +157,9 @@ class ServerMultiplePluginTest {
         assertThat(res2.status()).isEqualTo(HttpStatus.OK);
         assertThat(res2.contentUtf8()).isEqualTo("hello");
 
-        // Wrong cert for port 0 should fail.
-        final BlockingWebClient client3 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(0)).blocking();
+        // Wrong cert for port1 should fail.
+        final BlockingWebClient client3 =
+                WebClient.of("https://127.0.0.1:" + port1.actualPort()).blocking();
         assertThatThrownBy(() -> client3.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
                                                  RequestOptions.builder()
                                                                .clientTlsSpec(tlsSpec2)

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.security.SignatureException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class ServerMultiplePluginTest {
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension cert1 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsCertificateExtension cert2 =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(2)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(3)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            controlPlane.set(buildListener("listener-1", cert1),
+                             buildListener("listener-2", cert2));
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), "listener-1"));
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), "listener-2"));
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    private static Listener buildListener(String listenerName, XdsCertificateExtension cert) {
+        final Path certPath = cert.certificateFile().toPath();
+        final Path keyPath = cert.privateKeyFile().toPath();
+
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(listenerName, certPath, keyPath);
+
+        return XdsResourceReader.fromYaml(yaml, Listener.class);
+    }
+
+    @Test
+    void multiplePluginsOnDifferentPorts() {
+        final List<Integer> httpsPorts = server.server().activePorts().values().stream()
+                                              .filter(ServerPort::hasHttps)
+                                              .map(p -> p.localAddress().getPort())
+                                              .collect(Collectors.toList());
+        assertThat(httpsPorts).hasSize(2);
+        final ClientTlsSpec tlsSpec1 = ClientTlsSpec.builder()
+                                                    .trustedCertificates(cert1.certificate())
+                                                    .build();
+        final ClientTlsSpec tlsSpec2 = ClientTlsSpec.builder()
+                                                    .trustedCertificates(cert2.certificate())
+                                                    .build();
+
+        // Port 0 = listener-1 = cert1
+        final BlockingWebClient client1 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(0)).blocking();
+        final AggregatedHttpResponse res1 = client1.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
+                                                            RequestOptions.builder()
+                                                                          .clientTlsSpec(tlsSpec1)
+                                                                          .build());
+        assertThat(res1.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res1.contentUtf8()).isEqualTo("hello");
+
+        // Port 1 = listener-2 = cert2
+        final BlockingWebClient client2 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(1)).blocking();
+        final AggregatedHttpResponse res2 = client2.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
+                                                            RequestOptions.builder()
+                                                                          .clientTlsSpec(tlsSpec2)
+                                                                          .build());
+        assertThat(res2.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res2.contentUtf8()).isEqualTo("hello");
+
+        // Wrong cert for port 0 should fail.
+        final BlockingWebClient client3 = WebClient.of("https://127.0.0.1:" + httpsPorts.get(0)).blocking();
+        assertThatThrownBy(() -> client3.execute(HttpRequest.of(HttpMethod.GET, "/hello"),
+                                                 RequestOptions.builder()
+                                                               .clientTlsSpec(tlsSpec2)
+                                                               .build()))
+                .isInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseInstanceOf(SignatureException.class);
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class ServerXdsTest {
+
+    private static final String LISTENER_NAME = "server-listener";
+    private static final ServerPort xdsPort =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension xdsCert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(2)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final Path certPath = xdsCert.certificateFile().toPath();
+            final Path keyPath = xdsCert.privateKeyFile().toPath();
+
+            //language=YAML
+            final String yaml =
+                    """
+                    name: %s
+                    default_filter_chain:
+                      filters:
+                        - name: envoy.filters.network.http_connection_manager
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters\
+                    .network.http_connection_manager.v3.HttpConnectionManager
+                            stat_prefix: ingress_http
+                            route_config:
+                              name: local_route
+                              virtual_hosts:
+                                - name: local_service
+                                  domains: ["*"]
+                                  routes:
+                                    - match:
+                                        prefix: "/"
+                                      non_forwarding_action: {}
+                            http_filters:
+                              - name: envoy.filters.http.router
+                      transport_socket:
+                        name: envoy.transport_sockets.downstream_tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                    .tls.v3.DownstreamTlsContext
+                          common_tls_context:
+                            tls_certificates:
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
+                    """.formatted(LISTENER_NAME, certPath, keyPath);
+            controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+            sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
+                                     .port(xdsPort)
+                                     .build());
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello from xds"));
+        }
+    };
+
+    @Test
+    void mutualTlsTest() {
+        final Path certPath = xdsCert.certificateFile().toPath();
+
+        //language=YAML
+        final String clientBootstrapYaml =
+                """
+                static_resources:
+                  listeners:
+                    - name: client-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    route:
+                                      cluster: server-cluster
+                          http_filters:
+                            - name: envoy.filters.http.router
+                              typed_config:
+                                "@type": type.googleapis.com/envoy.extensions\
+                .filters.http.router.v3.Router
+                  clusters:
+                    - name: server-cluster
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: server-cluster
+                        endpoints:
+                          - lb_endpoints:
+                              - endpoint:
+                                  address:
+                                    socket_address:
+                                      address: 127.0.0.1
+                                      port_value: %d
+                      transport_socket:
+                        name: envoy.transport_sockets.tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.UpstreamTlsContext
+                          common_tls_context:
+                            validation_context:
+                              trusted_ca:
+                                filename: "%s"
+                """.formatted(xdsPort.actualPort(), certPath);
+
+        final Bootstrap clientBootstrap =
+                XdsResourceReader.fromYaml(clientBootstrapYaml, Bootstrap.class);
+        try (XdsBootstrap clientXdsBootstrap = XdsBootstrap.of(clientBootstrap);
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("client-listener",
+                                                                               clientXdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            assertThat(client.get("/hello").contentUtf8()).isEqualTo("hello from xds");
+        }
+    }
+
+    @Test
+    void unmanagedPortNotAffected() {
+        // ServerExtension's own HTTP port is not managed by XdsServerPlugin.
+        // Requests on this port should bypass xDS entirely and serve directly.
+        final AggregatedHttpResponse res =
+                WebClient.of(server.httpUri()).blocking().get("/hello");
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello from xds");
+    }
+
+    @Test
+    void managedPort() {
+        // The xDS-managed port goes through xDS and requires TLS.
+        final int port = xdsPort.actualPort();
+        assertThat(port).isGreaterThan(0);
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(xdsCert.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of("https://127.0.0.1:" + port).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello from xds");
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
@@ -56,20 +56,26 @@ class ServerXdsTest {
 
     @RegisterExtension
     @Order(0)
-    static final XdsCertificateExtension xdsCert =
+    static final XdsCertificateExtension serverCert =
             new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
 
     @RegisterExtension
     @Order(1)
-    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+    static final XdsCertificateExtension clientCert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
 
     @RegisterExtension
     @Order(2)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(3)
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
-            final Path certPath = xdsCert.certificateFile().toPath();
-            final Path keyPath = xdsCert.privateKeyFile().toPath();
+            final Path serverCertPath = serverCert.certificateFile().toPath();
+            final Path serverKeyPath = serverCert.privateKeyFile().toPath();
+            final Path clientCaCertPath = clientCert.certificateFile().toPath();
 
             //language=YAML
             final String yaml =
@@ -98,13 +104,17 @@ class ServerXdsTest {
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.transport_sockets\
                     .tls.v3.DownstreamTlsContext
+                          require_client_certificate: true
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
                                   filename: "%s"
                                 private_key:
                                   filename: "%s"
-                    """.formatted(LISTENER_NAME, certPath, keyPath);
+                            validation_context:
+                              trusted_ca:
+                                filename: "%s"
+                    """.formatted(LISTENER_NAME, serverCertPath, serverKeyPath, clientCaCertPath);
             controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
             sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
                                      .port(xdsPort)
@@ -115,7 +125,11 @@ class ServerXdsTest {
 
     @Test
     void mutualTlsTest() {
-        final Path certPath = xdsCert.certificateFile().toPath();
+        // Client presents clientCert, trusts serverCert.
+        // Server presents serverCert, trusts clientCert.
+        final Path clientCertPath = clientCert.certificateFile().toPath();
+        final Path clientKeyPath = clientCert.privateKeyFile().toPath();
+        final Path serverCaCertPath = serverCert.certificateFile().toPath();
 
         //language=YAML
         final String clientBootstrapYaml =
@@ -161,10 +175,15 @@ class ServerXdsTest {
                           "@type": type.googleapis.com/envoy.extensions.transport_sockets\
                 .tls.v3.UpstreamTlsContext
                           common_tls_context:
+                            tls_certificates:
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
                             validation_context:
                               trusted_ca:
                                 filename: "%s"
-                """.formatted(xdsPort.actualPort(), certPath);
+                """.formatted(xdsPort.actualPort(), clientCertPath, clientKeyPath, serverCaCertPath);
 
         final Bootstrap clientBootstrap =
                 XdsResourceReader.fromYaml(clientBootstrapYaml, Bootstrap.class);
@@ -188,11 +207,12 @@ class ServerXdsTest {
 
     @Test
     void managedPort() {
-        // The xDS-managed port goes through xDS and requires TLS.
+        // The xDS-managed port goes through xDS and requires mTLS.
         final int port = xdsPort.actualPort();
         assertThat(port).isGreaterThan(0);
         final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
-                                                   .trustedCertificates(xdsCert.certificate())
+                                                   .trustedCertificates(serverCert.certificate())
+                                                   .tlsKeyPair(clientCert.tlsKeyPair())
                                                    .build();
         final BlockingWebClient client = WebClient.of("https://127.0.0.1:" + port).blocking();
         final AggregatedHttpResponse res = client.execute(

--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -325,6 +325,7 @@ message Route {
     // without forwarding to an upstream host. This will be used in non-proxy
     // xDS clients like the gRPC server. It could also be used in the future
     // in Envoy for a filter that directly generates responses for requests.
+    option (armeria.xds.supported.oneof_field) = 18;
     NonForwardingAction non_forwarding_action = 18;
   }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/DownstreamTlsTransportSocketFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/DownstreamTlsTransportSocketFactory.java
@@ -73,4 +73,12 @@ final class DownstreamTlsTransportSocketFactory implements TransportSocketFactor
             return new TransportSocketSnapshot(transportSocket, tlsContext, certs, validation);
         });
     }
+
+    /**
+     * Returns {@code true} if the {@link DownstreamTlsContext} requires client certificates.
+     */
+    static boolean requireClientCertificate(DownstreamTlsContext tlsContext) {
+        return tlsContext.hasRequireClientCertificate() &&
+               tlsContext.getRequireClientCertificate().getValue();
+    }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +29,9 @@ import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientDecorationBuilder;
 import com.linecorp.armeria.client.ClientPreprocessors;
 import com.linecorp.armeria.client.ClientPreprocessorsBuilder;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.server.HttpService;
@@ -125,11 +127,16 @@ final class FilterUtil {
                                .build();
     }
 
-    static SnapshotStream<Optional<HttpService>> buildDownstreamServerFilter(
+    private static final HttpService NO_ROUTER_SERVICE =
+            (ctx, req) -> HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8,
+                                          "envoy.filters.http.router filter is required " +
+                                          "for server-side xDS");
+
+    static SnapshotStream<HttpService> buildDownstreamServerFilter(
             XdsExtensionRegistry extensionRegistry, FactoryContext factoryContext,
             List<HttpFilter> httpFilters, Map<String, Any> filterConfigs) {
         if (httpFilters.isEmpty()) {
-            return SnapshotStream.empty();
+            return SnapshotStream.just(NO_ROUTER_SERVICE);
         }
         final ImmutableList.Builder<SnapshotStream<XdsHttpFilter>> streams = ImmutableList.builder();
         for (int i = httpFilters.size() - 1; i >= 0; i--) {
@@ -143,17 +150,17 @@ final class FilterUtil {
         }
         final ImmutableList<SnapshotStream<XdsHttpFilter>> streamList = streams.build();
         if (streamList.isEmpty()) {
-            return SnapshotStream.empty();
+            return SnapshotStream.just(NO_ROUTER_SERVICE);
         }
         return SnapshotStream.combineNLatest(streamList).map(filters -> {
-            HttpService service = DelegatingHttpService.of();
+            HttpService service = NO_ROUTER_SERVICE;
             for (XdsHttpFilter f : filters) {
                 final DecoratingHttpServiceFunction decorator = f.serviceDecorator();
                 if (decorator != null) {
                     service = service.decorate(decorator);
                 }
             }
-            return Optional.of(service);
+            return service;
         });
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/HcmContext.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/HcmContext.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientPreprocessors;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.xds.client.endpoint.RouterFilterFactory;
+import com.linecorp.armeria.xds.stream.SnapshotStream;
+
+import io.envoyproxy.envoy.config.listener.v3.Filter;
+import io.envoyproxy.envoy.config.listener.v3.FilterChain;
+import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
+
+/**
+ * Holds the parsed {@link HttpConnectionManager} and the associated filter caching streams.
+ * Created once per filter chain in {@link ListenerFilterChainFactory} and shared with
+ * {@link RouteStream} so that HCM-level and per-route server filter subscriptions use the
+ * same underlying cache.
+ */
+final class HcmContext {
+
+    private final HttpConnectionManager hcm;
+    private final Function<Map<String, Any>, SnapshotStream<ClientPreprocessors>> downstream;
+    private final Function<Map<String, Any>, SnapshotStream<ClientDecoration>> upstream;
+    private final Function<Map<String, Any>, SnapshotStream<HttpService>> server;
+
+    @Nullable
+    static HcmContext from(FilterChain filterChain, XdsExtensionRegistry registry,
+                           SubscriptionContext context) {
+        final List<Filter> filters = filterChain.getFiltersList();
+        if (filters.isEmpty()) {
+            return null;
+        }
+        final Filter last = filters.get(filters.size() - 1);
+        final HttpConnectionManager hcm = HttpConnectionManagerFactory.extractHcm(last, registry);
+        if (hcm == null) {
+            return null;
+        }
+        return new HcmContext(hcm, registry, context);
+    }
+
+    HcmContext(HttpConnectionManager hcm, XdsExtensionRegistry registry,
+               SubscriptionContext context) {
+        this.hcm = hcm;
+        final List<HttpFilter> hcmHttpFilters = hcm.getHttpFiltersList();
+        final Router router = findRouter(hcm, registry);
+        final List<HttpFilter> upstreamFilters =
+                router != null ? router.getUpstreamHttpFiltersList() : ImmutableList.of();
+
+        downstream = SnapshotStream.caching(
+                filterConfigs -> FilterUtil.buildDownstreamFilter(
+                        registry, context, hcmHttpFilters, filterConfigs));
+        upstream = SnapshotStream.caching(
+                filterConfigs -> FilterUtil.buildUpstreamFilter(
+                        registry, context, upstreamFilters, filterConfigs));
+        server = SnapshotStream.caching(
+                filterConfigs -> FilterUtil.buildDownstreamServerFilter(
+                        registry, context, hcmHttpFilters, filterConfigs));
+    }
+
+    HttpConnectionManager hcm() {
+        return hcm;
+    }
+
+    SnapshotStream<ClientPreprocessors> downstream(Map<String, Any> filterConfigs) {
+        return downstream.apply(filterConfigs);
+    }
+
+    SnapshotStream<ClientDecoration> upstream(Map<String, Any> filterConfigs) {
+        return upstream.apply(filterConfigs);
+    }
+
+    SnapshotStream<HttpService> server(Map<String, Any> filterConfigs) {
+        return server.apply(filterConfigs);
+    }
+
+    @Nullable
+    private static Router findRouter(HttpConnectionManager hcm, XdsExtensionRegistry registry) {
+        final List<HttpFilter> httpFilters = hcm.getHttpFiltersList();
+        if (httpFilters.isEmpty()) {
+            return null;
+        }
+        final HttpFilter last = httpFilters.get(httpFilters.size() - 1);
+        if (last.hasTypedConfig() &&
+            RouterFilterFactory.extensionTypeUrl().equals(last.getTypedConfig().getTypeUrl())) {
+            return registry.unpack(last.getTypedConfig(), Router.class);
+        }
+        if (RouterFilterFactory.extensionName().equals(last.getName())) {
+            return Router.getDefaultInstance();
+        }
+        return null;
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/ListenerFilterChainFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ListenerFilterChainFactory.java
@@ -18,14 +18,12 @@ package com.linecorp.armeria.xds;
 
 import static com.linecorp.armeria.xds.XdsType.LISTENER;
 
-import java.util.List;
 import java.util.Optional;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
 
 import io.envoyproxy.envoy.config.core.v3.ConfigSource;
-import io.envoyproxy.envoy.config.listener.v3.Filter;
 import io.envoyproxy.envoy.config.listener.v3.FilterChain;
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
@@ -46,11 +44,17 @@ final class ListenerFilterChainFactory {
 
     SnapshotStream<FilterChainSnapshot> resolve(FilterChain filterChain,
                                                 @Nullable ConfigSource parentConfigSource) {
-        final HttpConnectionManager hcm = extractHcm(filterChain);
         final SnapshotStream<TransportSocketSnapshot> tsStream =
                 new TransportSocketStream(context, parentConfigSource, filterChain.getTransportSocket());
 
-        final SnapshotStream<Optional<RouteSnapshot>> routeStream = resolveRoute(hcm, parentConfigSource);
+        final HcmContext hcmContext = HcmContext.from(filterChain, registry, context);
+        if (hcmContext == null) {
+            return tsStream.map(transportSocket ->
+                    new FilterChainSnapshot(filterChain.getFilterChainMatch(),
+                                            transportSocket, null));
+        }
+        final SnapshotStream<Optional<RouteSnapshot>> routeStream =
+                resolveRoute(hcmContext, parentConfigSource);
 
         return SnapshotStream.combineLatest(
                 tsStream, routeStream, (transportSocket, route) ->
@@ -66,17 +70,15 @@ final class ListenerFilterChainFactory {
         }
         final HttpConnectionManager hcm = registry.unpack(listener.getApiListener().getApiListener(),
                                                           HttpConnectionManager.class);
-        return resolveRoute(hcm, parentConfigSource);
+        return resolveRoute(new HcmContext(hcm, registry, context), parentConfigSource);
     }
 
     private SnapshotStream<Optional<RouteSnapshot>> resolveRoute(
-            @Nullable HttpConnectionManager hcm, @Nullable ConfigSource parentConfigSource) {
-        if (hcm == null) {
-            return SnapshotStream.empty();
-        }
+            HcmContext hcmContext, @Nullable ConfigSource parentConfigSource) {
+        final HttpConnectionManager hcm = hcmContext.hcm();
         if (hcm.hasRouteConfig()) {
             final RouteConfiguration routeConfig = hcm.getRouteConfig();
-            return new RouteStream(context, routeConfig, hcm).map(Optional::of);
+            return new RouteStream(context, routeConfig, hcmContext).map(Optional::of);
         }
         if (hcm.hasRds()) {
             final Rds rds = hcm.getRds();
@@ -87,18 +89,8 @@ final class ListenerFilterChainFactory {
                 return SnapshotStream.error(new XdsResourceException(LISTENER, listenerResource.name(),
                                                                      "config source not found"));
             }
-            return new RouteStream(configSource, routeName, context, hcm).map(Optional::of);
+            return new RouteStream(configSource, routeName, context, hcmContext).map(Optional::of);
         }
         return SnapshotStream.empty();
-    }
-
-    @Nullable
-    private HttpConnectionManager extractHcm(FilterChain filterChain) {
-        final List<Filter> filters = filterChain.getFiltersList();
-        if (filters.isEmpty()) {
-            return null;
-        }
-        final Filter last = filters.get(filters.size() - 1);
-        return HttpConnectionManagerFactory.extractHcm(last, registry);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ListenerSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ListenerSnapshot.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +26,7 @@ import com.google.common.base.Objects;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ConnectionContext;
 
 import io.envoyproxy.envoy.config.listener.v3.Listener;
 
@@ -98,6 +101,20 @@ public final class ListenerSnapshot implements Snapshot<ListenerXdsResource> {
      */
     @Nullable
     public FilterChainSnapshot defaultFilterChain() {
+        return defaultFilterChain;
+    }
+
+    /**
+     * Returns the first {@link FilterChainSnapshot} that matches the given connection context,
+     * or the default filter chain if no explicit chain matches.
+     */
+    @Nullable
+    public FilterChainSnapshot matchFilterChain(ConnectionContext ctx) {
+        requireNonNull(ctx, "ctx");
+        // Simple: use first filter chain or default. Full matching deferred to follow-up PR.
+        if (!filterChains.isEmpty()) {
+            return filterChains.get(0);
+        }
         return defaultFilterChain;
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
@@ -26,11 +26,11 @@ import com.google.protobuf.Any;
 
 import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientPreprocessors;
-import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpPreClient;
 import com.linecorp.armeria.client.RpcClient;
 import com.linecorp.armeria.client.RpcPreClient;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.HttpService;
@@ -54,7 +54,6 @@ public final class RouteEntry {
     private final int index;
     private final HttpClient httpClient;
     private final RpcClient rpcClient;
-    @Nullable
     private final HttpService httpService;
     private final HttpPreClient httpPreClient;
     private final RpcPreClient rpcPreClient;
@@ -64,7 +63,7 @@ public final class RouteEntry {
                Map<String, Any> filterConfigs,
                ClientPreprocessors downstreamPreprocessors,
                @Nullable ClientDecoration retryDecoration,
-               ClientDecoration upstreamDecoration, @Nullable HttpService httpService) {
+               ClientDecoration upstreamDecoration, HttpService httpService) {
         this.route = route;
         this.clusterSnapshot = clusterSnapshot;
         this.index = index;
@@ -114,10 +113,8 @@ public final class RouteEntry {
     }
 
     /**
-     * Returns the composed {@link HttpService} from the HTTP filters for this route,
-     * or {@code null} if no server-side HTTP filters are configured.
+     * Returns the composed {@link HttpService} from the HTTP filters for this route.
      */
-    @Nullable
     @UnstableApi
     public HttpService httpService() {
         return httpService;
@@ -158,9 +155,9 @@ public final class RouteEntry {
     }
 
     /**
-     * Returns whether this route matches the specified {@link ClientRequestContext}.
+     * Returns whether this route matches the specified {@link RequestContext}.
      */
-    public boolean matches(ClientRequestContext ctx) {
+    public boolean matches(RequestContext ctx) {
         requireNonNull(ctx, "ctx");
         return matcher.matches(ctx);
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntryMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntryMatcher.java
@@ -23,11 +23,11 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
@@ -55,7 +55,7 @@ final class RouteEntryMatcher {
         pathMatcher = new PathMatcherImpl(routeMatch);
     }
 
-    boolean matches(ClientRequestContext ctx) {
+    boolean matches(RequestContext ctx) {
         final HttpRequest req = ctx.request();
         if (routeMatch.hasGrpc()) {
             if (!XdsCommonUtil.isGrpcRequest(req)) {
@@ -116,7 +116,7 @@ final class RouteEntryMatcher {
             }
         }
 
-        static QueryParams fromContext(ClientRequestContext ctx) {
+        static QueryParams fromContext(RequestContext ctx) {
             final String query = ctx.query();
             final QueryParams queryParams;
             if (query == null) {
@@ -220,7 +220,7 @@ final class RouteEntryMatcher {
     @VisibleForTesting
     static class PathMatcherImpl {
 
-        private final Predicate<ClientRequestContext> predicate;
+        private final Predicate<RequestContext> predicate;
 
         PathMatcherImpl(RouteMatch routeMatch) {
             final PathSpecifierCase pathSpecifierCase = routeMatch.getPathSpecifierCase();
@@ -282,7 +282,7 @@ final class RouteEntryMatcher {
             }
         }
 
-        boolean match(ClientRequestContext ctx) {
+        boolean match(RequestContext ctx) {
             return predicate.test(ctx);
         }
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteSnapshot.java
@@ -16,12 +16,18 @@
 
 package com.linecorp.armeria.xds;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
@@ -34,10 +40,13 @@ public final class RouteSnapshot implements Snapshot<RouteXdsResource> {
 
     private final RouteXdsResource routeXdsResource;
     private final List<VirtualHostSnapshot> virtualHostSnapshots;
+    private final VirtualHostMatcher virtualHostMatcher;
 
     RouteSnapshot(RouteXdsResource routeXdsResource, List<VirtualHostSnapshot> virtualHostSnapshots) {
         this.routeXdsResource = routeXdsResource;
         this.virtualHostSnapshots = ImmutableList.copyOf(virtualHostSnapshots);
+        virtualHostMatcher = new VirtualHostMatcher(
+                virtualHostSnapshots, routeXdsResource.resource().getIgnorePortInHostMatching());
     }
 
     @Override
@@ -50,6 +59,34 @@ public final class RouteSnapshot implements Snapshot<RouteXdsResource> {
      */
     public List<VirtualHostSnapshot> virtualHostSnapshots() {
         return virtualHostSnapshots;
+    }
+
+    /**
+     * Selects the first matching {@link RouteEntry} for the given {@link RequestContext}
+     * by matching virtual host by authority, then route by path/headers/query.
+     *
+     * @return the matched {@link RouteEntry}, or {@code null} if no route matches
+     */
+    @Nullable
+    public RouteEntry select(RequestContext ctx) {
+        requireNonNull(ctx, "ctx");
+        final String authority;
+        if (ctx instanceof ClientRequestContext) {
+            authority = ((ClientRequestContext) ctx).authority();
+        } else {
+            final HttpRequest request = ctx.request();
+            authority = request != null ? request.authority() : null;
+        }
+        final VirtualHostSnapshot vh = virtualHostMatcher.find(authority);
+        if (vh == null) {
+            return null;
+        }
+        for (RouteEntry entry : vh.routeEntries()) {
+            if (entry.matches(ctx)) {
+                return entry;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
@@ -18,10 +18,7 @@ package com.linecorp.armeria.xds;
 
 import static com.linecorp.armeria.xds.XdsType.ROUTE;
 
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
@@ -30,7 +27,6 @@ import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientPreprocessors;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.xds.client.endpoint.RouterFilterFactory;
 import com.linecorp.armeria.xds.stream.RefCountedStream;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
 import com.linecorp.armeria.xds.stream.Subscription;
@@ -40,9 +36,6 @@ import io.envoyproxy.envoy.config.route.v3.RetryPolicy;
 import io.envoyproxy.envoy.config.route.v3.Route;
 import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.config.route.v3.VirtualHost;
-import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
-import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
-import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 
 final class RouteStream extends RefCountedStream<RouteSnapshot> {
 
@@ -52,92 +45,55 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
     private final ConfigSource configSource;
     private final String resourceName;
     private final SubscriptionContext context;
-    @Nullable
-    private final HttpConnectionManager hcm;
+    private final HcmContext hcmContext;
 
     RouteStream(SubscriptionContext context, RouteConfiguration routeConfiguration,
-                @Nullable HttpConnectionManager hcm) {
+                HcmContext hcmContext) {
         this.context = context;
         this.routeConfiguration = routeConfiguration;
         resourceName = routeConfiguration.getName();
         configSource = null;
-        this.hcm = hcm;
+        this.hcmContext = hcmContext;
     }
 
     RouteStream(ConfigSource configSource, String resourceName, SubscriptionContext context,
-                @Nullable HttpConnectionManager hcm) {
+                HcmContext hcmContext) {
         this.configSource = configSource;
         this.resourceName = resourceName;
         this.context = context;
         routeConfiguration = null;
-        this.hcm = hcm;
+        this.hcmContext = hcmContext;
     }
 
     @Override
     protected Subscription onStart(SnapshotWatcher<RouteSnapshot> watcher) {
         if (routeConfiguration != null) {
-            return new RouteSnapshotStream(new RouteXdsResource(routeConfiguration), context, hcm)
+            return new RouteSnapshotStream(new RouteXdsResource(routeConfiguration), context, hcmContext)
                     .subscribe(watcher);
         }
         assert configSource != null;
         final SnapshotStream<RouteSnapshot> snapshotStream =
                 new ResourceNodeAdapter<RouteXdsResource>(configSource, context, resourceName, ROUTE)
-                        .switchMapEager(routeResource -> new RouteSnapshotStream(routeResource, context, hcm));
+                        .switchMapEager(routeResource ->
+                                new RouteSnapshotStream(routeResource, context, hcmContext));
         return snapshotStream.subscribe(watcher);
-    }
-
-    private static final class FilterCaches {
-        final Function<Map<String, Any>, SnapshotStream<ClientPreprocessors>> downstream;
-        final Function<Map<String, Any>, SnapshotStream<ClientDecoration>> upstream;
-        final Function<Map<String, Any>, SnapshotStream<Optional<HttpService>>> server;
-
-        FilterCaches(XdsExtensionRegistry registry, SubscriptionContext context,
-                     List<HttpFilter> hcmHttpFilters, List<HttpFilter> upstreamFilters) {
-            downstream = SnapshotStream.caching(
-                    filterConfigs -> FilterUtil.buildDownstreamFilter(
-                            registry, context, hcmHttpFilters, filterConfigs));
-            upstream = SnapshotStream.caching(
-                    filterConfigs -> FilterUtil.buildUpstreamFilter(
-                            registry, context, upstreamFilters, filterConfigs));
-            server = SnapshotStream.caching(
-                    filterConfigs -> FilterUtil.buildDownstreamServerFilter(
-                            registry, context, hcmHttpFilters, filterConfigs));
-        }
     }
 
     private static class RouteSnapshotStream extends RefCountedStream<RouteSnapshot> {
 
         private final RouteXdsResource routeResource;
         private final SubscriptionContext context;
-        @Nullable
-        private final HttpConnectionManager hcm;
+        private final HcmContext hcmContext;
 
         RouteSnapshotStream(RouteXdsResource routeResource, SubscriptionContext context,
-                            @Nullable HttpConnectionManager hcm) {
+                            HcmContext hcmContext) {
             this.routeResource = routeResource;
             this.context = context;
-            this.hcm = hcm;
+            this.hcmContext = hcmContext;
         }
 
         @Override
         protected Subscription onStart(SnapshotWatcher<RouteSnapshot> watcher) {
-            final XdsExtensionRegistry registry = context.extensionRegistry();
-
-            // Extract filter lists from the HCM (constant for all routes in this config)
-            final List<HttpFilter> hcmHttpFilters;
-            final List<HttpFilter> upstreamFilters;
-            if (hcm != null) {
-                hcmHttpFilters = hcm.getHttpFiltersList();
-                final Router router = findRouter(hcm, registry);
-                upstreamFilters = router != null ? router.getUpstreamHttpFiltersList() : ImmutableList.of();
-            } else {
-                hcmHttpFilters = ImmutableList.of();
-                upstreamFilters = ImmutableList.of();
-            }
-
-            final FilterCaches filterCaches = new FilterCaches(registry, context,
-                                                               hcmHttpFilters, upstreamFilters);
-
             final ImmutableList.Builder<VirtualHostStream> nodesBuilder = ImmutableList.builder();
             final RouteConfiguration routeConfiguration = routeResource.resource();
             for (int i = 0; i < routeConfiguration.getVirtualHostsList().size(); i++) {
@@ -146,33 +102,12 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
                         new VirtualHostXdsResource(virtualHost, routeResource.version(),
                                                    routeResource.revision());
                 nodesBuilder.add(new VirtualHostStream(i, vhostResource, context,
-                                                       routeResource, filterCaches));
+                                                       routeResource, hcmContext));
             }
             final SnapshotStream<RouteSnapshot> routeSnapshotStream =
                     SnapshotStream.combineNLatest(nodesBuilder.build())
                                   .map(list -> new RouteSnapshot(routeResource, list));
             return routeSnapshotStream.subscribe(watcher);
-        }
-
-        @Nullable
-        private static Router findRouter(@Nullable HttpConnectionManager hcm,
-                                         XdsExtensionRegistry registry) {
-            if (hcm == null) {
-                return null;
-            }
-            final List<HttpFilter> httpFilters = hcm.getHttpFiltersList();
-            if (httpFilters.isEmpty()) {
-                return null;
-            }
-            final HttpFilter last = httpFilters.get(httpFilters.size() - 1);
-            if (last.hasTypedConfig() &&
-                RouterFilterFactory.extensionTypeUrl().equals(last.getTypedConfig().getTypeUrl())) {
-                return registry.unpack(last.getTypedConfig(), Router.class);
-            }
-            if (RouterFilterFactory.extensionName().equals(last.getName())) {
-                return Router.getDefaultInstance();
-            }
-            return null;
         }
     }
 
@@ -182,15 +117,15 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
         private final VirtualHostXdsResource resource;
         private final SubscriptionContext context;
         private final RouteXdsResource routeResource;
-        private final FilterCaches filterCaches;
+        private final HcmContext hcmContext;
 
         VirtualHostStream(int index, VirtualHostXdsResource resource, SubscriptionContext context,
-                          RouteXdsResource routeResource, FilterCaches filterCaches) {
+                          RouteXdsResource routeResource, HcmContext hcmContext) {
             this.index = index;
             this.resource = resource;
             this.context = context;
             this.routeResource = routeResource;
-            this.filterCaches = filterCaches;
+            this.hcmContext = hcmContext;
         }
 
         @Override
@@ -200,7 +135,7 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             for (int i = 0; i < virtualHost.getRoutesList().size(); i++) {
                 final Route route = virtualHost.getRoutesList().get(i);
                 routeEntryNodesBuilder.add(new RouteEntryStream(i, route, context,
-                                                                routeResource, resource, filterCaches));
+                                                                routeResource, resource, hcmContext));
             }
             final SnapshotStream<VirtualHostSnapshot> vHostStream =
                     SnapshotStream.combineNLatest(routeEntryNodesBuilder.build())
@@ -217,18 +152,18 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
         private final String clusterName;
         private final RouteXdsResource routeResource;
         private final VirtualHostXdsResource vhostResource;
-        private final FilterCaches filterCaches;
+        private final HcmContext hcmContext;
 
         RouteEntryStream(int index, Route route, SubscriptionContext context,
                          RouteXdsResource routeResource, VirtualHostXdsResource vhostResource,
-                         FilterCaches filterCaches) {
+                         HcmContext hcmContext) {
             this.index = index;
             this.route = route;
             this.context = context;
             clusterName = route.getRoute().getCluster();
             this.routeResource = routeResource;
             this.vhostResource = vhostResource;
-            this.filterCaches = filterCaches;
+            this.hcmContext = hcmContext;
         }
 
         @Override
@@ -252,20 +187,16 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
                     FilterUtil.buildRetryDecoration(effectiveRetryPolicy);
 
             // Build filter streams (deduped via caches for routes with identical configs)
-            final SnapshotStream<ClientPreprocessors> downstreamStream =
-                    filterCaches.downstream.apply(filterConfigs);
-            final SnapshotStream<ClientDecoration> upstreamStream =
-                    filterCaches.upstream.apply(filterConfigs);
-
-            final SnapshotStream<Optional<HttpService>> httpServiceStream =
-                    filterCaches.server.apply(filterConfigs);
+            final SnapshotStream<ClientPreprocessors> downstreamStream = hcmContext.downstream(filterConfigs);
+            final SnapshotStream<ClientDecoration> upstreamStream = hcmContext.upstream(filterConfigs);
+            final SnapshotStream<HttpService> httpServiceStream = hcmContext.server(filterConfigs);
 
             if (!route.getRoute().hasCluster()) {
                 return SnapshotStream.combineLatest(
                         downstreamStream, upstreamStream, httpServiceStream,
                         (down, up, httpService) -> new RouteEntry(
                                 route, null, index, filterConfigs, down,
-                                retryDecoration, up, httpService.orElse(null)))
+                                retryDecoration, up, httpService))
                                      .subscribe(watcher);
             }
 
@@ -277,7 +208,7 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
                     clusterStream, downstreamStream, upstreamStream, httpServiceStream,
                     (cluster, down, up, httpService) -> new RouteEntry(
                             route, cluster, index, filterConfigs, down,
-                            retryDecoration, up, httpService.orElse(null)))
+                            retryDecoration, up, httpService))
                                  .subscribe(watcher);
         }
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/TransportSocketSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/TransportSocketSnapshot.java
@@ -29,13 +29,19 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.client.ClientTlsSpecBuilder;
+import com.linecorp.armeria.common.AbstractTlsSpecBuilder;
 import com.linecorp.armeria.common.TlsKeyPair;
 import com.linecorp.armeria.common.TlsPeerVerifierFactory;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ConnectionContext;
+import com.linecorp.armeria.server.ServerTlsSpec;
+import com.linecorp.armeria.server.ServerTlsSpecBuilder;
 
 import io.envoyproxy.envoy.config.core.v3.TransportSocket;
+import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
+import io.netty.handler.ssl.ClientAuth;
 
 /**
  * A snapshot of a {@link TransportSocket} resource with its associated TLS configuration.
@@ -53,12 +59,15 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
     private final CertificateValidationContextSnapshot validationContext;
     @Nullable
     private final ClientTlsSpec clientTlsSpec;
+    @Nullable
+    private final ServerTlsSpec serverTlsSpec;
 
     TransportSocketSnapshot(TransportSocket transportSocket) {
         this.transportSocket = transportSocket;
         tlsCertificates = ImmutableList.of();
         validationContext = null;
         clientTlsSpec = null;
+        serverTlsSpec = null;
     }
 
     TransportSocketSnapshot(TransportSocket transportSocket,
@@ -71,18 +80,25 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
         final TlsCertificateSnapshot firstCert = tlsCertificates.isEmpty() ? null
                                                                            : tlsCertificates.get(0);
         clientTlsSpec = buildClientTlsSpec(upstreamTlsContext, firstCert, this.validationContext);
+        serverTlsSpec = null;
     }
 
     TransportSocketSnapshot(TransportSocket transportSocket,
-                            Object downstreamTlsContext,
+                            DownstreamTlsContext downstreamTlsContext,
                             List<TlsCertificateSnapshot> tlsCertificates,
                             Optional<CertificateValidationContextSnapshot> validationContext) {
         this.transportSocket = transportSocket;
         this.tlsCertificates = ImmutableList.copyOf(tlsCertificates);
         this.validationContext = validationContext.orElse(null);
-        // TODO: build ServerTlsSpec from DownstreamTlsContext once server-side TLS
-        //  behavior can be verified via integration tests.
         clientTlsSpec = null;
+
+        final List<ServerTlsSpec> specs =
+                tlsCertificates.stream()
+                               .map(cert -> buildServerTlsSpec(downstreamTlsContext, cert,
+                                                               this.validationContext))
+                               .collect(ImmutableList.toImmutableList());
+        // Simple: use first spec. SNI-based selection deferred to follow-up PR.
+        serverTlsSpec = specs.isEmpty() ? null : specs.get(0);
     }
 
     @Override
@@ -122,6 +138,26 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
         return clientTlsSpec;
     }
 
+    /**
+     * Selects the best-matching {@link ServerTlsSpec} for the given connection using
+     * SNI-based certificate selection, following Envoy's
+     * <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#arch-overview-ssl-cert-select">
+     * certificate selection</a> algorithm.
+     *
+     * <p>Selection order:
+     * <ol>
+     *   <li>Exact SNI match against certificate DNS SANs (or CN if no SANs)</li>
+     *   <li>Wildcard match (one level only, e.g. {@code *.example.com})</li>
+     *   <li>Fallback to the first certificate</li>
+     * </ol>
+     *
+     * @return the selected {@link ServerTlsSpec}, or {@code null} if this transport socket
+     *         does not configure downstream TLS
+     */
+    public @Nullable ServerTlsSpec serverTlsSpec(ConnectionContext ctx) {
+        return serverTlsSpec;
+    }
+
     private static ClientTlsSpec buildClientTlsSpec(
             @Nullable UpstreamTlsContext upstreamTlsContext,
             @Nullable TlsCertificateSnapshot tlsCertificate,
@@ -138,13 +174,27 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
                 specBuilder.alpnProtocols(alpn);
             }
         }
+        applyCommonTlsConfig(specBuilder, tlsCertificate, validationContext, autoSniSanValidation);
+        return specBuilder.build();
+    }
+
+    private static <B extends AbstractTlsSpecBuilder<B, ?>> void applyCommonTlsConfig(
+            B builder,
+            @Nullable TlsCertificateSnapshot tlsCertificate,
+            @Nullable CertificateValidationContextSnapshot validationContext,
+            boolean autoSniSanValidation) {
+        if (tlsCertificate != null) {
+            final TlsKeyPair tlsKeyPair = tlsCertificate.tlsKeyPair();
+            if (tlsKeyPair != null) {
+                builder.tlsKeyPair(tlsKeyPair);
+            }
+        }
         final ImmutableList.Builder<TlsPeerVerifierFactory> verifiersBuilder = ImmutableList.builder();
         if (validationContext != null) {
             final boolean systemRootCerts = validationContext.xdsResource().hasSystemRootCerts();
             final List<X509Certificate> trustedCa = validationContext.trustedCa();
-            // set the trusted CA certificates
             if (trustedCa != null) {
-                specBuilder.trustedCertificates(trustedCa);
+                builder.trustedCertificates(trustedCa);
             } else if (systemRootCerts) {
                 // use java default root CAs
             } else {
@@ -157,30 +207,35 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
                             "Set 'system_root_certs: \\{}' or provide trusted_ca.");
                 verifiersBuilder.add(TlsPeerVerifierFactory.noVerify());
             }
-
-            // set peer verification rules - these are applied before trusted CA verification
-            // so that checks are run regardless of CA configuration
             final List<TlsPeerVerifierFactory> verifierFactories = validationContext.peerVerifierFactories();
             if (!verifierFactories.isEmpty()) {
                 verifiersBuilder.addAll(verifierFactories);
             }
         } else {
-            // No validation context — don't verify peer certs (matches Envoy SSL_VERIFY_NONE).
             logger.warn("TLS peer verification is disabled: no validation_context configured. " +
                         "Configure a validation_context with trusted_ca or system_root_certs.");
             verifiersBuilder.add(TlsPeerVerifierFactory.noVerify());
         }
-        if (tlsCertificate != null) {
-            final TlsKeyPair tlsKeyPair = tlsCertificate.tlsKeyPair();
-            if (tlsKeyPair != null) {
-                specBuilder.tlsKeyPair(tlsKeyPair);
-            }
-        }
         final List<TlsPeerVerifierFactory> verifierFactories = verifiersBuilder.build();
         if (!verifierFactories.isEmpty()) {
-            specBuilder.verifierFactories(verifierFactories);
+            builder.verifierFactories(verifierFactories);
         }
-        return specBuilder.build();
+    }
+
+    private static ServerTlsSpec buildServerTlsSpec(
+            DownstreamTlsContext downstreamTlsContext,
+            TlsCertificateSnapshot tlsCertificate,
+            @Nullable CertificateValidationContextSnapshot validationContext) {
+        if (tlsCertificate.tlsKeyPair() == null) {
+            throw new IllegalArgumentException(
+                    "Server TlsCertificateSnapshot must have a TlsKeyPair: " + tlsCertificate);
+        }
+        final ServerTlsSpecBuilder builder = ServerTlsSpec.builder();
+        applyCommonTlsConfig(builder, tlsCertificate, validationContext, false);
+        if (DownstreamTlsTransportSocketFactory.requireClientCertificate(downstreamTlsContext)) {
+            builder.clientAuth(ClientAuth.REQUIRE);
+        }
+        return builder.build();
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/armeria/xds/VirtualHostMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/VirtualHostMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 LY Corporation
+ * Copyright 2026 LY Corporation
  *
  * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.xds.client.endpoint;
+package com.linecorp.armeria.xds;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -26,13 +26,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import com.google.common.base.Ascii;
-import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.xds.ListenerSnapshot;
-import com.linecorp.armeria.xds.RouteSnapshot;
-import com.linecorp.armeria.xds.VirtualHostSnapshot;
 
 final class VirtualHostMatcher {
 
@@ -46,23 +41,14 @@ final class VirtualHostMatcher {
 
     private final boolean ignorePortInHostMatching;
 
-    VirtualHostMatcher(ListenerSnapshot listenerSnapshot) {
-        final RouteSnapshot routeSnapshot = listenerSnapshot.routeSnapshot();
-        if (routeSnapshot == null) {
-            exactMatch = Collections.emptyMap();
-            suffixMatch = ImmutableList.of();
-            prefixMatch = ImmutableList.of();
-            defaultVirtualHost = null;
-            ignorePortInHostMatching = false;
-            return;
-        }
-
+    VirtualHostMatcher(List<VirtualHostSnapshot> virtualHostSnapshots,
+                       boolean ignorePortInHostMatching) {
         final Map<String, VirtualHostSnapshot> exactMatch = new HashMap<>();
         final List<Entry<String, VirtualHostSnapshot>> prefixMatch = new ArrayList<>();
         final List<Entry<String, VirtualHostSnapshot>> suffixMatch = new ArrayList<>();
         VirtualHostSnapshot defaultVirtualHost = null;
 
-        for (VirtualHostSnapshot virtualHostSnapshot: routeSnapshot.virtualHostSnapshots()) {
+        for (VirtualHostSnapshot virtualHostSnapshot: virtualHostSnapshots) {
             for (String domain: virtualHostSnapshot.xdsResource().resource().getDomainsList()) {
                 domain = Ascii.toLowerCase(domain);
                 if ("*".equals(domain)) {
@@ -93,16 +79,14 @@ final class VirtualHostMatcher {
         this.suffixMatch = Collections.unmodifiableList(suffixMatch);
         this.prefixMatch = Collections.unmodifiableList(prefixMatch);
         this.defaultVirtualHost = defaultVirtualHost;
-
-        ignorePortInHostMatching = routeSnapshot.xdsResource().resource().getIgnorePortInHostMatching();
+        this.ignorePortInHostMatching = ignorePortInHostMatching;
     }
 
     @Nullable
-    VirtualHostSnapshot find(PreClientRequestContext ctx) {
+    VirtualHostSnapshot find(@Nullable String authority) {
         if (exactMatch.isEmpty() && prefixMatch.isEmpty() && suffixMatch.isEmpty()) {
             return defaultVirtualHost;
         }
-        String authority = ctx.authority();
         if (authority == null) {
             return defaultVirtualHost;
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouteConfig.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouteConfig.java
@@ -21,15 +21,12 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.ListenerSnapshot;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.RouteSnapshot;
-import com.linecorp.armeria.xds.VirtualHostSnapshot;
 
 final class RouteConfig {
     private final ListenerSnapshot listenerSnapshot;
-    private final VirtualHostMatcher virtualHostMatcher;
 
     RouteConfig(ListenerSnapshot listenerSnapshot) {
         this.listenerSnapshot = listenerSnapshot;
-        virtualHostMatcher = new VirtualHostMatcher(listenerSnapshot);
     }
 
     ListenerSnapshot listenerSnapshot() {
@@ -42,18 +39,11 @@ final class RouteConfig {
         if (routeSnapshot == null) {
             return null;
         }
-        final VirtualHostSnapshot virtualHostSnapshot = virtualHostMatcher.find(ctx);
-        if (virtualHostSnapshot == null) {
-            return null;
+        final RouteEntry entry = routeSnapshot.select(ctx);
+        if (entry != null) {
+            ctx.setAttr(XdsAttributeKeys.ROUTE_METADATA_MATCH,
+                        entry.route().getRoute().getMetadataMatch());
         }
-
-        for (RouteEntry entry: virtualHostSnapshot.routeEntries()) {
-            if (entry.matches(ctx)) {
-                ctx.setAttr(XdsAttributeKeys.ROUTE_METADATA_MATCH,
-                            entry.route().getRoute().getMetadataMatch());
-                return entry;
-            }
-        }
-        return null;
+        return entry;
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
@@ -28,9 +28,11 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
+import com.linecorp.armeria.xds.internal.DelegatingHttpService;
 
 import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
@@ -114,6 +116,11 @@ public final class RouterFilterFactory implements HttpFilterFactory {
         @Override
         public RpcPreprocessor rpcPreprocessor() {
             return rpcFilter::execute;
+        }
+
+        @Override
+        public DecoratingHttpServiceFunction serviceDecorator() {
+            return (delegate, ctx, req) -> DelegatingHttpService.of().serve(ctx, req);
         }
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingHttpService.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingHttpService.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.armeria.xds;
+package com.linecorp.armeria.xds.internal;
 
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -23,18 +23,18 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.AttributeKey;
 
-final class DelegatingHttpService implements HttpService {
+public final class DelegatingHttpService implements HttpService {
 
     private static final DelegatingHttpService INSTANCE = new DelegatingHttpService();
 
     private static final AttributeKey<HttpService> DELEGATE_KEY =
             AttributeKey.valueOf(DelegatingHttpService.class, "DELEGATE_KEY");
 
-    static DelegatingHttpService of() {
+    public static DelegatingHttpService of() {
         return INSTANCE;
     }
 
-    static void setDelegate(ServiceRequestContext ctx, HttpService delegate) {
+    public static void setDelegate(ServiceRequestContext ctx, HttpService delegate) {
         ctx.setAttr(DELEGATE_KEY, delegate);
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.xds.server;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.ConnectionContext;
 import com.linecorp.armeria.server.ServiceCallbackInvoker;
 import com.linecorp.armeria.server.ServiceConfig;
@@ -30,7 +29,6 @@ import com.linecorp.armeria.xds.RouteSnapshot;
 import com.linecorp.armeria.xds.SnapshotWatcher;
 import com.linecorp.armeria.xds.VirtualHostSnapshot;
 
-@UnstableApi
 final class ServerSnapshotWatcher implements SnapshotWatcher<ListenerSnapshot> {
 
     private final CompletableFuture<Void> readyFuture = new CompletableFuture<>();

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.server;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ConnectionContext;
+import com.linecorp.armeria.server.ServiceCallbackInvoker;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.xds.FilterChainSnapshot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteSnapshot;
+import com.linecorp.armeria.xds.SnapshotWatcher;
+import com.linecorp.armeria.xds.VirtualHostSnapshot;
+
+@UnstableApi
+final class ServerSnapshotWatcher implements SnapshotWatcher<ListenerSnapshot> {
+
+    private final CompletableFuture<Void> readyFuture = new CompletableFuture<>();
+    @Nullable
+    private volatile ListenerSnapshot listenerSnapshot;
+    @Nullable
+    private volatile ServiceConfig serviceConfig;
+
+    CompletableFuture<Void> whenReady() {
+        return readyFuture;
+    }
+
+    void serviceAdded(ServiceConfig serviceConfig) {
+        this.serviceConfig = serviceConfig;
+        invokeServiceAdded(serviceConfig);
+    }
+
+    private void invokeServiceAdded(ServiceConfig serviceConfig) {
+        final ListenerSnapshot current = listenerSnapshot;
+        if (current == null) {
+            return;
+        }
+        for (FilterChainSnapshot chain : current.filterChains()) {
+            invokeServiceAddedForChain(serviceConfig, chain);
+        }
+        final FilterChainSnapshot defaultChain = current.defaultFilterChain();
+        if (defaultChain != null) {
+            invokeServiceAddedForChain(serviceConfig, defaultChain);
+        }
+    }
+
+    private static void invokeServiceAddedForChain(ServiceConfig serviceConfig,
+                                                   FilterChainSnapshot chain) {
+        final RouteSnapshot routeSnapshot = chain.routeSnapshot();
+        if (routeSnapshot == null) {
+            return;
+        }
+        for (VirtualHostSnapshot vh : routeSnapshot.virtualHostSnapshots()) {
+            for (RouteEntry entry : vh.routeEntries()) {
+                ServiceCallbackInvoker.invokeServiceAdded(serviceConfig, entry.httpService());
+            }
+        }
+    }
+
+    @Nullable
+    FilterChainSnapshot match(ConnectionContext ctx) {
+        final ListenerSnapshot current = listenerSnapshot;
+        assert current != null;
+        return current.matchFilterChain(ctx);
+    }
+
+    @Override
+    public void onUpdate(@Nullable ListenerSnapshot listenerSnapshot, @Nullable Throwable t) {
+        if (t != null) {
+            readyFuture.completeExceptionally(t);
+            return;
+        }
+        assert listenerSnapshot != null;
+
+        final ServiceConfig cfg = serviceConfig;
+        if (cfg != null) {
+            invokeServiceAdded(cfg);
+        }
+        this.listenerSnapshot = listenerSnapshot;
+        readyFuture.complete(null);
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/ServerSnapshotWatcher.java
@@ -91,10 +91,10 @@ final class ServerSnapshotWatcher implements SnapshotWatcher<ListenerSnapshot> {
         assert listenerSnapshot != null;
 
         final ServiceConfig cfg = serviceConfig;
+        this.listenerSnapshot = listenerSnapshot;
         if (cfg != null) {
             invokeServiceAdded(cfg);
         }
-        this.listenerSnapshot = listenerSnapshot;
         readyFuture.complete(null);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
@@ -233,7 +233,7 @@ public final class XdsServerPlugin implements ServerPlugin {
             final RouteEntry entry = routeSnapshot.select(ctx);
             if (entry == null) {
                 // No matching virtual host or route.
-                return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8,
+                return HttpResponse.of(HttpStatus.NOT_FOUND, MediaType.PLAIN_TEXT_UTF_8,
                                        "No matching virtual host or route");
             }
             DelegatingHttpService.setDelegate(ctx, (HttpService) unwrap());

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.server;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.server.ConnectionAcceptor;
+import com.linecorp.armeria.server.ConnectionContext;
+import com.linecorp.armeria.server.HttpService;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerPlugin;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.server.ServerTlsProvider;
+import com.linecorp.armeria.server.ServerTlsSpec;
+import com.linecorp.armeria.server.ServiceConfig;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingHttpService;
+import com.linecorp.armeria.xds.FilterChainSnapshot;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteSnapshot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.internal.DelegatingHttpService;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * A {@link ServerPlugin} that applies xDS-based configuration to an Armeria {@link Server}.
+ *
+ * <p>On each incoming connection, the plugin performs
+ * <a href="https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#config-listener-v3-filterchainmatch">
+ * filter chain matching</a> to select the appropriate TLS certificate and HTTP filter chain.
+ * Per-request route matching then delegates to the xDS-configured HTTP filters and routes.
+ * Once a request goes through HTTP filters, user-defined {@link HttpService}s are invoked.
+ *
+ * <p>Only the ports explicitly specified when creating this plugin are managed by xDS
+ * configuration. The listener's port in the xDS config does not influence which ports are managed.
+ *
+ * <p>During {@link #install(ServerBuilder)}, this plugin blocks until the first xDS snapshot
+ * is resolved so that TLS certificates and filter chains are available before the server starts
+ * accepting connections. The timeout can be configured via
+ * {@link XdsServerPluginBuilder#readyTimeout(java.time.Duration)} (default: 30 seconds).
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * Server.builder()
+ *     .plugin(XdsServerPlugin.of(xdsBootstrap, "listener", 8080, 8443))
+ *     .service("/api", myService)
+ *     .build();
+ * }</pre>
+ */
+@UnstableApi
+public final class XdsServerPlugin implements ServerPlugin {
+
+    private static final AttributeKey<FilterChainSnapshot> MATCHED_FILTER_CHAIN =
+            AttributeKey.valueOf(XdsServerPlugin.class, "MATCHED_FILTER_CHAIN");
+    private static final UnmodifiableFuture<ServerTlsSpec> noTlsSpecFailure =
+            UnmodifiableFuture.exceptionallyCompletedFuture(
+                    new IllegalStateException("No matching ServerTlsSpec found."));
+
+    private final ListenerRoot listenerRoot;
+    private final ServerSnapshotWatcher watcher = new ServerSnapshotWatcher();
+    private final List<ServerPort> serverPorts;
+    private final Duration readyTimeout;
+
+    /**
+     * Creates a new {@link XdsServerPlugin} that subscribes to the given listener
+     * and listens on the specified port(s) with HTTP and HTTPS.
+     * If no ports are specified, an ephemeral port will be added and used.
+     */
+    public static XdsServerPlugin of(XdsBootstrap bootstrap, String listenerName, int... ports) {
+        return builder(bootstrap, listenerName, ports).build();
+    }
+
+    /**
+     * Returns a new {@link XdsServerPluginBuilder}.
+     * If no ports are specified, an ephemeral port will be added and used.
+     */
+    public static XdsServerPluginBuilder builder(XdsBootstrap bootstrap, String listenerName,
+                                                 int... ports) {
+        return new XdsServerPluginBuilder(bootstrap, listenerName, ports);
+    }
+
+    XdsServerPlugin(XdsBootstrap bootstrap, String listenerName,
+                    List<ServerPort> serverPorts, Duration readyTimeout) {
+        listenerRoot = bootstrap.listenerRoot(listenerName);
+        listenerRoot.addSnapshotWatcher(watcher);
+        this.serverPorts = serverPorts;
+        this.readyTimeout = readyTimeout;
+    }
+
+    @Override
+    public void install(ServerBuilder sb) {
+        try {
+            watcher.whenReady().get(readyTimeout.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            Exceptions.throwUnsafely(e);
+            return;
+        }
+        for (ServerPort serverPort : serverPorts) {
+            sb.port(serverPort);
+        }
+        final ConnectionAcceptor existingAcceptor = sb.connectionAcceptor();
+        sb.connectionAcceptor(new XdsConnectionAcceptor(existingAcceptor, serverPorts, watcher));
+        final ServerTlsProvider existingTlsProvider = sb.tlsProvider();
+        sb.tlsProvider(new XdsServerTlsProvider(existingTlsProvider));
+        sb.decorator(delegate -> new XdsRootDecorator(delegate, watcher));
+    }
+
+    @Override
+    public void close() {
+        listenerRoot.close();
+    }
+
+    private static final class XdsConnectionAcceptor implements ConnectionAcceptor {
+
+        private final ConnectionAcceptor existingAcceptor;
+        private final List<ServerPort> serverPorts;
+        private final ServerSnapshotWatcher watcher;
+
+        private XdsConnectionAcceptor(ConnectionAcceptor existingAcceptor,
+                                      List<ServerPort> serverPorts,
+                                      ServerSnapshotWatcher watcher) {
+            this.existingAcceptor = existingAcceptor;
+            this.serverPorts = serverPorts;
+            this.watcher = watcher;
+        }
+
+        @Override
+        public CompletableFuture<Boolean> accept(ConnectionContext ctx) {
+            // Only apply xDS policy to connections on xDS-managed ports.
+            // actualPort() resolves ephemeral ports (0) to the real bound port.
+            final int port = ctx.localAddress().getPort();
+            boolean managed = false;
+            for (ServerPort sp : serverPorts) {
+                if (sp.actualPort() == port) {
+                    managed = true;
+                    break;
+                }
+            }
+            if (!managed) {
+                return existingAcceptor.accept(ctx);
+            }
+            final FilterChainSnapshot matched = watcher.match(ctx);
+            if (matched != null) {
+                ctx.setAttr(MATCHED_FILTER_CHAIN, matched);
+                return existingAcceptor.accept(ctx);
+            }
+            return UnmodifiableFuture.completedFuture(false);
+        }
+    }
+
+    private static final class XdsServerTlsProvider implements ServerTlsProvider {
+
+        @Nullable
+        private final ServerTlsProvider existingTlsProvider;
+
+        private XdsServerTlsProvider(@Nullable ServerTlsProvider existingTlsProvider) {
+            this.existingTlsProvider = existingTlsProvider;
+        }
+
+        @Override
+        public CompletableFuture<@Nullable ServerTlsSpec> serverTlsSpec(ConnectionContext ctx) {
+            final FilterChainSnapshot matched = ctx.attr(MATCHED_FILTER_CHAIN);
+            if (matched == null) {
+                if (existingTlsProvider != null) {
+                    return existingTlsProvider.serverTlsSpec(ctx);
+                }
+                return UnmodifiableFuture.completedFuture(null);
+            } else {
+                final ServerTlsSpec spec = matched.transportSocketSnapshot().serverTlsSpec(ctx);
+                if (spec == null) {
+                    return noTlsSpecFailure;
+                }
+                return UnmodifiableFuture.completedFuture(spec);
+            }
+        }
+    }
+
+    private static final class XdsRootDecorator extends SimpleDecoratingHttpService {
+
+        private final ServerSnapshotWatcher watcher;
+
+        XdsRootDecorator(HttpService delegate, ServerSnapshotWatcher watcher) {
+            super(delegate);
+            this.watcher = watcher;
+        }
+
+        @Override
+        public void serviceAdded(ServiceConfig cfg) throws Exception {
+            super.serviceAdded(cfg);
+            watcher.serviceAdded(cfg);
+        }
+
+        @Override
+        public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+            final FilterChainSnapshot matched = ctx.attr(MATCHED_FILTER_CHAIN);
+            if (matched == null) {
+                // Not an xDS-managed port — serve directly.
+                return unwrap().serve(ctx, req);
+            }
+            final RouteSnapshot routeSnapshot = matched.routeSnapshot();
+            if (routeSnapshot == null) {
+                // HCM with routes is required for all filter chains.
+                return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8,
+                                       "HCM with routes is required for all filter chains");
+            }
+            final RouteEntry entry = routeSnapshot.select(ctx);
+            if (entry == null) {
+                // No matching virtual host or route.
+                return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE, MediaType.PLAIN_TEXT_UTF_8,
+                                       "No matching virtual host or route");
+            }
+            DelegatingHttpService.setDelegate(ctx, (HttpService) unwrap());
+            return entry.httpService().serve(ctx, req);
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPluginBuilder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPluginBuilder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.server;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.xds.XdsBootstrap;
+
+/**
+ * Builds a new {@link XdsServerPlugin}.
+ */
+@UnstableApi
+public final class XdsServerPluginBuilder {
+
+    private static final Duration DEFAULT_READY_TIMEOUT = Duration.ofSeconds(30);
+
+    private final XdsBootstrap bootstrap;
+    private final String listenerName;
+    private final List<ServerPort> serverPorts = new ArrayList<>();
+    private Duration readyTimeout = DEFAULT_READY_TIMEOUT;
+
+    XdsServerPluginBuilder(XdsBootstrap bootstrap, String listenerName, int... ports) {
+        this.bootstrap = requireNonNull(bootstrap, "bootstrap");
+        this.listenerName = requireNonNull(listenerName, "listenerName");
+        for (int port : ports) {
+            serverPorts.add(new ServerPort(port, SessionProtocol.HTTP, SessionProtocol.HTTPS));
+        }
+    }
+
+    /**
+     * Adds a {@link ServerPort} to listen on.
+     */
+    public XdsServerPluginBuilder port(ServerPort serverPort) {
+        requireNonNull(serverPort, "serverPort");
+        checkArgument(serverPort.hasProtocol(SessionProtocol.HTTP) &&
+                      serverPort.hasProtocol(SessionProtocol.HTTPS),
+                      "serverPort must support both HTTP and HTTPS: %s", serverPort);
+        serverPorts.add(serverPort);
+        return this;
+    }
+
+    /**
+     * Sets the maximum time to wait for the first xDS snapshot to be resolved before
+     * the server starts. Defaults to 30 seconds.
+     */
+    public XdsServerPluginBuilder readyTimeout(Duration readyTimeout) {
+        requireNonNull(readyTimeout, "readyTimeout");
+        checkArgument(!readyTimeout.isNegative(), "readyTimeout: %s (expected: >= 0)", readyTimeout);
+        this.readyTimeout = readyTimeout;
+        return this;
+    }
+
+    /**
+     * Builds a new {@link XdsServerPlugin}.
+     */
+    public XdsServerPlugin build() {
+        final List<ServerPort> ports;
+        if (serverPorts.isEmpty()) {
+            ports = ImmutableList.of(new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS));
+        } else {
+            ports = ImmutableList.copyOf(serverPorts);
+        }
+        return new XdsServerPlugin(bootstrap, listenerName, ports, readyTimeout);
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/package-info.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Server-side xDS integrations.
+ */
+@NonNullByDefault
+@UnstableApi
+package com.linecorp.armeria.xds.server;
+
+import com.linecorp.armeria.common.annotation.NonNullByDefault;
+import com.linecorp.armeria.common.annotation.UnstableApi;

--- a/xds/src/test/java/com/linecorp/armeria/xds/server/XdsServerPluginBuilderTest.java
+++ b/xds/src/test/java/com/linecorp/armeria/xds/server/XdsServerPluginBuilderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.armeria.xds.XdsBootstrap;
+
+class XdsServerPluginBuilderTest {
+
+    @Test
+    void portMustHaveBothHttpAndHttps() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener");
+        assertThatThrownBy(() -> builder.port(new ServerPort(8080, SessionProtocol.HTTP)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must support both HTTP and HTTPS");
+    }
+
+    @Test
+    void portWithBothProtocolsAccepted() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener");
+        // Should not throw
+        builder.port(new ServerPort(8080, SessionProtocol.HTTP, SessionProtocol.HTTPS));
+    }
+
+    @Test
+    void readyTimeoutNegativeThrows() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener");
+        assertThatThrownBy(() -> builder.readyTimeout(Duration.ofSeconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("readyTimeout");
+    }
+
+    @Test
+    void readyTimeoutZeroAllowed() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener");
+        // Should not throw
+        builder.readyTimeout(Duration.ZERO);
+    }
+
+    @Test
+    void httpsOnlyPortRejected() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener");
+        assertThatThrownBy(() -> builder.port(new ServerPort(8443, SessionProtocol.HTTPS)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must support both HTTP and HTTPS");
+    }
+
+    @Test
+    void builderCreatedWithPorts() {
+        final XdsBootstrap bootstrap = mock(XdsBootstrap.class);
+        // Builder created with int... ports — should not throw during builder creation.
+        final XdsServerPluginBuilder builder = XdsServerPlugin.builder(bootstrap, "test-listener", 0, 0);
+        assertThat(builder).isNotNull();
+    }
+}


### PR DESCRIPTION
Motivation:

This PR introduces server-side xDS support for Armeria. In a service mesh like Istio,
the control plane pushes configuration (TLS certificates, HTTP filters, routing rules)
to server workloads via the xDS protocol. Until now, Armeria's xDS integration only
supported the client side (endpoint discovery, load balancing, upstream TLS). This PR
adds the server-side counterpart so that an Armeria server can receive Listener and
RouteConfiguration resources from an xDS control plane and dynamically configure:

- **TLS certificates** — mTLS with certificates provisioned by the control plane
- **HTTP filter chains** — xDS HTTP filters applied as decorators before user services
- **Virtual host routing** — xDS route matching selects the correct filter chain per request

The key design decision is **"router = user code"**: xDS manages TLS and filter decoration,
but all Armeria VirtualHosts, Routes, and services remain user-defined. xDS never touches
service dispatch — it only wraps user services with xDS-configured filters.

Route matching and the mandatory router filter follow the design in
[gRFC A36: xDS-Enabled Servers](https://github.com/grpc/proposal/blob/master/A36-xds-for-servers.md),
including `non_forwarding_action` support for server-side routes.

This is the first PR in a series. Follow-up PRs will add:
- Full `FilterChainMatch` criteria (destination_port, server_names, transport_protocol, ALPN)
- SNI-based certificate selection (`ServerTlsSpecSelector`)
- Istio integration tests

Modifications:

- Added `XdsServerPlugin`, a `ServerPlugin` that subscribes to an xDS Listener and
  configures connection acceptance, TLS, and per-request filter decoration via
  `ConnectionAcceptor`, `ServerTlsProvider`, and a root decorator.
- Added `ConnectionLevelSetters` interface to `ServerBuilder` exposing getter methods
  for `ConnectionAcceptor` and `ServerTlsProvider`, allowing plugins to compose with
  existing connection-level configuration.
- Generalized `VirtualHostMatcher` and `RouteEntry` matching to handle both client-side
  and server-side use cases (moved `VirtualHostMatcher` from `client.endpoint` to
  top-level `xds` package, added `RouteSnapshot.select(RequestContext)`).
- Refactored HCM parsing and filter caching out of `RouteStream` into `HcmContext`
  so it can be shared across filter chains.
- Added `FilterUtil.buildDownstreamServerFilter()` and `RouteEntry.httpService()` for
  building and invoking server-side HTTP filter decorator chains.
- Simplified `ListenerSnapshot.matchFilterChain()` to first-chain / default-chain
  fallback and `TransportSocketSnapshot.serverTlsSpec()` to first-spec fallback
  (full matching deferred to follow-up PRs).

Result:

- Users can now configure an Armeria server to receive xDS configuration:
  ```java
  Server.builder()
      .plugin(XdsServerPlugin.of(xdsBootstrap, "listener_name", 8080))
      .service("/api", myService)
      .build();
  ```
- The plugin manages TLS certificates and HTTP filter decoration on the specified ports
  while leaving service routing entirely to the user.
- Ports not managed by the plugin are unaffected.
