### PR TITLE
Add metrics for `XdsLoadBalancer` selection

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -37,6 +39,7 @@ import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import com.linecorp.armeria.xds.ListenerRoot;
 import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
 
 import io.envoyproxy.controlplane.cache.v3.SimpleCache;
 import io.envoyproxy.controlplane.cache.v3.Snapshot;
@@ -623,8 +626,216 @@ class XdsLoadBalancerLifecycleObserverTest {
         });
     }
 
+    @Test
+    void selectionCounterBasicCase() throws Exception {
+        final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(
+                dynamicBootstrapYaml.formatted(server.httpPort()), Bootstrap.class);
+
+        //language=YAML
+        final String listenerYaml =
+                """
+                    name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                    .v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  cluster: my-cluster
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    """;
+
+        //language=YAML
+        final String clusterYaml =
+                """
+                    name: my-cluster
+                    type: EDS
+                    eds_cluster_config:
+                      eds_config:
+                        ads: {}
+                    """;
+
+        //language=YAML
+        final String endpointYaml =
+                """
+                  cluster_name: my-cluster
+                  endpoints:
+                  - locality:
+                      region: us-east-1
+                      zone: us-east-1a
+                    lb_endpoints:
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: 127.0.0.1
+                            port_value: %s
+                """.formatted(server.httpPort());
+
+        final Listener listener = XdsResourceReader.fromYaml(listenerYaml, Listener.class);
+        final Cluster cluster = XdsResourceReader.fromYaml(clusterYaml, Cluster.class);
+        final ClusterLoadAssignment endpoint = XdsResourceReader.fromYaml(endpointYaml,
+                                                                          ClusterLoadAssignment.class);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .meterRegistry(meterRegistry)
+                                                     .build()) {
+            version.incrementAndGet();
+            cache.setSnapshot(GROUP, Snapshot.create(ImmutableList.of(cluster), ImmutableList.of(endpoint),
+                                                     ImmutableList.of(listener), ImmutableList.of(),
+                                                     ImmutableList.of(), version.toString()));
+
+            try (XdsHttpPreprocessor preprocessor =
+                         XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+                final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+
+                // Send 3 requests
+                for (int i = 0; i < 3; i++) {
+                    assertThat(client.get("/hello").contentUtf8()).isEqualTo("world");
+                }
+
+                // Verify selection counters
+                await().untilAsserted(() -> {
+                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.request"));
+                    assertThat(lbMetrics).containsEntry(
+                            "armeria.xds.lb.request#count" +
+                            "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
+                            3.0);
+                });
+            }
+        }
+    }
+
+    @Test
+    void selectionCounterWithSubsets() throws Exception {
+        final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(
+                dynamicBootstrapYaml.formatted(server.httpPort()), Bootstrap.class);
+
+        //language=YAML
+        final String listenerYaml =
+                """
+                    name: my-listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                    .v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service1
+                            domains: [ "*" ]
+                            routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  cluster: my-cluster
+                                  metadata_match:
+                                    filter_metadata:
+                                      "envoy.lb":
+                                        version: v1
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    """;
+
+        //language=YAML
+        final String clusterYaml =
+                """
+                    name: my-cluster
+                    type: EDS
+                    eds_cluster_config:
+                      eds_config:
+                        ads: {}
+                    lb_subset_config:
+                      fallback_policy: ANY_ENDPOINT
+                      subset_selectors:
+                      - keys:
+                        - version
+                    """;
+
+        //language=YAML
+        final String endpointYaml =
+                """
+                  cluster_name: my-cluster
+                  endpoints:
+                  - lb_endpoints:
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: 127.0.0.1
+                            port_value: %s
+                      metadata:
+                        filter_metadata:
+                          "envoy.lb":
+                            version: v1
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: 127.0.0.1
+                            port_value: %s
+                      metadata:
+                        filter_metadata:
+                          "envoy.lb":
+                            version: v2
+                """.formatted(server.httpPort(), server.httpPort());
+
+        final Listener listener = XdsResourceReader.fromYaml(listenerYaml, Listener.class);
+        final Cluster cluster = XdsResourceReader.fromYaml(clusterYaml, Cluster.class);
+        final ClusterLoadAssignment endpoint = XdsResourceReader.fromYaml(endpointYaml,
+                                                                          ClusterLoadAssignment.class);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.builder(bootstrap)
+                                                     .meterRegistry(meterRegistry)
+                                                     .build()) {
+            version.incrementAndGet();
+            cache.setSnapshot(GROUP, Snapshot.create(ImmutableList.of(cluster), ImmutableList.of(endpoint),
+                                                     ImmutableList.of(listener), ImmutableList.of(),
+                                                     ImmutableList.of(), version.toString()));
+
+            try (XdsHttpPreprocessor preprocessor =
+                         XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap)) {
+                final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+
+                // Send 2 requests - route metadata_match selects subset version=v1
+                for (int i = 0; i < 2; i++) {
+                    assertThat(client.get("/hello").contentUtf8()).isEqualTo("world");
+                }
+
+                // Verify subset selection counter
+                await().untilAsserted(() -> {
+                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.request"));
+                    // Subset counter should record "version=v1"
+                    assertThat(lbMetrics).containsEntry(
+                            "armeria.xds.lb.request.subset#count" +
+                            "{cluster=my-cluster,result=hit,subset=version=v1}",
+                            2.0);
+                    // Priority/locality counter should also be recorded
+                    assertThat(lbMetrics).containsEntry(
+                            "armeria.xds.lb.request#count" +
+                            "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
+                            2.0);
+                });
+            }
+        }
+    }
+
     private static Map<String, Double> measureAll(final MeterRegistry meterRegistry) {
-        return measureAll(meterRegistry, key -> key.startsWith("armeria.xds.lb"));
+        return measureAll(meterRegistry, key -> key.startsWith("armeria.xds.lb") &&
+                                                !key.contains("lb.request"));
     }
 
     private static Map<String, Double> measureAll(final MeterRegistry meterRegistry,

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
@@ -707,9 +707,9 @@ class XdsLoadBalancerLifecycleObserverTest {
 
                 // Verify selection counters
                 await().untilAsserted(() -> {
-                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.request"));
+                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.select"));
                     assertThat(lbMetrics).containsEntry(
-                            "armeria.xds.lb.request#count" +
+                            "armeria.xds.lb.select#count" +
                             "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
                             3.0);
                 });
@@ -817,15 +817,15 @@ class XdsLoadBalancerLifecycleObserverTest {
 
                 // Verify subset selection counter
                 await().untilAsserted(() -> {
-                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.request"));
+                    final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.select"));
                     // Subset counter should record "version=v1"
                     assertThat(lbMetrics).containsEntry(
-                            "armeria.xds.lb.request.subset#count" +
+                            "armeria.xds.lb.select.subset#count" +
                             "{cluster=my-cluster,result=hit,subset=version=v1}",
                             2.0);
                     // Priority/locality counter should also be recorded
                     assertThat(lbMetrics).containsEntry(
-                            "armeria.xds.lb.request#count" +
+                            "armeria.xds.lb.select#count" +
                             "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
                             2.0);
                 });
@@ -835,7 +835,7 @@ class XdsLoadBalancerLifecycleObserverTest {
 
     private static Map<String, Double> measureAll(final MeterRegistry meterRegistry) {
         return measureAll(meterRegistry, key -> key.startsWith("armeria.xds.lb") &&
-                                                !key.contains("lb.request"));
+                                                !key.contains("lb.select"));
     }
 
     private static Map<String, Double> measureAll(final MeterRegistry meterRegistry,

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/XdsLoadBalancerLifecycleObserverTest.java
@@ -165,11 +165,11 @@ class XdsLoadBalancerLifecycleObserverTest {
                                 .put("armeria.xds.lb.state.rejected.count#count{cluster=my-cluster}", 0.0)
                                 // Membership metrics
                                 .put("armeria.xds.lb.membership.healthy#value" +
-                                     "{cluster=my-cluster,priority=0,region=,sub_zone=,zone=}", 1.0)
+                                     "{cluster=my-cluster,priority=0,region=,sub.zone=,zone=}", 1.0)
                                 .put("armeria.xds.lb.membership.total#value" +
-                                     "{cluster=my-cluster,priority=0,region=,sub_zone=,zone=}", 1.0)
+                                     "{cluster=my-cluster,priority=0,region=,sub.zone=,zone=}", 1.0)
                                 .put("armeria.xds.lb.membership.degraded#value" +
-                                     "{cluster=my-cluster,priority=0,region=,sub_zone=,zone=}", 0.0)
+                                     "{cluster=my-cluster,priority=0,region=,sub.zone=,zone=}", 0.0)
                                 // Load balancer state metrics
                                 .put("armeria.xds.lb.state.load.degraded#value" +
                                      "{cluster=my-cluster,priority=0}", 0.0)
@@ -179,11 +179,11 @@ class XdsLoadBalancerLifecycleObserverTest {
                                 .put("armeria.xds.lb.state.subsets#value{cluster=my-cluster}", 0.0)
                                 // Locality and zone metrics
                                 .put("armeria.xds.lb.locality.weight#value" +
-                                     "{cluster=my-cluster,priority=0,region=,sub_zone=,zone=}", 0.0)
+                                     "{cluster=my-cluster,priority=0,region=,sub.zone=,zone=}", 0.0)
                                 .put("armeria.xds.lb.zar.local.percentage#value" +
                                      "{cluster=my-cluster,priority=0}", 0.0)
                                 .put("armeria.xds.lb.zar.residual.percentage#value" +
-                                     "{cluster=my-cluster,priority=0,region=,sub_zone=,zone=}", 0.0)
+                                     "{cluster=my-cluster,priority=0,region=,sub.zone=,zone=}", 0.0)
                                 .build());
             });
         }
