### PR TITLE
Add support for `HttpProtocolOptions`

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HttpProtocolOptionsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HttpProtocolOptionsTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+
+class HttpProtocolOptionsTest {
+
+    @RegisterExtension
+    @Order(0)
+    static XdsCertificateExtension cert = new XdsCertificateExtension(new SelfSignedCertificateExtension());
+
+    @RegisterExtension
+    @Order(1)
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.https(0);
+            sb.tls(cert.tlsKeyPair());
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+        }
+    };
+
+    // language=YAML
+    private static final String BOOTSTRAP_TEMPLATE =
+            """
+            static_resources:
+              listeners:
+              - name: my-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.\
+            http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                          - match:
+                              prefix: /
+                            route:
+                              cluster: my-cluster
+                    http_filters:
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.\
+            http.router.v3.Router
+              clusters:
+              - name: my-cluster
+                type: STATIC
+                load_assignment:
+                  cluster_name: my-cluster
+                  endpoints:
+                  - lb_endpoints:
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: 127.0.0.1
+                            port_value: %d
+                typed_extension_protocol_options:
+                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                    "@type": type.googleapis.com/envoy.extensions.upstreams.\
+            http.v3.HttpProtocolOptions
+                    %s
+            """;
+
+    static Stream<Arguments> sessionProtocolSelection() {
+        return Stream.of(
+                Arguments.of("explicit_http_config: {http2_protocol_options: {}}",
+                             SessionProtocol.H2C),
+                Arguments.of("explicit_http_config: {http_protocol_options: {}}",
+                             SessionProtocol.H1C),
+                Arguments.of("auto_config: {}", SessionProtocol.HTTP)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void sessionProtocolSelection(String protocolConfig,
+                                  SessionProtocol expectedProtocol) {
+        final String yaml = BOOTSTRAP_TEMPLATE.formatted(
+                server.httpPort(), protocolConfig);
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(yaml, Bootstrap.class);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap);
+             ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            final AggregatedHttpResponse res = client.get("/");
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(captor.get().sessionProtocol()).isEqualTo(expectedProtocol);
+        }
+    }
+
+    // language=YAML
+    private static final String TLS_BOOTSTRAP_TEMPLATE =
+            """
+            static_resources:
+              listeners:
+              - name: my-listener
+                api_listener:
+                  api_listener:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.\
+            http_connection_manager.v3.HttpConnectionManager
+                    stat_prefix: http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                      - name: local_service
+                        domains: [ "*" ]
+                        routes:
+                          - match:
+                              prefix: /
+                            route:
+                              cluster: my-cluster
+                    http_filters:
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.\
+            http.router.v3.Router
+              clusters:
+              - name: my-cluster
+                type: STATIC
+                load_assignment:
+                  cluster_name: my-cluster
+                  endpoints:
+                  - lb_endpoints:
+                    - endpoint:
+                        address:
+                          socket_address:
+                            address: 127.0.0.1
+                            port_value: %d
+                transport_socket:
+                  name: envoy.transport_sockets.tls
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.transport_sockets.\
+            tls.v3.UpstreamTlsContext
+                    common_tls_context: {}
+                typed_extension_protocol_options:
+                  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+                    "@type": type.googleapis.com/envoy.extensions.upstreams.\
+            http.v3.HttpProtocolOptions
+                    %s
+            """;
+
+    static Stream<Arguments> tlsSessionProtocolSelection() {
+        return Stream.of(
+                Arguments.of("explicit_http_config: {http2_protocol_options: {}}",
+                             SessionProtocol.H2),
+                Arguments.of("explicit_http_config: {http_protocol_options: {}}",
+                             SessionProtocol.H1),
+                Arguments.of("auto_config: {}", SessionProtocol.HTTPS)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void tlsSessionProtocolSelection(String protocolConfig,
+                                     SessionProtocol expectedProtocol) {
+        final String yaml = TLS_BOOTSTRAP_TEMPLATE.formatted(
+                server.httpsPort(), protocolConfig);
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(yaml, Bootstrap.class);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor = XdsHttpPreprocessor.ofListener("my-listener", xdsBootstrap);
+             ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            final AggregatedHttpResponse res = client.get("/");
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThat(captor.get().sessionProtocol()).isEqualTo(expectedProtocol);
+        }
+    }
+}

