### PR TITLE
Add support for weighted clusters

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterFilterConfigTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterFilterConfigTest.java
@@ -21,6 +21,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -35,22 +36,22 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
-import com.linecorp.armeria.xds.XdsBootstrap;
 import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
 
-import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 
 class WeightedClusterFilterConfigTest {
 
     @RegisterExtension
+    @Order(0)
     static final ServerExtension echoServer = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) {
@@ -63,72 +64,55 @@ class WeightedClusterFilterConfigTest {
     };
 
     @RegisterExtension
-    static final EventLoopExtension eventLoop = new EventLoopExtension();
+    @Order(1)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension(
+            builder -> builder.extensionFactories(configReadingFilterFactory("test.marker.filter"))
+    );
 
     @Test
     void perClusterFilterConfig() {
         // A filter that reads a StringValue config and sets it as a header.
         // cluster-a has typed_per_filter_config that overrides the HCM default,
         // cluster-b has no override and uses the HCM default.
-        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
-
-        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
-                static_resources:
-                  listeners:
-                    - name: test-listener
-                      api_listener:
-                        api_listener:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+        controlPlane.set(staticCluster("cluster-a"));
+        final String version = controlPlane.set(listener("""
+                name: test-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network\
                 .http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: http
-                          route_config:
-                            name: local_route
-                            virtual_hosts:
-                            - name: local_service
-                              domains: [ "*" ]
-                              routes:
-                              - match:
-                                  prefix: /
-                                route:
-                                  weighted_clusters:
-                                    clusters:
-                                    - name: cluster-a
-                                      weight: 100
-                                      typed_per_filter_config:
-                                        test.marker.filter:
-                                          "@type": type.googleapis.com/google.protobuf.StringValue
-                                          value: "from-cluster-a"
-                          http_filters:
-                          - name: test.marker.filter
-                            typed_config:
-                              "@type": type.googleapis.com/google.protobuf.StringValue
-                              value: "default"
-                          - name: envoy.filters.http.router
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                        - match:
+                            prefix: /
+                          route:
+                            weighted_clusters:
+                              clusters:
+                              - name: cluster-a
+                                weight: 100
+                                typed_per_filter_config:
+                                  test.marker.filter:
+                                    "@type": type.googleapis.com/google.protobuf.StringValue
+                                    value: "from-cluster-a"
+                    http_filters:
+                    - name: test.marker.filter
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                        value: "default"
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http\
                 .router.v3.Router
-                  clusters:
-                    - name: cluster-a
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: cluster-a
-                        endpoints:
-                        - lb_endpoints:
-                          - endpoint:
-                              address:
-                                socket_address:
-                                  address: %s
-                                  port_value: %s
-                """.formatted(echoServer.httpSocketAddress().getHostString(),
-                              echoServer.httpPort()),
-                Bootstrap.class);
+                """));
+        controlPlane.awaitListener("test-listener", version);
 
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
-                                                     .eventExecutor(eventLoop.get())
-                                                     .extensionFactories(factory)
-                                                     .build();
-             XdsHttpPreprocessor preprocessor =
-                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+        try (XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", controlPlane.bootstrap())) {
             final BlockingWebClient client = WebClient.of(preprocessor).blocking();
 
             await().untilAsserted(() -> {
@@ -145,69 +129,49 @@ class WeightedClusterFilterConfigTest {
         // Route-level typed_per_filter_config sets "from-route".
         // ClusterWeight typed_per_filter_config sets "from-cluster" for the same filter.
         // ClusterWeight should win (higher precedence).
-        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
-
-        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
-                static_resources:
-                  listeners:
-                    - name: test-listener
-                      api_listener:
-                        api_listener:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+        controlPlane.set(staticCluster("cluster-a"));
+        final String version = controlPlane.set(listener("""
+                name: test-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network\
                 .http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: http
-                          route_config:
-                            name: local_route
-                            virtual_hosts:
-                            - name: local_service
-                              domains: [ "*" ]
-                              routes:
-                              - match:
-                                  prefix: /
-                                route:
-                                  weighted_clusters:
-                                    clusters:
-                                    - name: cluster-a
-                                      weight: 100
-                                      typed_per_filter_config:
-                                        test.marker.filter:
-                                          "@type": type.googleapis.com/google.protobuf.StringValue
-                                          value: "from-cluster"
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                        - match:
+                            prefix: /
+                          route:
+                            weighted_clusters:
+                              clusters:
+                              - name: cluster-a
+                                weight: 100
                                 typed_per_filter_config:
                                   test.marker.filter:
                                     "@type": type.googleapis.com/google.protobuf.StringValue
-                                    value: "from-route"
-                          http_filters:
-                          - name: test.marker.filter
-                            typed_config:
+                                    value: "from-cluster"
+                          typed_per_filter_config:
+                            test.marker.filter:
                               "@type": type.googleapis.com/google.protobuf.StringValue
-                              value: "default"
-                          - name: envoy.filters.http.router
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                              value: "from-route"
+                    http_filters:
+                    - name: test.marker.filter
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                        value: "default"
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http\
                 .router.v3.Router
-                  clusters:
-                    - name: cluster-a
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: cluster-a
-                        endpoints:
-                        - lb_endpoints:
-                          - endpoint:
-                              address:
-                                socket_address:
-                                  address: %s
-                                  port_value: %s
-                """.formatted(echoServer.httpSocketAddress().getHostString(),
-                              echoServer.httpPort()),
-                Bootstrap.class);
+                """));
+        controlPlane.awaitListener("test-listener", version);
 
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
-                                                     .eventExecutor(eventLoop.get())
-                                                     .extensionFactories(factory)
-                                                     .build();
-             XdsHttpPreprocessor preprocessor =
-                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+        try (XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", controlPlane.bootstrap())) {
             final BlockingWebClient client = WebClient.of(preprocessor).blocking();
 
             await().untilAsserted(() -> {
@@ -224,65 +188,45 @@ class WeightedClusterFilterConfigTest {
         // cluster-b has NO typed_per_filter_config.
         // Route-level typed_per_filter_config sets "from-route".
         // cluster-b should use the route-level config.
-        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
-
-        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
-                static_resources:
-                  listeners:
-                    - name: test-listener
-                      api_listener:
-                        api_listener:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+        controlPlane.set(staticCluster("cluster-b"));
+        final String version = controlPlane.set(listener("""
+                name: test-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network\
                 .http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: http
-                          route_config:
-                            name: local_route
-                            virtual_hosts:
-                            - name: local_service
-                              domains: [ "*" ]
-                              routes:
-                              - match:
-                                  prefix: /
-                                route:
-                                  weighted_clusters:
-                                    clusters:
-                                    - name: cluster-b
-                                      weight: 100
-                                typed_per_filter_config:
-                                  test.marker.filter:
-                                    "@type": type.googleapis.com/google.protobuf.StringValue
-                                    value: "from-route"
-                          http_filters:
-                          - name: test.marker.filter
-                            typed_config:
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                        - match:
+                            prefix: /
+                          route:
+                            weighted_clusters:
+                              clusters:
+                              - name: cluster-b
+                                weight: 100
+                          typed_per_filter_config:
+                            test.marker.filter:
                               "@type": type.googleapis.com/google.protobuf.StringValue
-                              value: "default"
-                          - name: envoy.filters.http.router
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                              value: "from-route"
+                    http_filters:
+                    - name: test.marker.filter
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                        value: "default"
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http\
                 .router.v3.Router
-                  clusters:
-                    - name: cluster-b
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: cluster-b
-                        endpoints:
-                        - lb_endpoints:
-                          - endpoint:
-                              address:
-                                socket_address:
-                                  address: %s
-                                  port_value: %s
-                """.formatted(echoServer.httpSocketAddress().getHostString(),
-                              echoServer.httpPort()),
-                Bootstrap.class);
+                """));
+        controlPlane.awaitListener("test-listener", version);
 
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
-                                                     .eventExecutor(eventLoop.get())
-                                                     .extensionFactories(factory)
-                                                     .build();
-             XdsHttpPreprocessor preprocessor =
-                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+        try (XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", controlPlane.bootstrap())) {
             final BlockingWebClient client = WebClient.of(preprocessor).blocking();
 
             await().untilAsserted(() -> {
@@ -298,75 +242,47 @@ class WeightedClusterFilterConfigTest {
     void snapshotStructureWithPerClusterConfig() {
         // Verify that RouteCluster carries per-cluster chains
         // when typed_per_filter_config is set on ClusterWeight.
-        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
-
-        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
-                static_resources:
-                  listeners:
-                    - name: test-listener
-                      api_listener:
-                        api_listener:
-                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+        controlPlane.set(staticCluster("cluster-a"), staticCluster("cluster-b"));
+        final String version = controlPlane.set(listener("""
+                name: test-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network\
                 .http_connection_manager.v3.HttpConnectionManager
-                          stat_prefix: http
-                          route_config:
-                            name: local_route
-                            virtual_hosts:
-                            - name: local_service
-                              domains: [ "*" ]
-                              routes:
-                              - match:
-                                  prefix: /
-                                route:
-                                  weighted_clusters:
-                                    clusters:
-                                    - name: cluster-a
-                                      weight: 50
-                                      typed_per_filter_config:
-                                        test.marker.filter:
-                                          "@type": type.googleapis.com/google.protobuf.StringValue
-                                          value: "override-a"
-                                    - name: cluster-b
-                                      weight: 50
-                          http_filters:
-                          - name: test.marker.filter
-                            typed_config:
-                              "@type": type.googleapis.com/google.protobuf.StringValue
-                              value: "default"
-                          - name: envoy.filters.http.router
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                        - match:
+                            prefix: /
+                          route:
+                            weighted_clusters:
+                              clusters:
+                              - name: cluster-a
+                                weight: 50
+                                typed_per_filter_config:
+                                  test.marker.filter:
+                                    "@type": type.googleapis.com/google.protobuf.StringValue
+                                    value: "override-a"
+                              - name: cluster-b
+                                weight: 50
+                    http_filters:
+                    - name: test.marker.filter
+                      typed_config:
+                        "@type": type.googleapis.com/google.protobuf.StringValue
+                        value: "default"
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http\
                 .router.v3.Router
-                  clusters:
-                    - name: cluster-a
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: cluster-a
-                        endpoints:
-                        - lb_endpoints:
-                          - endpoint:
-                              address:
-                                socket_address:
-                                  address: 127.0.0.1
-                                  port_value: 8080
-                    - name: cluster-b
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: cluster-b
-                        endpoints:
-                        - lb_endpoints:
-                          - endpoint:
-                              address:
-                                socket_address:
-                                  address: 127.0.0.1
-                                  port_value: 8080
-                """, Bootstrap.class);
+                """));
+        controlPlane.awaitListener("test-listener", version);
 
         final AtomicReference<ListenerSnapshot> snapshotRef = new AtomicReference<>();
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
-                                                     .extensionFactories(factory)
-                                                     .build()) {
-            final ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("test-listener");
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("test-listener")) {
             listenerRoot.addSnapshotWatcher((snapshot, t) -> {
                 if (snapshot != null) {
                     snapshotRef.set(snapshot);
@@ -394,6 +310,29 @@ class WeightedClusterFilterConfigTest {
                 assertThat(selected.httpClient()).isNotNull();
             });
         }
+    }
+
+    private Cluster staticCluster(String name) {
+        final String yaml = """
+                name: %s
+                type: STATIC
+                load_assignment:
+                  cluster_name: %s
+                  endpoints:
+                  - lb_endpoints:
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: %s
+                            port_value: %s
+                """.formatted(name, name,
+                              echoServer.httpSocketAddress().getHostString(),
+                              echoServer.httpPort());
+        return XdsResourceReader.fromYaml(yaml, Cluster.class);
+    }
+
+    private static Listener listener(String yaml) {
+        return XdsResourceReader.fromYaml(yaml, Listener.class);
     }
 
     /**

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterFilterConfigTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterFilterConfigTest.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.StringValue;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+import com.linecorp.armeria.xds.filter.FactoryContext;
+import com.linecorp.armeria.xds.filter.HttpFilterFactory;
+import com.linecorp.armeria.xds.filter.XdsHttpFilter;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
+
+class WeightedClusterFilterConfigTest {
+
+    @RegisterExtension
+    static final ServerExtension echoServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> {
+                final String marker = req.headers().get("x-cluster-filter", "none");
+                return HttpResponse.of(marker);
+            });
+            sb.http(0);
+        }
+    };
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @Test
+    void perClusterFilterConfig() {
+        // A filter that reads a StringValue config and sets it as a header.
+        // cluster-a has typed_per_filter_config that overrides the HCM default,
+        // cluster-b has no override and uses the HCM default.
+        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
+                static_resources:
+                  listeners:
+                    - name: test-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                            - name: local_service
+                              domains: [ "*" ]
+                              routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  weighted_clusters:
+                                    clusters:
+                                    - name: cluster-a
+                                      weight: 100
+                                      typed_per_filter_config:
+                                        test.marker.filter:
+                                          "@type": type.googleapis.com/google.protobuf.StringValue
+                                          value: "from-cluster-a"
+                          http_filters:
+                          - name: test.marker.filter
+                            typed_config:
+                              "@type": type.googleapis.com/google.protobuf.StringValue
+                              value: "default"
+                          - name: envoy.filters.http.router
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                    - name: cluster-a
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: cluster-a
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: %s
+                                  port_value: %s
+                """.formatted(echoServer.httpSocketAddress().getHostString(),
+                              echoServer.httpPort()),
+                Bootstrap.class);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .eventExecutor(eventLoop.get())
+                                                     .extensionFactories(factory)
+                                                     .build();
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse response = client.get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                // cluster-a has typed_per_filter_config override → "from-cluster-a"
+                assertThat(response.contentUtf8()).isEqualTo("from-cluster-a");
+            });
+        }
+    }
+
+    @Test
+    void perClusterFilterConfigPrecedence() {
+        // Route-level typed_per_filter_config sets "from-route".
+        // ClusterWeight typed_per_filter_config sets "from-cluster" for the same filter.
+        // ClusterWeight should win (higher precedence).
+        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
+                static_resources:
+                  listeners:
+                    - name: test-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                            - name: local_service
+                              domains: [ "*" ]
+                              routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  weighted_clusters:
+                                    clusters:
+                                    - name: cluster-a
+                                      weight: 100
+                                      typed_per_filter_config:
+                                        test.marker.filter:
+                                          "@type": type.googleapis.com/google.protobuf.StringValue
+                                          value: "from-cluster"
+                                typed_per_filter_config:
+                                  test.marker.filter:
+                                    "@type": type.googleapis.com/google.protobuf.StringValue
+                                    value: "from-route"
+                          http_filters:
+                          - name: test.marker.filter
+                            typed_config:
+                              "@type": type.googleapis.com/google.protobuf.StringValue
+                              value: "default"
+                          - name: envoy.filters.http.router
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                    - name: cluster-a
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: cluster-a
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: %s
+                                  port_value: %s
+                """.formatted(echoServer.httpSocketAddress().getHostString(),
+                              echoServer.httpPort()),
+                Bootstrap.class);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .eventExecutor(eventLoop.get())
+                                                     .extensionFactories(factory)
+                                                     .build();
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse response = client.get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                // ClusterWeight typed_per_filter_config wins over route-level
+                assertThat(response.contentUtf8()).isEqualTo("from-cluster");
+            });
+        }
+    }
+
+    @Test
+    void noOverrideUsesRouteConfig() {
+        // cluster-b has NO typed_per_filter_config.
+        // Route-level typed_per_filter_config sets "from-route".
+        // cluster-b should use the route-level config.
+        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
+                static_resources:
+                  listeners:
+                    - name: test-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                            - name: local_service
+                              domains: [ "*" ]
+                              routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  weighted_clusters:
+                                    clusters:
+                                    - name: cluster-b
+                                      weight: 100
+                                typed_per_filter_config:
+                                  test.marker.filter:
+                                    "@type": type.googleapis.com/google.protobuf.StringValue
+                                    value: "from-route"
+                          http_filters:
+                          - name: test.marker.filter
+                            typed_config:
+                              "@type": type.googleapis.com/google.protobuf.StringValue
+                              value: "default"
+                          - name: envoy.filters.http.router
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                    - name: cluster-b
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: cluster-b
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: %s
+                                  port_value: %s
+                """.formatted(echoServer.httpSocketAddress().getHostString(),
+                              echoServer.httpPort()),
+                Bootstrap.class);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .eventExecutor(eventLoop.get())
+                                                     .extensionFactories(factory)
+                                                     .build();
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse response = client.get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                // No cluster-level override → falls back to route-level config
+                assertThat(response.contentUtf8()).isEqualTo("from-route");
+            });
+        }
+    }
+
+    @Test
+    void snapshotStructureWithPerClusterConfig() {
+        // Verify that RouteCluster carries per-cluster chains
+        // when typed_per_filter_config is set on ClusterWeight.
+        final HttpFilterFactory factory = configReadingFilterFactory("test.marker.filter");
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml("""
+                static_resources:
+                  listeners:
+                    - name: test-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                            - name: local_service
+                              domains: [ "*" ]
+                              routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  weighted_clusters:
+                                    clusters:
+                                    - name: cluster-a
+                                      weight: 50
+                                      typed_per_filter_config:
+                                        test.marker.filter:
+                                          "@type": type.googleapis.com/google.protobuf.StringValue
+                                          value: "override-a"
+                                    - name: cluster-b
+                                      weight: 50
+                          http_filters:
+                          - name: test.marker.filter
+                            typed_config:
+                              "@type": type.googleapis.com/google.protobuf.StringValue
+                              value: "default"
+                          - name: envoy.filters.http.router
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                    - name: cluster-a
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: cluster-a
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: 127.0.0.1
+                                  port_value: 8080
+                    - name: cluster-b
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: cluster-b
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: 127.0.0.1
+                                  port_value: 8080
+                """, Bootstrap.class);
+
+        final AtomicReference<ListenerSnapshot> snapshotRef = new AtomicReference<>();
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .extensionFactories(factory)
+                                                     .build()) {
+            final ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("test-listener");
+            listenerRoot.addSnapshotWatcher((snapshot, t) -> {
+                if (snapshot != null) {
+                    snapshotRef.set(snapshot);
+                }
+            });
+
+            await().untilAsserted(() -> {
+                assertThat(snapshotRef.get()).isNotNull();
+                final var routeEntries = snapshotRef.get().routeSnapshot()
+                                                    .virtualHostSnapshots().get(0).routeEntries();
+                assertThat(routeEntries).hasSize(1);
+                final var wc = routeEntries.get(0).weightedClusters();
+                assertThat(wc).isNotNull().hasSize(2);
+                // All RouteCluster instances must have non-null chain accessors
+                for (var entry : wc) {
+                    assertThat(entry.httpPreClient()).isNotNull();
+                    assertThat(entry.rpcPreClient()).isNotNull();
+                    assertThat(entry.httpClient()).isNotNull();
+                    assertThat(entry.rpcClient()).isNotNull();
+                }
+                // Single-cluster select also returns chains
+                final var selected = routeEntries.get(0).resolve();
+                assertThat(selected).isNotNull();
+                assertThat(selected.httpPreClient()).isNotNull();
+                assertThat(selected.httpClient()).isNotNull();
+            });
+        }
+    }
+
+    /**
+     * Creates an {@link HttpFilterFactory} that reads the config as a {@link StringValue}
+     * and sets the value as the {@code x-cluster-filter} header on the request (preprocessor).
+     */
+    private static HttpFilterFactory configReadingFilterFactory(String filterName) {
+        return new HttpFilterFactory() {
+            @Override
+            public String name() {
+                return filterName;
+            }
+
+            @Override
+            @Nullable
+            public XdsHttpFilter create(HttpFilter httpFilter, Any config, FactoryContext context) {
+                final String marker;
+                if (config != null && config.is(StringValue.class)) {
+                    try {
+                        marker = config.unpack(StringValue.class).getValue();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                } else {
+                    marker = "unknown";
+                }
+                return new XdsHttpFilter() {
+                    @Override
+                    public com.linecorp.armeria.client.HttpPreprocessor httpPreprocessor() {
+                        return (delegate, ctx, req) -> {
+                            final HttpRequest newReq = req.withHeaders(
+                                    req.headers().toBuilder()
+                                       .set("x-cluster-filter", marker)
+                                       .build());
+                            ctx.updateRequest(newReq);
+                            return delegate.execute(ctx, newReq);
+                        };
+                    }
+                };
+            }
+        };
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
@@ -22,21 +22,13 @@ import static org.awaitility.Awaitility.await;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Struct;
 
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.grpc.GrpcService;
-import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
-import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
@@ -44,12 +36,7 @@ import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.SnapshotWatcher;
 import com.linecorp.armeria.xds.WeightedClusterSnapshot;
-import com.linecorp.armeria.xds.XdsBootstrap;
 
-import io.envoyproxy.controlplane.cache.v3.SimpleCache;
-import io.envoyproxy.controlplane.cache.v3.Snapshot;
-import io.envoyproxy.controlplane.server.V3DiscoveryServer;
-import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
 import io.envoyproxy.envoy.config.core.v3.Metadata;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
@@ -58,60 +45,19 @@ import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 
 class WeightedClusterTest {
 
-    private static final String GROUP = "key";
-    private static final String BOOTSTRAP_CLUSTER_NAME = "bootstrap-cluster";
-    private static final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
-    private static final AtomicLong version = new AtomicLong();
-
     @RegisterExtension
-    @Order(0)
-    static final ServerExtension server = new ServerExtension() {
-        @Override
-        protected void configure(ServerBuilder sb) {
-            final V3DiscoveryServer v3DiscoveryServer = new V3DiscoveryServer(cache);
-            sb.service(GrpcService.builder()
-                                  .addService(v3DiscoveryServer.getAggregatedDiscoveryServiceImpl())
-                                  .addService(v3DiscoveryServer.getListenerDiscoveryServiceImpl())
-                                  .addService(v3DiscoveryServer.getClusterDiscoveryServiceImpl())
-                                  .addService(v3DiscoveryServer.getRouteDiscoveryServiceImpl())
-                                  .addService(v3DiscoveryServer.getEndpointDiscoveryServiceImpl())
-                                  .build());
-            sb.http(0);
-        }
-    };
-
-    @RegisterExtension
-    @Order(1)
-    static final EventLoopExtension eventLoop = new EventLoopExtension();
-
-    @BeforeEach
-    void beforeEach() {
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(), ImmutableList.of(),
-                                         ImmutableList.of(), ImmutableList.of(),
-                                         ImmutableList.of(),
-                                         String.valueOf(version.incrementAndGet())));
-    }
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
 
     @Test
-    void weightedClustersSnapshotStructure() throws Exception {
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 80, "cluster-b", 20);
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+    void weightedClustersSnapshotStructure() {
+        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                         endpoint("cluster-b", "127.0.0.1", 5678));
+        controlPlane.set(weightedRouteConfig("route_0", "cluster-a", 80, "cluster-b", 20));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -143,24 +89,15 @@ class WeightedClusterTest {
     }
 
     @Test
-    void weightDistribution() throws Exception {
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 3, "cluster-b", 1);
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+    void weightDistribution() {
+        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                         endpoint("cluster-b", "127.0.0.1", 5678));
+        controlPlane.set(weightedRouteConfig("route_0", "cluster-a", 3, "cluster-b", 1));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -191,24 +128,15 @@ class WeightedClusterTest {
     }
 
     @Test
-    void dynamicUpdate() throws Exception {
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 50, "cluster-b", 50);
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+    void dynamicUpdate() {
+        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                         endpoint("cluster-b", "127.0.0.1", 5678));
+        controlPlane.set(weightedRouteConfig("route_0", "cluster-a", 50, "cluster-b", 50));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -220,12 +148,7 @@ class WeightedClusterTest {
 
             // Update endpoints for cluster-a
             final ClusterLoadAssignment updatedEndpointA = endpoint("cluster-a", "127.0.0.2", 9999);
-            cache.setSnapshot(GROUP,
-                              Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                             ImmutableList.of(updatedEndpointA, endpointB),
-                                             ImmutableList.of(listener),
-                                             ImmutableList.of(routeConfig),
-                                             ImmutableList.of(), nextVersion()));
+            controlPlane.set(updatedEndpointA, endpoint("cluster-b", "127.0.0.1", 5678));
 
             // Wait for re-emission with updated endpoint
             await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
@@ -241,26 +164,15 @@ class WeightedClusterTest {
     }
 
     @Test
-    void defaultWeight() throws Exception {
-        // Clusters without explicit weight default to 1
-        final RouteConfiguration routeConfig
-                = weightedRouteConfigNoWeights("route_0", "cluster-a", "cluster-b");
-        final Listener listener = listener("listener_0", "route_0");
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+    void defaultWeight() {
+        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                         endpoint("cluster-b", "127.0.0.1", 5678));
+        controlPlane.set(weightedRouteConfigNoWeights("route_0", "cluster-a", "cluster-b"));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -288,27 +200,15 @@ class WeightedClusterTest {
     }
 
     @Test
-    void metadataMatchMerging() throws Exception {
-        // Route-level metadata_match: envoy.lb: {version: "v1", stage: "prod"}
-        // cluster-a metadata_match:   envoy.lb: {stage: "canary"}         -> overrides stage
-        // cluster-b metadata_match:   (none)                              -> inherits route-level
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig = weightedRouteConfigWithMetadata("route_0");
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+    void metadataMatchMerging() {
+        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                         endpoint("cluster-b", "127.0.0.1", 5678));
+        controlPlane.set(weightedRouteConfigWithMetadata("route_0"));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -342,26 +242,14 @@ class WeightedClusterTest {
     }
 
     @Test
-    void metadataMatchMergingMultipleFilterKeys() throws Exception {
-        // Route-level metadata_match: envoy.lb: {version: "v1"}, custom.filter: {key1: "a"}
-        // cluster-a metadata_match:   custom.filter: {key2: "b"}
-        // Merged cluster-a: envoy.lb: {version: "v1"}, custom.filter: {key1: "a", key2: "b"}
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig =
-                weightedRouteConfigWithMultipleFilterKeys("route_0");
-        final Cluster clusterA = cluster("cluster-a");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+    void metadataMatchMergingMultipleFilterKeys() {
+        controlPlane.set(cluster("cluster-a"));
+        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234));
+        controlPlane.set(weightedRouteConfigWithMultipleFilterKeys("route_0"));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA),
-                                         ImmutableList.of(endpointA),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -388,27 +276,17 @@ class WeightedClusterTest {
     }
 
     @Test
-    void zeroWeightIsRejected() throws Exception {
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig =
-                weightedRouteConfigWithZeroWeight("route_0", "cluster-a", "cluster-b");
-        final Cluster clusterA = cluster("cluster-a");
-        final Cluster clusterB = cluster("cluster-b");
-        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
-        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
-
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
-                                         ImmutableList.of(endpointA, endpointB),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+    void zeroWeightIsRejected() {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
+
+            // Push invalid resources after the watcher is attached
+            controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+            controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                             endpoint("cluster-b", "127.0.0.1", 5678));
+            controlPlane.set(weightedRouteConfigWithZeroWeight("route_0", "cluster-a", "cluster-b"));
+            controlPlane.set(listener("listener_0", "route_0"));
 
             // The zero-weight should cause an error during route stream processing
             await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
@@ -424,22 +302,14 @@ class WeightedClusterTest {
     }
 
     @Test
-    void singleClusterUnchanged() throws Exception {
-        final Listener listener = listener("listener_0", "route_0");
-        final RouteConfiguration routeConfig = singleClusterRouteConfig("route_0", "cluster-single");
-        final Cluster cluster = cluster("cluster-single");
-        final ClusterLoadAssignment ep = endpoint("cluster-single", "127.0.0.1", 1234);
+    void singleClusterUnchanged() {
+        controlPlane.set(cluster("cluster-single"));
+        controlPlane.set(endpoint("cluster-single", "127.0.0.1", 1234));
+        controlPlane.set(singleClusterRouteConfig("route_0", "cluster-single"));
+        final String version = controlPlane.set(listener("listener_0", "route_0"));
+        controlPlane.awaitListener("listener_0", version);
 
-        cache.setSnapshot(GROUP,
-                          Snapshot.create(ImmutableList.of(cluster),
-                                         ImmutableList.of(ep),
-                                         ImmutableList.of(listener),
-                                         ImmutableList.of(routeConfig),
-                                         ImmutableList.of(), nextVersion()));
-
-        final Bootstrap bootstrap = bootstrap(server.httpPort());
-        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
-             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+        try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
@@ -460,40 +330,6 @@ class WeightedClusterTest {
             assertThat(routeEntry.resolve()).isNotNull();
             assertThat(routeEntry.resolve().clusterSnapshot()).isEqualTo(routeEntry.clusterSnapshot());
         }
-    }
-
-    private static String nextVersion() {
-        return String.valueOf(version.incrementAndGet());
-    }
-
-    private static Bootstrap bootstrap(int port) {
-        final String yaml = """
-                static_resources:
-                  clusters:
-                    - name: %s
-                      connect_timeout: 5s
-                      type: STATIC
-                      load_assignment:
-                        cluster_name: %s
-                        endpoints:
-                          - lb_endpoints:
-                              - endpoint:
-                                  address:
-                                    socket_address:
-                                      address: 127.0.0.1
-                                      port_value: %s
-                dynamic_resources:
-                  ads_config:
-                    api_type: AGGREGATED_GRPC
-                    grpc_services:
-                      - envoy_grpc:
-                          cluster_name: %s
-                  lds_config:
-                    ads: {}
-                  cds_config:
-                    ads: {}
-                """.formatted(BOOTSTRAP_CLUSTER_NAME, BOOTSTRAP_CLUSTER_NAME, port, BOOTSTRAP_CLUSTER_NAME);
-        return XdsResourceReader.fromYaml(yaml, Bootstrap.class);
     }
 
     private static Listener listener(String name, String routeName) {

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
@@ -1,0 +1,709 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Struct;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.RouteCluster;
+import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.SnapshotWatcher;
+import com.linecorp.armeria.xds.WeightedClusterSnapshot;
+import com.linecorp.armeria.xds.XdsBootstrap;
+
+import io.envoyproxy.controlplane.cache.v3.SimpleCache;
+import io.envoyproxy.controlplane.cache.v3.Snapshot;
+import io.envoyproxy.controlplane.server.V3DiscoveryServer;
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
+
+class WeightedClusterTest {
+
+    private static final String GROUP = "key";
+    private static final String BOOTSTRAP_CLUSTER_NAME = "bootstrap-cluster";
+    private static final SimpleCache<String> cache = new SimpleCache<>(node -> GROUP);
+    private static final AtomicLong version = new AtomicLong();
+
+    @RegisterExtension
+    @Order(0)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final V3DiscoveryServer v3DiscoveryServer = new V3DiscoveryServer(cache);
+            sb.service(GrpcService.builder()
+                                  .addService(v3DiscoveryServer.getAggregatedDiscoveryServiceImpl())
+                                  .addService(v3DiscoveryServer.getListenerDiscoveryServiceImpl())
+                                  .addService(v3DiscoveryServer.getClusterDiscoveryServiceImpl())
+                                  .addService(v3DiscoveryServer.getRouteDiscoveryServiceImpl())
+                                  .addService(v3DiscoveryServer.getEndpointDiscoveryServiceImpl())
+                                  .build());
+            sb.http(0);
+        }
+    };
+
+    @RegisterExtension
+    @Order(1)
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    @BeforeEach
+    void beforeEach() {
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(), ImmutableList.of(),
+                                         ImmutableList.of(), ImmutableList.of(),
+                                         ImmutableList.of(),
+                                         String.valueOf(version.incrementAndGet())));
+    }
+
+    @Test
+    void weightedClustersSnapshotStructure() throws Exception {
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 80, "cluster-b", 20);
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final ListenerSnapshot listenerSnapshot = watcher.lastSnapshot();
+            final List<RouteEntry> routeEntries =
+                    listenerSnapshot.routeSnapshot().virtualHostSnapshots().get(0).routeEntries();
+            assertThat(routeEntries).hasSize(1);
+
+            final RouteEntry routeEntry = routeEntries.get(0);
+            // Single cluster should be null for weighted routes
+            assertThat(routeEntry.clusterSnapshot()).isNull();
+            // Weighted cluster entries should be present
+            assertThat(routeEntry.weightedClusters()).isNotNull();
+            assertThat(routeEntry.weightedClusters()).hasSize(2);
+
+            final List<WeightedClusterSnapshot> entries = routeEntry.weightedClusters();
+            assertThat(entries.get(0).clusterSnapshot().xdsResource().name()).isEqualTo("cluster-a");
+            assertThat(entries.get(0).weight()).isEqualTo(80);
+            assertThat(entries.get(1).clusterSnapshot().xdsResource().name()).isEqualTo("cluster-b");
+            assertThat(entries.get(1).weight()).isEqualTo(20);
+
+            // resolve should always return a non-null target
+            assertThat(routeEntry.resolve()).isNotNull();
+        }
+    }
+
+    @Test
+    void weightDistribution() throws Exception {
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 3, "cluster-b", 1);
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final RouteEntry routeEntry =
+                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                           .routeEntries().get(0);
+
+            // Weighted round-robin is deterministic. Over one full cycle (totalWeight = 4),
+            // cluster-a (weight 3) is picked 3 times and cluster-b (weight 1) is picked once.
+            int countA = 0;
+            int countB = 0;
+            for (int i = 0; i < 4; i++) {
+                final RouteCluster selected = routeEntry.resolve();
+                assertThat(selected).isNotNull();
+                if ("cluster-a".equals(selected.clusterSnapshot().xdsResource().name())) {
+                    countA++;
+                } else {
+                    countB++;
+                }
+            }
+            assertThat(countA).isEqualTo(3);
+            assertThat(countB).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void dynamicUpdate() throws Exception {
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig = weightedRouteConfig("route_0", "cluster-a", 50, "cluster-b", 50);
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+                assertThat(watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                                  .routeEntries().get(0).weightedClusters()).hasSize(2);
+            });
+
+            // Update endpoints for cluster-a
+            final ClusterLoadAssignment updatedEndpointA = endpoint("cluster-a", "127.0.0.2", 9999);
+            cache.setSnapshot(GROUP,
+                              Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                             ImmutableList.of(updatedEndpointA, endpointB),
+                                             ImmutableList.of(listener),
+                                             ImmutableList.of(routeConfig),
+                                             ImmutableList.of(), nextVersion()));
+
+            // Wait for re-emission with updated endpoint
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                final ListenerSnapshot latest = watcher.lastSnapshot();
+                assertThat(latest).isNotNull();
+                final RouteEntry re = latest.routeSnapshot().virtualHostSnapshots().get(0)
+                                            .routeEntries().get(0);
+                assertThat(re.weightedClusters()).isNotNull();
+                final ClusterSnapshot csA = re.weightedClusters().get(0).clusterSnapshot();
+                assertThat(csA.endpointSnapshot().xdsResource().resource()).isEqualTo(updatedEndpointA);
+            });
+        }
+    }
+
+    @Test
+    void defaultWeight() throws Exception {
+        // Clusters without explicit weight default to 1
+        final RouteConfiguration routeConfig
+                = weightedRouteConfigNoWeights("route_0", "cluster-a", "cluster-b");
+        final Listener listener = listener("listener_0", "route_0");
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final RouteEntry routeEntry =
+                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                           .routeEntries().get(0);
+
+            assertThat(routeEntry.weightedClusters()).hasSize(2);
+            // Both should default to weight 1
+            assertThat(routeEntry.weightedClusters().get(0).weight()).isEqualTo(1);
+            assertThat(routeEntry.weightedClusters().get(1).weight()).isEqualTo(1);
+
+            // Equal weights: round-robin alternates between the two clusters
+            final RouteCluster first = routeEntry.resolve();
+            final RouteCluster second = routeEntry.resolve();
+            assertThat(first).isNotNull();
+            assertThat(second).isNotNull();
+            assertThat(first.clusterSnapshot().xdsResource().name())
+                    .isNotEqualTo(second.clusterSnapshot().xdsResource().name());
+        }
+    }
+
+    @Test
+    void metadataMatchMerging() throws Exception {
+        // Route-level metadata_match: envoy.lb: {version: "v1", stage: "prod"}
+        // cluster-a metadata_match:   envoy.lb: {stage: "canary"}         -> overrides stage
+        // cluster-b metadata_match:   (none)                              -> inherits route-level
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig = weightedRouteConfigWithMetadata("route_0");
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final RouteEntry routeEntry =
+                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                           .routeEntries().get(0);
+
+            assertThat(routeEntry.weightedClusters()).hasSize(2);
+
+            // cluster-a: route metadata merged with cluster metadata
+            // stage should be overridden to "canary", version should be preserved from route
+            final WeightedClusterSnapshot entryA = routeEntry.weightedClusters().get(0);
+            assertThat(entryA.clusterSnapshot().xdsResource().name()).isEqualTo("cluster-a");
+            final Metadata metadataA = entryA.metadataMatch();
+            final Struct envoyLbA = metadataA.getFilterMetadataOrThrow("envoy.lb");
+            assertThat(envoyLbA.getFieldsOrThrow("version").getStringValue()).isEqualTo("v1");
+            assertThat(envoyLbA.getFieldsOrThrow("stage").getStringValue()).isEqualTo("canary");
+
+            // cluster-b: no cluster-level metadata, should inherit route-level metadata as-is
+            final WeightedClusterSnapshot entryB = routeEntry.weightedClusters().get(1);
+            assertThat(entryB.clusterSnapshot().xdsResource().name()).isEqualTo("cluster-b");
+            final Metadata metadataB = entryB.metadataMatch();
+            final Struct envoyLbB = metadataB.getFilterMetadataOrThrow("envoy.lb");
+            assertThat(envoyLbB.getFieldsOrThrow("version").getStringValue()).isEqualTo("v1");
+            assertThat(envoyLbB.getFieldsOrThrow("stage").getStringValue()).isEqualTo("prod");
+        }
+    }
+
+    @Test
+    void metadataMatchMergingMultipleFilterKeys() throws Exception {
+        // Route-level metadata_match: envoy.lb: {version: "v1"}, custom.filter: {key1: "a"}
+        // cluster-a metadata_match:   custom.filter: {key2: "b"}
+        // Merged cluster-a: envoy.lb: {version: "v1"}, custom.filter: {key1: "a", key2: "b"}
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig =
+                weightedRouteConfigWithMultipleFilterKeys("route_0");
+        final Cluster clusterA = cluster("cluster-a");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA),
+                                         ImmutableList.of(endpointA),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final RouteEntry routeEntry =
+                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                           .routeEntries().get(0);
+
+            final WeightedClusterSnapshot entry = routeEntry.weightedClusters().get(0);
+            final Metadata metadata = entry.metadataMatch();
+
+            // envoy.lb from route-level preserved entirely
+            final Struct envoyLb = metadata.getFilterMetadataOrThrow("envoy.lb");
+            assertThat(envoyLb.getFieldsOrThrow("version").getStringValue()).isEqualTo("v1");
+
+            // custom.filter merged: key1 from route, key2 from cluster
+            final Struct customFilter = metadata.getFilterMetadataOrThrow("custom.filter");
+            assertThat(customFilter.getFieldsOrThrow("key1").getStringValue()).isEqualTo("a");
+            assertThat(customFilter.getFieldsOrThrow("key2").getStringValue()).isEqualTo("b");
+        }
+    }
+
+    @Test
+    void zeroWeightIsRejected() throws Exception {
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig =
+                weightedRouteConfigWithZeroWeight("route_0", "cluster-a", "cluster-b");
+        final Cluster clusterA = cluster("cluster-a");
+        final Cluster clusterB = cluster("cluster-b");
+        final ClusterLoadAssignment endpointA = endpoint("cluster-a", "127.0.0.1", 1234);
+        final ClusterLoadAssignment endpointB = endpoint("cluster-b", "127.0.0.1", 5678);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(clusterA, clusterB),
+                                         ImmutableList.of(endpointA, endpointB),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            // The zero-weight should cause an error during route stream processing
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.errors()).isNotEmpty();
+                assertThat(watcher.errors().get(0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("weight of 0");
+            });
+
+            // No successful snapshot should be emitted
+            assertThat(watcher.lastSnapshot()).isNull();
+        }
+    }
+
+    @Test
+    void singleClusterUnchanged() throws Exception {
+        final Listener listener = listener("listener_0", "route_0");
+        final RouteConfiguration routeConfig = singleClusterRouteConfig("route_0", "cluster-single");
+        final Cluster cluster = cluster("cluster-single");
+        final ClusterLoadAssignment ep = endpoint("cluster-single", "127.0.0.1", 1234);
+
+        cache.setSnapshot(GROUP,
+                          Snapshot.create(ImmutableList.of(cluster),
+                                         ImmutableList.of(ep),
+                                         ImmutableList.of(listener),
+                                         ImmutableList.of(routeConfig),
+                                         ImmutableList.of(), nextVersion()));
+
+        final Bootstrap bootstrap = bootstrap(server.httpPort());
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap, eventLoop.get());
+             ListenerRoot listenerRoot = xdsBootstrap.listenerRoot("listener_0")) {
+            final RecordingWatcher watcher = new RecordingWatcher();
+            listenerRoot.addSnapshotWatcher(watcher);
+
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+                assertThat(watcher.lastSnapshot()).isNotNull();
+            });
+
+            final RouteEntry routeEntry =
+                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
+                           .routeEntries().get(0);
+
+            // Single cluster route: clusterSnapshot non-null, weighted entries null
+            assertThat(routeEntry.clusterSnapshot()).isNotNull();
+            assertThat(routeEntry.clusterSnapshot().xdsResource().name()).isEqualTo("cluster-single");
+            assertThat(routeEntry.weightedClusters()).isNull();
+
+            // resolve returns the same single cluster
+            assertThat(routeEntry.resolve()).isNotNull();
+            assertThat(routeEntry.resolve().clusterSnapshot()).isEqualTo(routeEntry.clusterSnapshot());
+        }
+    }
+
+    private static String nextVersion() {
+        return String.valueOf(version.incrementAndGet());
+    }
+
+    private static Bootstrap bootstrap(int port) {
+        final String yaml = """
+                static_resources:
+                  clusters:
+                    - name: %s
+                      connect_timeout: 5s
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: %s
+                        endpoints:
+                          - lb_endpoints:
+                              - endpoint:
+                                  address:
+                                    socket_address:
+                                      address: 127.0.0.1
+                                      port_value: %s
+                dynamic_resources:
+                  ads_config:
+                    api_type: AGGREGATED_GRPC
+                    grpc_services:
+                      - envoy_grpc:
+                          cluster_name: %s
+                  lds_config:
+                    ads: {}
+                  cds_config:
+                    ads: {}
+                """.formatted(BOOTSTRAP_CLUSTER_NAME, BOOTSTRAP_CLUSTER_NAME, port, BOOTSTRAP_CLUSTER_NAME);
+        return XdsResourceReader.fromYaml(yaml, Bootstrap.class);
+    }
+
+    private static Listener listener(String name, String routeName) {
+        final String yaml = """
+                name: %s
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                    codec_type: AUTO
+                    stat_prefix: ingress_http
+                    rds:
+                      route_config_name: %s
+                      config_source:
+                        ads: {}
+                    http_filters:
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                """.formatted(name, routeName);
+        return XdsResourceReader.fromYaml(yaml, Listener.class);
+    }
+
+    private static RouteConfiguration weightedRouteConfig(String name,
+                                                          String cluster1, int weight1,
+                                                          String cluster2, int weight2) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: weighted-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          weighted_clusters:
+                            clusters:
+                              - name: %s
+                                weight: %d
+                              - name: %s
+                                weight: %d
+                """.formatted(name, cluster1, weight1, cluster2, weight2);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static RouteConfiguration weightedRouteConfigNoWeights(String name,
+                                                                   String cluster1, String cluster2) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: weighted-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          weighted_clusters:
+                            clusters:
+                              - name: %s
+                              - name: %s
+                """.formatted(name, cluster1, cluster2);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static RouteConfiguration singleClusterRouteConfig(String name, String clusterName) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: single-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          cluster: %s
+                """.formatted(name, clusterName);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static Cluster cluster(String name) {
+        final String yaml = """
+                name: %s
+                connect_timeout: 5s
+                type: EDS
+                eds_cluster_config:
+                  eds_config:
+                    ads: {}
+                  service_name: %s
+                """.formatted(name, name);
+        return XdsResourceReader.fromYaml(yaml, Cluster.class);
+    }
+
+    private static ClusterLoadAssignment endpoint(String clusterName, String address, int port) {
+        final String yaml = """
+                cluster_name: %s
+                endpoints:
+                  - lb_endpoints:
+                      - endpoint:
+                          address:
+                            socket_address:
+                              address: %s
+                              port_value: %d
+                """.formatted(clusterName, address, port);
+        return XdsResourceReader.fromYaml(yaml, ClusterLoadAssignment.class);
+    }
+
+    private static RouteConfiguration weightedRouteConfigWithMetadata(String name) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: weighted-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          metadata_match:
+                            filter_metadata:
+                              envoy.lb:
+                                version: "v1"
+                                stage: "prod"
+                          weighted_clusters:
+                            clusters:
+                              - name: cluster-a
+                                weight: 50
+                                metadata_match:
+                                  filter_metadata:
+                                    envoy.lb:
+                                      stage: "canary"
+                              - name: cluster-b
+                                weight: 50
+                """.formatted(name);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static RouteConfiguration weightedRouteConfigWithMultipleFilterKeys(String name) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: weighted-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          metadata_match:
+                            filter_metadata:
+                              envoy.lb:
+                                version: "v1"
+                              custom.filter:
+                                key1: "a"
+                          weighted_clusters:
+                            clusters:
+                              - name: cluster-a
+                                weight: 100
+                                metadata_match:
+                                  filter_metadata:
+                                    custom.filter:
+                                      key2: "b"
+                """.formatted(name);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static RouteConfiguration weightedRouteConfigWithZeroWeight(String name,
+                                                                       String cluster1,
+                                                                       String cluster2) {
+        final String yaml = """
+                name: %s
+                virtual_hosts:
+                  - name: weighted-vhost
+                    domains: ["*"]
+                    routes:
+                      - match:
+                          prefix: "/"
+                        route:
+                          weighted_clusters:
+                            clusters:
+                              - name: %s
+                                weight: 0
+                              - name: %s
+                                weight: 10
+                """.formatted(name, cluster1, cluster2);
+        return XdsResourceReader.fromYaml(yaml, RouteConfiguration.class);
+    }
+
+    private static final class RecordingWatcher implements SnapshotWatcher<ListenerSnapshot> {
+
+        private final List<ListenerSnapshot> snapshots = new CopyOnWriteArrayList<>();
+        private final List<Throwable> errors = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onUpdate(@Nullable ListenerSnapshot snapshot, @Nullable Throwable t) {
+            if (snapshot != null) {
+                snapshots.add(snapshot);
+            }
+            if (t != null) {
+                errors.add(t);
+            }
+        }
+
+        @Nullable
+        ListenerSnapshot lastSnapshot() {
+            if (snapshots.isEmpty()) {
+                return null;
+            }
+            return snapshots.get(snapshots.size() - 1);
+        }
+
+        List<Throwable> errors() {
+            return errors;
+        }
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/WeightedClusterTest.java
@@ -164,38 +164,28 @@ class WeightedClusterTest {
     }
 
     @Test
-    void defaultWeight() {
-        controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
-        controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
-                         endpoint("cluster-b", "127.0.0.1", 5678));
-        controlPlane.set(weightedRouteConfigNoWeights("route_0", "cluster-a", "cluster-b"));
-        final String version = controlPlane.set(listener("listener_0", "route_0"));
-        controlPlane.awaitListener("listener_0", version);
-
+    void missingWeightIsRejected() {
         try (ListenerRoot listenerRoot = controlPlane.bootstrap().listenerRoot("listener_0")) {
             final RecordingWatcher watcher = new RecordingWatcher();
             listenerRoot.addSnapshotWatcher(watcher);
 
+            // Push resources with missing weight after the watcher is attached
+            controlPlane.set(cluster("cluster-a"), cluster("cluster-b"));
+            controlPlane.set(endpoint("cluster-a", "127.0.0.1", 1234),
+                             endpoint("cluster-b", "127.0.0.1", 5678));
+            controlPlane.set(weightedRouteConfigNoWeights("route_0", "cluster-a", "cluster-b"));
+            controlPlane.set(listener("listener_0", "route_0"));
+
+            // Missing weight defaults to 0 and should be rejected like Envoy
             await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
-                assertThat(watcher.lastSnapshot()).isNotNull();
+                assertThat(watcher.errors()).isNotEmpty();
+                assertThat(watcher.errors().get(0))
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("weight of 0");
             });
 
-            final RouteEntry routeEntry =
-                    watcher.lastSnapshot().routeSnapshot().virtualHostSnapshots().get(0)
-                           .routeEntries().get(0);
-
-            assertThat(routeEntry.weightedClusters()).hasSize(2);
-            // Both should default to weight 1
-            assertThat(routeEntry.weightedClusters().get(0).weight()).isEqualTo(1);
-            assertThat(routeEntry.weightedClusters().get(1).weight()).isEqualTo(1);
-
-            // Equal weights: round-robin alternates between the two clusters
-            final RouteCluster first = routeEntry.resolve();
-            final RouteCluster second = routeEntry.resolve();
-            assertThat(first).isNotNull();
-            assertThat(second).isNotNull();
-            assertThat(first.clusterSnapshot().xdsResource().name())
-                    .isNotEqualTo(second.clusterSnapshot().xdsResource().name());
+            // No successful snapshot should be emitted
+            assertThat(watcher.lastSnapshot()).isNull();
         }
     }
 

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsControlPlaneExtension.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsControlPlaneExtension.java
@@ -121,18 +121,15 @@ public final class XdsControlPlaneExtension extends AbstractAllOrEachExtension {
         final String yaml =
                 """
                 dynamic_resources:
