### PR TITLE
Fix DNS socket leak in DnsEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/dns/DnsEndpointGroup.java
@@ -209,7 +209,8 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup implements DnsCache
     abstract ImmutableSortedSet<Endpoint> onDnsRecords(List<DnsRecord> records, int ttl) throws Exception;
 
     /**
-     * Stops polling DNS servers for service updates.
+     * Stops polling DNS servers for service updates and releases the underlying DNS resolver,
+     * including its UDP {@link io.netty.channel.socket.DatagramChannel}.
      */
     @Override
     protected final void doCloseAsync(CompletableFuture<?> future) {
@@ -217,7 +218,13 @@ abstract class DnsEndpointGroup extends DynamicEndpointGroup implements DnsCache
         if (scheduledFuture != null) {
             scheduledFuture.cancel(true);
         }
+        resolver.close();
         future.complete(null);
+    }
+
+    @VisibleForTesting
+    final DefaultDnsResolver resolver() {
+        return resolver;
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
+++ b/core/src/main/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroup.java
@@ -364,8 +364,9 @@ public final class HealthCheckedEndpointGroup extends DynamicEndpointGroup {
             } finally {
                 lock.unlock();
             }
-            return delegate.closeAsync();
-        }).handle((unused1, unused2) -> future.complete(null));
+            return null;
+        }).thenCompose(unused -> delegate.closeAsync())
+          .handle((unused1, unused2) -> future.complete(null));
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolver.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/dns/DefaultDnsResolver.java
@@ -66,6 +66,10 @@ public final class DefaultDnsResolver implements SafeCloseable {
     private final EventExecutor executor;
     private final long queryTimeoutMillis;
 
+    // Added only for testing. resolve do not check this condition.
+    @VisibleForTesting
+    private volatile boolean closed;
+
     public DefaultDnsResolver(DnsResolver delegate, DnsCache dnsCache, EventExecutor executor,
                               long queryTimeoutMillis) {
         this.delegate = delegate;
@@ -190,8 +194,14 @@ public final class DefaultDnsResolver implements SafeCloseable {
         return dnsCache;
     }
 
+    @VisibleForTesting
+    public boolean isClosed() {
+        return closed;
+    }
+
     @Override
     public void close() {
+        closed = true;
         delegate.close();
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/dns/DnsAddressEndpointGroupTest.java
@@ -703,4 +703,28 @@ class DnsAddressEndpointGroupTest {
             super.channelRead(ctx, msg);
         }
     }
+
+    @Test
+    void closesUnderlyingDnsResolverOnClose() throws Exception {
+        try (TestDnsServer server = new TestDnsServer(ImmutableMap.of(
+                new DefaultDnsQuestion("close-test.com.", A),
+                new DefaultDnsResponse(0).addRecord(ANSWER, newAddressRecord("close-test.com.", "1.2.3.4")),
+                new DefaultDnsQuestion("close-test.com.", AAAA),
+                new DefaultDnsResponse(0)
+        ))) {
+            final DnsAddressEndpointGroup group =
+                    DnsAddressEndpointGroup.builder("close-test.com")
+                                           .port(8080)
+                                           .serverAddresses(server.addr())
+                                           .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                                           .dnsCache(NoopDnsCache.INSTANCE)
+                                           .build();
+            group.whenReady().get(10, TimeUnit.SECONDS);
+
+            assertThat(group.resolver().isClosed()).isFalse();
+            group.close();
+            // The DefaultDnsResolver (and its underlying UDP DatagramChannel) must be released.
+            assertThat(group.resolver().isClosed()).isTrue();
+        }
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/healthcheck/HealthCheckedEndpointGroupTest.java
@@ -634,6 +634,54 @@ class HealthCheckedEndpointGroupTest {
                                              .containsOnly(candidate1, candidate2);
     }
 
+    @Test
+    void delegateIsClosedBeforeGroupCloseCompletes() throws Exception {
+        // A delegate whose close completes asynchronously, controlled by the test.
+        final CompletableFuture<Void> permitDelegateClose = new CompletableFuture<>();
+        final AtomicBoolean delegateClosed = new AtomicBoolean();
+
+        final DynamicEndpointGroup slowDelegate = new DynamicEndpointGroup() {
+            {
+                setEndpoints(ImmutableList.of(Endpoint.of("foo")));
+            }
+
+            @Override
+            protected void doCloseAsync(CompletableFuture<?> future) {
+                permitDelegateClose.whenComplete((unused, cause) -> {
+                    delegateClosed.set(true);
+                    future.complete(null);
+                });
+            }
+        };
+
+        final HealthCheckedEndpointGroup group =
+                new AbstractHealthCheckedEndpointGroupBuilder(slowDelegate) {
+                    @Override
+                    protected Function<? super HealthCheckerContext, ? extends AsyncCloseable>
+                    newCheckerFactory() {
+                        return ctx -> {
+                            ctx.updateHealth(1, null, null, null);
+                            return AsyncCloseableSupport.of();
+                        };
+                    }
+                }.build();
+        await().until(() -> !group.endpoints().isEmpty());
+
+        // Close the group in a separate thread so we can observe blocking behaviour.
+        final CompletableFuture<Void> groupCloseFuture = CompletableFuture.runAsync(group::close);
+
+        // group.close() must block until the delegate closes. Give it time to progress past
+        // the health-checker stop phase and reach the blocked delegate close.
+        Thread.sleep(500);
+        assertThat(groupCloseFuture).isNotDone();
+        assertThat(delegateClosed).isFalse();
+
+        // Unblock the delegate. group.close() must now complete.
+        permitDelegateClose.complete(null);
+        groupCloseFuture.get(5, TimeUnit.SECONDS);
+        assertThat(delegateClosed).isTrue();
+    }
+
     static final class MockEndpointGroup extends DynamicEndpointGroup {
 
         MockEndpointGroup() {}


### PR DESCRIPTION
Motivation:

`DnsEndpointGroup.doCloseAsync()` cancels the scheduled retry future but never calls `resolver.close()`. The `DefaultDnsResolver` wraps a Netty `DnsNameResolver` which, via `DnsResolveChannelPerResolverProvider`, binds a UDP `DatagramChannel` immediately at construction time. Because `resolver.close()` is never called, that channel is never released, leaking one UDP socket for every `DnsAddressEndpointGroup` instance created for the lifetime of the process.

Modifications:

- Added `resolver.close()` to `DnsEndpointGroup.doCloseAsync()` so the `DnsNameResolver` and its underlying UDP `DatagramChannel` are released when the group is closed.
- Changed `HealthCheckedEndpointGroup.doCloseAsync()` from `handle()` to `thenCompose()` when chaining `delegate.closeAsync()`, so the close future completes only after the delegate has fully closed.

Result:

- Every `DnsAddressEndpointGroup.close()` call now releases the UDP socket held by the underlying `DnsNameResolver`, preventing the leak.