@@ -548,33 +548,33 @@ class XdsLoadBalancerLifecycleObserverTest {
                     // Priority 0 locality-specific membership metrics
                     assertThat(lbMetrics).containsAllEntriesOf(ImmutableMap.<String, Double>builder()
                             .put("armeria.xds.lb.membership.healthy#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.total#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub_zone=,zone=}", 2.0)
+                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub.zone=,zone=}", 2.0)
                             .put("armeria.xds.lb.membership.degraded#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.healthy#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.total#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.degraded#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub_zone=,zone=}", 0.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub.zone=,zone=}", 0.0)
                             .put("armeria.xds.lb.membership.healthy#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.total#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub_zone=,zone=}", 1.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub.zone=,zone=}", 1.0)
                             .put("armeria.xds.lb.membership.degraded#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub_zone=,zone=}", 0.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub.zone=,zone=}", 0.0)
                             .build());
 
                     // Priority 1 locality-specific membership metrics (us-west-2: 1 healthy endpoint)
                     assertThat(lbMetrics).containsAllEntriesOf(ImmutableMap.of(
                             "armeria.xds.lb.membership.healthy#value" +
-                            "{cluster=my-cluster,priority=1,region=us-west-2,sub_zone=,zone=}", 1.0,
+                            "{cluster=my-cluster,priority=1,region=us-west-2,sub.zone=,zone=}", 1.0,
                             "armeria.xds.lb.membership.total#value" +
-                            "{cluster=my-cluster,priority=1,region=us-west-2,sub_zone=,zone=}", 1.0,
+                            "{cluster=my-cluster,priority=1,region=us-west-2,sub.zone=,zone=}", 1.0,
                             "armeria.xds.lb.membership.degraded#value" +
-                            "{cluster=my-cluster,priority=1,region=us-west-2,sub_zone=,zone=}", 0.0
+                            "{cluster=my-cluster,priority=1,region=us-west-2,sub.zone=,zone=}", 0.0
                     ));
 
                     // Verify load balancer state metrics per priority