--- a/xds-api/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds-api/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -1028,6 +1028,7 @@ message Cluster {
   // specific options.
   // [#next-major-version: make this a list of typed extensions.]
   // [#extension-category: envoy.upstream_options]
+  option (armeria.xds.supported.field) = 36;
   map<string, google.protobuf.Any> typed_extension_protocol_options = 36;
 
   // If the DNS refresh rate is specified and the cluster type is either

--- a/xds-api/src/main/proto/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
+++ b/xds-api/src/main/proto/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
@@ -11,6 +11,8 @@ import "envoy/extensions/filters/network/http_connection_manager/v3/http_connect
 import "udpa/annotations/status.proto";
 import "validate/validate.proto";
 
+import "armeria/xds/supported.proto";
+
 option java_package = "io.envoyproxy.envoy.extensions.upstreams.http.v3";
 option java_outer_classname = "HttpProtocolOptionsProto";
 option java_multiple_files = true;
@@ -69,8 +71,10 @@ message HttpProtocolOptions {
     oneof protocol_config {
       option (validate.required) = true;
 
+      option (armeria.xds.supported.oneof_field) = 1;
       config.core.v3.Http1ProtocolOptions http_protocol_options = 1;
 
+      option (armeria.xds.supported.oneof_field) = 2;
       config.core.v3.Http2ProtocolOptions http2_protocol_options = 2;
 
       // .. warning::
@@ -149,6 +153,7 @@ message HttpProtocolOptions {
     option (validate.required) = true;
 
     // To explicitly configure either HTTP/1 or HTTP/2 (but not both!) use ``explicit_http_config``.
+    option (armeria.xds.supported.oneof_field) = 3;
     ExplicitHttpConfig explicit_http_config = 3;
 
     // This allows switching on protocol based on what protocol the downstream
@@ -156,6 +161,7 @@ message HttpProtocolOptions {
     UseDownstreamHttpConfig use_downstream_protocol_config = 4;
 
     // This allows switching on protocol based on ALPN
+    option (armeria.xds.supported.oneof_field) = 5;
     AutoHttpConfig auto_config = 5;
   }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterFilterFactory.java
@@ -18,6 +18,8 @@ package com.linecorp.armeria.xds;
 
 import java.util.Set;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.client.ClientDecoration;
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.ClientTlsSpec;
@@ -43,6 +45,9 @@ import com.linecorp.armeria.xds.internal.DelegatingHttpClient;
 import com.linecorp.armeria.xds.internal.DelegatingRpcClient;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 import com.linecorp.armeria.xds.internal.XdsEndpoint;
+
+import io.envoyproxy.envoy.extensions.upstreams.http.v3.HttpProtocolOptions;
+import io.envoyproxy.envoy.extensions.upstreams.http.v3.HttpProtocolOptions.ExplicitHttpConfig;
 
 /**
  * A factory which injects cluster-related filters.
@@ -71,12 +76,21 @@ final class ClusterFilterFactory {
 
     private final XdsEndpointGroup endpointGroup;
     private final SessionProtocol sessionProtocol;
+    @Nullable
+    private final HttpProtocolOptions httpProtocolOptions;
 
     ClusterFilterFactory(XdsLoadBalancer loadBalancer,
+                         @Nullable HttpProtocolOptions httpProtocolOptions,
                          TransportSocketSnapshot transportSocket) {
         endpointGroup = XdsEndpointGroup.of(loadBalancer);
-        sessionProtocol = transportSocket.clientTlsSpec() != null ?
-                          SessionProtocol.HTTPS : SessionProtocol.HTTP;
+        this.httpProtocolOptions = httpProtocolOptions;
+        final boolean tls = transportSocket.clientTlsSpec() != null;
+        sessionProtocol = sessionProtocol(tls, httpProtocolOptions);
+    }
+
+    @Nullable
+    HttpProtocolOptions httpProtocolOptions() {
+        return httpProtocolOptions;
     }
 
     HttpPreprocessor httpPreprocessor() {
@@ -148,5 +162,26 @@ final class ClusterFilterFactory {
             clientTlsSpec = clientTlsSpec.toBuilder().alpnProtocols(alpnOverride).build();
         }
         ctx.setClientTlsSpec(clientTlsSpec);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("sessionProtocol", sessionProtocol)
+                          .toString();
+    }
+
+    private static SessionProtocol sessionProtocol(boolean tls,
+                                                   @Nullable HttpProtocolOptions httpProtocolOptions) {
+        if (httpProtocolOptions != null && httpProtocolOptions.hasExplicitHttpConfig()) {
+            final ExplicitHttpConfig explicitConfig = httpProtocolOptions.getExplicitHttpConfig();
+            if (explicitConfig.hasHttp2ProtocolOptions()) {
+                return tls ? SessionProtocol.H2 : SessionProtocol.H2C;
+            }
+            if (explicitConfig.hasHttpProtocolOptions()) {
+                return tls ? SessionProtocol.H1 : SessionProtocol.H1C;
+            }
+        }
+        return tls ? SessionProtocol.HTTPS : SessionProtocol.HTTP;
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterSnapshot.java
@@ -25,10 +25,12 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.RpcPreprocessor;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
 
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.envoyproxy.envoy.extensions.upstreams.http.v3.HttpProtocolOptions;
 
 /**
  * A snapshot of a {@link Cluster} resource.
@@ -41,21 +43,19 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     private final EndpointSnapshot endpointSnapshot;
     private final List<TransportSocketMatchSnapshot> transportSocketMatches;
     private final XdsLoadBalancer loadBalancer;
-    private final HttpPreprocessor httpPreprocessor;
-    private final RpcPreprocessor rpcPreprocessor;
+    private final ClusterFilterFactory clusterFilterFactory;
 
     ClusterSnapshot(ClusterXdsResource clusterXdsResource,
                     XdsLoadBalancer loadBalancer,
                     TransportSocketSnapshot transportSocket,
-                    List<TransportSocketMatchSnapshot> transportSocketMatches) {
+                    List<TransportSocketMatchSnapshot> transportSocketMatches,
+                    ClusterFilterFactory clusterFilterFactory) {
         this.clusterXdsResource = clusterXdsResource;
         this.transportSocket = transportSocket;
         this.loadBalancer = loadBalancer;
         endpointSnapshot = loadBalancer.endpointSnapshot();
         this.transportSocketMatches = transportSocketMatches;
-        final ClusterFilterFactory factory = new ClusterFilterFactory(loadBalancer, transportSocket);
-        httpPreprocessor = factory.httpPreprocessor();
-        rpcPreprocessor = factory.rpcPreprocessor();
+        this.clusterFilterFactory = clusterFilterFactory;
     }
 
     @Override
@@ -90,12 +90,22 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
     }
 
     /**
+     * Returns the parsed {@link HttpProtocolOptions} from the cluster's
+     * {@code typed_extension_protocol_options}, or {@code null} if not configured.
+     */
+    @Nullable
+    @UnstableApi
+    public HttpProtocolOptions httpProtocolOptions() {
+        return clusterFilterFactory.httpProtocolOptions();
+    }
+
+    /**
      * Returns an {@link HttpPreprocessor} that sets the endpoint group, session protocol,
      * and installs cluster-level decoration (retry + per-endpoint TLS) on the context.
      */
     @UnstableApi
     public HttpPreprocessor preprocessor() {
-        return httpPreprocessor;
+        return clusterFilterFactory.httpPreprocessor();
     }
 
     /**
@@ -104,7 +114,7 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
      */
     @UnstableApi
     public RpcPreprocessor rpcPreprocessor() {
-        return rpcPreprocessor;
+        return clusterFilterFactory.rpcPreprocessor();
     }
 
     /**
@@ -161,8 +171,7 @@ public final class ClusterSnapshot implements Snapshot<ClusterXdsResource> {
                           .add("transportSocketMatches",
                                SnapshotUtil.debugStrings(transportSocketMatches,
                                                          TransportSocketMatchSnapshot::toDebugString))
-                          .add("httpPreprocessor", httpPreprocessor)
-                          .add("rpcPreprocessor", rpcPreprocessor)
+                          .add("clusterFilterFactory", clusterFilterFactory)
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
@@ -30,10 +31,15 @@ import com.linecorp.armeria.xds.stream.RefCountedStream;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
 import com.linecorp.armeria.xds.stream.Subscription;
 
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
 import io.envoyproxy.envoy.config.cluster.v3.Cluster.TransportSocketMatch;
 import io.envoyproxy.envoy.config.core.v3.ConfigSource;
+import io.envoyproxy.envoy.extensions.upstreams.http.v3.HttpProtocolOptions;
 
 final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
+
+    private static final String HTTP_PROTOCOL_OPTIONS_KEY =
+            "envoy.extensions.upstreams.http.v3.HttpProtocolOptions";
 
     @Nullable
     private final ClusterXdsResource clusterXdsResource;
@@ -103,8 +109,23 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
             lbStream = lbFactory.register(resource, input.transportSocket,
                                           input.transportSocketMatches, null);
         }
-        return lbStream.map(lb -> new ClusterSnapshot(
-                resource, lb, input.transportSocket, input.transportSocketMatches));
+        final HttpProtocolOptions httpProtocolOptions = parseHttpProtocolOptions(resource.resource());
+        return lbStream.map(lb -> {
+            final ClusterFilterFactory factory =
+                    new ClusterFilterFactory(lb, httpProtocolOptions, input.transportSocket);
+            return new ClusterSnapshot(resource, lb, input.transportSocket, input.transportSocketMatches,
+                                       factory);
+        });
+    }
+
+    @Nullable
+    private HttpProtocolOptions parseHttpProtocolOptions(Cluster cluster) {
+        final Any any = cluster.getTypedExtensionProtocolOptionsMap()
+                               .get(HTTP_PROTOCOL_OPTIONS_KEY);
+        if (any == null) {
+            return null;
+        }
+        return context.extensionRegistry().unpack(any, HttpProtocolOptions.class);
     }
 
     private static class TransportSocketMatchesStream

--- a/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ClusterStream.java
@@ -89,13 +89,15 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
         final List<TransportSocketMatch> matches = resource.resource().getTransportSocketMatchesList();
         final TransportSocketMatchesStream socketMatchesStream =
                 new TransportSocketMatchesStream(context, configSource, matches);
-        return SnapshotStream.combineLatest(transportSocket, socketMatchesStream,
-                                            LoadBalancerInput::new)
-                             .switchMapEager(input -> clusterSnapshotStream(resource, input));
+        final HttpProtocolOptions httpProtocolOptions = parseHttpProtocolOptions(resource.resource());
+        return SnapshotStream.combineLatest(transportSocket, socketMatchesStream, LoadBalancerInput::new)
+                             .switchMapEager(input -> clusterSnapshotStream(resource,
+                                                                            httpProtocolOptions, input));
     }
 
-    private SnapshotStream<ClusterSnapshot> clusterSnapshotStream(ClusterXdsResource resource,
-                                                                  LoadBalancerInput input) {
+    private SnapshotStream<ClusterSnapshot> clusterSnapshotStream(
+            ClusterXdsResource resource, @Nullable HttpProtocolOptions httpProtocolOptions,
+            LoadBalancerInput input) {
         final SnapshotStream<XdsLoadBalancer> lbStream;
         if (context.clusterManager().hasLocalCluster() &&
             !resourceName.equals(context.clusterManager().localClusterName())) {
@@ -109,7 +111,6 @@ final class ClusterStream extends RefCountedStream<ClusterSnapshot> {
             lbStream = lbFactory.register(resource, input.transportSocket,
                                           input.transportSocketMatches, null);
         }
-        final HttpProtocolOptions httpProtocolOptions = parseHttpProtocolOptions(resource.resource());
         return lbStream.map(lb -> {
             final ClusterFilterFactory factory =
                     new ClusterFilterFactory(lb, httpProtocolOptions, input.transportSocket);


### PR DESCRIPTION
Motivation:

When a cluster configures `typed_extension_protocol_options` with `envoy.extensions.upstreams.http.v3.HttpProtocolOptions`, Envoy uses the `ExplicitHttpConfig` or `AutoHttpConfig` to determine which HTTP version to use for upstream connections. Previously, Armeria's xDS client ignored this configuration and always defaulted to `HTTP`/`HTTPS` based solely on whether TLS was enabled, which meant clusters that explicitly declared HTTP/2 or HTTP/1 were not honored.

Modifications:

- Parse `HttpProtocolOptions` from the cluster's `typed_extension_protocol_options` map in `ClusterStream` and pass it into `ClusterFilterFactory`.
- Derive `SessionProtocol` from the parsed options in `ClusterFilterFactory`:
  - `explicit_http_config` with `http2_protocol_options` → `H2` / `H2C`
  - `explicit_http_config` with `http_protocol_options` → `H1` / `H1C`
  - `auto_config` or absent → `HTTPS` / `HTTP` (existing default behavior)

Result:

- The xDS client now respects `HttpProtocolOptions` from cluster configuration and selects the correct `SessionProtocol` (`H1`, `H1C`, `H2`, `H2C`, `HTTP`, `HTTPS`) accordingly.
