### PR TITLE
Fix minor xDS bugs in filter chain TLS matching, locality routing, and state replay

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -429,7 +429,7 @@ class ServerFilterChainMatchTest {
                                                    .trustedCertificates(certA.certificate())
                                                    .build();
         try (ClientFactory cf = ClientFactory.builder().build()) {
-            final BlockingWebClient httpsClient = WebClient.builder(server.httpUri())
+            final BlockingWebClient httpsClient = WebClient.builder(server.httpsUri())
                                                            .factory(cf)
                                                            .build()
                                                            .blocking();

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -381,6 +381,110 @@ class ServerFilterChainMatchTest {
     }
 
     @Test
+    void tlsFilterChainRejectsPlaintextConnection() {
+        final Path certPath = certA.certificateFile().toPath();
+        final Path keyPath = certA.privateKeyFile().toPath();
+
+        // Default filter chain requires TLS — plaintext HTTP should be rejected.
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                  transport_socket:
+                    name: envoy.transport_sockets.downstream_tls
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.DownstreamTlsContext
+                      common_tls_context:
+                        tls_certificates:
+                          - certificate_chain:
+                              filename: '%s'
+                            private_key:
+                              filename: '%s'
+                """.formatted(LISTENER_NAME, certPath, keyPath);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        // HTTPS should succeed.
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certA.certificate())
+                                                   .build();
+        final BlockingWebClient httpsClient = WebClient.of(server.httpsUri()).blocking();
+        final AggregatedHttpResponse httpsRes = httpsClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+        assertThat(httpsRes.status()).isEqualTo(HttpStatus.OK);
+
+        // Plaintext HTTP should be rejected because the matched chain requires TLS.
+        final BlockingWebClient httpClient = WebClient.of(server.httpUri()).blocking();
+        assertThatThrownBy(() -> httpClient.get("/hello"))
+                .isInstanceOf(UnprocessedRequestException.class);
+    }
+
+    @Test
+    void plaintextFilterChainRejectsHttpsConnection() {
+        // Default filter chain has no transport_socket (plaintext only).
+        //language=YAML
+        final String yaml =
+                """
+                name: %s
+                default_filter_chain:
+                  filters:
+                    - name: envoy.filters.network.http_connection_manager
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters\
+                .network.http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: ingress_http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                            - name: local_service
+                              domains: ["*"]
+                              routes:
+                                - match:
+                                    prefix: "/"
+                                  non_forwarding_action: {}
+                        http_filters:
+                          - name: envoy.filters.http.router
+                """.formatted(LISTENER_NAME);
+        final String ver = controlPlane.set(XdsResourceReader.fromYaml(yaml, Listener.class));
+        controlPlane.awaitListener(LISTENER_NAME, ver);
+
+        // Plaintext HTTP should succeed.
+        final BlockingWebClient httpClient = WebClient.of(server.httpUri()).blocking();
+        final AggregatedHttpResponse httpRes = httpClient.get("/hello");
+        assertThat(httpRes.status()).isEqualTo(HttpStatus.OK);
+
+        // HTTPS should be rejected because the matched chain has no TLS.
+        final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
+                                                   .trustedCertificates(certA.certificate())
+                                                   .build();
+        final BlockingWebClient httpsClient = WebClient.of(server.httpsUri()).blocking();
+        assertThatThrownBy(() -> httpsClient.execute(
+                HttpRequest.of(HttpMethod.GET, "/hello"),
+                RequestOptions.builder().clientTlsSpec(tlsSpec).build()))
+                .isInstanceOf(UnprocessedRequestException.class);
+    }
+
+    @Test
     void unmatchedConnectionRejected() {
         final Path certPathA = certA.certificateFile().toPath();
         final Path keyPathA = certA.privateKeyFile().toPath();

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerFilterChainMatchTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.RequestOptions;
@@ -353,9 +354,9 @@ class ServerFilterChainMatchTest {
 
         // SNI "test.example.com" should match "*.example.com" chain → certA
         final ClientTlsSpec wildcardTlsSpec = ClientTlsSpec.builder()
-                                                            .trustedCertificates(certA.certificate())
-                                                            .endpointIdentificationAlgorithm("")
-                                                            .build();
+                                                           .trustedCertificates(certA.certificate())
+                                                           .endpointIdentificationAlgorithm("")
+                                                           .build();
         final Endpoint wildcardEndpoint = Endpoint.of("test.example.com", port).withIpAddr("127.0.0.1");
         final BlockingWebClient wildcardClient =
                 WebClient.builder(SessionProtocol.HTTPS, wildcardEndpoint).build().blocking();
@@ -367,9 +368,9 @@ class ServerFilterChainMatchTest {
 
         // SNI "other.net" should NOT match "*.example.com" → default chain → certDefault
         final ClientTlsSpec defaultTlsSpec = ClientTlsSpec.builder()
-                                                           .trustedCertificates(certDefault.certificate())
-                                                           .endpointIdentificationAlgorithm("")
-                                                           .build();
+                                                          .trustedCertificates(certDefault.certificate())
+                                                          .endpointIdentificationAlgorithm("")
+                                                          .build();
         final Endpoint otherEndpoint = Endpoint.of("other.net", port).withIpAddr("127.0.0.1");
         final BlockingWebClient defaultClient =
                 WebClient.builder(SessionProtocol.HTTPS, otherEndpoint).build().blocking();
@@ -427,16 +428,26 @@ class ServerFilterChainMatchTest {
         final ClientTlsSpec tlsSpec = ClientTlsSpec.builder()
                                                    .trustedCertificates(certA.certificate())
                                                    .build();
-        final BlockingWebClient httpsClient = WebClient.of(server.httpsUri()).blocking();
-        final AggregatedHttpResponse httpsRes = httpsClient.execute(
-                HttpRequest.of(HttpMethod.GET, "/hello"),
-                RequestOptions.builder().clientTlsSpec(tlsSpec).build());
-        assertThat(httpsRes.status()).isEqualTo(HttpStatus.OK);
+        try (ClientFactory cf = ClientFactory.builder().build()) {
+            final BlockingWebClient httpsClient = WebClient.builder(server.httpUri())
+                                                           .factory(cf)
+                                                           .build()
+                                                           .blocking();
+            final AggregatedHttpResponse httpsRes = httpsClient.execute(
+                    HttpRequest.of(HttpMethod.GET, "/hello"),
+                    RequestOptions.builder().clientTlsSpec(tlsSpec).build());
+            assertThat(httpsRes.status()).isEqualTo(HttpStatus.OK);
+        }
 
         // Plaintext HTTP should be rejected because the matched chain requires TLS.
-        final BlockingWebClient httpClient = WebClient.of(server.httpUri()).blocking();
-        assertThatThrownBy(() -> httpClient.get("/hello"))
-                .isInstanceOf(UnprocessedRequestException.class);
+        try (ClientFactory cf = ClientFactory.builder().build()) {
+            final BlockingWebClient httpClient = WebClient.builder(server.httpUri())
+                                                          .factory(cf)
+                                                          .build()
+                                                          .blocking();
+            assertThatThrownBy(() -> httpClient.get("/hello"))
+                    .isInstanceOf(UnprocessedRequestException.class);
+        }
     }
 
     @Test

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/server/ServerXdsTest.java
@@ -53,6 +53,8 @@ class ServerXdsTest {
     private static final String LISTENER_NAME = "server-listener";
     private static final ServerPort xdsPort =
             new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
+    private static final ServerPort unmanagedPort =
+            new ServerPort(0, SessionProtocol.HTTP, SessionProtocol.HTTPS);
 
     @RegisterExtension
     @Order(0)
@@ -119,6 +121,7 @@ class ServerXdsTest {
             sb.plugin(XdsServerPlugin.builder(controlPlane.bootstrap(), LISTENER_NAME)
                                      .port(xdsPort)
                                      .build());
+            sb.port(unmanagedPort);
             sb.service("/hello", (ctx, req) -> HttpResponse.of("hello from xds"));
         }
     };
@@ -200,7 +203,7 @@ class ServerXdsTest {
         // ServerExtension's own HTTP port is not managed by XdsServerPlugin.
         // Requests on this port should bypass xDS entirely and serve directly.
         final AggregatedHttpResponse res =
-                WebClient.of(server.httpUri()).blocking().get("/hello");
+                WebClient.of("http://127.0.0.1:" + unmanagedPort.actualPort()).blocking().get("/hello");
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("hello from xds");
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/StateCoordinator.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/StateCoordinator.java
@@ -60,7 +60,7 @@ final class StateCoordinator implements SafeCloseable {
     <T extends XdsResource> boolean register(XdsType type, String resourceName,
                                              SnapshotWatcher<T> watcher) {
         final boolean updated = subscriberStorage.register(type, resourceName, watcher);
-        replayToWatcher(type, resourceName, watcher);
+        replayToWatcher(type, resourceName, watcher, updated);
         return updated;
     }
 
@@ -70,10 +70,20 @@ final class StateCoordinator implements SafeCloseable {
     }
 
     private <T extends XdsResource> void replayToWatcher(XdsType type, String resourceName,
-                                                         SnapshotWatcher<T> watcher) {
+                                                         SnapshotWatcher<T> watcher,
+                                                         boolean newSubscriber) {
         @SuppressWarnings("unchecked")
         final T cached = (T) stateStore.resource(type, resourceName);
-        if (cached != null) {
+        if (cached == null) {
+            return;
+        }
+        if (newSubscriber) {
+            final CompositeSnapshotWatcher<XdsResource> subscriber =
+                    subscriberStorage.subscriber(type, resourceName);
+            if (subscriber != null) {
+                subscriber.onUpdate(cached, null);
+            }
+        } else {
             watcher.onUpdate(cached, null);
         }
     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsResourceReader.java
@@ -68,10 +68,11 @@ public final class XdsResourceReader {
     // The YAML mapper handles both YAML and JSON since JSON is a subset of YAML.
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
 
-    private static final class DefaultParserHolder {
+    private static final class DefaultTypeRegistryHolder {
+        static final TypeRegistry TYPE_REGISTRY = buildDefaultTypeRegistry();
         static final Parser PARSER = JsonFormat.parser()
                                                .ignoringUnknownFields()
-                                               .usingTypeRegistry(buildDefaultTypeRegistry());
+                                               .usingTypeRegistry(TYPE_REGISTRY);
 
         private static TypeRegistry buildDefaultTypeRegistry() {
             final TypeRegistry.Builder builder = TypeRegistry.newBuilder();
@@ -84,7 +85,7 @@ public final class XdsResourceReader {
                     "io.envoyproxy",
                     "com.github.udpa",
                     "com.github.xds",
-            };
+                    };
             for (String pkg : defaultPackages) {
                 addPackage(pkg, configuration, filterBuilder);
             }
@@ -115,10 +116,19 @@ public final class XdsResourceReader {
         }
 
         private static void addPackage(String pkg, ConfigurationBuilder configuration,
-                                        FilterBuilder filterBuilder) {
+                                       FilterBuilder filterBuilder) {
             configuration.addUrls(ClasspathHelper.forPackage(pkg));
             filterBuilder.include(FilterBuilder.prefix(pkg));
         }
+    }
+
+    /**
+     * Returns the default {@link TypeRegistry} containing all well-known Envoy protobuf types.
+     * This can be used to create a {@link com.google.protobuf.util.JsonFormat.Printer} that
+     * correctly serializes {@code Any}-wrapped xDS messages.
+     */
+    public static TypeRegistry typeRegistry() {
+        return DefaultTypeRegistryHolder.TYPE_REGISTRY;
     }
 
     /**
@@ -129,7 +139,7 @@ public final class XdsResourceReader {
     public static <T extends GeneratedMessageV3> T from(String yamlOrJson, Class<T> clazz) {
         requireNonNull(yamlOrJson, "yamlOrJson");
         requireNonNull(clazz, "clazz");
-        return parse(yamlOrJson, clazz, DefaultParserHolder.PARSER);
+        return parse(yamlOrJson, clazz, DefaultTypeRegistryHolder.PARSER);
     }
 
     /**

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LocalityRoutingStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LocalityRoutingStateFactory.java
@@ -190,7 +190,7 @@ final class LocalityRoutingStateFactory {
             if (state == State.NO_LOCALITY_ROUTING) {
                 return 0;
             }
-            return 1.0 * localPercentageToRoute / MOD;
+            return 100.0 * localPercentageToRoute / MOD;
         }
 
         Locality tryChooseLocalLocalityHosts(HostSet hostSet, XdsRandom random) {

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LocalityRoutingStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/LocalityRoutingStateFactory.java
@@ -185,12 +185,12 @@ final class LocalityRoutingStateFactory {
 
         double localPercentage() {
             if (state == State.LOCALITY_DIRECT) {
-                return 100;
+                return 1;
             }
             if (state == State.NO_LOCALITY_ROUTING) {
                 return 0;
             }
-            return 100.0 * localPercentageToRoute / MOD;
+            return 1.0 * localPercentageToRoute / MOD;
         }
 
         Locality tryChooseLocalLocalityHosts(HostSet hostSet, XdsRandom random) {

--- a/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/server/XdsServerPlugin.java
@@ -24,6 +24,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.common.util.Exceptions;
@@ -168,6 +169,16 @@ public final class XdsServerPlugin implements ServerPlugin {
             }
             final FilterChainSnapshot matched = watcher.match(ctx);
             if (matched != null) {
+                // Verify the matched filter chain's TLS config is consistent
+                // with the connection protocol.
+                final ServerTlsSpec spec = matched.transportSocketSnapshot().serverTlsSpec(ctx);
+                final boolean isTls = ctx.sessionProtocol() == SessionProtocol.HTTPS;
+                if (spec != null && !isTls) {
+                    return UnmodifiableFuture.completedFuture(false);
+                }
+                if (spec == null && isTls) {
+                    return UnmodifiableFuture.completedFuture(false);
+                }
                 ctx.setAttr(MATCHED_FILTER_CHAIN, matched);
                 return existingAcceptor.accept(ctx);
             }


### PR DESCRIPTION
## Motivation:

While implementing the xds example, several minor bugs were discovered in the xDS module:

1. The xDS server plugin did not verify that a matched filter chain's TLS configuration is consistent with the actual connection protocol. A TLS-configured filter chain would incorrectly accept plaintext connections and vice versa.
2. The locality routing percentage calculation used `100.0` instead of `1.0`, producing inconsistent routing percentages.
3. When a new watcher registered in `StateCoordinator` and a cached resource already existed, the cached value was replayed directly to the individual watcher rather than through the `CompositeSnapshotWatcher`. Since `CompositeSnapshotWatcher` tracks whether an update has been received, bypassing it caused it to still consider the resource missing and emit a spurious `MissingXdsResourceException`.

Misc) Added a `XdsResourceReader.typeRegistry()` public API so `JsonFormat.Printer` can also use loaded protos

## Modifications:

- Added a TLS/plaintext consistency check in `XdsServerPlugin` that rejects connections when the matched filter chain's TLS configuration doesn't match the session protocol (e.g., plaintext request on a TLS-required chain, or HTTPS request on a plaintext-only chain).
- Fixed the locality routing percentage multiplier from `100.0` to `1.0` in `LocalityRoutingStateFactory`.
- Updated `StateCoordinator.replayToWatcher()` to replay cached resources through `CompositeSnapshotWatcher` for new subscribers, so that the composite correctly records the update and avoids emitting a false `MissingXdsResourceException`.
- Exposed `XdsResourceReader.typeRegistry()` as a public API so that external code can create a `JsonFormat.Printer` that correctly serializes `Any`-wrapped xDS messages.
- Added integration tests (`tlsFilterChainRejectsPlaintextConnection`, `plaintextFilterChainRejectsHttpsConnection`) to verify that mismatched TLS/plaintext connections are properly rejected.

## Result:

- xDS server-side filter chain matching now correctly rejects connections where the protocol doesn't match the filter chain's TLS configuration.
- Locality-aware routing uses correct percentages for routing decisions.
- Watchers no longer receive false `MissingXdsResourceException` when a cached resource exists at the time of registration for path-type config sources