@@ -594,14 +594,14 @@ class XdsLoadBalancerLifecycleObserverTest {
                     assertThat(lbMetrics).containsAllEntriesOf(ImmutableMap.<String, Double>builder()
                             // Priority 0 locality weights (actual values from test output)
                             .put("armeria.xds.lb.locality.weight#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub_zone=,zone=}", 50.0)
+                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub.zone=,zone=}", 50.0)
                             .put("armeria.xds.lb.locality.weight#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub_zone=,zone=}", 200.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub.zone=,zone=}", 200.0)
                             .put("armeria.xds.lb.locality.weight#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub_zone=,zone=}", 200.0)
+                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub.zone=,zone=}", 200.0)
                             // Priority 1 locality weight (weight=300 for us-west-2)
                             .put("armeria.xds.lb.locality.weight#value" +
-                                 "{cluster=my-cluster,priority=1,region=us-west-2,sub_zone=,zone=}", 300.0)
+                                 "{cluster=my-cluster,priority=1,region=us-west-2,sub.zone=,zone=}", 300.0)
                             .build());
 
                     // Zone-aware routing (ZAR) metrics
@@ -609,11 +609,11 @@ class XdsLoadBalancerLifecycleObserverTest {
                             .put("armeria.xds.lb.zar.local.percentage#value" +
                                  "{cluster=my-cluster,priority=0}", 0.5)
                             .put("armeria.xds.lb.zar.residual.percentage#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub_zone=,zone=}", 0.0)
+                                 "{cluster=my-cluster,priority=0,region=us-east-1,sub.zone=,zone=}", 0.0)
                             .put("armeria.xds.lb.zar.residual.percentage#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub_zone=,zone=}", 0.5)
+                                 "{cluster=my-cluster,priority=0,region=us-west-1,sub.zone=,zone=}", 0.5)
                             .put("armeria.xds.lb.zar.residual.percentage#value" +
-                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub_zone=,zone=}", 0.5)
+                                 "{cluster=my-cluster,priority=0,region=us-west-2,sub.zone=,zone=}", 0.5)
                             .build());
                 });
             }
@@ -710,7 +710,7 @@ class XdsLoadBalancerLifecycleObserverTest {
                     final var lbMetrics = measureAll(meterRegistry, key -> key.contains("lb.select"));
                     assertThat(lbMetrics).containsEntry(
                             "armeria.xds.lb.select#count" +
-                            "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
+                            "{cluster=my-cluster,priority=0,region=,result=hit,sub.zone=,zone=}",
                             3.0);
                 });
             }
@@ -826,7 +826,7 @@ class XdsLoadBalancerLifecycleObserverTest {
                     // Priority/locality counter should also be recorded
                     assertThat(lbMetrics).containsEntry(
                             "armeria.xds.lb.select#count" +
-                            "{cluster=my-cluster,priority=0,region=,result=hit,sub_zone=,zone=}",
+                            "{cluster=my-cluster,priority=0,region=,result=hit,sub.zone=,zone=}",
                             2.0);
                 });
             }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultLoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultLoadBalancer.java
