### PR TITLE
Add exponential_backoff_factor field to RetryBackOff proto message

### DIFF
--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -1647,6 +1647,9 @@ message RetryPolicy {
     // of Envoy's back-off algorithm.
     option (armeria.xds.supported.field) = 2;
     google.protobuf.Duration max_interval = 2 [(validate.rules).duration = {gt {}}];
+
+    // Specifies the exponential backoff factor that Envoy doesn't support. (2x is by default).
+    google.protobuf.UInt32Value exponential_backoff_factor = 1000;
   }
 
   message ResetHeader {


### PR DESCRIPTION
Motivation:

Armeria's xDS retry backoff needs to support a configurable exponential backoff factor, which Envoy does not natively provide (its default is 2x).

Modifications:

- Add `exponential_backoff_factor` (field number 1000) of type `google.protobuf.UInt32Value` to the `RetryBackOff` message in `route_components.proto`. Field number 1000 is used to indicate this is an Armeria extension not present in the upstream Envoy proto definition.

Result:

- xDS `RetryBackOff` configuration can now specify a custom exponential backoff multiplier for retry intervals.