### PR TITLE
Allow users to customize TLS for connections to proxy servers via CONNECT

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
@@ -59,7 +59,16 @@ public final class ClientTlsSpecBuilder extends AbstractTlsSpecBuilder<ClientTls
         endpointIdentificationAlgorithm = clientTlsSpec.endpointIdentificationAlgorithm();
     }
 
-    ClientTlsSpecBuilder alpnProtocols(SessionProtocol sessionProtocol) {
+    /**
+     * Sets the ALPN protocol names based on the specified {@link SessionProtocol}.
+     * If the protocol is an explicit HTTP/1 variant, only {@code "http/1.1"} is used.
+     * Otherwise, both {@code "h2"} and {@code "http/1.1"} are used.
+     */
+    public ClientTlsSpecBuilder alpnProtocols(SessionProtocol sessionProtocol) {
+        requireNonNull(sessionProtocol, "sessionProtocol");
+        checkArgument(SessionProtocol.httpAndHttpsValues().contains(sessionProtocol),
+                      "sessionProtocol: %s (expected: one of %s)",
+                      sessionProtocol, SessionProtocol.httpAndHttpsValues());
         if (sessionProtocol.isExplicitHttp1()) {
             alpnProtocols = SslContextUtil.DEFAULT_HTTP1_ALPN_PROTOCOLS;
         } else {

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -120,7 +120,7 @@ final class HttpChannelPool implements AsyncCloseable {
                                     sslContextFactory, clientFactory.defaultSslContexts());
     }
 
-    private void configureProxy(Channel ch, ProxyConfig proxyConfig, ClientTlsSpec tlsSpec) {
+    private void configureProxy(Channel ch, ProxyConfig proxyConfig) {
         if (proxyConfig.proxyType() == ProxyType.DIRECT) {
             return;
         }
@@ -157,11 +157,14 @@ final class HttpChannelPool implements AsyncCloseable {
         proxyHandler.setConnectTimeoutMillis(connectTimeoutMillis);
         ch.pipeline().addFirst(proxyHandler);
 
-        if (proxyConfig instanceof ConnectProxyConfig && ((ConnectProxyConfig) proxyConfig).useTls()) {
-            final SslContext sslCtx = bootstraps.getOrCreateSslContext(tlsSpec);
-            ch.pipeline().addFirst(sslCtx.newHandler(ch.alloc(), proxyAddress.getHostString(),
-                                                     proxyAddress.getPort()));
-            ch.closeFuture().addListener(unused -> bootstraps.release(sslCtx));
+        if (proxyConfig instanceof ConnectProxyConfig) {
+            final ClientTlsSpec proxyTlsSpec = ((ConnectProxyConfig) proxyConfig).clientTlsSpec();
+            if (proxyTlsSpec != null) {
+                final SslContext sslCtx = bootstraps.getOrCreateSslContext(proxyTlsSpec);
+                ch.pipeline().addFirst(sslCtx.newHandler(ch.alloc(), proxyAddress.getHostString(),
+                                                         proxyAddress.getPort()));
+                ch.closeFuture().addListener(unused -> bootstraps.release(sslCtx));
+            }
         }
     }
 
@@ -407,7 +410,7 @@ final class HttpChannelPool implements AsyncCloseable {
                 final Channel channel = registerFuture.channel();
                 ConnectionEventListener.setToChannelAttr(
                         desiredProtocol, clientFactory.connectionPoolListener(), channel);
-                configureProxy(channel, poolKey.proxyConfig, poolKey.tlsSpec);
+                configureProxy(channel, poolKey.proxyConfig);
 
                 if (desiredProtocol.isTls() && timingsBuilder != null) {
                     channel.attr(TIMINGS_BUILDER_KEY).set(timingsBuilder);

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ConnectProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ConnectProxyConfig.java
@@ -119,8 +119,7 @@ public final class ConnectProxyConfig extends ProxyConfig {
 
     @Override
     public ProxyConfig withProxyAddress(InetSocketAddress newProxyAddress) {
-        return new ConnectProxyConfig(newProxyAddress, this.username,
-                                      this.password, this.headers, this.clientTlsSpec);
+        return new ConnectProxyConfig(newProxyAddress, username, password, headers, clientTlsSpec);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ConnectProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ConnectProxyConfig.java
@@ -21,13 +21,19 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * CONNECT proxy configuration.
  */
 public final class ConnectProxyConfig extends ProxyConfig {
+
+    private static final ClientTlsSpec DEFAULT_PROXY_TLS_SPEC =
+            ClientTlsSpec.builder().alpnProtocols(SessionProtocol.H1).build();
 
     private final InetSocketAddress proxyAddress;
 
@@ -39,15 +45,27 @@ public final class ConnectProxyConfig extends ProxyConfig {
 
     private final HttpHeaders headers;
 
-    private final boolean useTls;
+    @Nullable
+    private final ClientTlsSpec clientTlsSpec;
 
     ConnectProxyConfig(InetSocketAddress proxyAddress, @Nullable String username,
                        @Nullable String password, HttpHeaders headers, boolean useTls) {
+        this(proxyAddress, username, password, headers, useTls ? DEFAULT_PROXY_TLS_SPEC : null);
+    }
+
+    ConnectProxyConfig(InetSocketAddress proxyAddress, @Nullable String username,
+                       @Nullable String password, HttpHeaders headers,
+                       @Nullable ClientTlsSpec clientTlsSpec) {
+        if (clientTlsSpec != null) {
+            if (clientTlsSpec.alpnProtocols().isEmpty()) {
+                clientTlsSpec = clientTlsSpec.toBuilder().alpnProtocols(SessionProtocol.H1).build();
+            }
+        }
         this.proxyAddress = proxyAddress;
         this.username = username;
         this.password = password;
         this.headers = headers;
-        this.useTls = useTls;
+        this.clientTlsSpec = clientTlsSpec;
     }
 
     @Override
@@ -82,7 +100,16 @@ public final class ConnectProxyConfig extends ProxyConfig {
      * Returns whether ssl is enabled.
      */
     public boolean useTls() {
-        return useTls;
+        return clientTlsSpec != null;
+    }
+
+    /**
+     * Returns the {@link ClientTlsSpec} for the proxy connection, or {@code null} if TLS is not used.
+     */
+    @UnstableApi
+    @Nullable
+    public ClientTlsSpec clientTlsSpec() {
+        return clientTlsSpec;
     }
 
     @Override
@@ -93,7 +120,7 @@ public final class ConnectProxyConfig extends ProxyConfig {
     @Override
     public ProxyConfig withProxyAddress(InetSocketAddress newProxyAddress) {
         return new ConnectProxyConfig(newProxyAddress, this.username,
-                                      this.password, this.headers, this.useTls);
+                                      this.password, this.headers, this.clientTlsSpec);
     }
 
     @Override
@@ -105,16 +132,16 @@ public final class ConnectProxyConfig extends ProxyConfig {
             return false;
         }
         final ConnectProxyConfig that = (ConnectProxyConfig) o;
-        return useTls == that.useTls &&
-               proxyAddress.equals(that.proxyAddress) &&
+        return proxyAddress.equals(that.proxyAddress) &&
                Objects.equals(username, that.username) &&
                Objects.equals(password, that.password) &&
-               headers.equals(that.headers);
+               headers.equals(that.headers) &&
+               Objects.equals(clientTlsSpec, that.clientTlsSpec);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(proxyAddress, username, password, headers, useTls);
+        return Objects.hash(proxyAddress, username, password, headers, clientTlsSpec);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
@@ -154,8 +154,7 @@ public abstract class ProxyConfig {
      * @param clientTlsSpec the TLS spec for the proxy connection
      */
     @UnstableApi
-    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress,
-                                             ClientTlsSpec clientTlsSpec) {
+    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress, ClientTlsSpec clientTlsSpec) {
         requireNonNull(proxyAddress, "proxyAddress");
         requireNonNull(clientTlsSpec, "clientTlsSpec");
         return new ConnectProxyConfig(proxyAddress, null, null, HttpHeaders.of(), clientTlsSpec);

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import java.net.InetSocketAddress;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
@@ -143,6 +144,38 @@ public abstract class ProxyConfig {
         requireNonNull(password, "password");
         requireNonNull(headers, "headers");
         return new ConnectProxyConfig(proxyAddress, username, password, headers, useTls);
+    }
+
+    /**
+     * Creates a {@code ProxyConfig} configuration for CONNECT protocol with a custom
+     * {@link ClientTlsSpec} for the proxy connection.
+     *
+     * @param proxyAddress the proxy address
+     * @param clientTlsSpec the TLS spec for the proxy connection
+     */
+    @UnstableApi
+    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress,
+                                             ClientTlsSpec clientTlsSpec) {
+        requireNonNull(proxyAddress, "proxyAddress");
+        requireNonNull(clientTlsSpec, "clientTlsSpec");
+        return new ConnectProxyConfig(proxyAddress, null, null, HttpHeaders.of(), clientTlsSpec);
+    }
+
+    /**
+     * Creates a {@code ProxyConfig} configuration for CONNECT protocol with a custom
+     * {@link ClientTlsSpec} for the proxy connection.
+     *
+     * @param proxyAddress the proxy address
+     * @param headers the {@link HttpHeaders} to send to the proxy
+     * @param clientTlsSpec the TLS spec for the proxy connection
+     */
+    @UnstableApi
+    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress, HttpHeaders headers,
+                                             ClientTlsSpec clientTlsSpec) {
+        requireNonNull(proxyAddress, "proxyAddress");
+        requireNonNull(headers, "headers");
+        requireNonNull(clientTlsSpec, "clientTlsSpec");
+        return new ConnectProxyConfig(proxyAddress, null, null, headers, clientTlsSpec);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/client/proxy/ProxyConfig.java
@@ -165,16 +165,19 @@ public abstract class ProxyConfig {
      * {@link ClientTlsSpec} for the proxy connection.
      *
      * @param proxyAddress the proxy address
+     * @param username the username
+     * @param password the password
      * @param headers the {@link HttpHeaders} to send to the proxy
      * @param clientTlsSpec the TLS spec for the proxy connection
      */
     @UnstableApi
-    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress, HttpHeaders headers,
-                                             ClientTlsSpec clientTlsSpec) {
+    public static ConnectProxyConfig connect(InetSocketAddress proxyAddress,
+                                             @Nullable String username, @Nullable String password,
+                                             HttpHeaders headers, ClientTlsSpec clientTlsSpec) {
         requireNonNull(proxyAddress, "proxyAddress");
         requireNonNull(headers, "headers");
         requireNonNull(clientTlsSpec, "clientTlsSpec");
-        return new ConnectProxyConfig(proxyAddress, null, null, headers, clientTlsSpec);
+        return new ConnectProxyConfig(proxyAddress, username, password, headers, clientTlsSpec);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/proxy/ProxyClientIntegrationTest.java
@@ -57,6 +57,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.client.DNSResolverFacadeUtils;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.SessionProtocolNegotiationException;
@@ -69,6 +70,7 @@ import com.linecorp.armeria.common.Flags;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.TlsPeerVerifierFactory;
 import com.linecorp.armeria.common.TlsProvider;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.testing.BlockingUtils;
@@ -531,9 +533,13 @@ class ProxyClientIntegrationTest {
     @ParameterizedTest
     @MethodSource("sessionAndEndpointProvider")
     void testHttpsProxy(SessionProtocol protocol, Endpoint endpoint) throws Exception {
+        final ClientTlsSpec clientTlsSpec =
+                ClientTlsSpec.builder()
+                             .verifierFactories(TlsPeerVerifierFactory.noVerify())
+                             .build();
         final ClientFactory clientFactory =
                 ClientFactory.builder().tlsNoVerify().proxyConfig(
-                        ProxyConfig.connect(httpsProxyServer.address(), true)).build();
+                        ProxyConfig.connect(httpsProxyServer.address(), clientTlsSpec)).build();
         final WebClient webClient = WebClient.builder(protocol, endpoint)
                                              .factory(clientFactory)
                                              .decorator(LoggingClient.newDecorator())
@@ -550,17 +556,22 @@ class ProxyClientIntegrationTest {
     @ParameterizedTest
     @MethodSource("sessionAndEndpointProvider")
     void testMTlsHttpsProxyWithTlsProvider(SessionProtocol protocol, Endpoint endpoint) throws Exception {
+        final ClientTlsSpec clientTlsSpec =
+                ClientTlsSpec.builder()
+                             .tlsKeyPair(clientSsc.tlsKeyPair())
+                             .trustedCertificates(proxySsc.certificate())
+                             .build();
         final TlsProvider tlsProvider =
                 TlsProvider.builder()
                            .keyPair(clientSsc.tlsKeyPair())
-                           .trustedCertificates(proxySsc.certificate(), backendSsc.certificate())
+                           .trustedCertificates(backendSsc.certificate())
                            .build();
 
         final ClientFactory clientFactory =
                 ClientFactory.builder()
                              .tlsProvider(tlsProvider)
-                             .proxyConfig(
-                                     ProxyConfig.connect(mTlsHttpsProxyServer.address(), true)).build();
+                             .proxyConfig(ProxyConfig.connect(mTlsHttpsProxyServer.address(), clientTlsSpec))
+                             .build();
         final WebClient webClient = WebClient.builder(protocol, endpoint)
                                              .factory(clientFactory)
                                              .decorator(LoggingClient.newDecorator())


### PR DESCRIPTION
Motivation:

When using a CONNECT proxy with TLS (`ProxyConfig.connect(addr, useTls=true)`), the proxy connection's TLS settings are implicitly derived from the client factory's global TLS configuration. This makes it impossible to configure different TLS settings for the proxy connection versus the backend connection — for example, using separate trust stores, client certificates (mTLS), or ALPN protocols for each hop.

Modifications:

- Added `ProxyConfig.connect(InetSocketAddress, ClientTlsSpec)` and `ProxyConfig.connect(InetSocketAddress, HttpHeaders, ClientTlsSpec)` factory methods that accept a `ClientTlsSpec` for fine-grained proxy TLS configuration.
- Replaced the `boolean useTls` field in `ConnectProxyConfig` with a `@Nullable ClientTlsSpec clientTlsSpec` field. The existing `useTls()` method is preserved (returns `clientTlsSpec != null`) for backward compatibility.
- Added `ConnectProxyConfig.clientTlsSpec()` accessor to retrieve the proxy TLS spec.
- When a `ClientTlsSpec` is provided without explicit ALPN protocols, it defaults to HTTP/1.1 — CONNECT proxies speak HTTP/1.1, so advertising `h2` to the proxy would be incorrect.
- Changed `HttpChannelPool.configureProxy()` to read the TLS spec directly from `ConnectProxyConfig.clientTlsSpec()` instead of receiving it as a separate parameter, decoupling proxy TLS from backend TLS.
- Made `ClientTlsSpecBuilder.alpnProtocols(SessionProtocol)` public so it can be called from `ConnectProxyConfig` (different package). 

Result:

- Users can now configure independent TLS settings for the CONNECT proxy connection, including custom trust stores, client certificates for proxy mTLS, and ALPN protocols, without affecting the backend TLS configuration.
- **Breaking change**: Previously, `ProxyConfig.connect(addr, useTls=true)` reused the backend/client-factory TLS configuration (trust store, client certificates, etc.) for the proxy connection. Now, it uses a default `ClientTlsSpec` with system defaults. Users who relied on the client factory's TLS settings being applied to the proxy connection should migrate to `ProxyConfig.connect(addr, ClientTlsSpec)` with an explicitly configured `ClientTlsSpec`.
