### PR TITLE
Add filter chain matching and SNI-based TLS selection for server-side xDS

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/util/CertificateUtil.java
@@ -28,6 +28,7 @@ import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
@@ -121,6 +122,35 @@ public final class CertificateUtil {
             logger.warn("Failed to parse subject alternative names from a certificate: {}", cert, ex);
             return null;
         }
+    }
+
+    public static List<String> extractDnsNames(X509Certificate cert) {
+        requireNonNull(cert, "cert");
+        try {
+            final Collection<List<?>> altNames = cert.getSubjectAlternativeNames();
+            if (altNames != null) {
+                final ImmutableList.Builder<String> dnsNames = ImmutableList.builder();
+                for (List<?> altName : altNames) {
+                    final Integer type = altName.size() >= 2 ? (Integer) altName.get(0) : null;
+                    // Type 2 is DNS name.
+                    if (type != null && type == 2) {
+                        dnsNames.add(((String) altName.get(1)).toLowerCase(Locale.ROOT));
+                    }
+                }
+                return dnsNames.build();
+            }
+        } catch (CertificateParsingException e) {
+            return Exceptions.throwUnsafely(e);
+        }
+        try {
+            final String cn = extractCommonName(cert);
+            if (cn != null) {
+                return ImmutableList.of(cn.toLowerCase(Locale.ROOT));
+            }
+        } catch (CertificateEncodingException e) {
+            return Exceptions.throwUnsafely(e);
+        }
+        return ImmutableList.of();
     }
 
     @Nullable

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/BootstrapSecretsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/BootstrapSecretsTest.java
@@ -110,13 +110,13 @@ class BootstrapSecretsTest {
                     - name: my-cert
                       tls_certificate:
                         private_key:
-                          filename: %s
+                          filename: '%s'
                         certificate_chain:
-                          filename: %s
+                          filename: '%s'
                     - name: my-validation
                       validation_context:
                         trusted_ca:
-                          filename: %s
+                          filename: '%s'
                 """;
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/CertificateValidationContextTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/CertificateValidationContextTest.java
@@ -116,9 +116,9 @@ class CertificateValidationContextTest {
                       common_tls_context:
                         tls_certificates:
                           - private_key:
-                              filename: %s
+                              filename: '%s'
                             certificate_chain:
-                              filename: %s
+                              filename: '%s'
                         combined_validation_context:
                           default_validation_context: {}
                           validation_context_sds_secret_config:
@@ -159,7 +159,7 @@ class CertificateValidationContextTest {
                 name: validation-certs
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(invalidCaFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
         version.incrementAndGet();
@@ -275,7 +275,7 @@ class CertificateValidationContextTest {
                 name: validation-certs
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(multiCaFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
         version.incrementAndGet();
@@ -323,7 +323,7 @@ class CertificateValidationContextTest {
                 name: validation-certs
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(caFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
         version.incrementAndGet();
@@ -398,9 +398,9 @@ class CertificateValidationContextTest {
                       common_tls_context:
                         tls_certificates:
                           - private_key:
-                              filename: %s
+                              filename: '%s'
                             certificate_chain:
-                              filename: %s
+                              filename: '%s'
                         combined_validation_context:
                           default_validation_context:
                             match_subject_alt_names:
@@ -443,7 +443,7 @@ class CertificateValidationContextTest {
                 name: validation-certs
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(caFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
         version.incrementAndGet();
@@ -491,7 +491,7 @@ class CertificateValidationContextTest {
                 name: validation-certs
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   match_subject_alt_names:
                     - exact: "override.example.com"
                 """.formatted(caFile.getAbsolutePath());

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ControlPlaneTlsIntegrationTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ControlPlaneTlsIntegrationTest.java
@@ -157,7 +157,7 @@ class ControlPlaneTlsIntegrationTest {
                 """
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   match_typed_subject_alt_names:
                   - san_type: IP_ADDRESS
                     matcher:
@@ -192,7 +192,7 @@ class ControlPlaneTlsIntegrationTest {
                 """
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   match_typed_subject_alt_names:
                   - san_type: IP_ADDRESS
                     matcher:
@@ -219,7 +219,7 @@ class ControlPlaneTlsIntegrationTest {
                 """
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   verify_certificate_spki:
                     - "%s"
                   match_typed_subject_alt_names:
@@ -247,7 +247,7 @@ class ControlPlaneTlsIntegrationTest {
                 """
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   match_typed_subject_alt_names:
                   - san_type: IP_ADDRESS
                     matcher:
@@ -273,12 +273,12 @@ class ControlPlaneTlsIntegrationTest {
                 """
                 tls_certificates:
                   - private_key:
-                      filename: %s
+                      filename: '%s'
                     certificate_chain:
-                      filename: %s
+                      filename: '%s'
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                   match_typed_subject_alt_names:
                   - san_type: IP_ADDRESS
                     matcher:

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DataSourcePolicyTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DataSourcePolicyTest.java
@@ -179,9 +179,9 @@ class DataSourcePolicyTest {
                           common_tls_context:
                             tls_certificates:
                               - private_key:
-                                  filename: %s
+                                  filename: '%s'
                                 certificate_chain:
-                                  filename: %s
+                                  filename: '%s'
                 """.formatted(certsDir.resolve("private_key.pem"),
                               certsDir.resolve("certificate.pem"));
         return XdsResourceReader.fromYaml(bootstrapStr, Bootstrap.class);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DataSourceTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DataSourceTest.java
@@ -87,9 +87,9 @@ class DataSourceTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(certificate1.privateKeyFile().toPath().toString(),
                               certificate1.certificateFile().toPath().toString());
         final Secret secret = XdsResourceReader.fromYaml(tlsCertYaml, Secret.class);
@@ -205,9 +205,9 @@ class DataSourceTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(privateKeyFile.getAbsolutePath(),
                               certificateFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(tlsCertYaml, Secret.class);
@@ -344,9 +344,9 @@ class DataSourceTest {
                   watched_directory:
                     path: %s
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(watchDir.getAbsolutePath(),
                               privateKeyFile.getAbsolutePath(),
                               certificateFile.getAbsolutePath());
@@ -496,9 +496,9 @@ class DataSourceTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(privateKeyFile.getAbsolutePath(),
                               certificateFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(tlsCertYaml, Secret.class);
@@ -615,9 +615,9 @@ class DataSourceTest {
                   watched_directory:
                     path: %s
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(watchDir.getAbsolutePath(),
                               privateKeyFile.getAbsolutePath(),
                               certificateFile.getAbsolutePath());
@@ -1054,9 +1054,9 @@ class DataSourceTest {
                   watched_directory:
                     path: %s
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(tempDir.getAbsolutePath(),
                               privateKeyFile.getAbsolutePath(),
                               certificateFile.getAbsolutePath());

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DynamicSecretTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/DynamicSecretTest.java
@@ -84,9 +84,9 @@ class DynamicSecretTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """;
     //language=YAML
     private static final String validationContextYaml =
@@ -94,7 +94,7 @@ class DynamicSecretTest {
                 name: my-validation
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """;
 
     // YAML
@@ -168,7 +168,7 @@ class DynamicSecretTest {
                     - name: my-validation
                       validation_context:
                         trusted_ca:
-                          filename: %s
+                          filename: '%s'
                 """;
 
     @Test
@@ -285,7 +285,7 @@ class DynamicSecretTest {
                     - name: my-validation
                       validation_context:
                         trusted_ca:
-                          filename: %s
+                          filename: '%s'
                 """;
 
     @Test
@@ -504,7 +504,7 @@ class DynamicSecretTest {
                 name: my-cert-validation
                 validation_context:
                   trusted_ca:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(certificate2.certificateFile().toPath().toString());
         final Secret secret2 = XdsResourceReader.fromYaml(validationYaml, Secret.class);
         version.incrementAndGet();
@@ -604,9 +604,9 @@ class DynamicSecretTest {
                     - name: my-cert
                       tls_certificate:
                         private_key:
-                          filename: %s
+                          filename: '%s'
                         certificate_chain:
-                          filename: %s
+                          filename: '%s'
                 """;
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ErrorHandlingTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ErrorHandlingTest.java
@@ -701,9 +701,9 @@ class ErrorHandlingTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(certificate.privateKeyFile().toPath().toString(),
                               invalidCertFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
@@ -748,9 +748,9 @@ class ErrorHandlingTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(invalidKeyFile.getAbsolutePath(),
                               certificate.certificateFile().toPath().toString());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
@@ -794,9 +794,9 @@ class ErrorHandlingTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(certificate.privateKeyFile().toPath().toString(),
                               missingFile.getAbsolutePath());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
@@ -836,9 +836,9 @@ class ErrorHandlingTest {
                 name: wrong-cert-name
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(certificate.privateKeyFile().toPath().toString(),
                               certificate.certificateFile().toPath().toString());
         final Secret secret = XdsResourceReader.fromYaml(secretYaml, Secret.class);
@@ -872,9 +872,9 @@ class ErrorHandlingTest {
                     name: my-cert
                     tls_certificate:
                       private_key:
-                        filename: %s
+                        filename: '%s'
                       certificate_chain:
-                        filename: %s
+                        filename: '%s'
                     """.formatted(certificate.privateKeyFile().toPath().toString(),
                                   certificate.certificateFile().toPath().toString());
             final Secret correctSecret = XdsResourceReader.fromYaml(correctSecretYaml, Secret.class);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/PipeEndpointTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/PipeEndpointTest.java
@@ -331,9 +331,9 @@ class PipeEndpointTest {
                 name: %s
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """.formatted(name,
                               cert.privateKeyFile().toPath().toString(),
                               cert.certificateFile().toPath().toString());

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ResourceNodeMetricTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ResourceNodeMetricTest.java
@@ -1032,9 +1032,9 @@ class ResourceNodeMetricTest {
                 name: my-cert
                 tls_certificate:
                   private_key:
-                    filename: %s
+                    filename: '%s'
                   certificate_chain:
-                    filename: %s
+                    filename: '%s'
                 """;
 
         //language=YAML

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TlsPeerVerificationIntegrationTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TlsPeerVerificationIntegrationTest.java
@@ -220,7 +220,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 verify_certificate_hash:
@@ -250,7 +250,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 match_typed_subject_alt_names:
@@ -278,7 +278,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_hash:
                   - "%s"
                 match_typed_subject_alt_names:
@@ -307,7 +307,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 verify_certificate_hash:
@@ -338,7 +338,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 verify_certificate_hash:
@@ -368,7 +368,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 match_typed_subject_alt_names:
                   - san_type: IP_ADDRESS
                     matcher:
@@ -393,7 +393,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 match_typed_subject_alt_names:
                   - san_type: DNS
                     matcher:
@@ -418,7 +418,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 match_typed_subject_alt_names:
                   - san_type: URI
                     matcher:
@@ -443,7 +443,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 match_typed_subject_alt_names:
                   - san_type: DNS
                     matcher:
@@ -482,7 +482,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_hash:
                   - "%s"
                 match_typed_subject_alt_names:
@@ -511,7 +511,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 verify_certificate_hash:
@@ -541,7 +541,7 @@ class TlsPeerVerificationIntegrationTest {
         final String validationContext =
                 """
                 trusted_ca:
-                  filename: %s
+                  filename: '%s'
                 verify_certificate_spki:
                   - "%s"
                 verify_certificate_hash:

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsEndpointGroupTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsEndpointGroupTest.java
@@ -208,7 +208,7 @@ class XdsEndpointGroupTest {
                 common_tls_context:
                   validation_context:
                     trusted_ca:
-                      filename: %s
+                      filename: '%s'
             """.formatted(name, trustedCaFile.getAbsolutePath());
         }
         return XdsResourceReader.fromYaml(yaml, Cluster.class);
@@ -332,7 +332,7 @@ class XdsEndpointGroupTest {
                     common_tls_context:
                       validation_context:
                         trusted_ca:
-                          filename: %s
+                          filename: '%s'
             """.formatted(clusterName, clusterName, clusterName, address, port,
                           trustedCaFile.getAbsolutePath());
         }

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsPreprocessorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsPreprocessorTest.java
@@ -206,7 +206,7 @@ class XdsPreprocessorTest {
                 common_tls_context:
                   validation_context:
                     trusted_ca:
-                      filename: %s
+                      filename: '%s'
             """.formatted(name, trustedCaFile.getAbsolutePath());
         }
         return XdsResourceReader.fromYaml(yaml, Cluster.class);
@@ -330,7 +330,7 @@ class XdsPreprocessorTest {
                     common_tls_context:
                       validation_context:
                         trusted_ca:
-                          filename: %s
+                          filename: '%s'
             """.formatted(clusterName, clusterName, clusterName, address, port,
                           trustedCaFile.getAbsolutePath());
         }

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerDecoratorTest.java
@@ -130,9 +130,9 @@ class ServerDecoratorTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(LISTENER_NAME, certPath, keyPath);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);
@@ -186,9 +186,9 @@ class ServerDecoratorTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(LISTENER_NAME, certPath, keyPath);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);
@@ -239,9 +239,9 @@ class ServerDecoratorTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(LISTENER_NAME, certPath, keyPath);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);
@@ -304,9 +304,9 @@ class ServerDecoratorTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(LISTENER_NAME, certPath, keyPath);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFallbackTest.java
@@ -118,9 +118,9 @@ class ServerFallbackTest {
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                     """.formatted(LISTENER_NAME, certPath, keyPath);
             controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
 

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.UnprocessedRequestException;
 import com.linecorp.armeria.client.WebClient;
@@ -37,6 +38,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
@@ -266,6 +268,116 @@ class ServerFilterChainMatchTest {
                 RequestOptions.builder().clientTlsSpec(wrongTlsSpec).build()))
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(SSLHandshakeException.class);
+    }
+
+    @Test
+    void wildcardServerNameMatch() {
+        final Path certPathA = certA.certificateFile().toPath();
+        final Path keyPathA = certA.privateKeyFile().toPath();
+        final Path certPathDefault = certDefault.certificateFile().toPath();
+        final Path keyPathDefault = certDefault.privateKeyFile().toPath();
+
+        // Chain with wildcard server_names=["*.example.com"] and certA.
+        // Default chain with certDefault.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                filter_chains:
+                  - filter_chain_match:
+                      server_names:
+                        - "*.example.com"
+                      transport_protocol: "tls"
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: ingress_http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - name: envoy.filters.http.router
+                    transport_socket:
+                      name: envoy.transport_sockets.downstream_tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                        common_tls_context:
+                          tls_certificates:
+                            - certificate_chain:
+                                filename: '%s'
+                              private_key:
+                                filename: '%s'
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: '%s'
+                            private_key:
+                              filename: '%s'
+                """.formatted(LISTENER_NAME, certPathA, keyPathA, certPathDefault, keyPathDefault);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        final int port = server.httpsPort();
+
+        // SNI "test.example.com" should match "*.example.com" chain → certA
+        final ClientTlsSpec wildcardTlsSpec = ClientTlsSpec.builder()
+                                                            .trustedCertificates(certA.certificate())
+                                                            .endpointIdentificationAlgorithm("")
+                                                            .build();
+        final Endpoint wildcardEndpoint = Endpoint.of("test.example.com", port).withIpAddr("127.0.0.1");
+        final BlockingWebClient wildcardClient =
+                WebClient.builder(SessionProtocol.HTTPS, wildcardEndpoint).build().blocking();
+        final AggregatedHttpResponse wildcardRes = wildcardClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(wildcardTlsSpec).build());
+        assertThat(wildcardRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(wildcardRes.contentUtf8()).isEqualTo("hello");
+
+        // SNI "other.net" should NOT match "*.example.com" → default chain → certDefault
+        final ClientTlsSpec defaultTlsSpec = ClientTlsSpec.builder()
+                                                           .trustedCertificates(certDefault.certificate())
+                                                           .endpointIdentificationAlgorithm("")
+                                                           .build();
+        final Endpoint otherEndpoint = Endpoint.of("other.net", port).withIpAddr("127.0.0.1");
+        final BlockingWebClient defaultClient =
+                WebClient.builder(SessionProtocol.HTTPS, otherEndpoint).build().blocking();
+        final AggregatedHttpResponse defaultRes = defaultClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(defaultTlsSpec).build());
+        assertThat(defaultRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(defaultRes.contentUtf8()).isEqualTo("hello");
     }
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -20,7 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
-import java.security.SignatureException;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -264,7 +265,7 @@ class ServerFilterChainMatchTest {
                 HttpRequest.of(HttpMethod.GET, "/hello"),
                 RequestOptions.builder().clientTlsSpec(wrongTlsSpec).build()))
                 .isInstanceOf(UnprocessedRequestException.class)
-                .hasRootCauseInstanceOf(SignatureException.class);
+                .hasCauseInstanceOf(SSLHandshakeException.class);
     }
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.security.SignatureException;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.UnprocessedRequestException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class ServerFilterChainMatchTest {
+
+    private static final String LISTENER_NAME = "filter-chain-listener";
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension certA =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsCertificateExtension certDefault =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    // A cert that no server chain ever presents — used only for negative assertions.
+    @RegisterExtension
+    @Order(2)
+    static final XdsCertificateExtension certWrong =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    @Order(3)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(4)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            // Push a minimal listener to unblock XdsServerPlugin.install().
+            controlPlane.set(Listener.newBuilder().setName(LISTENER_NAME).build());
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME));
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    @Test
+    void matchByTransportProtocol() {
+        final Path certPathA = certA.certificateFile().toPath();
+        final Path keyPathA = certA.privateKeyFile().toPath();
+
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                filter_chains:
+                  - filter_chain_match:
+                      transport_protocol: "tls"
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: ingress_http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - name: envoy.filters.http.router
+                    transport_socket:
+                      name: envoy.transport_sockets.downstream_tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                        common_tls_context:
+                          tls_certificates:
+                            - certificate_chain:
+                                filename: "%s"
+                              private_key:
+                                filename: "%s"
+                  - filter_chain_match:
+                      transport_protocol: "raw_buffer"
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: ingress_http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - name: envoy.filters.http.router
+                """.formatted(LISTENER_NAME, certPathA, keyPathA);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        // HTTPS connection should match the "tls" chain and present certA.
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certA.certificate())
+                                                   .build();
+        final BlockingWebClient httpsClient =
+                WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse httpsRes = httpsClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(httpsRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(httpsRes.contentUtf8()).isEqualTo("hello");
+
+        // HTTP (plaintext) connection should match the "raw_buffer" chain.
+        final AggregatedHttpResponse httpRes =
+                WebClient.of(server.httpUri()).blocking().get("/hello");
+        assertThat(httpRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(httpRes.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void defaultFilterChainFallback() {
+        final Path certPathA = certA.certificateFile().toPath();
+        final Path keyPathA = certA.privateKeyFile().toPath();
+        final Path certPathDefault = certDefault.certificateFile().toPath();
+        final Path keyPathDefault = certDefault.privateKeyFile().toPath();
+
+        // Chain A requires server_names=["no-such-host.example.com"] — will never match.
+        // Default chain has certDefault — should always be used.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                filter_chains:
+                  - filter_chain_match:
+                      server_names:
+                        - "no-such-host.example.com"
+                      transport_protocol: "tls"
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: ingress_http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - name: envoy.filters.http.router
+                    transport_socket:
+                      name: envoy.transport_sockets.downstream_tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                        common_tls_context:
+                          tls_certificates:
+                            - certificate_chain:
+                                filename: "%s"
+                              private_key:
+                                filename: "%s"
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: "%s"
+                            private_key:
+                              filename: "%s"
+                """.formatted(LISTENER_NAME, certPathA, keyPathA, certPathDefault, keyPathDefault);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        // The specific chain requires server_names=["no-such-host.example.com"]
+        // which won't match. The default chain with certDefault should be used.
+        final ClientTlsSpec defaultTlsSpec = ClientTlsSpec.builder()
+                                                          .trustedCertificates(certDefault.certificate())
+                                                          .build();
+        final BlockingWebClient defaultClient = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse res = defaultClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(defaultTlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+
+        // certWrong should NOT work since the server presents certDefault.
+        final ClientTlsSpec wrongTlsSpec = ClientTlsSpec.builder()
+                                                        .trustedCertificates(certWrong.certificate())
+                                                        .build();
+        final BlockingWebClient wrongClient = WebClient.of(server.httpsUri()).blocking();
+        assertThatThrownBy(() -> wrongClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(wrongTlsSpec).build()))
+                .isInstanceOf(UnprocessedRequestException.class)
+                .hasRootCauseInstanceOf(SignatureException.class);
+    }
+
+    @Test
+    void unmatchedConnectionRejected() {
+        final Path certPathA = certA.certificateFile().toPath();
+        final Path keyPathA = certA.privateKeyFile().toPath();
+
+        // Only chain matches server_names=["no-such-host.example.com"], no default chain.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                filter_chains:
+                  - filter_chain_match:
+                      server_names:
+                        - "no-such-host.example.com"
+                      transport_protocol: "tls"
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: ingress_http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: "/"
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - name: envoy.filters.http.router
+                    transport_socket:
+                      name: envoy.transport_sockets.downstream_tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                        common_tls_context:
+                          tls_certificates:
+                            - certificate_chain:
+                                filename: "%s"
+                              private_key:
+                                filename: "%s"
+                """.formatted(LISTENER_NAME, certPathA, keyPathA);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        // No chain matches (server_names don't match), no default chain.
+        // Connection should be rejected.
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certWrong.certificate())
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        assertThatThrownBy(() -> client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build()))
+                .isInstanceOf(UnprocessedRequestException.class);
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -120,9 +120,9 @@ class ServerFilterChainMatchTest {
                         common_tls_context:
                           tls_certificates:
                             - certificate_chain:
-                                filename: "%s"
+                                filename: '%s'
                               private_key:
-                                filename: "%s"
+                                filename: '%s'
                   - filter_chain_match:
                       transport_protocol: "raw_buffer"
                     filters:
@@ -208,9 +208,9 @@ class ServerFilterChainMatchTest {
                         common_tls_context:
                           tls_certificates:
                             - certificate_chain:
-                                filename: "%s"
+                                filename: '%s'
                               private_key:
-                                filename: "%s"
+                                filename: '%s'
                 default_filter_chain:
                   filters:
                     - name: envoy.filters.network.http_connection_manager
@@ -237,9 +237,9 @@ class ServerFilterChainMatchTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(LISTENER_NAME, certPathA, keyPathA, certPathDefault, keyPathDefault);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);
@@ -308,9 +308,9 @@ class ServerFilterChainMatchTest {
                         common_tls_context:
                           tls_certificates:
                             - certificate_chain:
-                                filename: "%s"
+                                filename: '%s'
                               private_key:
-                                filename: "%s"
+                                filename: '%s'
                 """.formatted(LISTENER_NAME, certPathA, keyPathA);
         final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
         controlPlane.awaitListener(LISTENER_NAME, ver);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiPortTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiPortTest.java
@@ -97,9 +97,9 @@ class ServerMultiPortTest {
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                     """.formatted(LISTENER_NAME, certPath, keyPath);
             controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
             sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME, 0, 0));

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerMultiplePluginTest.java
@@ -120,9 +120,9 @@ class ServerMultiplePluginTest {
                       common_tls_context:
                         tls_certificates:
                           - certificate_chain:
-                              filename: "%s"
+                              filename: '%s'
                             private_key:
-                              filename: "%s"
+                              filename: '%s'
                 """.formatted(listenerName, certPath, keyPath);
 
         return XdsResourceReader.fromYaml(yaml, Listener.class);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerTlsSpecSelectorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerTlsSpecSelectorTest.java
@@ -103,13 +103,13 @@ class ServerTlsSpecSelectorTest {
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                     """.formatted(LISTENER_NAME, certPathFoo, keyPathFoo, certPathBar, keyPathBar);
             controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
             sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME));

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerTlsSpecSelectorTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerTlsSpecSelectorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientTlsSpec;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.RequestOptions;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.it.XdsCertificateExtension;
+import com.linecorp.armeria.xds.it.XdsControlPlaneExtension;
+import com.linecorp.armeria.xds.it.XdsResourceReader;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.listener.v3.Listener;
+
+class ServerTlsSpecSelectorTest {
+
+    private static final String LISTENER_NAME = "sni-listener";
+
+    @RegisterExtension
+    @Order(0)
+    static final XdsCertificateExtension certFoo =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("foo.example.com"));
+
+    @RegisterExtension
+    @Order(1)
+    static final XdsCertificateExtension certBar =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("bar.example.com"));
+
+    @RegisterExtension
+    @Order(2)
+    static final XdsControlPlaneExtension controlPlane = new XdsControlPlaneExtension();
+
+    @RegisterExtension
+    @Order(3)
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final Path certPathFoo = certFoo.certificateFile().toPath();
+            final Path keyPathFoo = certFoo.privateKeyFile().toPath();
+            final Path certPathBar = certBar.certificateFile().toPath();
+            final Path keyPathBar = certBar.privateKeyFile().toPath();
+
+            //language=YAML
+            final String yaml =
+                    """
+                    name: %s
+                    default_filter_chain:
+                      filters:
+                        - name: envoy.filters.network.http_connection_manager
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters\
+                    .network.http_connection_manager.v3.HttpConnectionManager
+                            stat_prefix: ingress_http
+                            route_config:
+                              name: local_route
+                              virtual_hosts:
+                                - name: local_service
+                                  domains: ["*"]
+                                  routes:
+                                    - match:
+                                        prefix: "/"
+                                      non_forwarding_action: {}
+                            http_filters:
+                              - name: envoy.filters.http.router
+                      transport_socket:
+                        name: envoy.transport_sockets.downstream_tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                    .tls.v3.DownstreamTlsContext
+                          common_tls_context:
+                            tls_certificates:
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
+                              - certificate_chain:
+                                  filename: "%s"
+                                private_key:
+                                  filename: "%s"
+                    """.formatted(LISTENER_NAME, certPathFoo, keyPathFoo, certPathBar, keyPathBar);
+            controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+            sb.plugin(XdsServerPlugin.of(controlPlane.bootstrap(), LISTENER_NAME));
+            sb.service("/hello", (ctx, req) -> HttpResponse.of("hello"));
+        }
+    };
+
+    @Test
+    void exactSniMatch() {
+        final int port = server.httpsPort();
+
+        // SNI "foo.example.com" → certFoo should be presented.
+        // Trust only certFoo: if certBar were presented, the handshake would fail.
+        final ClientTlsSpec fooTlsSpec = ClientTlsSpec.builder()
+                                                      .trustedCertificates(certFoo.certificate())
+                                                      .build();
+        final Endpoint fooEndpoint = Endpoint.of("foo.example.com", port).withIpAddr("127.0.0.1");
+        final BlockingWebClient fooClient =
+                WebClient.builder(SessionProtocol.HTTPS, fooEndpoint).build().blocking();
+        final AggregatedHttpResponse fooRes = fooClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(fooTlsSpec).build());
+        assertThat(fooRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(fooRes.contentUtf8()).isEqualTo("hello");
+
+        // SNI "bar.example.com" → certBar should be presented.
+        // Trust only certBar: if certFoo were presented, the handshake would fail.
+        final ClientTlsSpec barTlsSpec = ClientTlsSpec.builder()
+                                                      .trustedCertificates(certBar.certificate())
+                                                      .build();
+        final Endpoint barEndpoint = Endpoint.of("bar.example.com", port).withIpAddr("127.0.0.1");
+        final BlockingWebClient barClient =
+                WebClient.builder(SessionProtocol.HTTPS, barEndpoint).build().blocking();
+        final AggregatedHttpResponse barRes = barClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(barTlsSpec).build());
+        assertThat(barRes.status()).isEqualTo(HttpStatus.OK);
+        assertThat(barRes.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void fallbackToFirstCert() {
+        // Unknown SNI → first cert (certFoo) should be presented.
+        // Trust only certFoo, disable hostname verification since the cert CN
+        // (foo.example.com) won't match the SNI (unknown.example.com).
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certFoo.certificate())
+                                                   .endpointIdentificationAlgorithm("")
+                                                   .build();
+        final int port = server.httpsPort();
+        final Endpoint endpoint = Endpoint.of("unknown.example.com", port).withIpAddr("127.0.0.1");
+        final BlockingWebClient client =
+                WebClient.builder(SessionProtocol.HTTPS, endpoint).build().blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void noSniReturnsFirstCert() {
+        // Connect by IP (127.0.0.1) — no SNI hostname is sent.
+        // Server should present the first cert (certFoo).
+        // Disable hostname verification since the cert CN (foo.example.com) won't match 127.0.0.1.
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certFoo.certificate())
+                                                   .endpointIdentificationAlgorithm("")
+                                                   .build();
+        final BlockingWebClient client = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse res = client.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThat(res.contentUtf8()).isEqualTo("hello");
+    }
+}

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
@@ -108,12 +108,12 @@ class ServerXdsTest {
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                             validation_context:
                               trusted_ca:
-                                filename: "%s"
+                                filename: '%s'
                     """.formatted(LISTENER_NAME, serverCertPath, serverKeyPath, clientCaCertPath);
             controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
             sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
@@ -177,12 +177,12 @@ class ServerXdsTest {
                           common_tls_context:
                             tls_certificates:
                               - certificate_chain:
-                                  filename: "%s"
+                                  filename: '%s'
                                 private_key:
-                                  filename: "%s"
+                                  filename: '%s'
                             validation_context:
                               trusted_ca:
-                                filename: "%s"
+                                filename: '%s'
                 """.formatted(xdsPort.actualPort(), clientCertPath, clientKeyPath, serverCaCertPath);
 
         final Bootstrap clientBootstrap =

--- a/xds-api/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds-api/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -115,6 +115,7 @@ message FilterChainMatch {
 
   // Optional destination port to consider when use_original_dst is set on the
   // listener in determining a filter chain match.
+  option (armeria.xds.supported.field) = 8;
   google.protobuf.UInt32Value destination_port = 8 [(validate.rules).uint32 = {lte: 65535 gte: 1}];
 
   // If non-empty, an IP address and prefix length to match addresses when the
@@ -163,6 +164,7 @@ message FilterChainMatch {
   //
   //   See the :ref:`FAQ entry <faq_how_to_setup_sni>` on how to configure SNI for more
   //   information.
+  option (armeria.xds.supported.field) = 11;
   repeated string server_names = 11;
 
   // If non-empty, a transport protocol to consider when determining a filter chain match.
@@ -174,6 +176,7 @@ message FilterChainMatch {
   // * ``raw_buffer`` - default, used when no transport protocol is detected,
   // * ``tls`` - set by :ref:`envoy.filters.listener.tls_inspector <config_listener_filters_tls_inspector>`
   //   when TLS protocol is detected.
+  option (armeria.xds.supported.field) = 9;
   string transport_protocol = 9;
 
   // If non-empty, a list of application protocols (e.g. ALPN for TLS protocol) to consider when
@@ -195,6 +198,7 @@ message FilterChainMatch {
   //   However, the use of ALPN is pretty much limited to the HTTP/2 traffic on the Internet,
   //   and matching on values other than ``h2`` is going to lead to a lot of false negatives,
   //   unless all connecting clients are known to use ALPN.
+  option (armeria.xds.supported.field) = 10;
   repeated string application_protocols = 10;
 }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
@@ -17,6 +17,7 @@
 package com.linecorp.armeria.xds;
 
 import java.util.List;
+import java.util.Locale;
 
 import com.google.common.collect.ImmutableList;
 
@@ -180,13 +181,15 @@ final class FilterChainMatcher {
         }
 
         @Override
-        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
-                                                 ConnectionContext ctx) {
+        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics, ConnectionContext ctx) {
             final String sniHostname = ctx.sniHostname();
+            if (sniHostname == null || sniHostname.isEmpty()) {
+                return ImmutableList.of();
+            }
+            final String normalizedSni = sniHostname.toLowerCase(Locale.ROOT);
             final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
             for (FilterChainSnapshot fcs : specifics) {
-                if (sniHostname != null && !sniHostname.isEmpty() &&
-                    fcs.filterChainMatch().getServerNamesList().contains(sniHostname)) {
+                if (fcs.filterChainMatch().getServerNamesList().contains(normalizedSni)) {
                     matched.add(fcs);
                 }
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
@@ -224,7 +224,7 @@ final class FilterChainMatcher {
         // e.g., "*.example.com" matches suffix ".example.com" but not ".com".
         private static boolean hasWildcardServerName(List<String> serverNames, String suffix) {
             for (String name : serverNames) {
-                if (name.charAt(0) == '*' && name.length() == suffix.length() + 1 &&
+                if (name.length() == suffix.length() + 1 && name.charAt(0) == '*' &&
                     name.endsWith(suffix)) {
                     return true;
                 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ConnectionContext;
+
+/**
+ * Selects the best-matching {@link FilterChainSnapshot} for a {@link ConnectionContext}
+ * using a BFS-style multi-pass narrowing algorithm that replicates Envoy's
+ * <a href="https://github.com/envoyproxy/envoy/blob/74ef415825d391edc129afd17d2cb640abe785e9/source/common/listener_manager/filter_chain_manager_impl.cc#L543">
+ * filter chain matching</a> semantics.
+ *
+ * <p>At each priority level the candidate list is narrowed: if any candidate specifies
+ * a value for that criterion and the value matches the connection, only those candidates
+ * survive; otherwise the wildcard (unset) candidates are kept. If specific candidates
+ * exist but none match, the wildcards act as fallback. When all candidates are eliminated
+ * the default filter chain is returned.
+ *
+ * <p>Priority order (highest to lowest):
+ * <ol>
+ *   <li>{@code destination_port}</li>
+ *   <li>{@code prefix_ranges} (destination IP)</li>
+ *   <li>{@code server_names}</li>
+ *   <li>{@code transport_protocol}</li>
+ *   <li>{@code application_protocols}</li>
+ *   <li>{@code direct_source_prefix_ranges}</li>
+ *   <li>{@code source_type}</li>
+ *   <li>{@code source_prefix_ranges}</li>
+ *   <li>{@code source_ports}</li>
+ * </ol>
+ *
+ * <p>Each {@link NarrowStep} precomputes the wildcard/specific partition of the full chain
+ * list. Levels where all chains are wildcard are skipped entirely at match time. When the
+ * candidate list has not been narrowed by a prior step (reference equality with the full
+ * list), the precomputed partition is reused to avoid redundant iteration.
+ */
+final class FilterChainMatcher {
+
+    private abstract static class NarrowStep {
+
+        private final List<FilterChainSnapshot> allChains;
+        private final ImmutableList<FilterChainSnapshot> precomputedSpecifics;
+        private final ImmutableList<FilterChainSnapshot> precomputedWildcards;
+
+        NarrowStep(List<FilterChainSnapshot> allChains) {
+            this.allChains = allChains;
+            final ImmutableList.Builder<FilterChainSnapshot> specifics = ImmutableList.builder();
+            final ImmutableList.Builder<FilterChainSnapshot> wildcards = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : allChains) {
+                if (isSpecific(fcs)) {
+                    specifics.add(fcs);
+                } else {
+                    wildcards.add(fcs);
+                }
+            }
+            precomputedSpecifics = specifics.build();
+            precomputedWildcards = wildcards.build();
+        }
+
+        abstract boolean isSpecific(FilterChainSnapshot fcs);
+
+        abstract List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
+                                                          ConnectionContext ctx);
+
+        final List<FilterChainSnapshot> narrow(List<FilterChainSnapshot> candidates,
+                                               ConnectionContext ctx) {
+            if (precomputedSpecifics.isEmpty()) {
+                return candidates;
+            }
+            if (candidates != allChains) {
+                return slowPath(candidates, ctx);
+            }
+            final List<FilterChainSnapshot> matched = matchSpecifics(precomputedSpecifics, ctx);
+            return matched.isEmpty() ? precomputedWildcards : matched;
+        }
+
+        private List<FilterChainSnapshot> slowPath(List<FilterChainSnapshot> candidates,
+                                                   ConnectionContext ctx) {
+            final ImmutableList.Builder<FilterChainSnapshot> specifics = ImmutableList.builder();
+            final ImmutableList.Builder<FilterChainSnapshot> wildcards = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : candidates) {
+                if (isSpecific(fcs)) {
+                    specifics.add(fcs);
+                } else {
+                    wildcards.add(fcs);
+                }
+            }
+            final List<FilterChainSnapshot> matched = matchSpecifics(specifics.build(), ctx);
+            return matched.isEmpty() ? wildcards.build() : matched;
+        }
+    }
+
+    private final ImmutableList<FilterChainSnapshot> allChains;
+    private final ImmutableList<NarrowStep> steps;
+
+    FilterChainMatcher(List<FilterChainSnapshot> filterChains) {
+        allChains = ImmutableList.copyOf(filterChains);
+        // Steps are in priority order. Skipped upstream levels (2, 6-9) are omitted.
+        // 2. prefix_ranges (destination IP) — skipped. Envoy narrows by longest CIDR prefix match.
+        // 6. direct_source_prefix_ranges — skipped. Envoy narrows by CIDR match on direct remote address.
+        // 7. source_type — skipped. Envoy narrows by ANY/SAME_IP_OR_LOOPBACK/EXTERNAL.
+        // 8. source_prefix_ranges — skipped. Envoy narrows by CIDR match on remote address.
+        // 9. source_ports — skipped. Envoy narrows by exact match on remote port.
+        steps = ImmutableList.of(
+                new DestinationPortStep(allChains),   // 1
+                new ServerNamesStep(allChains),       // 3
+                new TransportProtocolStep(allChains), // 4
+                new ApplicationProtocolsStep(allChains) // 5
+        );
+    }
+
+    @Nullable
+    FilterChainSnapshot match(@Nullable FilterChainSnapshot defaultFilterChain,
+                              ConnectionContext ctx) {
+        List<FilterChainSnapshot> candidates = allChains;
+        for (NarrowStep step : steps) {
+            candidates = step.narrow(candidates, ctx);
+
+            if (candidates.isEmpty()) {
+                return defaultFilterChain;
+            }
+        }
+        return candidates.get(0);
+    }
+
+    private static final class DestinationPortStep extends NarrowStep {
+
+        DestinationPortStep(List<FilterChainSnapshot> allChains) {
+            super(allChains);
+        }
+
+        @Override
+        boolean isSpecific(FilterChainSnapshot fcs) {
+            return fcs.filterChainMatch().hasDestinationPort();
+        }
+
+        @Override
+        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
+                                                 ConnectionContext ctx) {
+            final int port = ctx.localAddress().getPort();
+            final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : specifics) {
+                if (fcs.filterChainMatch().getDestinationPort().getValue() == port) {
+                    matched.add(fcs);
+                }
+            }
+            return matched.build();
+        }
+    }
+
+    // Exact-match only; wildcard domain suffix matching (e.g. *.example.com) is not implemented.
+    private static final class ServerNamesStep extends NarrowStep {
+
+        ServerNamesStep(List<FilterChainSnapshot> allChains) {
+            super(allChains);
+        }
+
+        @Override
+        boolean isSpecific(FilterChainSnapshot fcs) {
+            return !fcs.filterChainMatch().getServerNamesList().isEmpty();
+        }
+
+        @Override
+        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
+                                                 ConnectionContext ctx) {
+            final String sniHostname = ctx.sniHostname();
+            final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : specifics) {
+                if (sniHostname != null && !sniHostname.isEmpty() &&
+                    fcs.filterChainMatch().getServerNamesList().contains(sniHostname)) {
+                    matched.add(fcs);
+                }
+            }
+            return matched.build();
+        }
+    }
+
+    private static final class TransportProtocolStep extends NarrowStep {
+
+        TransportProtocolStep(List<FilterChainSnapshot> allChains) {
+            super(allChains);
+        }
+
+        @Override
+        boolean isSpecific(FilterChainSnapshot fcs) {
+            return !fcs.filterChainMatch().getTransportProtocol().isEmpty();
+        }
+
+        @Override
+        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
+                                                 ConnectionContext ctx) {
+            final String transportProtocol = ctx.sessionProtocol().isTls() ? "tls" : "raw_buffer";
+            final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : specifics) {
+                if (fcs.filterChainMatch().getTransportProtocol().equals(transportProtocol)) {
+                    matched.add(fcs);
+                }
+            }
+            return matched.build();
+        }
+    }
+
+    private static final class ApplicationProtocolsStep extends NarrowStep {
+
+        ApplicationProtocolsStep(List<FilterChainSnapshot> allChains) {
+            super(allChains);
+        }
+
+        @Override
+        boolean isSpecific(FilterChainSnapshot fcs) {
+            return !fcs.filterChainMatch().getApplicationProtocolsList().isEmpty();
+        }
+
+        @Override
+        List<FilterChainSnapshot> matchSpecifics(List<FilterChainSnapshot> specifics,
+                                                 ConnectionContext ctx) {
+            final List<String> alpnProtocols = ctx.alpnProtocols();
+            final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
+            for (FilterChainSnapshot fcs : specifics) {
+                final List<String> matchAlpn = fcs.filterChainMatch().getApplicationProtocolsList();
+                for (String offered : alpnProtocols) {
+                    if (matchAlpn.contains(offered)) {
+                        matched.add(fcs);
+                        break;
+                    }
+                }
+            }
+            return matched.build();
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/FilterChainMatcher.java
@@ -168,7 +168,10 @@ final class FilterChainMatcher {
         }
     }
 
-    // Exact-match only; wildcard domain suffix matching (e.g. *.example.com) is not implemented.
+    // Supports exact and wildcard (e.g. *.example.com) server name matching following Envoy's
+    // findFilterChainForServerName semantics: exact match first, then progressively less specific
+    // wildcard suffixes (".example.com" before ".com"), then catch-all (no server_names).
+    // https://github.com/envoyproxy/envoy/blob/74ef415/source/common/listener_manager/filter_chain_manager_impl.cc#L608-L637
     private static final class ServerNamesStep extends NarrowStep {
 
         ServerNamesStep(List<FilterChainSnapshot> allChains) {
@@ -187,13 +190,46 @@ final class FilterChainMatcher {
                 return ImmutableList.of();
             }
             final String normalizedSni = sniHostname.toLowerCase(Locale.ROOT);
-            final ImmutableList.Builder<FilterChainSnapshot> matched = ImmutableList.builder();
+            // exact match
+            final ImmutableList.Builder<FilterChainSnapshot> exactMatched = ImmutableList.builder();
             for (FilterChainSnapshot fcs : specifics) {
                 if (fcs.filterChainMatch().getServerNamesList().contains(normalizedSni)) {
-                    matched.add(fcs);
+                    exactMatched.add(fcs);
                 }
             }
-            return matched.build();
+            final ImmutableList<FilterChainSnapshot> exact = exactMatched.build();
+            if (!exact.isEmpty()) {
+                return exact;
+            }
+            // wildcard match
+            int pos = normalizedSni.indexOf('.', 1);
+            while (pos > 0 && pos < normalizedSni.length() - 1) {
+                final String suffix = normalizedSni.substring(pos);
+                final ImmutableList.Builder<FilterChainSnapshot> wildcardMatched = ImmutableList.builder();
+                for (FilterChainSnapshot fcs : specifics) {
+                    if (hasWildcardServerName(fcs.filterChainMatch().getServerNamesList(), suffix)) {
+                        wildcardMatched.add(fcs);
+                    }
+                }
+                final ImmutableList<FilterChainSnapshot> wildcard = wildcardMatched.build();
+                if (!wildcard.isEmpty()) {
+                    return wildcard;
+                }
+                pos = normalizedSni.indexOf('.', pos + 1);
+            }
+            return ImmutableList.of();
+        }
+
+        // Checks if any server name in the list is a wildcard that matches the given suffix.
+        // e.g., "*.example.com" matches suffix ".example.com" but not ".com".
+        private static boolean hasWildcardServerName(List<String> serverNames, String suffix) {
+            for (String name : serverNames) {
+                if (name.charAt(0) == '*' && name.length() == suffix.length() + 1 &&
+                    name.endsWith(suffix)) {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/ListenerSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ListenerSnapshot.java
@@ -44,6 +44,7 @@ public final class ListenerSnapshot implements Snapshot<ListenerXdsResource> {
     private final RouteSnapshot apiListenerRoute;
     @Nullable
     private final RouteSnapshot defaultRouteSnapshot;
+    private final FilterChainMatcher filterChainMatcher;
 
     ListenerSnapshot(ListenerXdsResource listenerXdsResource,
                      Optional<RouteSnapshot> apiListenerRoute,
@@ -54,6 +55,7 @@ public final class ListenerSnapshot implements Snapshot<ListenerXdsResource> {
         this.defaultFilterChain = defaultFilterChain.orElse(null);
         this.apiListenerRoute = apiListenerRoute.orElse(null);
         defaultRouteSnapshot = defaultRouteSnapshot();
+        filterChainMatcher = new FilterChainMatcher(filterChains);
     }
 
     @Override
@@ -111,11 +113,7 @@ public final class ListenerSnapshot implements Snapshot<ListenerXdsResource> {
     @Nullable
     public FilterChainSnapshot matchFilterChain(ConnectionContext ctx) {
         requireNonNull(ctx, "ctx");
-        // Simple: use first filter chain or default. Full matching deferred to follow-up PR.
-        if (!filterChains.isEmpty()) {
-            return filterChains.get(0);
-        }
-        return defaultFilterChain;
+        return filterChainMatcher.match(defaultFilterChain, ctx);
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
@@ -16,21 +16,18 @@
 
 package com.linecorp.armeria.xds;
 
-import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.TlsKeyPair;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.internal.common.util.CertificateUtil;
 import com.linecorp.armeria.server.ConnectionContext;
 import com.linecorp.armeria.server.ServerTlsSpec;
 
@@ -75,7 +72,10 @@ final class ServerTlsSpecSelector {
             if (exact != null) {
                 return exact;
             }
-            // Wildcard match: "www.example.com" → ".example.com"
+            // Wildcard match: "www.example.com" → look up ".example.com"
+            // Follows Envoy's DefaultTlsCertificateSelector: strip the first DNS label and
+            // look up the suffix.
+            // https://github.com/envoyproxy/envoy/blob/74ef415/source/common/tls/default_tls_certificate_selector.cc#L254-L260
             final int dotPos = normalizedSni.indexOf('.', 1);
             if (dotPos > 0 && dotPos < normalizedSni.length() - 1) {
                 final ServerTlsSpec wildcard = serverNameMap.get(normalizedSni.substring(dotPos));
@@ -97,47 +97,11 @@ final class ServerTlsSpecSelector {
             }
             final ServerTlsSpec spec = specs.get(i);
             final X509Certificate firstCert = keyPair.certificateChain().get(0);
-            for (String name : extractDnsNames(firstCert)) {
+            for (String name : CertificateUtil.extractDnsNames(firstCert)) {
                 final String key = name.startsWith("*.") ? name.substring(1) : name;
                 nameMap.putIfAbsent(key, spec);
             }
         }
         return ImmutableMap.copyOf(nameMap);
-    }
-
-    // Uses DNS SANs if present; falls back to CN per RFC 6125 §6.4.4.
-    static List<String> extractDnsNames(X509Certificate cert) {
-        final Collection<List<?>> sans;
-        try {
-            sans = cert.getSubjectAlternativeNames();
-        } catch (CertificateParsingException e) {
-            return Exceptions.throwUnsafely(e);
-        }
-        if (sans != null) {
-            final ImmutableList.Builder<String> dnsNames = ImmutableList.builder();
-            for (List<?> san : sans) {
-                if (san.size() >= 2 && Objects.equals(2, san.get(0))) {
-                    dnsNames.add(((String) san.get(1)).toLowerCase(Locale.ROOT));
-                }
-            }
-            return dnsNames.build();
-        }
-        final String cn = extractCn(cert);
-        if (cn != null) {
-            return ImmutableList.of(cn.toLowerCase(Locale.ROOT));
-        }
-        return ImmutableList.of();
-    }
-
-    @Nullable
-    private static String extractCn(X509Certificate cert) {
-        final String dn = cert.getSubjectX500Principal().getName();
-        for (String rdn : dn.split(",")) {
-            final String trimmed = rdn.trim();
-            if (trimmed.toUpperCase(Locale.ROOT).startsWith("CN=")) {
-                return trimmed.substring(3);
-            }
-        }
-        return null;
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.TlsKeyPair;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.ConnectionContext;
+import com.linecorp.armeria.server.ServerTlsSpec;
+
+/**
+ * Selects the best-matching {@link ServerTlsSpec} for a connection using SNI-based
+ * certificate selection, following Envoy's
+ * <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#arch-overview-ssl-cert-select">
+ * certificate selection</a> algorithm.
+ *
+ * <p>Selection order:
+ * <ol>
+ *   <li>Exact SNI match against certificate DNS SANs (or CN if no SANs)</li>
+ *   <li>Wildcard match (one level only, e.g. {@code *.example.com})</li>
+ *   <li>Fallback to the first certificate</li>
+ * </ol>
+ *
+ * <p>The server name map follows Envoy's {@code DefaultTlsCertificateSelector}: exact names
+ * are stored as-is, wildcard names (e.g. {@code *.example.com}) are stored as
+ * {@code .example.com}. The first certificate for a given name wins.
+ */
+final class ServerTlsSpecSelector {
+
+    private final ImmutableList<ServerTlsSpec> specs;
+    private final Map<String, ServerTlsSpec> serverNameMap;
+
+    ServerTlsSpecSelector(List<ServerTlsSpec> specs,
+                          List<TlsCertificateSnapshot> tlsCertificates) {
+        this.specs = ImmutableList.copyOf(specs);
+        serverNameMap = buildServerNameMap(specs, tlsCertificates);
+    }
+
+    @Nullable
+    ServerTlsSpec select(ConnectionContext ctx) {
+        if (specs.isEmpty()) {
+            return null;
+        }
+        final String sni = ctx.sniHostname();
+        if (sni != null && !sni.isEmpty()) {
+            final String normalizedSni = sni.toLowerCase(Locale.ROOT);
+            // Exact match
+            final ServerTlsSpec exact = serverNameMap.get(normalizedSni);
+            if (exact != null) {
+                return exact;
+            }
+            // Wildcard match: "www.example.com" → ".example.com"
+            final int dotPos = normalizedSni.indexOf('.', 1);
+            if (dotPos > 0 && dotPos < normalizedSni.length() - 1) {
+                final ServerTlsSpec wildcard = serverNameMap.get(normalizedSni.substring(dotPos));
+                if (wildcard != null) {
+                    return wildcard;
+                }
+            }
+        }
+        return specs.get(0);
+    }
+
+    private static Map<String, ServerTlsSpec> buildServerNameMap(
+            List<ServerTlsSpec> specs, List<TlsCertificateSnapshot> tlsCertificates) {
+        final Map<String, ServerTlsSpec> nameMap = new HashMap<>();
+        for (int i = 0; i < tlsCertificates.size(); i++) {
+            final TlsKeyPair keyPair = tlsCertificates.get(i).tlsKeyPair();
+            if (keyPair == null || keyPair.certificateChain().isEmpty()) {
+                continue;
+            }
+            final ServerTlsSpec spec = specs.get(i);
+            final X509Certificate firstCert = keyPair.certificateChain().get(0);
+            for (String name : extractDnsNames(firstCert)) {
+                final String key = name.startsWith("*.") ? name.substring(1) : name;
+                nameMap.putIfAbsent(key, spec);
+            }
+        }
+        return ImmutableMap.copyOf(nameMap);
+    }
+
+    // Uses DNS SANs if present; falls back to CN per RFC 6125 §6.4.4.
+    static List<String> extractDnsNames(X509Certificate cert) {
+        final Collection<List<?>> sans;
+        try {
+            sans = cert.getSubjectAlternativeNames();
+        } catch (CertificateParsingException e) {
+            return Exceptions.throwUnsafely(e);
+        }
+        if (sans != null) {
+            final ImmutableList.Builder<String> dnsNames = ImmutableList.builder();
+            for (List<?> san : sans) {
+                if (san.size() >= 2 && Objects.equals(2, san.get(0))) {
+                    dnsNames.add(((String) san.get(1)).toLowerCase(Locale.ROOT));
+                }
+            }
+            final ImmutableList<String> result = dnsNames.build();
+            if (!result.isEmpty()) {
+                return result;
+            }
+        }
+        final String cn = extractCn(cert);
+        if (cn != null) {
+            return ImmutableList.of(cn.toLowerCase(Locale.ROOT));
+        }
+        return ImmutableList.of();
+    }
+
+    @Nullable
+    private static String extractCn(X509Certificate cert) {
+        final String dn = cert.getSubjectX500Principal().getName();
+        for (String rdn : dn.split(",")) {
+            final String trimmed = rdn.trim();
+            if (trimmed.toUpperCase(Locale.ROOT).startsWith("CN=")) {
+                return trimmed.substring(3);
+            }
+        }
+        return null;
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ServerTlsSpecSelector.java
@@ -120,10 +120,7 @@ final class ServerTlsSpecSelector {
                     dnsNames.add(((String) san.get(1)).toLowerCase(Locale.ROOT));
                 }
             }
-            final ImmutableList<String> result = dnsNames.build();
-            if (!result.isEmpty()) {
-                return result;
-            }
+            return dnsNames.build();
         }
         final String cn = extractCn(cert);
         if (cn != null) {

--- a/xds/src/main/java/com/linecorp/armeria/xds/TransportSocketSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/TransportSocketSnapshot.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds;
 
+import static java.util.Objects.requireNonNull;
+
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Optional;
@@ -60,14 +62,14 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
     @Nullable
     private final ClientTlsSpec clientTlsSpec;
     @Nullable
-    private final ServerTlsSpec serverTlsSpec;
+    private final ServerTlsSpecSelector serverTlsSpecSelector;
 
     TransportSocketSnapshot(TransportSocket transportSocket) {
         this.transportSocket = transportSocket;
         tlsCertificates = ImmutableList.of();
         validationContext = null;
         clientTlsSpec = null;
-        serverTlsSpec = null;
+        serverTlsSpecSelector = null;
     }
 
     TransportSocketSnapshot(TransportSocket transportSocket,
@@ -80,7 +82,7 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
         final TlsCertificateSnapshot firstCert = tlsCertificates.isEmpty() ? null
                                                                            : tlsCertificates.get(0);
         clientTlsSpec = buildClientTlsSpec(upstreamTlsContext, firstCert, this.validationContext);
-        serverTlsSpec = null;
+        serverTlsSpecSelector = null;
     }
 
     TransportSocketSnapshot(TransportSocket transportSocket,
@@ -97,8 +99,7 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
                                .map(cert -> buildServerTlsSpec(downstreamTlsContext, cert,
                                                                this.validationContext))
                                .collect(ImmutableList.toImmutableList());
-        // Simple: use first spec. SNI-based selection deferred to follow-up PR.
-        serverTlsSpec = specs.isEmpty() ? null : specs.get(0);
+        serverTlsSpecSelector = new ServerTlsSpecSelector(specs, this.tlsCertificates);
     }
 
     @Override
@@ -155,7 +156,8 @@ public final class TransportSocketSnapshot implements Snapshot<TransportSocket> 
      *         does not configure downstream TLS
      */
     public @Nullable ServerTlsSpec serverTlsSpec(ConnectionContext ctx) {
-        return serverTlsSpec;
+        requireNonNull(ctx, "ctx");
+        return serverTlsSpecSelector != null ? serverTlsSpecSelector.select(ctx) : null;
     }
 
     private static ClientTlsSpec buildClientTlsSpec(


### PR DESCRIPTION
Motivation:

This is a subset of #6797 that adds server-side filter chain matching and SNI-based TLS certificate selection to the xDS module. When Armeria acts as an xDS-managed server, incoming connections need to be matched against the listener's `filter_chains` to determine which TLS configuration and routing to apply — replicating Envoy's [filter chain matching](https://github.com/envoyproxy/envoy/blob/74ef415825d391edc129afd17d2cb640abe785e9/source/common/listener_manager/filter_chain_manager_impl.cc#L543) semantics.

Modifications:

- Added `FilterChainMatcher` which implements Envoy's BFS-style multi-pass narrowing algorithm. Supported match dimensions (in priority order): `destination_port`, `server_names`, `transport_protocol`, `application_protocols`. Each level precomputes specific/wildcard partitions to avoid redundant iteration.
- Added `ServerTlsSpecSelector` which implements SNI-based certificate selection: exact DNS SAN match → wildcard match (e.g. `*.example.com`) → fallback to first certificate. Follows Envoy's `DefaultTlsCertificateSelector` behavior.
- Added `ListenerSnapshot.matchFilterChain(ConnectionContext)` that delegates to `FilterChainMatcher`.
- Added `TransportSocketSnapshot.serverTlsSpec(ConnectionContext)` that delegates to `ServerTlsSpecSelector`. The downstream constructor builds a `ServerTlsSpec` per certificate using the shared `applyCommonTlsConfig` method (same trust/verifier logic as the client path).
- Marked `destination_port`, `server_names`, `transport_protocol`, and `application_protocols` fields as supported in `listener_components.proto`.
- Added `ServerFilterChainMatchTest` — verifies transport protocol matching, default filter chain fallback, and unmatched connection rejection.
- Added `ServerTlsSpecSelectorTest` — verifies exact SNI match, wildcard fallback, and no-SNI fallback.

Result:

- `ListenerSnapshot` can now select the correct filter chain for an incoming connection based on destination port, SNI hostname, transport protocol, and ALPN.
- `TransportSocketSnapshot` can select the correct server TLS certificate based on SNI, supporting multi-certificate downstream listeners.