@@ -66,6 +66,7 @@ final class DefaultLoadBalancer implements XdsLoadBalancer {
     public Endpoint selectNow(ClientRequestContext ctx) {
         final PrioritySet prioritySet = lbState.prioritySet();
         if (prioritySet.priorities().isEmpty()) {
+            selectionRecorder.record(-1, null, LbSelectionRecorder.RESULT_NO_ENDPOINTS);
             return null;
         }
         XdsRandom random = ctx.attr(XdsAttributeKeys.XDS_RANDOM);
@@ -74,6 +75,7 @@ final class DefaultLoadBalancer implements XdsLoadBalancer {
         }
         final HostsSource hostsSource = hostSourceToUse(lbState, random, localityRoutingState);
         if (hostsSource == null) {
+            selectionRecorder.record(-1, null, LbSelectionRecorder.RESULT_NO_HOST_SOURCE);
             return null;
         }
         final HostSet hostSet = prioritySet.hostSets().get(hostsSource.priority);

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultLoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultLoadBalancer.java
@@ -45,11 +45,14 @@ final class DefaultLoadBalancer implements XdsLoadBalancer {
     private final XdsLoadBalancer localLoadBalancer;
     @Nullable
     private final LocalityRoutingState localityRoutingState;
+    private final LbSelectionRecorder selectionRecorder;
 
     DefaultLoadBalancer(PrioritySet prioritySet, Locality locality,
-                        @Nullable XdsLoadBalancer localLoadBalancer) {
+                        @Nullable XdsLoadBalancer localLoadBalancer,
+                        LbSelectionRecorder selectionRecorder) {
         lbState = DefaultLbStateFactory.newInstance(prioritySet);
         this.localLoadBalancer = localLoadBalancer;
+        this.selectionRecorder = selectionRecorder;
         if (localLoadBalancer != null) {
             localityRoutingState = new LocalityRoutingStateFactory(locality)
                     .create(prioritySet, localLoadBalancer);
@@ -80,33 +83,34 @@ final class DefaultLoadBalancer implements XdsLoadBalancer {
                                             prioritySet.cluster().getName() + "), hostsSource(" +
                                             hostsSource + ')');
         }
+        final Endpoint endpoint;
         switch (hostsSource.sourceType) {
             case ALL_HOSTS:
-                return hostSet.hostsEndpointGroup().selectNow(ctx);
+                endpoint = hostSet.hostsEndpointGroup().selectNow(ctx);
+                break;
             case HEALTHY_HOSTS:
-                return hostSet.healthyHostsEndpointGroup().selectNow(ctx);
+                endpoint = hostSet.healthyHostsEndpointGroup().selectNow(ctx);
+                break;
             case DEGRADED_HOSTS:
-                return hostSet.degradedHostsEndpointGroup().selectNow(ctx);
+                endpoint = hostSet.degradedHostsEndpointGroup().selectNow(ctx);
+                break;
             case LOCALITY_HEALTHY_HOSTS:
                 final Map<Locality, EndpointGroup> healthyLocalities =
                         hostSet.healthyEndpointGroupPerLocality();
                 final EndpointGroup healthyEndpointGroup = healthyLocalities.get(hostsSource.locality);
-                if (healthyEndpointGroup != null) {
-                    return healthyEndpointGroup.selectNow(ctx);
-                }
+                endpoint = healthyEndpointGroup != null ? healthyEndpointGroup.selectNow(ctx) : null;
                 break;
             case LOCALITY_DEGRADED_HOSTS:
                 final Map<Locality, EndpointGroup> degradedLocalities =
                         hostSet.degradedEndpointGroupPerLocality();
                 final EndpointGroup degradedEndpointGroup = degradedLocalities.get(hostsSource.locality);
-                if (degradedEndpointGroup != null) {
-                    return degradedEndpointGroup.selectNow(ctx);
-                }
+                endpoint = degradedEndpointGroup != null ? degradedEndpointGroup.selectNow(ctx) : null;
                 break;
             default:
                 throw new Error();
         }
-        return null;
+        selectionRecorder.record(hostsSource.priority, hostsSource.locality, endpoint);
+        return endpoint;
     }
 
     @Nullable

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerFactory.java
@@ -42,6 +42,8 @@ final class DefaultXdsLoadBalancerFactory implements XdsLoadBalancerFactory {
     private final EventExecutor eventLoop;
     private final Locality locality;
     private final XdsLoadBalancerLifecycleObserver observer;
+    private final LbSelectionRecorder selectionRecorder;
+    private final SubsetSelectionRecorder subsetRecorder;
 
     DefaultXdsLoadBalancerFactory(FactoryContext context, String clusterName) {
         factoryContext = context;
@@ -49,6 +51,10 @@ final class DefaultXdsLoadBalancerFactory implements XdsLoadBalancerFactory {
         locality = context.bootstrap().getNode().getLocality();
         observer = new DefaultXdsLoadBalancerLifecycleObserver(
                 context.meterIdPrefix(), context.meterRegistry(), clusterName);
+        selectionRecorder = new LbSelectionRecorder(context.meterRegistry(), context.meterIdPrefix(),
+                                                    clusterName);
+        subsetRecorder = new SubsetSelectionRecorder(context.meterRegistry(),
+                                                     context.meterIdPrefix(), clusterName);
     }
 
     @Override
@@ -161,10 +167,12 @@ final class DefaultXdsLoadBalancerFactory implements XdsLoadBalancerFactory {
                         new PriorityStateManager(clusterXdsResource, endpointSnapshot, endpoints).build();
 
                 XdsLoadBalancer loadBalancer =
-                        new DefaultLoadBalancer(prioritySet, locality, localLoadBalancer);
+                        new DefaultLoadBalancer(prioritySet, locality, localLoadBalancer,
+                                                selectionRecorder);
                 if (clusterXdsResource.resource().hasLbSubsetConfig()) {
                     loadBalancer = new SubsetLoadBalancer(prioritySet, loadBalancer, locality,
-                                                          localLoadBalancer);
+                                                          localLoadBalancer, selectionRecorder,
+                                                          subsetRecorder);
                 }
                 observer.stateUpdated(clusterXdsResource, loadBalancer);
                 watcher.onUpdate(loadBalancer, null);

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerLifecycleObserver.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerLifecycleObserver.java
@@ -232,7 +232,7 @@ final class DefaultXdsLoadBalancerLifecycleObserver implements XdsLoadBalancerLi
             this.locality = locality;
             prefix = prefix.withTags("region", locality.getRegion(),
                                      "zone", locality.getZone(),
-                                     "sub_zone", locality.getSubZone());
+                                     "sub.zone", locality.getSubZone());
             final ImmutableList.Builder<Meter> metersBuilder = ImmutableList.builder();
             metersBuilder.add(Gauge.builder(prefix.name("lb.membership.total"), () -> total)
                                    .tags(prefix.tags())

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
@@ -29,8 +29,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 final class LbSelectionRecorder {
 
-    private static final String RESULT_HIT = "hit";
-    private static final String RESULT_MISS = "miss";
+    static final String RESULT_HIT = "hit";
+    static final String RESULT_MISS = "miss";
+    static final String RESULT_NO_ENDPOINTS = "no_endpoints";
+    static final String RESULT_NO_HOST_SOURCE = "no_host_source";
 
     private final MeterIdPrefix prefix;
     private final MeterRegistry meterRegistry;
@@ -42,7 +44,11 @@ final class LbSelectionRecorder {
     }
 
     void record(int priority, @Nullable Locality locality, @Nullable Endpoint endpoint) {
-        requestCounters.computeIfAbsent(RequestKey.of(priority, locality, endpoint != null),
+        record(priority, locality, endpoint != null ? RESULT_HIT : RESULT_MISS);
+    }
+
+    void record(int priority, @Nullable Locality locality, String result) {
+        requestCounters.computeIfAbsent(RequestKey.of(priority, locality, result),
                                         this::createRequestCounter)
                        .increment();
     }
@@ -65,7 +71,7 @@ final class LbSelectionRecorder {
                       .tag("priority", Integer.toString(key.priority))
                       .tag("region", region)
                       .tag("result", key.result)
-                      .tag("sub_zone", subZone)
+                      .tag("sub.zone", subZone)
                       .tag("zone", zone)
                       .register(meterRegistry);
     }
@@ -79,11 +85,16 @@ final class LbSelectionRecorder {
         final Locality locality;
         final String result;
 
-        static RequestKey of(int priority, @Nullable Locality locality, boolean hit) {
+        static RequestKey of(int priority, @Nullable Locality locality, String result) {
             if (priority == 0 && locality == null) {
-                return hit ? PRIORITY_0_HIT : PRIORITY_0_MISS;
+                if (RESULT_HIT.equals(result)) {
+                    return PRIORITY_0_HIT;
+                }
+                if (RESULT_MISS.equals(result)) {
+                    return PRIORITY_0_MISS;
+                }
             }
-            return new RequestKey(priority, locality, hit ? RESULT_HIT : RESULT_MISS);
+            return new RequestKey(priority, locality, result);
         }
 
         private RequestKey(int priority, @Nullable Locality locality, String result) {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class LbSelectionRecorder {
+
+    private static final String RESULT_HIT = "hit";
+    private static final String RESULT_MISS = "miss";
+
+    private final MeterIdPrefix prefix;
+    private final MeterRegistry meterRegistry;
+    private final ConcurrentHashMap<RequestKey, Counter> requestCounters = new ConcurrentHashMap<>();
+
+    LbSelectionRecorder(MeterRegistry meterRegistry, MeterIdPrefix prefix, String clusterName) {
+        this.meterRegistry = meterRegistry;
+        this.prefix = prefix.withTags("cluster", clusterName);
+    }
+
+    void record(int priority, @Nullable Locality locality, @Nullable Endpoint endpoint) {
+        requestCounters.computeIfAbsent(RequestKey.of(priority, locality, endpoint != null),
+                                        this::createRequestCounter)
+                       .increment();
+    }
+
+    private Counter createRequestCounter(RequestKey key) {
+        final String region;
+        final String zone;
+        final String subZone;
+        if (key.locality != null) {
+            region = key.locality.getRegion();
+            zone = key.locality.getZone();
+            subZone = key.locality.getSubZone();
+        } else {
+            region = "";
+            zone = "";
+            subZone = "";
+        }
+        return Counter.builder(prefix.name("lb.request"))
+                      .tags(prefix.tags())
+                      .tag("priority", Integer.toString(key.priority))
+                      .tag("region", region)
+                      .tag("result", key.result)
+                      .tag("sub_zone", subZone)
+                      .tag("zone", zone)
+                      .register(meterRegistry);
+    }
+
+    private static final class RequestKey {
+        private static final RequestKey PRIORITY_0_HIT = new RequestKey(0, null, RESULT_HIT);
+        private static final RequestKey PRIORITY_0_MISS = new RequestKey(0, null, RESULT_MISS);
+
+        final int priority;
+        @Nullable
+        final Locality locality;
+        final String result;
+
+        static RequestKey of(int priority, @Nullable Locality locality, boolean hit) {
+            if (priority == 0 && locality == null) {
+                return hit ? PRIORITY_0_HIT : PRIORITY_0_MISS;
+            }
+            return new RequestKey(priority, locality, hit ? RESULT_HIT : RESULT_MISS);
+        }
+
+        private RequestKey(int priority, @Nullable Locality locality, String result) {
+            this.priority = priority;
+            this.locality = locality;
+            this.result = result;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof RequestKey)) {
+                return false;
+            }
+            final RequestKey that = (RequestKey) o;
+            return priority == that.priority &&
+                   Objects.equals(locality, that.locality) &&
+                   result.equals(that.result);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(priority, locality, result);
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LbSelectionRecorder.java
@@ -60,7 +60,7 @@ final class LbSelectionRecorder {
             zone = "";
             subZone = "";
         }
-        return Counter.builder(prefix.name("lb.request"))
+        return Counter.builder(prefix.name("lb.select"))
                       .tags(prefix.tags())
                       .tag("priority", Integer.toString(key.priority))
                       .tag("region", region)

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetLoadBalancer.java
@@ -50,27 +50,33 @@ final class SubsetLoadBalancer implements XdsLoadBalancer {
     private static final Logger logger = LoggerFactory.getLogger(SubsetLoadBalancer.class);
 
     private final XdsLoadBalancer allEndpointsLoadBalancer;
-    private final Locality locality;
     @Nullable
-    private final XdsLoadBalancer localLoadBalancer;
+    private final XdsLoadBalancer fallbackLoadBalancer;
+    private final SubsetSelectionRecorder subsetRecorder;
 
     private final Map<Struct, XdsLoadBalancer> subsetLoadBalancers;
     private final Map<Struct, LoadBalancerState> subsetStates;
     private final LbSubsetConfig lbSubsetConfig;
-    private final LbSubsetFallbackPolicy fallbackPolicy;
 
     SubsetLoadBalancer(PrioritySet prioritySet, XdsLoadBalancer allEndpointsLoadBalancer,
-                       Locality locality, @Nullable XdsLoadBalancer localLoadBalancer) {
+                       Locality locality, @Nullable XdsLoadBalancer localLoadBalancer,
+                       LbSelectionRecorder selectionRecorder, SubsetSelectionRecorder subsetRecorder) {
         this.allEndpointsLoadBalancer = allEndpointsLoadBalancer;
-        this.locality = locality;
-        this.localLoadBalancer = localLoadBalancer;
+        this.subsetRecorder = subsetRecorder;
 
         final Cluster cluster = prioritySet.cluster();
         lbSubsetConfig = cluster.getLbSubsetConfig();
-        fallbackPolicy = lbSubsetFallbackPolicy(lbSubsetConfig);
+        final LbSubsetFallbackPolicy fallbackPolicy = lbSubsetFallbackPolicy(lbSubsetConfig);
 
-        subsetLoadBalancers = createSubsetLoadBalancers(prioritySet);
+        subsetLoadBalancers = createSubsetLoadBalancers(prioritySet, locality, localLoadBalancer,
+                                                        selectionRecorder, subsetRecorder);
         subsetStates = ImmutableMap.copyOf(subsetLoadBalancers);
+
+        if (fallbackPolicy == LbSubsetFallbackPolicy.ANY_ENDPOINT) {
+            fallbackLoadBalancer = subsetRecorder.wrapFallback(allEndpointsLoadBalancer);
+        } else {
+            fallbackLoadBalancer = null;
+        }
     }
 
     private static LbSubsetFallbackPolicy lbSubsetFallbackPolicy(LbSubsetConfig lbSubsetConfig) {
@@ -92,11 +98,11 @@ final class SubsetLoadBalancer implements XdsLoadBalancer {
         if (subsetLoadBalancer != null) {
             return subsetLoadBalancer.selectNow(ctx);
         }
-        if (fallbackPolicy == LbSubsetFallbackPolicy.NO_FALLBACK) {
-            return null;
+        if (fallbackLoadBalancer != null) {
+            return fallbackLoadBalancer.selectNow(ctx);
         }
-        assert fallbackPolicy == LbSubsetFallbackPolicy.ANY_ENDPOINT;
-        return allEndpointsLoadBalancer.selectNow(ctx);
+        subsetRecorder.recordNoMatch();
+        return null;
     }
 
     @Override
@@ -110,7 +116,10 @@ final class SubsetLoadBalancer implements XdsLoadBalancer {
         return allEndpointsLoadBalancer.localLoadBalancer();
     }
 
-    private Map<Struct, XdsLoadBalancer> createSubsetLoadBalancers(PrioritySet prioritySet) {
+    private static Map<Struct, XdsLoadBalancer> createSubsetLoadBalancers(
+            PrioritySet prioritySet, Locality locality, @Nullable XdsLoadBalancer localLoadBalancer,
+            LbSelectionRecorder selectionRecorder, SubsetSelectionRecorder subsetRecorder) {
+        final LbSubsetConfig lbSubsetConfig = prioritySet.cluster().getLbSubsetConfig();
         final Map<Struct, List<Endpoint>> endpointsPerFilterStruct = new HashMap<>();
         for (LbSubsetSelector subsetSelector: lbSubsetConfig.getSubsetSelectorsList()) {
             final ProtocolStringList keys = subsetSelector.getKeysList();
@@ -142,8 +151,9 @@ final class SubsetLoadBalancer implements XdsLoadBalancer {
                                              prioritySet.endpointSnapshot(),
                                              entry.getValue()).build();
             final DefaultLoadBalancer subsetLoadBalancer =
-                    new DefaultLoadBalancer(subsetPrioritySet, locality, localLoadBalancer);
-            builder.put(entry.getKey(), subsetLoadBalancer);
+                    new DefaultLoadBalancer(subsetPrioritySet, locality, localLoadBalancer,
+                                            selectionRecorder);
+            builder.put(entry.getKey(), subsetRecorder.wrap(subsetLoadBalancer, entry.getKey()));
         }
         return builder.build();
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetSelectionRecorder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetSelectionRecorder.java
@@ -44,7 +44,7 @@ final class SubsetSelectionRecorder {
     SubsetSelectionRecorder(MeterRegistry meterRegistry, MeterIdPrefix prefix, String clusterName) {
         this.meterRegistry = meterRegistry;
         this.prefix = prefix.withTags("cluster", clusterName);
-        noMatchCounter = Counter.builder(this.prefix.name("lb.request.subset"))
+        noMatchCounter = Counter.builder(this.prefix.name("lb.select.subset"))
                                 .tags(this.prefix.tags())
                                 .tag("result", "miss")
                                 .tag("subset", "_no_match_")
@@ -65,12 +65,12 @@ final class SubsetSelectionRecorder {
     }
 
     private XdsLoadBalancer createRecordingLoadBalancer(XdsLoadBalancer delegate, String subsetValue) {
-        final Counter hitCounter = Counter.builder(prefix.name("lb.request.subset"))
+        final Counter hitCounter = Counter.builder(prefix.name("lb.select.subset"))
                                               .tags(prefix.tags())
                                               .tag("result", "hit")
                                               .tag("subset", subsetValue)
                                               .register(meterRegistry);
-        final Counter missCounter = Counter.builder(prefix.name("lb.request.subset"))
+        final Counter missCounter = Counter.builder(prefix.name("lb.select.subset"))
                                            .tags(prefix.tags())
                                            .tag("result", "miss")
                                            .tag("subset", subsetValue)

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetSelectionRecorder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/SubsetSelectionRecorder.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.client.endpoint;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
+import com.linecorp.armeria.xds.EndpointSnapshot;
+
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class SubsetSelectionRecorder {
+
+    private static final String FALLBACK_SUBSET = "_fallback_";
+
+    private final MeterRegistry meterRegistry;
+    private final MeterIdPrefix prefix;
+    private final Counter noMatchCounter;
+
+    SubsetSelectionRecorder(MeterRegistry meterRegistry, MeterIdPrefix prefix, String clusterName) {
+        this.meterRegistry = meterRegistry;
+        this.prefix = prefix.withTags("cluster", clusterName);
+        noMatchCounter = Counter.builder(this.prefix.name("lb.request.subset"))
+                                .tags(this.prefix.tags())
+                                .tag("result", "miss")
+                                .tag("subset", "_no_match_")
+                                .register(meterRegistry);
+    }
+
+    XdsLoadBalancer wrap(XdsLoadBalancer delegate, Struct subsetMetadata) {
+        final String subsetValue = serializeStruct(subsetMetadata);
+        return createRecordingLoadBalancer(delegate, subsetValue);
+    }
+
+    XdsLoadBalancer wrapFallback(XdsLoadBalancer delegate) {
+        return createRecordingLoadBalancer(delegate, FALLBACK_SUBSET);
+    }
+
+    void recordNoMatch() {
+        noMatchCounter.increment();
+    }
+
+    private XdsLoadBalancer createRecordingLoadBalancer(XdsLoadBalancer delegate, String subsetValue) {
+        final Counter hitCounter = Counter.builder(prefix.name("lb.request.subset"))
+                                              .tags(prefix.tags())
+                                              .tag("result", "hit")
+                                              .tag("subset", subsetValue)
+                                              .register(meterRegistry);
+        final Counter missCounter = Counter.builder(prefix.name("lb.request.subset"))
+                                           .tags(prefix.tags())
+                                           .tag("result", "miss")
+                                           .tag("subset", subsetValue)
+                                           .register(meterRegistry);
+        return new RecordingLoadBalancer(delegate, hitCounter, missCounter);
+    }
+
+    private static String serializeStruct(Struct struct) {
+        return struct.getFieldsMap().entrySet().stream()
+                     .sorted(Map.Entry.comparingByKey())
+                     .map(e -> e.getKey() + '=' + valueToString(e.getValue()))
+                     .collect(Collectors.joining(","));
+    }
+
+    private static String valueToString(Value value) {
+        switch (value.getKindCase()) {
+            case STRING_VALUE:
+                return value.getStringValue();
+            case NUMBER_VALUE:
+                return Double.toString(value.getNumberValue());
+            case BOOL_VALUE:
+                return Boolean.toString(value.getBoolValue());
+            default:
+                return value.toString().trim();
+        }
+    }
+
+    private static final class RecordingLoadBalancer implements XdsLoadBalancer {
+
+        private final XdsLoadBalancer delegate;
+        private final Counter hitCounter;
+        private final Counter missCounter;
+
+        RecordingLoadBalancer(XdsLoadBalancer delegate, Counter hitCounter, Counter missCounter) {
+            this.delegate = delegate;
+            this.hitCounter = hitCounter;
+            this.missCounter = missCounter;
+        }
+
+        @Nullable
+        @Override
+        public Endpoint selectNow(ClientRequestContext ctx) {
+            final Endpoint endpoint = delegate.selectNow(ctx);
+            (endpoint != null ? hitCounter : missCounter).increment();
+            return endpoint;
+        }
+
+        @Override
+        public Map<Integer, HostSet> hostSets() {
+            return delegate.hostSets();
+        }
+
+        @Override
+        public Map<Integer, Boolean> perPriorityPanic() {
+            return delegate.perPriorityPanic();
+        }
+
+        @Override
+        public Map<Integer, Integer> healthyPriorityLoad() {
+            return delegate.healthyPriorityLoad();
+        }
+
+        @Override
+        public Map<Integer, Integer> degradedPriorityLoad() {
+            return delegate.degradedPriorityLoad();
+        }
+
+        @Override
+        public Map<Locality, Double> zarResidualPercentages() {
+            return delegate.zarResidualPercentages();
+        }
+
+        @Override
+        public double zarLocalPercentage() {
+            return delegate.zarLocalPercentage();
+        }
+
+        @Override
+        public Map<Struct, LoadBalancerState> subsetStates() {
+            return delegate.subsetStates();
+        }
+
+        @Override
+        public List<Endpoint> allEndpoints() {
+            return delegate.allEndpoints();
+        }
+
+        @Override
+        public EndpointSnapshot endpointSnapshot() {
+            return delegate.endpointSnapshot();
+        }
+
+        @Nullable
+        @Override
+        public LoadBalancerState localLoadBalancer() {
+            return delegate.localLoadBalancer();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Add per-request selection metrics to the xDS load balancer so users can observe endpoint selection behavior at runtime — how often selections hit or miss, broken down by priority, locality, and subset.

Modifications:

- Add `LbSelectionRecorder` that records per-request endpoint selection outcomes (`hit`/`miss`) as counters, tagged by cluster, priority, locality (region/zone/sub_zone), and result. Pre-allocates `RequestKey` instances for the common priority-0 path to avoid allocation on every request.
- Add `SubsetSelectionRecorder` that wraps subset load balancers with a `RecordingLoadBalancer` decorator to track per-subset selection outcomes (`hit`/`miss`), plus a `_no_match_` counter when no subset matches and no fallback is configured.
- Wire both recorders into `DefaultXdsLoadBalancerFactory`, `DefaultLoadBalancer`, and `SubsetLoadBalancer`.
- Refactor `SubsetLoadBalancer` to pre-resolve fallback policy into a nullable `fallbackLoadBalancer` field and make `createSubsetLoadBalancers` static.
- Add `selectionCounterBasicCase` and `selectionCounterWithSubsets` tests in `XdsLoadBalancerLifecycleObserverTest`.

Result:

- Users gain visibility into xDS load balancer selection behavior via `armeria.xds.lb.request` (priority/locality level) and `armeria.xds.lb.request.subset` (subset level) counters, each tagged with `result=hit` or `result=miss`.
