### PR TITLE
Allow users to set `ClientTlsProvider` and customize SNI via `ClientReqeustContext#setSniHostname`

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/BootstrapClientTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BootstrapClientTlsProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link ClientTlsProvider} that resolves TLS specs from the pre-computed
+ * {@link BootstrapSslContexts} based on the session protocol.
+ */
+final class BootstrapClientTlsProvider implements ClientTlsProvider {
+
+    private final BootstrapSslContexts bootstrapSslContexts;
+
+    BootstrapClientTlsProvider(BootstrapSslContexts bootstrapSslContexts) {
+        this.bootstrapSslContexts = requireNonNull(bootstrapSslContexts, "bootstrapSslContexts");
+    }
+
+    @Override
+    public ClientTlsSpec clientTlsSpec(ClientRequestContext ctx) {
+        return bootstrapSslContexts.getClientTlsSpec(ctx.sessionProtocol());
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/BootstrapSslContexts.java
+++ b/core/src/main/java/com/linecorp/armeria/client/BootstrapSslContexts.java
@@ -17,6 +17,8 @@
 package com.linecorp.armeria.client;
 
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.internal.common.SslContextFactory;
 
 import io.netty.handler.ssl.SslContext;
@@ -25,11 +27,11 @@ final class BootstrapSslContexts {
 
     private final ClientTlsSpec http1OnlyTlsSpec;
     private final ClientTlsSpec defaultTlsSpec;
+    private final SslContextFactory sslContextFactory;
     private final SslContext http1OnlySslCtx;
     private final SslContext sslCtx;
 
-    BootstrapSslContexts(ClientTlsSpec baseClientTlsSpec, ClientFactoryOptions options,
-                         SslContextFactory sslContextFactory) {
+    BootstrapSslContexts(ClientTlsSpec baseClientTlsSpec, ClientFactoryOptions options) {
         http1OnlyTlsSpec = baseClientTlsSpec.toBuilder()
                                             .engineType(options.tlsEngineType())
                                             .alpnProtocols(SessionProtocol.H1)
@@ -40,8 +42,19 @@ final class BootstrapSslContexts {
                                           .alpnProtocols(SessionProtocol.H2)
                                           .tlsCustomizer(options.tlsCustomizer())
                                           .build();
+
+        @Nullable
+        MeterIdPrefix meterIdPrefix = null;
+        if (options.tlsConfig() != ClientTlsConfig.NOOP) {
+            meterIdPrefix = options.tlsConfig().meterIdPrefix();
+        }
+        sslContextFactory = new SslContextFactory(meterIdPrefix, options.meterRegistry());
         http1OnlySslCtx = sslContextFactory.getOrCreate(http1OnlyTlsSpec);
         sslCtx = sslContextFactory.getOrCreate(defaultTlsSpec);
+    }
+
+    SslContextFactory sslContextFactory() {
+        return sslContextFactory;
     }
 
     ClientTlsSpec getClientTlsSpec(SessionProtocol sessionProtocol) {
@@ -52,8 +65,8 @@ final class BootstrapSslContexts {
         return httpPreference == HttpPreference.HTTP1_REQUIRED ? http1OnlySslCtx : sslCtx;
     }
 
-    void release(SslContextFactory factory) {
-        factory.release(http1OnlySslCtx);
-        factory.release(sslCtx);
+    void release() {
+        sslContextFactory.release(http1OnlySslCtx);
+        sslContextFactory.release(sslCtx);
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -131,6 +131,8 @@ public final class ClientFactoryBuilder implements TlsSetters {
     @Nullable
     private TlsProvider tlsProvider;
     @Nullable
+    private ClientTlsProvider clientTlsProvider;
+    @Nullable
     private ClientTlsConfig tlsConfig;
     private ClientTlsSpec clientTlsSpec = ClientTlsSpec.of();
     private boolean staticTlsSettingsSet;
@@ -472,6 +474,9 @@ public final class ClientFactoryBuilder implements TlsSetters {
 
     /**
      * Sets the {@link TlsProvider} that provides {@link TlsKeyPair}s for client certificate authentication.
+     *
+     * <p>Note: This method and {@link #tlsProvider(ClientTlsProvider)} are mutually exclusive.
+     * Calling one will clear the other.
      * <pre>
      * ClientFactory
      *   .builder()
@@ -490,6 +495,7 @@ public final class ClientFactoryBuilder implements TlsSetters {
         checkState(!staticTlsSettingsSet,
                    "Cannot configure the TlsProvider because static TLS settings have been set already.");
         this.tlsProvider = tlsProvider;
+        clientTlsProvider = null;
         tlsConfig = null;
         return this;
     }
@@ -504,8 +510,27 @@ public final class ClientFactoryBuilder implements TlsSetters {
         return this;
     }
 
+    /**
+     * Sets the {@link ClientTlsProvider} which resolves TLS configuration per request.
+     *
+     * <p>Note: This method and {@link #tlsProvider(TlsProvider)} are mutually exclusive.
+     * Calling one will clear the other.
+     */
+    @UnstableApi
+    public ClientFactoryBuilder tlsProvider(ClientTlsProvider clientTlsProvider) {
+        requireNonNull(clientTlsProvider, "clientTlsProvider");
+        checkState(!staticTlsSettingsSet,
+                   "Cannot configure the ClientTlsProvider because static TLS settings have been set " +
+                   "already.");
+        this.clientTlsProvider = clientTlsProvider;
+        tlsProvider = null;
+        tlsConfig = null;
+        return this;
+    }
+
     private void ensureNoTlsProvider() {
-        checkState(tlsProvider == null, "Cannot configure TLS settings because a TlsProvider has been set.");
+        checkState(tlsProvider == null && clientTlsProvider == null,
+                   "Cannot configure TLS settings because a TlsProvider has been set.");
     }
 
     /**
@@ -1124,21 +1149,42 @@ public final class ClientFactoryBuilder implements TlsSetters {
      * Returns a newly-created {@link ClientFactory} based on the properties of this builder.
      */
     public ClientFactory build() {
-        final ClientFactoryOptions options = buildOptions();
-        final ClientTlsSpec baseClientTlsSpec = buildTlsSpec(clientTlsSpec, tlsNoVerifySet, insecureHosts);
-        return new DefaultClientFactory(new HttpClientFactory(
-                options, autoCloseConnectionPoolListener, baseClientTlsSpec));
+        final ClientFactoryOptions baseOptions = buildOptions();
+        final BootstrapSslContexts bootstrapSslContexts = buildBootstrapSslContexts(baseOptions);
+        final ClientFactoryOptions options = buildTlsOptions(baseOptions, bootstrapSslContexts);
+        return new DefaultClientFactory(new HttpClientFactory(options, bootstrapSslContexts,
+                                                              autoCloseConnectionPoolListener));
     }
 
-    private static ClientTlsSpec buildTlsSpec(
-            ClientTlsSpec clientTlsSpec, boolean tlsNoVerifySet, Set<String> insecureHosts) {
+    private ClientFactoryOptions buildTlsOptions(ClientFactoryOptions baseOptions,
+                                                 BootstrapSslContexts bootstrapSslContexts) {
+        final ClientTlsProvider delegate;
+        if (clientTlsProvider != null) {
+            delegate = clientTlsProvider;
+        } else if (tlsProvider != null) {
+            delegate = new TlsProviderAdapter(tlsProvider, tlsConfig, baseOptions.tlsEngineType());
+        } else {
+            delegate = new BootstrapClientTlsProvider(bootstrapSslContexts);
+        }
+        final ClientTlsProvider effectiveProvider = new DefaultClientTlsProvider(delegate);
+        return ClientFactoryOptions.of(
+                baseOptions,
+                ImmutableList.of(ClientFactoryOptions.CLIENT_TLS_PROVIDER.newValue(effectiveProvider)));
+    }
+
+    private BootstrapSslContexts buildBootstrapSslContexts(ClientFactoryOptions options) {
         final ClientTlsSpecBuilder builder = clientTlsSpec.toBuilder();
         if (tlsNoVerifySet) {
             builder.verifierFactories(TlsPeerVerifierFactory.noVerify());
         } else if (!insecureHosts.isEmpty()) {
             builder.verifierFactories(TlsPeerVerifierFactory.insecureHosts(insecureHosts));
         }
-        return builder.build();
+        boolean allowUnsafeCiphers = options.tlsAllowUnsafeCiphers();
+        if (options.tlsConfig() != ClientTlsConfig.NOOP) {
+            allowUnsafeCiphers = options.tlsConfig().allowsUnsafeCiphers();
+        }
+        builder.allowUnsafeCiphers(allowUnsafeCiphers);
+        return new BootstrapSslContexts(builder.build(), options);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -1166,7 +1166,7 @@ public final class ClientFactoryBuilder implements TlsSetters {
         } else {
             delegate = new BootstrapClientTlsProvider(bootstrapSslContexts);
         }
-        final ClientTlsProvider effectiveProvider = new DefaultClientTlsProvider(delegate);
+        final ClientTlsProvider effectiveProvider = new NullCheckingClientTlsProvider(delegate);
         return ClientFactoryOptions.of(
                 baseOptions,
                 ImmutableList.of(ClientFactoryOptions.CLIENT_TLS_PROVIDER.newValue(effectiveProvider)));

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -127,6 +127,13 @@ public final class ClientFactoryOptions
             ClientFactoryOption.define("TLS_CONFIG", ClientTlsConfig.NOOP);
 
     /**
+     * The {@link ClientTlsProvider} which resolves TLS configuration per request.
+     */
+    @UnstableApi
+    public static final ClientFactoryOption<ClientTlsProvider> CLIENT_TLS_PROVIDER =
+            ClientFactoryOption.define("CLIENT_TLS_PROVIDER", NullClientTlsProvider.INSTANCE);
+
+    /**
      * The factory that creates an {@link AddressResolverGroup} which resolves remote addresses into
      * {@link InetSocketAddress}es.
      */
@@ -730,6 +737,14 @@ public final class ClientFactoryOptions
     @UnstableApi
     public ClientTlsConfig tlsConfig() {
         return get(TLS_CONFIG);
+    }
+
+    /**
+     * Returns the {@link ClientTlsProvider} which resolves TLS configuration per request.
+     */
+    @UnstableApi
+    public ClientTlsProvider clientTlsProvider() {
+        return get(CLIENT_TLS_PROVIDER);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContext.java
@@ -634,6 +634,25 @@ public interface ClientRequestContext extends RequestContext {
     void setClientTlsSpec(ClientTlsSpec clientTlsSpec);
 
     /**
+     * Returns the SNI (Server Name Indication) hostname for the TLS handshake.
+     * This is precomputed from the endpoint and authority: for IP-only endpoints, the
+     * authority-derived server name is used; otherwise the endpoint host is used.
+     * Trailing dots are stripped.
+     *
+     * <p>Returns {@code null} if the session protocol is not TLS or the hostname could not be determined.
+     */
+    @UnstableApi
+    @Nullable
+    String sniHostname();
+
+    /**
+     * Sets the SNI (Server Name Indication) hostname for the TLS handshake.
+     * This overrides the automatically precomputed value.
+     */
+    @UnstableApi
+    void setSniHostname(String sniHostname);
+
+    /**
      * Returns the local address that was requested to be bound when making a connection for this request.
      * This represents the intent set before the connection is established, unlike
      * {@link #localAddress()} which returns the actual local socket address read from the

--- a/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientRequestContextWrapper.java
@@ -187,6 +187,18 @@ public class ClientRequestContextWrapper
 
     @Override
     @UnstableApi
+    public @Nullable String sniHostname() {
+        return unwrap().sniHostname();
+    }
+
+    @Override
+    @UnstableApi
+    public void setSniHostname(String sniHostname) {
+        unwrap().setSniHostname(sniHostname);
+    }
+
+    @Override
+    @UnstableApi
     public @Nullable InetSocketAddress localBindAddress() {
         return unwrap().localBindAddress();
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Resolves TLS configuration for client connections.
+ */
+@UnstableApi
+@FunctionalInterface
+public interface ClientTlsProvider {
+
+    /**
+     * Returns the {@link ClientTlsSpec} for the connection.
+     *
+     * @param ctx the client request context
+     * @return the {@link ClientTlsSpec} for the connection
+     */
+    ClientTlsSpec clientTlsSpec(ClientRequestContext ctx);
+}

--- a/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientTlsSpecBuilder.java
@@ -71,6 +71,11 @@ public final class ClientTlsSpecBuilder extends AbstractTlsSpecBuilder<ClientTls
     /**
      * Sets the ALPN protocol names for TLS negotiation. If not set (empty), the ALPN protocols
      * are automatically derived from the {@link SessionProtocol} at connection time.
+     *
+     * <p><b>Warning</b>: This is an advanced feature. When custom ALPN protocols are set, they will
+     * <b>not</b> be overridden by the {@link SessionProtocol} defaults. You must ensure that the
+     * specified protocols are compatible with the target server and the session protocol being used;
+     * otherwise, TLS negotiation may fail or the connection may behave unexpectedly.
      */
     public ClientTlsSpecBuilder alpnProtocols(Collection<String> alpnProtocols) {
         requireNonNull(alpnProtocols, "alpnProtocols");

--- a/core/src/main/java/com/linecorp/armeria/client/DefaultClientTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/client/DefaultClientTlsProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static java.util.Objects.requireNonNull;
+
+final class DefaultClientTlsProvider implements ClientTlsProvider {
+
+    private final ClientTlsProvider delegate;
+
+    DefaultClientTlsProvider(ClientTlsProvider delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public ClientTlsSpec clientTlsSpec(ClientRequestContext ctx) {
+        final ClientTlsSpec spec = delegate.clientTlsSpec(ctx);
+        return requireNonNull(spec, "ClientTlsProvider.clientTlsSpec() returned null");
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientDelegate.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.security.cert.X509Certificate;
-import java.util.List;
 import java.util.function.BiConsumer;
 
 import com.linecorp.armeria.client.HttpChannelPool.PoolKey;
@@ -34,9 +32,6 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.IpAddressRejectedException;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
-import com.linecorp.armeria.common.TlsKeyPair;
-import com.linecorp.armeria.common.TlsPeerVerifierFactory;
-import com.linecorp.armeria.common.TlsProvider;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.ClientConnectionTimings;
 import com.linecorp.armeria.common.logging.ClientConnectionTimingsBuilder;
@@ -48,14 +43,12 @@ import com.linecorp.armeria.internal.client.DecodedHttpResponse;
 import com.linecorp.armeria.internal.client.HttpSession;
 import com.linecorp.armeria.internal.client.PooledChannel;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
-import com.linecorp.armeria.internal.common.SchemeAndAuthority;
 import com.linecorp.armeria.server.ProxiedAddresses;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.resolver.AddressResolverGroup;
-import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Future;
 
 final class HttpClientDelegate implements HttpClient {
@@ -223,24 +216,16 @@ final class HttpClientDelegate implements HttpClient {
                                               ClientConnectionTimingsBuilder timingsBuilder,
                                               ProxyConfig proxyConfig) {
         final SessionProtocol protocol = ctx.sessionProtocol();
-        if (protocol.isTls() && endpoint.isIpAddrOnly()) {
-            // The connection will be established with the IP address but `host` set to the `Endpoint`
-            // could be used for SNI. It would make users send HTTPS requests with CSLB or configure a reverse
-            // proxy based on an authority.
-            final String serverName = authorityToServerName(ctx.authority());
-            if (serverName != null) {
-                endpoint = endpoint.withHost(serverName);
-            }
+        final String sniHostname = ctx.sniHostname();
+        if (sniHostname != null) {
+            endpoint = endpoint.withHost(sniHostname);
         }
-        // Remove the trailing dot of the host name because SNI does not allow it.
-        // https://lists.w3.org/Archives/Public/ietf-http-wg/2016JanMar/0430.html
         endpoint = endpoint.withoutTrailingDot();
 
-        final TlsProvider tlsProvider = factory.options().tlsProvider();
         final ClientTlsSpec tlsSpec;
         try {
-            tlsSpec = determineTlsSpec(endpoint, protocol, tlsProvider, ctx);
-        } catch (IllegalArgumentException e) {
+            tlsSpec = determineTlsSpec(protocol, ctx);
+        } catch (RuntimeException e) {
             earlyCancelRequest(e, ctx, timingsBuilder);
             return;
         }
@@ -287,70 +272,18 @@ final class HttpClientDelegate implements HttpClient {
         }
     }
 
-    private ClientTlsSpec determineTlsSpec(Endpoint endpoint, SessionProtocol sessionProtocol,
-                                           TlsProvider tlsProvider, ClientRequestContext ctx) {
+    private ClientTlsSpec determineTlsSpec(SessionProtocol sessionProtocol, ClientRequestContext ctx) {
         final ClientTlsSpec reqTlsSpec = ctx.clientTlsSpec();
+        final ClientTlsSpec tlsSpec;
         if (reqTlsSpec != null) {
-            if (reqTlsSpec.alpnProtocols().isEmpty()) {
-                return reqTlsSpec.toBuilder().alpnProtocols(sessionProtocol).build();
-            }
-            return reqTlsSpec;
+            tlsSpec = reqTlsSpec;
+        } else {
+            tlsSpec = factory.options().clientTlsProvider().clientTlsSpec(ctx);
         }
-        if (tlsProvider != NullTlsProvider.INSTANCE) {
-            TlsKeyPair keyPair = null;
-            final String hostname = endpoint.toSocketAddress(-1).getHostString();
-            if (hostname != null) {
-                keyPair = tlsProvider.keyPair(hostname);
-            }
-            if (keyPair == null) {
-                keyPair = tlsProvider.keyPair("*");
-            }
-            final ClientTlsConfig config = factory.options().tlsConfig();
-            List<X509Certificate> certs = null;
-            if (hostname != null) {
-                certs = tlsProvider.trustedCertificates(hostname);
-            }
-            if (certs == null) {
-                certs = tlsProvider.trustedCertificates("*");
-            }
-
-            final ClientTlsSpecBuilder builder =
-                    ClientTlsSpec.builder()
-                                 .tlsCustomizer(config.tlsCustomizer())
-                                 .engineType(factory.options().tlsEngineType())
-                                 .allowUnsafeCiphers(config.allowsUnsafeCiphers())
-                                 .alpnProtocols(sessionProtocol);
-            if (keyPair != null) {
-                builder.tlsKeyPair(keyPair);
-            }
-            if (certs != null) {
-                builder.trustedCertificates(certs);
-            }
-            if (config.tlsNoVerifySet()) {
-                builder.verifierFactories(TlsPeerVerifierFactory.noVerify());
-            } else if (!config.insecureHosts().isEmpty()) {
-                builder.verifierFactories(TlsPeerVerifierFactory.insecureHosts(config.insecureHosts()));
-            }
-            return builder.build();
+        if (tlsSpec.alpnProtocols().isEmpty()) {
+            return tlsSpec.toBuilder().alpnProtocols(sessionProtocol).build();
         }
-        // proxies may use TLS, so just return the default spec
-        return factory.defaultSslContexts().getClientTlsSpec(sessionProtocol.withTls());
-    }
-
-    @Nullable
-    private static String authorityToServerName(@Nullable String authority) {
-        if (authority == null) {
-            return null;
-        }
-        String serverName = SchemeAndAuthority.of(null, authority).host();
-        if (NetUtil.isValidIpV4Address(serverName) || NetUtil.isValidIpV6Address(serverName)) {
-            return null;
-        }
-        serverName = serverName.trim();
-        if (serverName.isEmpty()) {
-            return null;
-        }
-        return serverName;
+        return tlsSpec;
     }
 
     private void resolveProxyConfig(SessionProtocol protocol, Endpoint endpoint, ClientRequestContext ctx,

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -47,7 +47,6 @@ import com.linecorp.armeria.common.Scheme;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
-import com.linecorp.armeria.common.metric.MeterIdPrefix;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.ReleasableHolder;
 import com.linecorp.armeria.common.util.ShutdownHooks;
@@ -87,7 +86,6 @@ final class HttpClientFactory implements ClientFactory {
     private final Bootstrap inetBaseBootstrap;
     @Nullable
     private final Bootstrap unixBaseBootstrap;
-    private final SslContextFactory sslContextFactory;
     private final AddressResolverGroup<InetSocketAddress> addressResolverGroup;
     private final int http2InitialConnectionWindowSize;
     private final int http2InitialStreamWindowSize;
@@ -124,8 +122,8 @@ final class HttpClientFactory implements ClientFactory {
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
     private final BootstrapSslContexts bootstrapSslContexts;
 
-    HttpClientFactory(ClientFactoryOptions options, boolean autoCloseConnectionPoolListener,
-                      ClientTlsSpec baseClientTlsSpec) {
+    HttpClientFactory(ClientFactoryOptions options, BootstrapSslContexts bootstrapSslContexts,
+                      boolean autoCloseConnectionPoolListener) {
         workerGroup = options.workerGroup();
 
         @SuppressWarnings("unchecked")
@@ -164,17 +162,7 @@ final class HttpClientFactory implements ClientFactory {
             unixBaseBootstrap = null;
         }
 
-        MeterIdPrefix meterIdPrefix = null;
-        boolean allowUnsafeCiphers = options.tlsAllowUnsafeCiphers();
-        if (options.tlsConfig() != ClientTlsConfig.NOOP) {
-            meterIdPrefix = options.tlsConfig().meterIdPrefix();
-            allowUnsafeCiphers = options.tlsConfig().allowsUnsafeCiphers();
-        }
-        final ClientTlsSpec resolvedTlsSpec = baseClientTlsSpec.toBuilder()
-                                                                .allowUnsafeCiphers(allowUnsafeCiphers)
-                                                                .build();
-        sslContextFactory = new SslContextFactory(meterIdPrefix, options.meterRegistry());
-        bootstrapSslContexts = new BootstrapSslContexts(resolvedTlsSpec, options, sslContextFactory);
+        this.bootstrapSslContexts = bootstrapSslContexts;
 
         http2InitialConnectionWindowSize = options.http2InitialConnectionWindowSize();
         http2InitialStreamWindowSize = options.http2InitialStreamWindowSize();
@@ -462,7 +450,7 @@ final class HttpClientFactory implements ClientFactory {
             if (autoCloseConnectionPoolListener) {
                 connectionPoolListener.close();
             }
-            bootstrapSslContexts.release(sslContextFactory);
+            bootstrapSslContexts.release();
             if (shutdownWorkerGroupOnClose) {
                 workerGroup.shutdownGracefully().addListener((FutureListener<Object>) f -> {
                     if (f.cause() != null) {
@@ -509,13 +497,14 @@ final class HttpClientFactory implements ClientFactory {
             return pool;
         }
 
-        return pools.computeIfAbsent(eventLoop,
-                                     e -> new HttpChannelPool(this, eventLoop, sslContextFactory));
+        return pools.computeIfAbsent(
+                eventLoop,
+                e -> new HttpChannelPool(this, eventLoop, bootstrapSslContexts.sslContextFactory()));
     }
 
     @VisibleForTesting
     SslContextFactory sslContextFactory() {
-        return sslContextFactory;
+        return bootstrapSslContexts.sslContextFactory();
     }
 
     BootstrapSslContexts defaultSslContexts() {

--- a/core/src/main/java/com/linecorp/armeria/client/NullCheckingClientTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/client/NullCheckingClientTlsProvider.java
@@ -18,11 +18,11 @@ package com.linecorp.armeria.client;
 
 import static java.util.Objects.requireNonNull;
 
-final class DefaultClientTlsProvider implements ClientTlsProvider {
+final class NullCheckingClientTlsProvider implements ClientTlsProvider {
 
     private final ClientTlsProvider delegate;
 
-    DefaultClientTlsProvider(ClientTlsProvider delegate) {
+    NullCheckingClientTlsProvider(ClientTlsProvider delegate) {
         this.delegate = requireNonNull(delegate, "delegate");
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/NullClientTlsProvider.java
+++ b/core/src/main/java/com/linecorp/armeria/client/NullClientTlsProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+enum NullClientTlsProvider implements ClientTlsProvider {
+    INSTANCE;
+
+    @Override
+    public ClientTlsSpec clientTlsSpec(ClientRequestContext ctx) {
+        throw new UnsupportedOperationException(
+                "NullClientTlsProvider should never be called. " +
+                "CLIENT_TLS_PROVIDER must be set by ClientFactoryBuilder.build().");
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/TlsProviderAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TlsProviderAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.TlsKeyPair;
+import com.linecorp.armeria.common.TlsPeerVerifierFactory;
+import com.linecorp.armeria.common.TlsProvider;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.util.TlsEngineType;
+
+final class TlsProviderAdapter implements ClientTlsProvider {
+
+    private final TlsProvider tlsProvider;
+    private final @Nullable ClientTlsConfig tlsConfig;
+    private final TlsEngineType tlsEngineType;
+
+    TlsProviderAdapter(TlsProvider tlsProvider, @Nullable ClientTlsConfig tlsConfig,
+                       TlsEngineType tlsEngineType) {
+        this.tlsProvider = tlsProvider;
+        this.tlsConfig = tlsConfig;
+        this.tlsEngineType = tlsEngineType;
+    }
+
+    @Override
+    public ClientTlsSpec clientTlsSpec(ClientRequestContext ctx) {
+        final SessionProtocol sessionProtocol = ctx.sessionProtocol();
+        // The SNI hostname is precomputed on the context by ClientUtil before this is called.
+        final String hostname = ctx.sniHostname();
+        TlsKeyPair keyPair = null;
+        if (hostname != null) {
+            keyPair = tlsProvider.keyPair(hostname);
+        }
+        if (keyPair == null) {
+            keyPair = tlsProvider.keyPair("*");
+        }
+        List<X509Certificate> certs = null;
+        if (hostname != null) {
+            certs = tlsProvider.trustedCertificates(hostname);
+        }
+        if (certs == null) {
+            certs = tlsProvider.trustedCertificates("*");
+        }
+
+        final ClientTlsSpecBuilder builder =
+                ClientTlsSpec.builder()
+                             .engineType(tlsEngineType)
+                             .alpnProtocols(sessionProtocol);
+        if (tlsConfig != null) {
+            builder.tlsCustomizer(tlsConfig.tlsCustomizer())
+                   .allowUnsafeCiphers(tlsConfig.allowsUnsafeCiphers());
+        }
+        if (keyPair != null) {
+            builder.tlsKeyPair(keyPair);
+        }
+        if (certs != null) {
+            builder.trustedCertificates(certs);
+        }
+        if (tlsConfig != null) {
+            if (tlsConfig.tlsNoVerifySet()) {
+                builder.verifierFactories(TlsPeerVerifierFactory.noVerify());
+            } else if (!tlsConfig.insecureHosts().isEmpty()) {
+                builder.verifierFactories(TlsPeerVerifierFactory.insecureHosts(tlsConfig.insecureHosts()));
+            }
+        }
+        return builder.build();
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/client/TlsProviderAdapter.java
+++ b/core/src/main/java/com/linecorp/armeria/client/TlsProviderAdapter.java
@@ -42,18 +42,24 @@ final class TlsProviderAdapter implements ClientTlsProvider {
     @Override
     public ClientTlsSpec clientTlsSpec(ClientRequestContext ctx) {
         final SessionProtocol sessionProtocol = ctx.sessionProtocol();
-        // The SNI hostname is precomputed on the context by ClientUtil before this is called.
-        final String hostname = ctx.sniHostname();
+        final String sniHostname = ctx.sniHostname();
+        final String lookupKey;
+        if (sniHostname != null) {
+            lookupKey = sniHostname;
+        } else {
+            final Endpoint endpoint = ctx.endpoint();
+            lookupKey = endpoint != null ? endpoint.host() : null;
+        }
         TlsKeyPair keyPair = null;
-        if (hostname != null) {
-            keyPair = tlsProvider.keyPair(hostname);
+        if (lookupKey != null) {
+            keyPair = tlsProvider.keyPair(lookupKey);
         }
         if (keyPair == null) {
             keyPair = tlsProvider.keyPair("*");
         }
         List<X509Certificate> certs = null;
-        if (hostname != null) {
-            certs = tlsProvider.trustedCertificates(hostname);
+        if (lookupKey != null) {
+            certs = tlsProvider.trustedCertificates(lookupKey);
         }
         if (certs == null) {
             certs = tlsProvider.trustedCertificates("*");

--- a/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/DefaultClientRequestContext.java
@@ -98,6 +98,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.util.AttributeKey;
+import io.netty.util.NetUtil;
 
 /**
  * Default {@link ClientRequestContext} implementation.
@@ -184,6 +185,10 @@ public final class DefaultClientRequestContext
     private Function<RpcClient, RpcClient> rpcClientCustomizer = Function.identity();
     @Nullable
     private ClientTlsSpec clientTlsSpec;
+    @Nullable
+    private String sniHostname;
+    @Nullable
+    private String defaultSniHostname;
     @Nullable
     private InetSocketAddress localBindAddress;
 
@@ -518,6 +523,51 @@ public final class DefaultClientRequestContext
 
     private void updateEndpoint(@Nullable Endpoint endpoint) {
         this.endpoint = endpoint;
+        defaultSniHostname = computeDefaultSniHostname(endpoint);
+        updateInternalHeaders();
+    }
+
+    @Nullable
+    private String computeDefaultSniHostname(@Nullable Endpoint endpoint) {
+        if (endpoint == null) {
+            return null;
+        }
+        String hostname;
+        if (endpoint.isIpAddrOnly()) {
+            hostname = authorityToServerName(authority());
+            if (hostname == null) {
+                return null;
+            }
+        } else {
+            hostname = endpoint.host();
+        }
+        // Strip trailing dot — not allowed in SNI.
+        if (hostname.endsWith(".")) {
+            hostname = hostname.substring(0, hostname.length() - 1);
+        }
+        if (hostname.isEmpty()) {
+            return null;
+        }
+        return hostname;
+    }
+
+    @Nullable
+    private static String authorityToServerName(@Nullable String authority) {
+        if (authority == null) {
+            return null;
+        }
+        String serverName = SchemeAndAuthority.of(null, authority).host();
+        if (NetUtil.isValidIpV4Address(serverName) || NetUtil.isValidIpV6Address(serverName)) {
+            return null;
+        }
+        serverName = serverName.trim();
+        if (serverName.isEmpty()) {
+            return null;
+        }
+        return serverName;
+    }
+
+    private void updateInternalHeaders() {
         internalRequestHeaders = computeInternalHeaders(defaultInternalRequestHeaders,
                                                         endpoint, sessionProtocol,
                                                         options().autoFillOriginHeader());
@@ -644,6 +694,7 @@ public final class DefaultClientRequestContext
         additionalRequestHeaders = ctx.additionalRequestHeaders();
         responseTimeoutMode = ctx.responseTimeoutMode();
         clientTlsSpec = ctx.clientTlsSpec();
+        sniHostname = ctx.sniHostname;
         localBindAddress = ctx.localBindAddress();
 
         for (final Iterator<Entry<AttributeKey<?>, Object>> i = ctx.ownAttrs(); i.hasNext();) {
@@ -726,8 +777,13 @@ public final class DefaultClientRequestContext
     @Override
     public void setSessionProtocol(SessionProtocol sessionProtocol) {
         checkState(!initializationTriggered(), "Cannot update sessionProtocol after initialization");
+        setSessionProtocol0(sessionProtocol);
+    }
+
+    private void setSessionProtocol0(SessionProtocol sessionProtocol) {
         this.sessionProtocol = desiredSessionProtocol(requireNonNull(sessionProtocol, "sessionProtocol"),
                                                       options);
+        updateInternalHeaders();
     }
 
     @Override
@@ -1108,6 +1164,19 @@ public final class DefaultClientRequestContext
     @Override
     public void setClientTlsSpec(ClientTlsSpec clientTlsSpec) {
         this.clientTlsSpec = requireNonNull(clientTlsSpec, "clientTlsSpec");
+    }
+
+    @Override
+    public @Nullable String sniHostname() {
+        if (sniHostname != null) {
+            return sniHostname;
+        }
+        return defaultSniHostname;
+    }
+
+    @Override
+    public void setSniHostname(String sniHostname) {
+        this.sniHostname = requireNonNull(sniHostname, "sniHostname");
     }
 
     @Override

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -111,6 +111,9 @@ class ClientFactoryBuilderTest {
                 final ClientFactoryOption<?> option = optionValue.option();
                 if (option.compareTo(ClientFactoryOptions.IDLE_TIMEOUT_MILLIS) == 0) {
                     assertThat(factory1Option.get(option)).isNotEqualTo(factory2Option.get(option));
+                } else if (option.compareTo(ClientFactoryOptions.CLIENT_TLS_PROVIDER) == 0) {
+                    // Always rebuilt by build(), so identity differs.
+                    continue;
                 } else {
                     assertThat(factory1Option.get(option)).isEqualTo(factory2Option.get(option));
                 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientTlsProviderInterfaceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientTlsProviderInterfaceTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.TlsProvider;
+import com.linecorp.armeria.internal.testing.MockAddressResolverGroup;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServerTlsConfig;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.handler.ssl.ClientAuth;
+
+class ClientTlsProviderInterfaceTest {
+
+    @Order(0)
+    @RegisterExtension
+    static final SelfSignedCertificateExtension serverCert = new SelfSignedCertificateExtension();
+
+    @Order(1)
+    @RegisterExtension
+    static final SelfSignedCertificateExtension sniCert = new SelfSignedCertificateExtension("sni.host");
+
+    @Order(2)
+    @RegisterExtension
+    static final SelfSignedCertificateExtension clientCert = new SelfSignedCertificateExtension();
+
+    @Order(3)
+    @RegisterExtension
+    static final SelfSignedCertificateExtension untrustedCert = new SelfSignedCertificateExtension();
+
+    @Order(4)
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.https(0)
+              .tls(serverCert.tlsKeyPair())
+              .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @Order(5)
+    @RegisterExtension
+    static final ServerExtension sniServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.https(0)
+              .tlsProvider(TlsProvider.builder()
+                                      .keyPair(serverCert.tlsKeyPair())
+                                      .keyPair("sni.host", sniCert.tlsKeyPair())
+                                      .build())
+              .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @Order(6)
+    @RegisterExtension
+    static final ServerExtension mtlsServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.https(0)
+              .tlsProvider(TlsProvider.builder()
+                                      .keyPair(serverCert.tlsKeyPair())
+                                      .trustedCertificates(clientCert.certificate())
+                                      .build(),
+                           ServerTlsConfig.builder().clientAuth(ClientAuth.REQUIRE).build())
+              .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    @Test
+    void success() {
+        final ClientTlsProvider provider = ctx ->
+                ClientTlsSpec.builder()
+                             .trustedCertificates(serverCert.certificate())
+                             .build();
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.httpsUri())
+                             .factory(factory).build().blocking();
+            assertThat(client.get("/").status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Test
+    void failure_untrustedCert() {
+        final ClientTlsProvider provider = ctx ->
+                ClientTlsSpec.builder()
+                             .trustedCertificates(untrustedCert.certificate())
+                             .build();
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.httpsUri())
+                             .factory(factory).build().blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class)
+                    .hasCauseInstanceOf(javax.net.ssl.SSLHandshakeException.class);
+        }
+    }
+
+    @Test
+    void mtls() {
+        final ClientTlsProvider provider = ctx ->
+                ClientTlsSpec.builder()
+                             .trustedCertificates(serverCert.certificate())
+                             .tlsKeyPair(clientCert.tlsKeyPair())
+                             .build();
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(mtlsServer.httpsUri())
+                             .factory(factory).build().blocking();
+            assertThat(client.get("/").status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Test
+    void throwsException() {
+        final ClientTlsProvider provider = ctx -> {
+            throw new RuntimeException("provider error");
+        };
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.httpsUri())
+                             .factory(factory).build().blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class)
+                    .hasCauseInstanceOf(RuntimeException.class)
+                    .hasRootCauseMessage("provider error");
+        }
+    }
+
+    @Test
+    void returnsNull() {
+        final ClientTlsProvider provider = ctx -> null;
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(server.httpsUri())
+                             .factory(factory).build().blocking();
+            assertThatThrownBy(() -> client.get("/"))
+                    .isInstanceOf(UnprocessedRequestException.class)
+                    .hasCauseInstanceOf(NullPointerException.class)
+                    .hasMessageContaining(
+                            "ClientTlsProvider.clientTlsSpec() returned null");
+        }
+    }
+
+    @Test
+    void setSniHostname() {
+        final ClientTlsProvider provider = ctx -> {
+            assertThat(ctx.sniHostname()).isEqualTo("sni.host");
+            return ClientTlsSpec.builder()
+                                .trustedCertificates(sniCert.certificate())
+                                .build();
+        };
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder(sniServer.httpsUri())
+                             .factory(factory)
+                             .decorator((delegate, ctx, req) -> {
+                                 ctx.setSniHostname("sni.host");
+                                 return delegate.execute(ctx, req);
+                             })
+                             .build().blocking();
+            assertThat(client.get("/").status())
+                    .isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Test
+    void sniHostnameAvailable() {
+        final ClientTlsProvider provider = ctx -> {
+            assertThat(ctx.sniHostname()).isEqualTo("example.com");
+            return ClientTlsSpec.builder()
+                                .trustedCertificates(serverCert.certificate())
+                                .endpointIdentificationAlgorithm("")
+                                .build();
+        };
+        try (ClientFactory factory =
+                     ClientFactory.builder()
+                                  .addressResolverGroupFactory(unused -> MockAddressResolverGroup.localhost())
+                                  .tlsProvider(provider).build()) {
+            final BlockingWebClient client =
+                    WebClient.builder("https://example.com:" + server.httpsPort())
+                             .factory(factory).build().blocking();
+            assertThat(client.get("/").status()).isEqualTo(HttpStatus.OK);
+        }
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/client/TrailingDotSniTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/TrailingDotSniTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.TlsProvider;
@@ -76,7 +75,7 @@ class TrailingDotSniTest {
     }
 
     @Test
-    void usesAuthorityHeader() {
+    void sniRespected() {
         try (ClientFactory factory = ClientFactory.builder()
                                                   .tlsCustomizer(b -> b.trustManager(ssc.certificate()))
                                                   .build()) {
@@ -85,7 +84,7 @@ class TrailingDotSniTest {
                     WebClient.builder(server.httpsUri())
                              .factory(factory)
                              .decorator((delegate, ctx, req) -> {
-                                 ctx.setAdditionalRequestHeader(HttpHeaderNames.AUTHORITY, "example.com");
+                                 ctx.setSniHostname("example.com");
                                  return delegate.execute(ctx, req);
                              })
                              .build()


### PR DESCRIPTION
Motivation:

Currently, client TLS configuration is resolved through an internal chain of logic scattered across `HttpClientDelegate`, `HttpClientFactory`, and `BootstrapSslContexts`. There is no clean abstraction that allows users to dynamically resolve TLS settings per-request based on context such as the target hostname. Additionally, the SNI hostname is computed inline in `HttpClientDelegate` and is not accessible from `ClientRequestContext`, making it difficult to use in custom TLS resolution logic.

Modifications:

- Added `ClientTlsProvider` — a `@FunctionalInterface` that resolves a `ClientTlsSpec` given a `ClientRequestContext`. This allows users to dynamically configure TLS (trusted certificates, client key pairs, etc.) on a per-request basis.
  - Added `DefaultClientTlsProvider` which wraps a delegate and validates that a non-null `ClientTlsSpec` is returned.
  - Added `NullClientTlsProvider` as a sentinel default for `ClientFactoryOptions`.
  - Added `TlsProviderAdapter` which adapts the existing `TlsProvider` into a `ClientTlsProvider`, using `ctx.sniHostname()` for hostname-based certificate lookup.
  - Added `BootstrapClientTlsProvider` which resolves TLS from pre-computed `BootstrapSslContexts` based on session protocol.
- Added `sniHostname()` and `setSniHostname(String)` to `ClientRequestContext`, allowing the SNI hostname to be read or overridden (e.g., in a decorator). The default value is auto-computed from the endpoint when it is set.
- Added `ClientFactoryBuilder.tlsProvider(ClientTlsProvider)` — mutually exclusive with `tlsProvider(TlsProvider)`. Calling one clears the other.
- Simplified `HttpClientDelegate.determineTlsSpec()` to delegate to the `ClientTlsProvider` chain, with ALPN fill-in applied uniformly to both request-level overrides and provider-returned specs.
- Refactored `BootstrapSslContexts` to own its `SslContextFactory` internally.

Result:

- Users can now set a `ClientTlsProvider` on `ClientFactoryBuilder` to dynamically resolve TLS configuration per request:
  ```java
  ClientFactory.builder()
               .tlsProvider((ClientTlsProvider) ctx -> {
                   return ClientTlsSpec.builder()
                                       .trustedCertificates(...)
                                       .build();
               })
               .build();
  ```
- Users can read or override the SNI hostname via `ClientRequestContext.sniHostname()` / `setSniHostname(String)`, e.g., in a decorator:
  ```java
  WebClient.builder(...)
           .decorator((delegate, ctx, req) -> {
               ctx.setSniHostname("custom.host");
               return delegate.execute(ctx, req);
           })
           .build();
  ```
- **Breaking change**: The SNI hostname is now precomputed when the endpoint is set in `ClientRequestContext`, rather than being derived from the authority at connection time. If a decorator modifies the authority or host header, it will no longer automatically affect the SNI hostname. Users should call `ctx.setSniHostname(...)` explicitly in such cases.
