### PR TITLE
Minor xDS related cleanups

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/CustomConfigSourceTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/CustomConfigSourceTest.java
@@ -117,7 +117,9 @@ class CustomConfigSourceTest {
                 dynamic_resources:
                   cds_config:
                     custom_config_source:
-                      "@type": "type.googleapis.com/google.protobuf.Empty"
+                      name: http-config-source
+                      typed_config:
+                        "@type": "type.googleapis.com/google.protobuf.Empty"
                 """.formatted(configServer.httpPort());
 
         final Bootstrap bootstrap = XdsResourceReader.fromYaml(bootstrapYaml);

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TestXdsExtensionFactoryProvider.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/TestXdsExtensionFactoryProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import com.linecorp.armeria.xds.XdsExtensionFactory;
+import com.linecorp.armeria.xds.XdsExtensionFactoryProvider;
+
+public class TestXdsExtensionFactoryProvider {
+
+    public static class ClusterType implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new TestEndpointListClusterTypeFactory();
+        }
+    }
+
+    public static class ConfigSource implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new CustomConfigSourceTest.HttpConfigSourceFactory();
+        }
+    }
+}

--- a/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.XdsExtensionFactoryProvider
+++ b/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.XdsExtensionFactoryProvider
@@ -1,0 +1,2 @@
+com.linecorp.armeria.xds.it.TestXdsExtensionFactoryProvider$ClusterType
+com.linecorp.armeria.xds.it.TestXdsExtensionFactoryProvider$ConfigSource

--- a/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.client.endpoint.ClusterTypeFactory
+++ b/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.client.endpoint.ClusterTypeFactory
@@ -1,1 +1,0 @@
-com.linecorp.armeria.xds.it.TestEndpointListClusterTypeFactory

--- a/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory
+++ b/it/xds-client/src/test/resources/META-INF/services/com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory
@@ -1,1 +1,0 @@
-com.linecorp.armeria.xds.it.CustomConfigSourceTest$HttpConfigSourceFactory

--- a/it/xds-istio/src/test/java/com/linecorp/armeria/it/xds/filter/IstioExtensionFactoryProviders.java
+++ b/it/xds-istio/src/test/java/com/linecorp/armeria/it/xds/filter/IstioExtensionFactoryProviders.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.it.xds.filter;
+
+import com.linecorp.armeria.xds.XdsExtensionFactory;
+import com.linecorp.armeria.xds.XdsExtensionFactoryProvider;
+
+public class IstioExtensionFactoryProviders {
+
+    public static class IstioStats implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.IstioStats();
+        }
+    }
+
+    public static class IstioAlpn implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.IstioAlpn();
+        }
+    }
+
+    public static class IstioMetadataExchange implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.IstioMetadataExchange();
+        }
+    }
+
+    public static class EnvoyFault implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyFault();
+        }
+    }
+
+    public static class EnvoyCors implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyCors();
+        }
+    }
+
+    public static class EnvoyGzipCompressor implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyGzipCompressor();
+        }
+    }
+
+    public static class EnvoyZstdCompressor implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyZstdCompressor();
+        }
+    }
+
+    public static class EnvoyBrotliCompressor implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyBrotliCompressor();
+        }
+    }
+
+    public static class EnvoyGrpcStats implements XdsExtensionFactoryProvider {
+        @Override
+        public XdsExtensionFactory newFactory() {
+            return new IstioFilterFactories.EnvoyGrpcStats();
+        }
+    }
+}

--- a/it/xds-istio/src/test/resources/META-INF/services/com.linecorp.armeria.xds.XdsExtensionFactoryProvider
+++ b/it/xds-istio/src/test/resources/META-INF/services/com.linecorp.armeria.xds.XdsExtensionFactoryProvider
@@ -1,0 +1,9 @@
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$IstioStats
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$IstioAlpn
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$IstioMetadataExchange
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyFault
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyCors
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyGzipCompressor
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyZstdCompressor
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyBrotliCompressor
+com.linecorp.armeria.it.xds.filter.IstioExtensionFactoryProviders$EnvoyGrpcStats

--- a/it/xds-istio/src/test/resources/META-INF/services/com.linecorp.armeria.xds.filter.HttpFilterFactory
+++ b/it/xds-istio/src/test/resources/META-INF/services/com.linecorp.armeria.xds.filter.HttpFilterFactory
@@ -1,9 +1,0 @@
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$IstioStats
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$IstioAlpn
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$IstioMetadataExchange
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyFault
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyCors
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyGzipCompressor
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyZstdCompressor
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyBrotliCompressor
-com.linecorp.armeria.it.xds.filter.IstioFilterFactories$EnvoyGrpcStats

--- a/xds-api/src/main/proto/envoy/config/core/v3/config_source.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/config_source.proto
@@ -254,12 +254,13 @@ message ConfigSource {
     SelfConfigSource self = 5;
 
     // Armeria extension: a custom config source implementation resolved via
-    // the extension registry by the Any's type URL. This allows plugging in
-    // non-standard config sources (e.g. CentralDogma, etcd, Consul) without
-    // modifying the upstream proto definition.
+    // the extension registry by the typed_config's type URL (primary) or name
+    // (fallback). This allows plugging in non-standard config sources
+    // (e.g. CentralDogma, etcd, Consul) without modifying the upstream proto
+    // definition.
     // The large field number avoids conflicts with future upstream additions.
     option (armeria.xds.supported.oneof_field) = 1000;
-    google.protobuf.Any custom_config_source = 1000;
+    TypedExtensionConfig custom_config_source = 1000;
   }
 
   // When this timeout is specified, Envoy will wait no longer than the specified time for first

--- a/xds/src/main/java/com/linecorp/armeria/xds/ControlPlaneClientManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ControlPlaneClientManager.java
@@ -123,8 +123,9 @@ final class ControlPlaneClientManager implements SafeCloseable {
                         PathSotwConfigSourceSubscriptionFactory.NAME,
                         SotwConfigSourceSubscriptionFactory.class);
             case CUSTOM_CONFIG_SOURCE:
-                return extensionRegistry.queryByTypeUrl(
-                        configSource.getCustomConfigSource().getTypeUrl(),
+                return extensionRegistry.query(
+                        configSource.getCustomConfigSource().getTypedConfig(),
+                        configSource.getCustomConfigSource().getName(),
                         SotwConfigSourceSubscriptionFactory.class);
             default:
                 return null;

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionFactoryProvider.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionFactoryProvider.java
@@ -23,7 +23,14 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  *
  * <p>Implement this interface and register it via {@link java.util.ServiceLoader} to supply
  * a custom extension factory (HTTP filter, config source, cluster type, etc.) without
- * passing it through {@link XdsBootstrapBuilder#extensionFactories}.
+ * passing it through {@link XdsBootstrapBuilder#extensionFactories(XdsExtensionFactory...)}.
+ *
+ * <p>The returned factory must implement one of the following supported sub-interfaces:
+ * <ul>
+ *   <li>{@link com.linecorp.armeria.xds.filter.HttpFilterFactory}</li>
+ *   <li>{@link com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory}</li>
+ *   <li>{@link com.linecorp.armeria.xds.client.endpoint.ClusterTypeFactory}</li>
+ * </ul>
  *
  * <p>Example usage:
  * <pre>{@code
@@ -42,11 +49,12 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * }</pre>
  */
 @UnstableApi
+@FunctionalInterface
 public interface XdsExtensionFactoryProvider {
 
     /**
      * Creates a new {@link XdsExtensionFactory} instance.
-     * The returned factory may be any subtype of {@link XdsExtensionFactory}, such as
+     * The returned factory must implement one of the supported sub-interfaces:
      * {@link com.linecorp.armeria.xds.filter.HttpFilterFactory},
      * {@link com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory}, or
      * {@link com.linecorp.armeria.xds.client.endpoint.ClusterTypeFactory}.

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionFactoryProvider.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionFactoryProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * SPI for providing an {@link XdsExtensionFactory} to the {@link XdsExtensionRegistry}.
+ *
+ * <p>Implement this interface and register it via {@link java.util.ServiceLoader} to supply
+ * a custom extension factory (HTTP filter, config source, cluster type, etc.) without
+ * passing it through {@link XdsBootstrapBuilder#extensionFactories}.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * public class MyConfigSourceProvider implements XdsExtensionFactoryProvider {
+ *     @Override
+ *     public XdsExtensionFactory newFactory() {
+ *         return new MyConfigSourceFactory();
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Then register in
+ * {@code META-INF/services/com.linecorp.armeria.xds.XdsExtensionFactoryProvider}:
+ * <pre>{@code
+ * com.mycompany.MyConfigSourceProvider
+ * }</pre>
+ */
+@UnstableApi
+public interface XdsExtensionFactoryProvider {
+
+    /**
+     * Creates a new {@link XdsExtensionFactory} instance.
+     * The returned factory may be any subtype of {@link XdsExtensionFactory}, such as
+     * {@link com.linecorp.armeria.xds.filter.HttpFilterFactory},
+     * {@link com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory}, or
+     * {@link com.linecorp.armeria.xds.client.endpoint.ClusterTypeFactory}.
+     */
+    XdsExtensionFactory newFactory();
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
@@ -19,8 +19,10 @@ package com.linecorp.armeria.xds;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 
@@ -48,6 +50,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 @UnstableApi
 public final class XdsExtensionRegistry {
 
+    private static final Set<Class<? extends XdsExtensionFactory>> SUPPORTED_FACTORY_TYPES =
+            ImmutableSet.of(HttpFilterFactory.class,
+                            SotwConfigSourceSubscriptionFactory.class,
+                            ClusterTypeFactory.class);
+
     private final Map<String, XdsExtensionFactory> byTypeUrl;
     private final Map<String, XdsExtensionFactory> byName;
     private final XdsResourceValidator validator;
@@ -69,18 +76,15 @@ public final class XdsExtensionRegistry {
         final ImmutableMap.Builder<String, XdsExtensionFactory> byTypeUrl = ImmutableMap.builder();
 
         // SPI-loaded factories (user-provided extensions)
-        ServiceLoader.load(HttpFilterFactory.class).forEach(factory -> {
+        for (XdsExtensionFactoryProvider provider : ServiceLoader.load(XdsExtensionFactoryProvider.class)) {
+            final XdsExtensionFactory factory = provider.newFactory();
+            validateFactoryType(factory);
             register(factory, byName, byTypeUrl);
-        });
-        ServiceLoader.load(SotwConfigSourceSubscriptionFactory.class).forEach(factory -> {
-            register(factory, byName, byTypeUrl);
-        });
-        ServiceLoader.load(ClusterTypeFactory.class).forEach(factory -> {
-            register(factory, byName, byTypeUrl);
-        });
+        }
 
         // Builder-provided factories
         for (XdsExtensionFactory factory : extensionFactories) {
+            validateFactoryType(factory);
             register(factory, byName, byTypeUrl);
         }
 
@@ -99,6 +103,17 @@ public final class XdsExtensionRegistry {
         register(RawBufferTransportSocketFactory.INSTANCE, byName, byTypeUrl);
 
         return new XdsExtensionRegistry(byTypeUrl.buildKeepingLast(), byName.buildKeepingLast(), validator);
+    }
+
+    private static void validateFactoryType(XdsExtensionFactory factory) {
+        for (Class<? extends XdsExtensionFactory> type : SUPPORTED_FACTORY_TYPES) {
+            if (type.isInstance(factory)) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unsupported factory type: " + factory.getClass().getName() +
+                ". Must implement one of: " + SUPPORTED_FACTORY_TYPES);
     }
 
     private static void register(XdsExtensionFactory factory,

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -106,6 +108,7 @@ public final class XdsExtensionRegistry {
     }
 
     private static void validateFactoryType(XdsExtensionFactory factory) {
+        requireNonNull(factory, "factory");
         for (Class<? extends XdsExtensionFactory> type : SUPPORTED_FACTORY_TYPES) {
             if (type.isInstance(factory)) {
                 return;

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ServiceLoader;
 
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
@@ -49,7 +50,8 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  *
  * <p>All well-known Envoy protobuf types (under the {@code io.envoyproxy}, {@code com.github.udpa}
  * and {@code com.github.xds} packages) are automatically registered so that {@code @type} fields
- * in YAML/JSON are resolved correctly.
+ * in YAML/JSON are resolved correctly. Additional packages can be registered via
+ * the {@link XdsTypeRegistryPackageProvider} SPI.
  *
  * <p>Since YAML is a superset of JSON, all methods accept both formats.
  *
@@ -73,18 +75,28 @@ public final class XdsResourceReader {
 
         private static TypeRegistry buildDefaultTypeRegistry() {
             final TypeRegistry.Builder builder = TypeRegistry.newBuilder();
-            final String[] packages = {
-                    "io.envoyproxy",
-                    "com.github.udpa",
-                    "com.github.xds",
-                    };
             final FilterBuilder filterBuilder = new FilterBuilder();
             final ConfigurationBuilder configuration = new ConfigurationBuilder()
                     .setScanners(new SubTypesScanner());
-            for (String pkg : packages) {
-                configuration.addUrls(ClasspathHelper.forPackage(pkg));
-                filterBuilder.include(FilterBuilder.prefix(pkg));
+
+            // Built-in packages
+            final String[] defaultPackages = {
+                    "io.envoyproxy",
+                    "com.github.udpa",
+                    "com.github.xds",
+            };
+            for (String pkg : defaultPackages) {
+                addPackage(pkg, configuration, filterBuilder);
             }
+
+            // SPI-provided packages
+            for (XdsTypeRegistryPackageProvider provider
+                    : ServiceLoader.load(XdsTypeRegistryPackageProvider.class)) {
+                for (String pkg : provider.packages()) {
+                    addPackage(pkg, configuration, filterBuilder);
+                }
+            }
+
             configuration.filterInputsBy(filterBuilder);
             final Reflections reflections = new Reflections(configuration);
             for (Class<?> clazz : reflections.getSubTypesOf(GeneratedMessageV3.class)) {
@@ -97,6 +109,12 @@ public final class XdsResourceReader {
                 }
             }
             return builder.build();
+        }
+
+        private static void addPackage(String pkg, ConfigurationBuilder configuration,
+                                        FilterBuilder filterBuilder) {
+            configuration.addUrls(ClasspathHelper.forPackage(pkg));
+            filterBuilder.include(FilterBuilder.prefix(pkg));
         }
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
@@ -92,7 +92,10 @@ public final class XdsResourceReader {
             // SPI-provided packages
             for (XdsTypeRegistryPackageProvider provider
                     : ServiceLoader.load(XdsTypeRegistryPackageProvider.class)) {
-                for (String pkg : provider.packages()) {
+                final Iterable<String> packages = provider.packages();
+                requireNonNull(packages, "packages");
+                for (String pkg : packages) {
+                    requireNonNull(pkg, "pkg");
                     addPackage(pkg, configuration, filterBuilder);
                 }
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsTypeRegistryPackageProvider.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsTypeRegistryPackageProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * SPI for providing additional Java packages to scan when building the
+ * {@link com.google.protobuf.util.JsonFormat.TypeRegistry TypeRegistry} used by {@link XdsResourceReader}.
+ *
+ * <p>By default, {@link XdsResourceReader} scans the {@code io.envoyproxy}, {@code com.github.udpa}
+ * and {@code com.github.xds} packages. Implement this interface and register it via
+ * {@link java.util.ServiceLoader} to add custom packages containing protobuf types that should
+ * be resolvable via {@code @type} annotations in YAML/JSON.
+ *
+ * <p>Packages are matched by prefix — specifying {@code "com.mycompany.xds"} will also cover
+ * {@code "com.mycompany.xds.v1"}, {@code "com.mycompany.xds.config"}, etc.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * public class MyPackageProvider implements XdsTypeRegistryPackageProvider {
+ *     @Override
+ *     public Iterable<String> packages() {
+ *         return List.of("com.mycompany.xds");
+ *     }
+ * }
+ * }</pre>
+ *
+ * <p>Then register in {@code META-INF/services/com.linecorp.armeria.xds.XdsTypeRegistryPackageProvider}:
+ * <pre>{@code
+ * com.mycompany.xds.MyPackageProvider
+ * }</pre>
+ */
+@UnstableApi
+public interface XdsTypeRegistryPackageProvider {
+
+    /**
+     * Returns the Java packages to scan for protobuf types.
+     * Each package is matched by prefix — sub-packages are included automatically.
+     */
+    Iterable<String> packages();
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsTypeRegistryPackageProvider.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsTypeRegistryPackageProvider.java
@@ -46,6 +46,7 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * }</pre>
  */
 @UnstableApi
+@FunctionalInterface
 public interface XdsTypeRegistryPackageProvider {
 
     /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouteConfigSelector.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouteConfigSelector.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import java.util.concurrent.CompletableFuture;
+
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.client.AbstractAsyncSelector;
@@ -26,11 +28,16 @@ import com.linecorp.armeria.xds.SnapshotWatcher;
 final class RouteConfigSelector extends AbstractAsyncSelector<RouteConfig>
         implements SnapshotWatcher<ListenerSnapshot> {
 
+    private final CompletableFuture<Void> readyFuture = new CompletableFuture<>();
     @Nullable
     private volatile RouteConfig routeConfig;
 
     RouteConfigSelector(ListenerRoot listenerRoot) {
         listenerRoot.addSnapshotWatcher(this);
+    }
+
+    CompletableFuture<Void> whenReady() {
+        return readyFuture;
     }
 
     @Override
@@ -46,5 +53,6 @@ final class RouteConfigSelector extends AbstractAsyncSelector<RouteConfig>
         }
         routeConfig = new RouteConfig(snapshot);
         refresh();
+        readyFuture.complete(null);
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsPreprocessor.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsPreprocessor.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.common.Request;
 import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.TimeoutException;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.XdsBootstrap;
@@ -80,6 +81,14 @@ abstract class XdsPreprocessor<I extends Request, O extends Response>
 
     abstract O execute1(PreClient<I, O> delegate, PreClientRequestContext ctx, I req,
                         RouteConfig routeConfig) throws Exception;
+
+    /**
+     * Returns a {@link CompletableFuture} which is completed when the initial xDS configuration is ready.
+     */
+    @UnstableApi
+    public CompletableFuture<Void> whenReady() {
+        return routeConfigSelector.whenReady();
+    }
 
     @Override
     public void close() {


### PR DESCRIPTION
Motivation:

There are four improvements needed for the xDS extension system:

1. `XdsResourceReader` uses a hardcoded set of protobuf packages (`io.envoyproxy`, `com.github.udpa`, `com.github.xds`) for its `TypeRegistry`. When users define custom protobuf extensions (e.g. for `PathConfigSource` YAML/JSON files), the `@type` annotations cannot be resolved unless the reader knows about those packages.

2. The `custom_config_source` proto field uses a bare `google.protobuf.Any`, which only provides a type URL for extension resolution. This is inconsistent with the rest of the Envoy config model, which uses `TypedExtensionConfig` (name + typed_config) to allow fallback resolution by name.

3. Extension factories are registered via three separate `ServiceLoader` SPIs (`HttpFilterFactory`, `SotwConfigSourceSubscriptionFactory`, `ClusterTypeFactory`). This is fragmented — users need to know which specific sub-interface to register under, and adding new factory types would require yet another SPI.

4. `XdsHttpPreprocessor` and `XdsRpcPreprocessor` lack a `whenReady()` method, making it difficult for users to wait for the initial xDS configuration before sending requests.

Modifications:

- Added `XdsTypeRegistryPackageProvider` SPI that lets users register additional Java packages for the `TypeRegistry` used by `XdsResourceReader`. Packages are prefix-matched.
- Changed the `custom_config_source` proto field from `google.protobuf.Any` to `TypedExtensionConfig`, enabling resolution by both type URL (primary) and name (fallback).
- Updated `ControlPlaneClientManager.resolveStreamFactory()` to use the new `query(Any, name)` method.
- Introduced `XdsExtensionFactoryProvider` as a unified SPI replacing the three separate `ServiceLoader` registrations. Each provider returns a single `XdsExtensionFactory` via `newFactory()`.
- Added `validateFactoryType()` in `XdsExtensionRegistry` to ensure SPI/builder-provided factories implement a supported sub-interface.
- Migrated `it/xds-client` and `it/xds-istio` test modules to the new unified SPI.
- Deleted the old per-type `META-INF/services` files.
- Added `whenReady()` to `XdsPreprocessor`, backed by a `CompletableFuture<Void>` in `RouteConfigSelector` that completes on the first successful snapshot.

Result:

- Users can register custom protobuf packages via `XdsTypeRegistryPackageProvider` SPI so that `XdsResourceReader` resolves custom `@type` annotations in YAML/JSON.
- `custom_config_source` now supports name-based resolution in addition to type URL.
- Users only need to implement a single SPI (`XdsExtensionFactoryProvider`) to register any type of extension factory.
- Users can call `preprocessor.whenReady().join()` (or compose asynchronously) to wait for the initial xDS configuration before sending requests.