+                  ads_config:
+                    api_type: AGGREGATED_GRPC
+                    grpc_services:
+                      - envoy_grpc:
+                          cluster_name: xds-cluster
                   lds_config:
-                    api_config_source:
-                      api_type: GRPC
-                      grpc_services:
-                        - envoy_grpc:
-                            cluster_name: xds-cluster
+                    ads: {}
                   cds_config:
-                    api_config_source:
-                      api_type: GRPC
-                      grpc_services:
-                        - envoy_grpc:
-                            cluster_name: xds-cluster
+                    ads: {}
                 static_resources:
                   clusters:
                     - name: xds-cluster

--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -454,6 +454,7 @@ message WeightedCluster {
     // [#next-major-version: Need to add back the validation rule: (validate.rules).string = {min_len: 1}]
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
+    option (armeria.xds.supported.field) = 1;
     string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // Only one of ``name`` and ``cluster_header`` may be specified.
@@ -481,6 +482,7 @@ message WeightedCluster {
     // is determined by its weight. The sum of weights across all
     // entries in the clusters array must be greater than 0, and must not exceed
     // uint32_t maximal value (4294967295).
+    option (armeria.xds.supported.field) = 2;
     google.protobuf.UInt32Value weight = 2;
 
     // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
@@ -488,6 +490,7 @@ message WeightedCluster {
     // load balancing. Note that this will be merged with what's provided in
     // :ref:`RouteAction.metadata_match <envoy_v3_api_field_config.route.v3.RouteAction.metadata_match>`, with
     // values here taking precedence. The filter name should be specified as ``envoy.lb``.
+    option (armeria.xds.supported.field) = 3;
     core.v3.Metadata metadata_match = 3;
 
     // Specifies a list of headers to be added to requests when this cluster is selected
@@ -530,6 +533,7 @@ message WeightedCluster {
     // [#comment: An entry's value may be wrapped in a
     // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
     // message to specify additional options.]
+    option (armeria.xds.supported.field) = 10;
     map<string, google.protobuf.Any> typed_per_filter_config = 10;
 
     oneof host_rewrite_specifier {
@@ -541,6 +545,7 @@ message WeightedCluster {
   }
 
   // Specifies one or more upstream clusters associated with the route.
+  option (armeria.xds.supported.field) = 1;
   repeated ClusterWeight clusters = 1 [(validate.rules).repeated = {min_items: 1}];
 
   // Specifies the total weight across all clusters. The sum of all cluster weights must equal this
@@ -1176,6 +1181,7 @@ message RouteAction {
     // assigned to each cluster. See
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
+    option (armeria.xds.supported.oneof_field) = 3;
     WeightedCluster weighted_clusters = 3;
 
     // Name of the cluster specifier plugin to use to determine the cluster for requests on this route.

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
@@ -92,13 +92,13 @@ final class ClusterFilterFactory {
         ctx.setEndpointGroup(endpointGroup);
         ctx.setSessionProtocol(sessionProtocol);
 
-        final RouteEntry route = ctx.attr(XdsCommonUtil.SELECTED_ROUTE);
+        final RouteCluster routeCluster = ctx.attr(XdsCommonUtil.ROUTE_CLUSTER);
         final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
         if (ctxExt != null) {
-            final HttpClient httpClient = route != null ?
-                                          route.httpClient() : CLUSTER_ONLY_HTTP_CLIENT;
-            final RpcClient rpcClient = route != null ?
-                                        route.rpcClient() : CLUSTER_ONLY_RPC_CLIENT;
+            final HttpClient httpClient = routeCluster != null ?
+                                          routeCluster.httpClient() : CLUSTER_ONLY_HTTP_CLIENT;
+            final RpcClient rpcClient = routeCluster != null ?
+                                        routeCluster.rpcClient() : CLUSTER_ONLY_RPC_CLIENT;
             ctxExt.httpClientCustomizer(actualClient -> {
                 DelegatingHttpClient.setDelegate(ctx, actualClient);
                 return httpClient;

--- a/xds/src/main/java/com/linecorp/armeria/xds/DefaultRouteCluster.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/DefaultRouteCluster.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientPreprocessors;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreClient;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+
+final class DefaultRouteCluster implements RouteCluster {
+
+    private final ClusterSnapshot clusterSnapshot;
+    private final Metadata metadataMatch;
+    private final HttpPreClient httpPreClient;
+    private final RpcPreClient rpcPreClient;
+    private final HttpClient httpClient;
+    private final RpcClient rpcClient;
+
+    DefaultRouteCluster(ClusterSnapshot clusterSnapshot, Metadata metadataMatch,
+                        @Nullable ClientDecoration retryDecoration,
+                        ClientPreprocessors downstreamPreprocessors,
+                        ClientDecoration upstreamDecoration) {
+        this.clusterSnapshot = requireNonNull(clusterSnapshot, "clusterSnapshot");
+        this.metadataMatch = requireNonNull(metadataMatch, "metadataMatch");
+        httpPreClient = FilterUtil.buildHttpPreClient(downstreamPreprocessors);
+        rpcPreClient = FilterUtil.buildRpcPreClient(downstreamPreprocessors);
+        httpClient = FilterUtil.buildHttpClient(retryDecoration, upstreamDecoration);
+        rpcClient = FilterUtil.buildRpcClient(upstreamDecoration);
+    }
+
+    @Override
+    public ClusterSnapshot clusterSnapshot() {
+        return clusterSnapshot;
+    }
+
+    @Override
+    public Metadata metadataMatch() {
+        return metadataMatch;
+    }
+
+    @Override
+    public HttpPreClient httpPreClient() {
+        return httpPreClient;
+    }
+
+    @Override
+    public RpcPreClient rpcPreClient() {
+        return rpcPreClient;
+    }
+
+    @Override
+    public HttpClient httpClient() {
+        return httpClient;
+    }
+
+    @Override
+    public RpcClient rpcClient() {
+        return rpcClient;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultRouteCluster that = (DefaultRouteCluster) o;
+        return Objects.equals(clusterSnapshot, that.clusterSnapshot) &&
+               Objects.equals(metadataMatch, that.metadataMatch);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterSnapshot, metadataMatch);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("clusterSnapshot", clusterSnapshot)
+                          .add("metadataMatch", metadataMatch)
+                          .toString();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterUtil.java
@@ -29,6 +29,10 @@ import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientDecorationBuilder;
 import com.linecorp.armeria.client.ClientPreprocessors;
 import com.linecorp.armeria.client.ClientPreprocessorsBuilder;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreClient;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -38,6 +42,8 @@ import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
+import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
+import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
 
 import io.envoyproxy.envoy.config.route.v3.RetryPolicy;
@@ -47,13 +53,25 @@ import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3
 final class FilterUtil {
 
     static Map<String, Any> mergeFilterConfigs(
-            Map<String, Any> routeConfigFilterConfigs,
-            Map<String, Any> vhostFilterConfigs,
-            Map<String, Any> routeFilterConfigs) {
+            Map<String, Any> first,
+            Map<String, Any> second) {
+        if (second.isEmpty()) {
+            return first;
+        }
         return ImmutableMap.<String, Any>builder()
-                           .putAll(routeConfigFilterConfigs)
-                           .putAll(vhostFilterConfigs)
-                           .putAll(routeFilterConfigs)
+                           .putAll(first)
+                           .putAll(second)
+                           .buildKeepingLast();
+    }
+
+    static Map<String, Any> mergeFilterConfigs(
+            Map<String, Any> first,
+            Map<String, Any> second,
+            Map<String, Any> third) {
+        return ImmutableMap.<String, Any>builder()
+                           .putAll(first)
+                           .putAll(second)
+                           .putAll(third)
                            .buildKeepingLast();
     }
 
@@ -187,6 +205,29 @@ final class FilterUtil {
                       httpFilter.getConfigTypeCase());
         return factory.createStream(httpFilter, filterConfig, factoryContext)
                       .rescheduleEventsOn(factoryContext.eventLoop());
+    }
+
+    static HttpPreClient buildHttpPreClient(ClientPreprocessors downstreamPreprocessors) {
+        return downstreamPreprocessors.decorate(DelegatingHttpClient.of());
+    }
+
+    static RpcPreClient buildRpcPreClient(ClientPreprocessors downstreamPreprocessors) {
+        return downstreamPreprocessors.rpcDecorate(DelegatingRpcClient.of());
+    }
+
+    static HttpClient buildHttpClient(@Nullable ClientDecoration retryDecoration,
+                                      ClientDecoration upstreamDecoration) {
+        HttpClient clusterHttp = ClusterFilterFactory.DECORATION.decorate(
+                upstreamDecoration.decorate(DelegatingHttpClient.of()));
+        if (retryDecoration != null) {
+            clusterHttp = retryDecoration.decorate(clusterHttp);
+        }
+        return clusterHttp;
+    }
+
+    static RpcClient buildRpcClient(ClientDecoration upstreamDecoration) {
+        return ClusterFilterFactory.DECORATION.rpcDecorate(
+                upstreamDecoration.rpcDecorate(DelegatingRpcClient.of()));
     }
 
     private FilterUtil() {}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteCluster.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteCluster.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreClient;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+
+/**
+ * The result of route resolution via {@link RouteEntry#resolve()}.
+ * Contains the resolved cluster, metadata match criteria, and pre-built filter chains.
+ */
+@UnstableApi
+public interface RouteCluster {
+
+    /**
+     * Returns the selected {@link ClusterSnapshot}.
+     */
+    ClusterSnapshot clusterSnapshot();
+
+    /**
+     * Returns the metadata match criteria.
+     */
+    Metadata metadataMatch();
+
+    /**
+     * Returns the downstream {@link HttpPreClient} chain for this route.
+     */
+    HttpPreClient httpPreClient();
+
+    /**
+     * Returns the downstream {@link RpcPreClient} chain for this route.
+     */
+    RpcPreClient rpcPreClient();
+
+    /**
+     * Returns the pre-built {@link HttpClient} chain for this route.
+     */
+    HttpClient httpClient();
+
+    /**
+     * Returns the pre-built {@link RpcClient} chain for this route.
+     */
+    RpcClient rpcClient();
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
@@ -88,7 +88,7 @@ final class RouteClusterFactory {
                 new ArrayList<>(clusterWeightList.size());
         for (ClusterWeight clusterWeight : clusterWeightList) {
             final String name = clusterWeight.getName();
-            final int weight = clusterWeight.hasWeight() ? clusterWeight.getWeight().getValue() : 1;
+            final int weight = clusterWeight.getWeight().getValue();
             checkArgument(weight > 0, "weighted cluster '%s' has a weight of 0", name);
             final Metadata mergedMetadata = mergeMetadata(routeMetadataMatch, clusterWeight.getMetadataMatch());
             final SnapshotStream<ClusterSnapshot> clusterStream =

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.Struct;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientPreprocessors;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.xds.stream.SnapshotStream;
+
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+import io.envoyproxy.envoy.config.route.v3.Route;
+import io.envoyproxy.envoy.config.route.v3.RouteAction;
+import io.envoyproxy.envoy.config.route.v3.WeightedCluster;
+import io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight;
+
+final class RouteClusterFactory {
+
+    private final SubscriptionContext context;
+    private final HcmContext hcmContext;
+    private final Map<String, Any> routeFilterConfigs;
+    @Nullable
+    private final ClientDecoration retryDecoration;
+
+    RouteClusterFactory(SubscriptionContext context, HcmContext hcmContext,
+                        Map<String, Any> routeFilterConfigs,
+                        @Nullable ClientDecoration retryDecoration) {
+        this.context = context;
+        this.hcmContext = hcmContext;
+        this.routeFilterConfigs = routeFilterConfigs;
+        this.retryDecoration = retryDecoration;
+    }
+
+    SnapshotStream<RouteClusterResolver> resolve(Route route) {
+        final RouteAction routeAction = route.getRoute();
+        if (routeAction.hasWeightedClusters()) {
+            return resolveWeightedClusters(routeAction);
+        }
+        if (routeAction.hasCluster()) {
+            return resolveCluster(routeAction);
+        }
+        return SnapshotStream.just(RouteClusterResolver.empty());
+    }
+
+    private SnapshotStream<RouteClusterResolver> resolveCluster(RouteAction routeAction) {
+        final String clusterName = routeAction.getCluster();
+        final Metadata routeMetadataMatch = routeAction.getMetadataMatch();
+        final SnapshotStream<ClusterSnapshot> clusterStream =
+                w -> context.clusterManager().register(clusterName, context, w);
+        final SnapshotStream<ClientPreprocessors> downstreamStream = hcmContext.downstream(routeFilterConfigs);
+        final SnapshotStream<ClientDecoration> upstreamStream = hcmContext.upstream(routeFilterConfigs);
+        return SnapshotStream.combineLatest(
+                clusterStream, downstreamStream, upstreamStream,
+                (cs, down, up) -> {
+                    return RouteClusterResolver.ofSingle(new DefaultRouteCluster(cs, routeMetadataMatch,
+                                                                                 retryDecoration, down, up));
+                });
+    }
+
+    private SnapshotStream<RouteClusterResolver> resolveWeightedClusters(RouteAction routeAction) {
+        final WeightedCluster weightedClusters = routeAction.getWeightedClusters();
+        final Metadata routeMetadataMatch = routeAction.getMetadataMatch();
+        final List<ClusterWeight> clusterWeightList = weightedClusters.getClustersList();
+
+        final List<SnapshotStream<WeightedClusterSnapshot>> wcStreams =
+                new ArrayList<>(clusterWeightList.size());
+        for (ClusterWeight clusterWeight : clusterWeightList) {
+            final String name = clusterWeight.getName();
+            final int weight = clusterWeight.hasWeight() ? clusterWeight.getWeight().getValue() : 1;
+            checkArgument(weight > 0, "weighted cluster '%s' has a weight of 0", name);
+            final Metadata mergedMetadata = mergeMetadata(routeMetadataMatch, clusterWeight.getMetadataMatch());
+            final SnapshotStream<ClusterSnapshot> clusterStream =
+                    w -> context.clusterManager().register(name, context, w);
+
+            final Map<String, Any> merged =
+                    FilterUtil.mergeFilterConfigs(routeFilterConfigs,
+                                                  clusterWeight.getTypedPerFilterConfigMap());
+            final SnapshotStream<ClientPreprocessors> downstreamStream = hcmContext.downstream(merged);
+            final SnapshotStream<ClientDecoration> upstreamStream = hcmContext.upstream(merged);
+
+            wcStreams.add(SnapshotStream.combineLatest(
+                    clusterStream, downstreamStream, upstreamStream,
+                    (clusterSnapshot, downstreamFilters, upstreamFilter) -> {
+                        return new WeightedClusterSnapshot(clusterSnapshot, weight, mergedMetadata,
+                                                           retryDecoration, downstreamFilters, upstreamFilter);
+                    }));
+        }
+
+        return SnapshotStream.combineNLatest(wcStreams).map(RouteClusterResolver::ofWeighted);
+    }
+
+    /**
+     * Merges two {@link Metadata} instances. Values from {@code second} take precedence
+     * over values from {@code first} within each filter metadata key.
+     */
+    static Metadata mergeMetadata(Metadata first, Metadata second) {
+        if (second.equals(Metadata.getDefaultInstance())) {
+            return first;
+        }
+        if (first.equals(Metadata.getDefaultInstance())) {
+            return second;
+        }
+        final Metadata.Builder builder = first.toBuilder();
+        for (Map.Entry<String, Struct> entry : second.getFilterMetadataMap().entrySet()) {
+            final String filterName = entry.getKey();
+            final Struct secondStruct = entry.getValue();
+            final Struct firstStruct = first.getFilterMetadataOrDefault(filterName, null);
+            if (firstStruct == null) {
+                builder.putFilterMetadata(filterName, secondStruct);
+            } else {
+                builder.putFilterMetadata(filterName, firstStruct.toBuilder()
+                                                                 .putAllFields(secondStruct.getFieldsMap())
+                                                                 .build());
+            }
+        }
+        return builder.build();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterResolver.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterResolver.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.loadbalancer.LoadBalancer;
+import com.linecorp.armeria.common.loadbalancer.SimpleLoadBalancer;
+
+final class RouteClusterResolver {
+
+    private static final RouteClusterResolver EMPTY = new RouteClusterResolver(null, null, null);
+
+    @Nullable
+    private final RouteCluster singleCluster;
+    @Nullable
+    private final List<WeightedClusterSnapshot> weightedClusters;
+    @Nullable
+    private final SimpleLoadBalancer<WeightedClusterSnapshot> loadBalancer;
+
+    private RouteClusterResolver(@Nullable RouteCluster singleCluster,
+                            @Nullable List<WeightedClusterSnapshot> weightedClusters,
+                            @Nullable SimpleLoadBalancer<WeightedClusterSnapshot> loadBalancer) {
+        this.singleCluster = singleCluster;
+        this.weightedClusters = weightedClusters;
+        this.loadBalancer = loadBalancer;
+    }
+
+    static RouteClusterResolver ofSingle(DefaultRouteCluster routeCluster) {
+        requireNonNull(routeCluster, "routeCluster");
+        return new RouteClusterResolver(routeCluster, null, null);
+    }
+
+    static RouteClusterResolver ofWeighted(List<WeightedClusterSnapshot> weightedClusters) {
+        requireNonNull(weightedClusters, "weightedClusters");
+        return new RouteClusterResolver(null, weightedClusters,
+                                   LoadBalancer.ofWeightedRoundRobin(weightedClusters));
+    }
+
+    static RouteClusterResolver empty() {
+        return EMPTY;
+    }
+
+    @Nullable
+    ClusterSnapshot clusterSnapshot() {
+        return singleCluster != null ? singleCluster.clusterSnapshot() : null;
+    }
+
+    @Nullable
+    List<WeightedClusterSnapshot> weightedClusters() {
+        return weightedClusters;
+    }
+
+    @Nullable
+    RouteCluster resolve() {
+        if (singleCluster != null) {
+            return singleCluster;
+        }
+        if (loadBalancer != null) {
+            return loadBalancer.pick();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RouteClusterResolver that = (RouteClusterResolver) o;
+        return Objects.equals(singleCluster, that.singleCluster) &&
+               Objects.equals(weightedClusters, that.weightedClusters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(singleCluster, weightedClusters);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
+                          .add("singleCluster", singleCluster)
+                          .add("weightedClusters", weightedClusters)
+                          .toString();
+    }
+
+    String toDebugString() {
+        final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
+        helper.add("singleCluster",
+                   SnapshotUtil.debugString(singleCluster,
+                                            rc -> rc.clusterSnapshot().toDebugString()));
+        if (weightedClusters != null) {
+            helper.add("weightedClusters",
+                        SnapshotUtil.debugStrings(weightedClusters,
+                                                  wc -> wc.clusterSnapshot().toDebugString()));
+        }
+        return helper.toString();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterResolver.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterResolver.java
@@ -39,8 +39,8 @@ final class RouteClusterResolver {
     private final SimpleLoadBalancer<WeightedClusterSnapshot> loadBalancer;
 
     private RouteClusterResolver(@Nullable RouteCluster singleCluster,
-                            @Nullable List<WeightedClusterSnapshot> weightedClusters,
-                            @Nullable SimpleLoadBalancer<WeightedClusterSnapshot> loadBalancer) {
+                                 @Nullable List<WeightedClusterSnapshot> weightedClusters,
+                                 @Nullable SimpleLoadBalancer<WeightedClusterSnapshot> loadBalancer) {
         this.singleCluster = singleCluster;
         this.weightedClusters = weightedClusters;
         this.loadBalancer = loadBalancer;
@@ -54,7 +54,7 @@ final class RouteClusterResolver {
     static RouteClusterResolver ofWeighted(List<WeightedClusterSnapshot> weightedClusters) {
         requireNonNull(weightedClusters, "weightedClusters");
         return new RouteClusterResolver(null, weightedClusters,
-                                   LoadBalancer.ofWeightedRoundRobin(weightedClusters));
+                                        LoadBalancer.ofWeightedRoundRobin(weightedClusters));
     }
 
     static RouteClusterResolver empty() {

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
@@ -18,29 +18,19 @@ package com.linecorp.armeria.xds;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
-import com.google.protobuf.Any;
 
-import com.linecorp.armeria.client.ClientDecoration;
-import com.linecorp.armeria.client.ClientPreprocessors;
-import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.client.HttpPreClient;
-import com.linecorp.armeria.client.RpcClient;
-import com.linecorp.armeria.client.RpcPreClient;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.HttpService;
-import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
-import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
 
 import io.envoyproxy.envoy.config.route.v3.Route;
 import io.envoyproxy.envoy.config.route.v3.RouteAction;
 import io.envoyproxy.envoy.config.route.v3.VirtualHost;
-import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
 
 /**
  * Represents a {@link Route}.
@@ -48,41 +38,18 @@ import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3
 public final class RouteEntry {
 
     private final Route route;
-    @Nullable
-    private final ClusterSnapshot clusterSnapshot;
-    private final Map<String, Any> filterConfigs;
+    private final RouteClusterResolver routeResolver;
     private final int index;
-    private final HttpClient httpClient;
-    private final RpcClient rpcClient;
     private final HttpService httpService;
-    private final HttpPreClient httpPreClient;
-    private final RpcPreClient rpcPreClient;
     private final RouteEntryMatcher matcher;
 
-    RouteEntry(Route route, @Nullable ClusterSnapshot clusterSnapshot, int index,
-               Map<String, Any> filterConfigs,
-               ClientPreprocessors downstreamPreprocessors,
-               @Nullable ClientDecoration retryDecoration,
-               ClientDecoration upstreamDecoration, HttpService httpService) {
+    RouteEntry(Route route, RouteClusterResolver routeResolver, int index,
+               HttpService httpService) {
         this.route = route;
-        this.clusterSnapshot = clusterSnapshot;
+        this.routeResolver = routeResolver;
         this.index = index;
-        this.filterConfigs = filterConfigs;
         this.httpService = httpService;
         matcher = new RouteEntryMatcher(route.getMatch());
-
-        // Pre-build the full cluster chain: retry → ClusterFilter → upstream filters → delegate
-        HttpClient clusterHttp = ClusterFilterFactory.DECORATION.decorate(
-                upstreamDecoration.decorate(DelegatingHttpClient.of()));
-        if (retryDecoration != null) {
-            clusterHttp = retryDecoration.decorate(clusterHttp);
-        }
-        httpClient = clusterHttp;
-        rpcClient = ClusterFilterFactory.DECORATION.rpcDecorate(
-                upstreamDecoration.rpcDecorate(DelegatingRpcClient.of()));
-
-        httpPreClient = downstreamPreprocessors.decorate(DelegatingHttpClient.of());
-        rpcPreClient = downstreamPreprocessors.rpcDecorate(DelegatingRpcClient.of());
     }
 
     /**
@@ -94,22 +61,34 @@ public final class RouteEntry {
 
     /**
      * The {@link ClusterSnapshot} that is represented by {@link RouteAction#getCluster()}.
-     * If the {@link RouteAction} does not reference a cluster, the returned value may be {@code null}.
+     * If the {@link RouteAction} does not reference a single cluster (e.g. when using weighted clusters),
+     * the returned value may be {@code null}.
+     * Use {@link #resolve()} for a unified way to obtain a target regardless of the cluster specifier.
      */
     @Nullable
     public ClusterSnapshot clusterSnapshot() {
-        return clusterSnapshot;
+        return routeResolver.clusterSnapshot();
     }
 
     /**
-     * Returns the raw per-route filter config {@link Any} from
-     * {@link Route#getTypedPerFilterConfigMap()}, or {@code null} if not present.
-     *
-     * @param filterName the filter name represented by {@link HttpFilter#getName()}
+     * Returns the list of {@link WeightedClusterSnapshot}s for this route, or {@code null}
+     * if this route uses a single cluster or no cluster.
      */
     @Nullable
-    public Any filterConfig(String filterName) {
-        return filterConfigs.get(filterName);
+    @UnstableApi
+    public List<WeightedClusterSnapshot> weightedClusters() {
+        return routeResolver.weightedClusters();
+    }
+
+    /**
+     * Selects a target for this route. For single-cluster routes, returns the target directly.
+     * For weighted-cluster routes, performs a weighted random selection.
+     * Returns {@code null} if no target is configured.
+     */
+    @Nullable
+    @UnstableApi
+    public RouteCluster resolve() {
+        return routeResolver.resolve();
     }
 
     /**
@@ -118,40 +97,6 @@ public final class RouteEntry {
     @UnstableApi
     public HttpService httpService() {
         return httpService;
-    }
-
-    /**
-     * Returns the downstream {@link HttpPreClient} chain for this route.
-     */
-    @UnstableApi
-    public HttpPreClient httpPreClient() {
-        return httpPreClient;
-    }
-
-    /**
-     * Returns the downstream {@link RpcPreClient} chain for this route.
-     */
-    @UnstableApi
-    public RpcPreClient rpcPreClient() {
-        return rpcPreClient;
-    }
-
-    /**
-     * Returns the pre-built {@link HttpClient} chain for this route. This chain includes
-     * retry, cluster filter, and upstream HTTP filters ending with a {@link DelegatingHttpClient}.
-     */
-    @UnstableApi
-    public HttpClient httpClient() {
-        return httpClient;
-    }
-
-    /**
-     * Returns the pre-built {@link RpcClient} chain for this route. This chain includes
-     * cluster filter and upstream RPC filters ending with a {@link DelegatingRpcClient}.
-     */
-    @UnstableApi
-    public RpcClient rpcClient() {
-        return rpcClient;
     }
 
     /**
@@ -180,19 +125,20 @@ public final class RouteEntry {
         final RouteEntry that = (RouteEntry) o;
         return Objects.equals(route, that.route) &&
                Objects.equals(index, that.index) &&
-               Objects.equals(clusterSnapshot, that.clusterSnapshot);
+               Objects.equals(routeResolver, that.routeResolver);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(route, clusterSnapshot, index);
+        return Objects.hash(route, routeResolver, index);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
                           .add("index", index)
-                          .add("clusterSnapshot", clusterSnapshot)
+                          .add("routeResolver", routeResolver)
                           .toString();
     }
 
@@ -201,9 +147,7 @@ public final class RouteEntry {
                           .omitNullValues()
                           .add("index", index)
                           .add("route", route)
-                          .add("clusterSnapshot",
-                               SnapshotUtil.debugString(clusterSnapshot,
-                                                        ClusterSnapshot::toDebugString))
+                          .add("routeResolver", routeResolver.toDebugString())
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntry.java
@@ -38,15 +38,14 @@ import io.envoyproxy.envoy.config.route.v3.VirtualHost;
 public final class RouteEntry {
 
     private final Route route;
-    private final RouteClusterResolver routeResolver;
+    private final RouteClusterResolver resolver;
     private final int index;
     private final HttpService httpService;
     private final RouteEntryMatcher matcher;
 
-    RouteEntry(Route route, RouteClusterResolver routeResolver, int index,
-               HttpService httpService) {
+    RouteEntry(Route route, RouteClusterResolver resolver, int index, HttpService httpService) {
         this.route = route;
-        this.routeResolver = routeResolver;
+        this.resolver = resolver;
         this.index = index;
         this.httpService = httpService;
         matcher = new RouteEntryMatcher(route.getMatch());
@@ -67,7 +66,7 @@ public final class RouteEntry {
      */
     @Nullable
     public ClusterSnapshot clusterSnapshot() {
-        return routeResolver.clusterSnapshot();
+        return resolver.clusterSnapshot();
     }
 
     /**
@@ -77,18 +76,18 @@ public final class RouteEntry {
     @Nullable
     @UnstableApi
     public List<WeightedClusterSnapshot> weightedClusters() {
-        return routeResolver.weightedClusters();
+        return resolver.weightedClusters();
     }
 
     /**
      * Selects a target for this route. For single-cluster routes, returns the target directly.
-     * For weighted-cluster routes, performs a weighted random selection.
+     * For weighted-cluster routes, performs a weighted round-robin selection.
      * Returns {@code null} if no target is configured.
      */
     @Nullable
     @UnstableApi
     public RouteCluster resolve() {
-        return routeResolver.resolve();
+        return resolver.resolve();
     }
 
     /**
@@ -125,12 +124,12 @@ public final class RouteEntry {
         final RouteEntry that = (RouteEntry) o;
         return Objects.equals(route, that.route) &&
                Objects.equals(index, that.index) &&
-               Objects.equals(routeResolver, that.routeResolver);
+               Objects.equals(resolver, that.resolver);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(route, routeResolver, index);
+        return Objects.hash(route, resolver, index);
     }
 
     @Override
@@ -138,7 +137,7 @@ public final class RouteEntry {
         return MoreObjects.toStringHelper(this)
                           .omitNullValues()
                           .add("index", index)
-                          .add("routeResolver", routeResolver)
+                          .add("routeResolver", resolver)
                           .toString();
     }
 
@@ -147,7 +146,7 @@ public final class RouteEntry {
                           .omitNullValues()
                           .add("index", index)
                           .add("route", route)
-                          .add("routeResolver", routeResolver.toDebugString())
+                          .add("routeResolver", resolver.toDebugString())
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 
 import com.linecorp.armeria.client.ClientDecoration;
-import com.linecorp.armeria.client.ClientPreprocessors;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.xds.stream.RefCountedStream;
@@ -75,7 +74,7 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
         final SnapshotStream<RouteSnapshot> snapshotStream =
                 new ResourceNodeAdapter<RouteXdsResource>(configSource, context, resourceName, ROUTE)
                         .switchMapEager(routeResource ->
-                                new RouteSnapshotStream(routeResource, context, hcmContext));
+                                                new RouteSnapshotStream(routeResource, context, hcmContext));
         return snapshotStream.subscribe(watcher);
     }
 
@@ -149,7 +148,6 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
         private final int index;
         private final Route route;
         private final SubscriptionContext context;
-        private final String clusterName;
         private final RouteXdsResource routeResource;
         private final VirtualHostXdsResource vhostResource;
         private final HcmContext hcmContext;
@@ -160,7 +158,6 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             this.index = index;
             this.route = route;
             this.context = context;
-            clusterName = route.getRoute().getCluster();
             this.routeResource = routeResource;
             this.vhostResource = vhostResource;
             this.hcmContext = hcmContext;
@@ -186,29 +183,15 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             final ClientDecoration retryDecoration =
                     FilterUtil.buildRetryDecoration(effectiveRetryPolicy);
 
-            // Build filter streams (deduped via caches for routes with identical configs)
-            final SnapshotStream<ClientPreprocessors> downstreamStream = hcmContext.downstream(filterConfigs);
-            final SnapshotStream<ClientDecoration> upstreamStream = hcmContext.upstream(filterConfigs);
+            final SnapshotStream<RouteClusterResolver> routeResolverStream =
+                    new RouteClusterFactory(context, hcmContext, filterConfigs, retryDecoration)
+                            .resolve(route);
             final SnapshotStream<HttpService> httpServiceStream = hcmContext.server(filterConfigs);
 
-            if (!route.getRoute().hasCluster()) {
-                return SnapshotStream.combineLatest(
-                        downstreamStream, upstreamStream, httpServiceStream,
-                        (down, up, httpService) -> new RouteEntry(
-                                route, null, index, filterConfigs, down,
-                                retryDecoration, up, httpService))
-                                     .subscribe(watcher);
-            }
-
-            // Wrap cluster registration as SnapshotStream
-            final SnapshotStream<ClusterSnapshot> clusterStream =
-                    w -> context.clusterManager().register(clusterName, context, w);
-
-            return SnapshotStream.combineLatest(
-                    clusterStream, downstreamStream, upstreamStream, httpServiceStream,
-                    (cluster, down, up, httpService) -> new RouteEntry(
-                            route, cluster, index, filterConfigs, down,
-                            retryDecoration, up, httpService))
+            return SnapshotStream.combineLatest(routeResolverStream, httpServiceStream,
+                                                (resolver, httpService) -> {
+                                                    return new RouteEntry(route, resolver, index, httpService);
+                                                })
                                  .subscribe(watcher);
         }
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/WeightedClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/WeightedClusterSnapshot.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.armeria.client.ClientDecoration;
+import com.linecorp.armeria.client.ClientPreprocessors;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.RpcPreClient;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.loadbalancer.Weighted;
+
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+import io.envoyproxy.envoy.config.route.v3.WeightedCluster.ClusterWeight;
+
+/**
+ * Represents a single entry in a {@link ClusterWeight} with
+ * its resolved {@link ClusterSnapshot} and weight.
+ */
+@UnstableApi
+public final class WeightedClusterSnapshot implements RouteCluster, Weighted {
+
+    private final ClusterSnapshot clusterSnapshot;
+    private final int weight;
+    private final Metadata metadataMatch;
+    private final HttpPreClient httpPreClient;
+    private final RpcPreClient rpcPreClient;
+    private final HttpClient httpClient;
+    private final RpcClient rpcClient;
+
+    WeightedClusterSnapshot(ClusterSnapshot clusterSnapshot, int weight, Metadata metadataMatch,
+                            @Nullable ClientDecoration retryDecoration,
+                            ClientPreprocessors downstreamPreprocessors,
+                            ClientDecoration upstreamDecoration) {
+        this.clusterSnapshot = requireNonNull(clusterSnapshot, "clusterSnapshot");
+        this.weight = weight;
+        this.metadataMatch = requireNonNull(metadataMatch, "metadataMatch");
+        httpPreClient = FilterUtil.buildHttpPreClient(downstreamPreprocessors);
+        rpcPreClient = FilterUtil.buildRpcPreClient(downstreamPreprocessors);
+        httpClient = FilterUtil.buildHttpClient(retryDecoration, upstreamDecoration);
+        rpcClient = FilterUtil.buildRpcClient(upstreamDecoration);
+    }
+
+    /**
+     * Returns the resolved {@link ClusterSnapshot} for this weighted cluster entry.
+     */
+    @Override
+    public ClusterSnapshot clusterSnapshot() {
+        return clusterSnapshot;
+    }
+
+    /**
+     * Returns the weight for this cluster entry.
+     */
+    @Override
+    public int weight() {
+        return weight;
+    }
+
+    /**
+     * Returns the metadata match criteria.
+     */
+    @Override
+    public Metadata metadataMatch() {
+        return metadataMatch;
+    }
+
+    @Override
+    public HttpPreClient httpPreClient() {
+        return httpPreClient;
+    }
+
+    @Override
+    public RpcPreClient rpcPreClient() {
+        return rpcPreClient;
+    }
+
+    @Override
+    public HttpClient httpClient() {
+        return httpClient;
+    }
+
+    @Override
+    public RpcClient rpcClient() {
+        return rpcClient;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final WeightedClusterSnapshot that = (WeightedClusterSnapshot) o;
+        return weight == that.weight &&
+               Objects.equals(clusterSnapshot, that.clusterSnapshot) &&
+               Objects.equals(metadataMatch, that.metadataMatch);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterSnapshot, weight, metadataMatch);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("clusterSnapshot", clusterSnapshot)
+                          .add("weight", weight)
+                          .add("metadataMatch", metadataMatch)
+                          .toString();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilter.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.xds.ClusterSnapshot;
-import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 final class RouterFilter<I extends Request, O extends Response> implements Preprocessor<I, O> {
@@ -36,29 +36,17 @@ final class RouterFilter<I extends Request, O extends Response> implements Prepr
 
     @Override
     public O execute(PreClient<I, O> delegate, PreClientRequestContext ctx, I req) throws Exception {
-        final RouteEntry selectedRoute = ctx.attr(XdsCommonUtil.SELECTED_ROUTE);
-        if (selectedRoute == null) {
+        final RouteCluster routeCluster = ctx.attr(XdsCommonUtil.ROUTE_CLUSTER);
+        if (routeCluster == null) {
             final UnprocessedRequestException e = UnprocessedRequestException.of(
                     new IllegalArgumentException(
-                            "SELECTED_ROUTE is not set for the ctx. If a new ctx has been used, " +
+                            "ROUTE_CLUSTER is not set for the ctx. If a new ctx has been used, " +
                             "please make sure to use ctx.newDerivedContext()."));
             ctx.cancel(e);
             throw e;
         }
-        final ClusterSnapshot clusterSnapshot = selectedRoute.clusterSnapshot();
-        if (clusterSnapshot == null) {
-            final UnprocessedRequestException e = UnprocessedRequestException.of(
-                    new IllegalArgumentException("No cluster is specified for selected route '" +
-                                                 selectedRoute + "'."));
-            ctx.cancel(e);
-            throw e;
-        }
-
-        final long responseTimeoutMillis =
-                XdsCommonUtil.durationToMillis(selectedRoute.route().getRoute().getTimeout(), -1);
-        if (responseTimeoutMillis > 0) {
-            ctx.setResponseTimeoutMillis(responseTimeoutMillis);
-        }
+        final ClusterSnapshot clusterSnapshot = routeCluster.clusterSnapshot();
+        ctx.setAttr(XdsAttributeKeys.ROUTE_METADATA_MATCH, routeCluster.metadataMatch());
 
         @SuppressWarnings("unchecked")
         final Preprocessor<I, O> preprocessor = (Preprocessor<I, O>) (isRpc ?

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -38,9 +38,9 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
-import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.RouteSnapshot;
 import com.linecorp.armeria.xds.SnapshotWatcher;
 import com.linecorp.armeria.xds.VirtualHostSnapshot;
@@ -146,11 +146,11 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
         if (virtualHostSnapshot.routeEntries().isEmpty()) {
             return;
         }
-        final RouteCluster routeCluster = virtualHostSnapshot.routeEntries().get(0).resolve();
-        if (routeCluster == null) {
+        final ClusterSnapshot clusterSnapshot = virtualHostSnapshot.routeEntries().get(0).clusterSnapshot();
+        if (clusterSnapshot == null) {
             return;
         }
-        final XdsLoadBalancer loadBalancer = routeCluster.clusterSnapshot().loadBalancer();
+        final XdsLoadBalancer loadBalancer = clusterSnapshot.loadBalancer();
 
         this.loadBalancer = loadBalancer;
         endpoints = loadBalancer.allEndpoints();

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointGroup.java
@@ -38,9 +38,9 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.AbstractListenable;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
-import com.linecorp.armeria.xds.ClusterSnapshot;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.RouteSnapshot;
 import com.linecorp.armeria.xds.SnapshotWatcher;
 import com.linecorp.armeria.xds.VirtualHostSnapshot;
@@ -146,11 +146,11 @@ public final class XdsEndpointGroup extends AbstractListenable<List<Endpoint>>
         if (virtualHostSnapshot.routeEntries().isEmpty()) {
             return;
         }
-        final ClusterSnapshot clusterSnapshot = virtualHostSnapshot.routeEntries().get(0).clusterSnapshot();
-        if (clusterSnapshot == null) {
+        final RouteCluster routeCluster = virtualHostSnapshot.routeEntries().get(0).resolve();
+        if (routeCluster == null) {
             return;
         }
-        final XdsLoadBalancer loadBalancer = clusterSnapshot.loadBalancer();
+        final XdsLoadBalancer loadBalancer = routeCluster.clusterSnapshot().loadBalancer();
 
         this.loadBalancer = loadBalancer;
         endpoints = loadBalancer.allEndpoints();

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHttpPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHttpPreprocessor.java
@@ -21,14 +21,12 @@ import static java.util.Objects.requireNonNull;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
-import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.XdsBootstrap;
 import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
-import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 /**
  * An {@link HttpPreprocessor} implementation which allows clients to execute requests based on
@@ -62,15 +60,8 @@ public final class XdsHttpPreprocessor extends XdsPreprocessor<HttpRequest, Http
 
     @Override
     HttpResponse execute1(PreClient<HttpRequest, HttpResponse> delegate, PreClientRequestContext ctx,
-                          HttpRequest req, RouteConfig routeConfig) throws Exception {
-        final RouteEntry selectedRoute = routeConfig.select(ctx);
-        if (selectedRoute == null) {
-            throw UnprocessedRequestException.of(
-                    new IllegalArgumentException("No route for listener '" +
-                                                 routeConfig.listenerSnapshot() + "'."));
-        }
-        ctx.setAttr(XdsCommonUtil.SELECTED_ROUTE, selectedRoute);
+                          HttpRequest req, RouteCluster routeCluster) throws Exception {
         DelegatingHttpClient.setDelegate(ctx, delegate);
-        return selectedRoute.httpPreClient().execute(ctx, req);
+        return routeCluster.httpPreClient().execute(ctx, req);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsPreprocessor.java
@@ -29,8 +29,12 @@ import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.RouteCluster;
+import com.linecorp.armeria.xds.RouteEntry;
 import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
+import io.envoyproxy.envoy.config.route.v3.RouteAction;
 import io.netty.channel.EventLoop;
 
 abstract class XdsPreprocessor<I extends Request, O extends Response>
@@ -75,11 +79,29 @@ abstract class XdsPreprocessor<I extends Request, O extends Response>
             throw UnprocessedRequestException.of(
                     new TimeoutException("Couldn't select a snapshot for listener '" + listenerName + "'."));
         }
-        return execute1(delegate, ctx, req, routeConfig);
+        final RouteEntry selectedRoute = routeConfig.select(ctx);
+        if (selectedRoute == null) {
+            throw UnprocessedRequestException.of(
+                    new IllegalArgumentException("No route for listener '" +
+                                                 routeConfig.listenerSnapshot() + "'."));
+        }
+        final RouteCluster routeCluster = selectedRoute.resolve();
+        if (routeCluster == null) {
+            throw UnprocessedRequestException.of(
+                    new IllegalArgumentException("No cluster is specified for selected route."));
+        }
+        ctx.setAttr(XdsCommonUtil.ROUTE_CLUSTER, routeCluster);
+        final RouteAction routeAction = selectedRoute.route().getRoute();
+        final long responseTimeoutMillis =
+                XdsCommonUtil.durationToMillis(routeAction.getTimeout(), -1);
+        if (responseTimeoutMillis > 0) {
+            ctx.setResponseTimeoutMillis(responseTimeoutMillis);
+        }
+        return execute1(delegate, ctx, req, routeCluster);
     }
 
     abstract O execute1(PreClient<I, O> delegate, PreClientRequestContext ctx, I req,
-                        RouteConfig routeConfig) throws Exception;
+                        RouteCluster routeCluster) throws Exception;
 
     @Override
     public void close() {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsRpcPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsRpcPreprocessor.java
@@ -21,14 +21,12 @@ import static java.util.Objects.requireNonNull;
 import com.linecorp.armeria.client.PreClient;
 import com.linecorp.armeria.client.PreClientRequestContext;
 import com.linecorp.armeria.client.RpcPreprocessor;
-import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.UnstableApi;
-import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.XdsBootstrap;
 import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
-import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 /**
  * An {@link RpcPreprocessor} implementation which allows clients to execute requests based on
@@ -62,15 +60,8 @@ public final class XdsRpcPreprocessor extends XdsPreprocessor<RpcRequest, RpcRes
 
     @Override
     RpcResponse execute1(PreClient<RpcRequest, RpcResponse> delegate, PreClientRequestContext ctx,
-                         RpcRequest req, RouteConfig routeConfig) throws Exception {
-        final RouteEntry selectedRoute = routeConfig.select(ctx);
-        if (selectedRoute == null) {
-            throw UnprocessedRequestException.of(
-                    new IllegalArgumentException("No route for listener '" +
-                                                 routeConfig.listenerSnapshot() + "'."));
-        }
-        ctx.setAttr(XdsCommonUtil.SELECTED_ROUTE, selectedRoute);
+                         RpcRequest req, RouteCluster routeCluster) throws Exception {
         DelegatingRpcClient.setDelegate(ctx, delegate);
-        return selectedRoute.rpcPreClient().execute(ctx, req);
+        return routeCluster.rpcPreClient().execute(ctx, req);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingHttpClient.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingHttpClient.java
@@ -33,9 +33,9 @@ public final class DelegatingHttpClient implements HttpClient, HttpPreClient {
     private static final DelegatingHttpClient INSTANCE = new DelegatingHttpClient();
 
     private static final AttributeKey<Client<HttpRequest, HttpResponse>> CLIENT_DELEGATE_KEY =
-            AttributeKey.valueOf(DelegatingHttpClient.class, "DELEGATE_KEY");
+            AttributeKey.valueOf(DelegatingHttpClient.class, "CLIENT_DELEGATE_KEY");
     private static final AttributeKey<PreClient<HttpRequest, HttpResponse>> PRECLIENT_DELEGATE_KEY =
-            AttributeKey.valueOf(DelegatingHttpClient.class, "DELEGATE_KEY");
+            AttributeKey.valueOf(DelegatingHttpClient.class, "PRECLIENT_DELEGATE_KEY");
 
     public static DelegatingHttpClient of() {
         return INSTANCE;

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingRpcClient.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/DelegatingRpcClient.java
@@ -34,10 +34,10 @@ public final class DelegatingRpcClient implements RpcClient, RpcPreClient {
     private static final DelegatingRpcClient INSTANCE = new DelegatingRpcClient();
 
     private static final AttributeKey<Client<RpcRequest, RpcResponse>> CLIENT_DELEGATE_KEY =
-            AttributeKey.valueOf(DelegatingRpcClient.class, "DELEGATE_KEY");
+            AttributeKey.valueOf(DelegatingRpcClient.class, "CLIENT_DELEGATE_KEY");
 
     private static final AttributeKey<PreClient<RpcRequest, RpcResponse>> PRECLIENT_DELEGATE_KEY =
-            AttributeKey.valueOf(DelegatingRpcClient.class, "DELEGATE_KEY");
+            AttributeKey.valueOf(DelegatingRpcClient.class, "PRECLIENT_DELEGATE_KEY");
 
     public static DelegatingRpcClient of() {
         return INSTANCE;

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsCommonUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsCommonUtil.java
@@ -25,14 +25,14 @@ import com.google.protobuf.UInt32Value;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.xds.RouteEntry;
+import com.linecorp.armeria.xds.RouteCluster;
 
 import io.netty.util.AttributeKey;
 
 public final class XdsCommonUtil {
 
-    public static final AttributeKey<RouteEntry> SELECTED_ROUTE =
-            AttributeKey.valueOf(XdsCommonUtil.class, "SELECTED_ROUTE");
+    public static final AttributeKey<RouteCluster> ROUTE_CLUSTER =
+            AttributeKey.valueOf(XdsCommonUtil.class, "ROUTE_CLUSTER");
 
     /**
      * An attribute key for overriding the ALPN protocols on upstream TLS connections.


### PR DESCRIPTION
Motivation:

Envoy's `RouteAction` supports `weighted_clusters` for distributing traffic across multiple
clusters with configurable weights. Each `ClusterWeight` can also carry its own
`typed_per_filter_config` and `metadata_match`, allowing per-cluster filter overrides
and metadata matching.

Previously, Armeria did not support weighted clusters. All filter chains (downstream
preprocessors, upstream decorators) were built once per route and stored in `RouteEntry`,
with no mechanism to select among multiple clusters or apply per-cluster configurations.

Modifications:

- Introduced `RouteCluster` interface (the result of `RouteEntry.resolve()`) which carries
  the resolved `ClusterSnapshot`, metadata match, and pre-built client-side filter chains
  (`httpPreClient`, `rpcPreClient`, `httpClient`, `rpcClient`).
- Moved all client-side chain fields from `RouteEntry` to `RouteCluster` implementations
  (`DefaultRouteCluster` for single-cluster, `WeightedClusterSnapshot` for weighted clusters).
- Added `RouteClusterResolver` (package-private) to encapsulate single vs. weighted cluster
  resolution with weighted round-robin selection.
- Added `RouteClusterFactory` to build per-cluster downstream/upstream filter streams.
  For each `ClusterWeight`, its `typed_per_filter_config` is merged with the route-level
  config via `FilterUtil.mergeFilterConfigs()`. `HcmContext.caching()` ensures stream
  deduplication when no cluster-weight override exists.
- Moved the shared route selection, resolve, and timeout logic from `XdsHttpPreprocessor` /
  `XdsRpcPreprocessor` into `XdsPreprocessor.execute0()` to eliminate duplication.
- Added chain-building helpers (`buildHttpPreClient`, `buildRpcPreClient`, `buildHttpClient`,
  `buildRpcClient`) to `FilterUtil`, shared by `DefaultRouteCluster` and
  `WeightedClusterSnapshot`.

Result:

- Weighted clusters are now supported. Routes with `weighted_clusters` distribute traffic
  across clusters using weighted round-robin selection.
- Each `ClusterWeight` respects its own `typed_per_filter_config` (full Envoy precedence:
  `RouteConfiguration < VirtualHost < Route < ClusterWeight`) and `metadata_match`.
- No behavioral change for existing single-cluster routes.
