### PR TITLE
Add xDS fault injection filter support  

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/RouteEntryMatcherTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/RouteEntryMatcherTest.java
@@ -35,9 +35,9 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.xds.RouteEntryMatcher.HeaderMatcherImpl;
 import com.linecorp.armeria.xds.RouteEntryMatcher.QueryParamsMatcherImpl;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
+import com.linecorp.armeria.xds.internal.XdsHeaderMatcher;
 
 import io.envoyproxy.envoy.config.route.v3.HeaderMatcher;
 import io.envoyproxy.envoy.config.route.v3.QueryParameterMatcher;
@@ -485,7 +485,7 @@ class RouteEntryMatcherTest {
     @ParameterizedTest
     @MethodSource("headerMatch_args")
     void headerMatch(HeaderMatcher headerMatcher, RequestHeaders requestHeaders, boolean expectedResult) {
-        final HeaderMatcherImpl matcher = new HeaderMatcherImpl(headerMatcher);
+        final XdsHeaderMatcher matcher = XdsHeaderMatcher.of(headerMatcher);
         assertThat(matcher.matches(requestHeaders)).isEqualTo(expectedResult);
     }
 
@@ -804,7 +804,7 @@ class RouteEntryMatcherTest {
     @MethodSource("deprecatedHeaderMatcher_args")
     @DisplayName("Test that deprecated HeaderMatcher values throw IllegalArgumentException")
     void deprecatedHeaderMatcher(HeaderMatcher headerMatcher) {
-        assertThatThrownBy(() -> new HeaderMatcherImpl(headerMatcher))
+        assertThatThrownBy(() -> XdsHeaderMatcher.of(headerMatcher))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Using deprecated field")
                 .hasMessageContaining("Use 'STRING_MATCH' instead");

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/FaultInjectionFilterTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/FaultInjectionFilterTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.base.Stopwatch;
+
+import com.linecorp.armeria.client.ClientRequestContextCaptor;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+import com.linecorp.armeria.xds.server.XdsServerPlugin;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+
+class FaultInjectionFilterTest {
+
+    @RegisterExtension
+    static final ServerExtension backendServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of("OK"));
+            sb.http(0);
+        }
+    };
+
+    private static final Bootstrap SERVER_BOOTSTRAP = XdsResourceReader.fromYaml("""
+            static_resources:
+              listeners:
+                - name: test-listener
+                  default_filter_chain:
+                    filters:
+                      - name: envoy.filters.network.http_connection_manager
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+            .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                              - name: local_service
+                                domains: ["*"]
+                                routes:
+                                  - match:
+                                      prefix: /
+                                    non_forwarding_action: {}
+                          http_filters:
+                            - {
+                                name: envoy.filters.http.fault,
+                                typed_config: {
+                                  "@type": "type.googleapis.com/envoy.extensions.filters\
+            .http.fault.v3.HTTPFault",
+                                  abort: {http_status: 503, percentage: {numerator: 100, denominator: HUNDRED}}
+                                }
+                              }
+                            - name: envoy.filters.http.router
+            """);
+
+    private static final XdsBootstrap SERVER_XDS_BOOTSTRAP = XdsBootstrap.of(SERVER_BOOTSTRAP);
+
+    @AfterAll
+    static void tearDown() {
+        SERVER_XDS_BOOTSTRAP.close();
+    }
+
+    @RegisterExtension
+    static final ServerExtension faultServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.plugin(XdsServerPlugin.of(SERVER_XDS_BOOTSTRAP, "test-listener"));
+            sb.service("/", (ctx, req) -> HttpResponse.of("OK"));
+        }
+    };
+
+    @Test
+    void abortAt100Percent() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "abort: {http_status: 503, percentage: {numerator: 100, denominator: HUNDRED}}");
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void abortAt0PercentPassesThrough() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "abort: {http_status: 503, percentage: {numerator: 0, denominator: HUNDRED}}");
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                assertThat(response.contentUtf8()).isEqualTo("OK");
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void delayAddsLatency() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "delay: {fixed_delay: 0.500s, percentage: {numerator: 100, denominator: HUNDRED}}");
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final Stopwatch stopwatch = Stopwatch.createStarted();
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                final long elapsedMillis = stopwatch.elapsed().toMillis();
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                assertThat(elapsedMillis).isGreaterThanOrEqualTo(400);
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void abortAndDelayCombined() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "abort: {http_status: 429, percentage: {numerator: 100, denominator: HUNDRED}}, " +
+                "delay: {fixed_delay: 0.300s, percentage: {numerator: 100, denominator: HUNDRED}}");
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final Stopwatch stopwatch = Stopwatch.createStarted();
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                final long elapsedMillis = stopwatch.elapsed().toMillis();
+                assertThat(response.status()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+                assertThat(elapsedMillis).isGreaterThanOrEqualTo(200);
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void disabledFaultFilterPassesThrough() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "abort: {http_status: 503, percentage: {numerator: 100, denominator: HUNDRED}}", true);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                assertThat(response.contentUtf8()).isEqualTo("OK");
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void headerMatchAbort() {
+        final Bootstrap bootstrap = clientBootstrap(
+                "abort: {http_status: 503, percentage: {numerator: 100, denominator: HUNDRED}}, " +
+                "headers: [{name: x-fault-inject, present_match: true}]");
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("test-listener", xdsBootstrap)) {
+            // Request with matching header gets aborted
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking()
+                                 .prepare().get("/").header("x-fault-inject", "true").execute();
+                assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+            // Request without matching header passes through
+            try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+                final AggregatedHttpResponse response =
+                        WebClient.of(preprocessor).blocking().get("/");
+                assertThat(response.status()).isEqualTo(HttpStatus.OK);
+                assertThat(response.contentUtf8()).isEqualTo("OK");
+                await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+            }
+        }
+    }
+
+    @Test
+    void serverSideAbort() {
+        try (ClientRequestContextCaptor captor = Clients.newContextCaptor()) {
+            final AggregatedHttpResponse response =
+                    WebClient.of(faultServer.httpUri()).blocking().get("/");
+            assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+            await().untilAsserted(() -> assertThat(captor.get().log().isComplete()).isTrue());
+        }
+    }
+
+    private static Bootstrap clientBootstrap(String faultConfig) {
+        return clientBootstrap(faultConfig, false);
+    }
+
+    private static Bootstrap clientBootstrap(String faultConfig, boolean disabled) {
+        return XdsResourceReader.fromYaml("""
+                static_resources:
+                  listeners:
+                    - name: test-listener
+                      api_listener:
+                        api_listener:
+                          "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                          stat_prefix: http
+                          route_config:
+                            name: local_route
+                            virtual_hosts:
+                            - name: local_service
+                              domains: [ "*" ]
+                              routes:
+                              - match:
+                                  prefix: /
+                                route:
+                                  cluster: test-cluster
+                          http_filters:
+                          - {
+                              name: envoy.filters.http.fault,
+                              disabled: %s,
+                              typed_config: {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault",
+                                %s
+                              }
+                            }
+                          - name: envoy.filters.http.router
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                    - name: test-cluster
+                      type: STATIC
+                      load_assignment:
+                        cluster_name: test-cluster
+                        endpoints:
+                        - lb_endpoints:
+                          - endpoint:
+                              address:
+                                socket_address:
+                                  address: %s
+                                  port_value: %s
+                """.formatted(disabled, faultConfig,
+                              backendServer.httpSocketAddress().getHostString(),
+                              backendServer.httpPort()));
+    }
+}

--- a/xds-api/src/main/proto/envoy/config/core/v3/base.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/base.proto
@@ -158,6 +158,7 @@ message Node {
   // <config_cluster_manager_cds>`, and :ref:`HTTP tracing
   // <arch_overview_tracing>`, either in this message or via
   // :option:`--service-node`.
+  option (armeria.xds.supported.field) = 1;
   string id = 1;
 
   // Defines the local service cluster name where Envoy is running. Though

--- a/xds-api/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -10,6 +10,8 @@ import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
+import "armeria/xds/supported.proto";
+
 option java_package = "io.envoyproxy.envoy.extensions.filters.common.fault.v3";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
@@ -50,6 +52,7 @@ message FaultDelay {
     // the JSON/YAML Duration mapping. For HTTP/Mongo, the specified
     // delay will be injected before a new request/operation.
     // This is required if type is FIXED.
+    option (armeria.xds.supported.oneof_field) = 3;
     google.protobuf.Duration fixed_delay = 3 [(validate.rules).duration = {gt {}}];
 
     // Fault delays are controlled via an HTTP header (if applicable).
@@ -57,6 +60,7 @@ message FaultDelay {
   }
 
   // The percentage of operations/connections/requests on which the delay will be injected.
+  option (armeria.xds.supported.field) = 4;
   type.v3.FractionalPercent percentage = 4;
 }
 

--- a/xds-api/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -13,6 +13,8 @@ import "udpa/annotations/status.proto";
 import "udpa/annotations/versioning.proto";
 import "validate/validate.proto";
 
+import "armeria/xds/supported.proto";
+
 option java_package = "io.envoyproxy.envoy.extensions.filters.http.fault.v3";
 option java_outer_classname = "FaultProto";
 option java_multiple_files = true;
@@ -42,6 +44,7 @@ message FaultAbort {
     option (validate.required) = true;
 
     // HTTP status code to use to abort the HTTP request.
+    option (armeria.xds.supported.oneof_field) = 2;
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
     // gRPC status code to use to abort the gRPC request.
@@ -53,6 +56,7 @@ message FaultAbort {
 
   // The percentage of requests/operations/connections that will be aborted with the error code
   // provided.
+  option (armeria.xds.supported.field) = 3;
   type.v3.FractionalPercent percentage = 3;
 }
 
@@ -63,10 +67,12 @@ message HTTPFault {
 
   // If specified, the filter will inject delays based on the values in the
   // object.
+  option (armeria.xds.supported.field) = 1;
   common.fault.v3.FaultDelay delay = 1;
 
   // If specified, the filter will abort requests based on the values in
   // the object. At least ``abort`` or ``delay`` must be specified.
+  option (armeria.xds.supported.field) = 2;
   FaultAbort abort = 2;
 
   // Specifies the name of the (destination) upstream cluster that the
@@ -83,6 +89,7 @@ message HTTPFault {
   // headers in the filter config. A match will happen if all the headers in the
   // config are present in the request with the same values (or based on
   // presence if the ``value`` field is not in the config).
+  option (armeria.xds.supported.field) = 4;
   repeated config.route.v3.HeaderMatcher headers = 4;
 
   // Faults are injected for the specified list of downstream hosts. If this

--- a/xds-api/src/main/proto/envoy/type/v3/percent.proto
+++ b/xds-api/src/main/proto/envoy/type/v3/percent.proto
@@ -52,9 +52,11 @@ message FractionalPercent {
   }
 
   // Specifies the numerator. Defaults to 0.
+  option (armeria.xds.supported.field) = 1;
   uint32 numerator = 1;
 
   // Specifies the denominator. If the denominator specified is less than the numerator, the final
   // fractional percentage is capped at 1 (100%).
+  option (armeria.xds.supported.field) = 2;
   DenominatorType denominator = 2 [(validate.rules).enum = {defined_only: true}];
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
@@ -56,8 +56,8 @@ import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.logging.RequestLog;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
-import com.linecorp.armeria.xds.RouteEntryMatcher.HeaderMatcherImpl;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
+import com.linecorp.armeria.xds.internal.XdsHeaderMatcher;
 
 import io.envoyproxy.envoy.config.route.v3.HeaderMatcher;
 import io.envoyproxy.envoy.config.route.v3.RetryPolicy;
@@ -87,18 +87,18 @@ final class RetryStateFactory {
                             REQUEST_HEADER_MAX_RETRIES, REQUEST_HEADER_RETRIABLE_STATUS_CODES,
                             REQUEST_HEADER_RETRIABLE_HEADER_NAMES);
 
-    private final List<HeaderMatcherImpl> retriableRequestHeadersMatchers;
+    private final List<XdsHeaderMatcher> retriableRequestHeadersMatchers;
     private final RetryStateImpl defaultRetryState;
     private final RetryConfig<HttpResponse> defaultRetryConfig;
     private final RetryConfig<RpcResponse> defaultRpcRetryConfig;
 
     RetryStateFactory(RetryPolicy retryPolicy) {
         final Set<RetryPolicyTypes> policies = parseRetryOn(retryPolicy.getRetryOn());
-        final List<HeaderMatcherImpl> retriableResponseHeaderMatchers =
-                retryPolicy.getRetriableHeadersList().stream().map(HeaderMatcherImpl::new)
+        final List<XdsHeaderMatcher> retriableResponseHeaderMatchers =
+                retryPolicy.getRetriableHeadersList().stream().map(XdsHeaderMatcher::of)
                            .collect(ImmutableList.toImmutableList());
         retriableRequestHeadersMatchers = retryPolicy.getRetriableRequestHeadersList().stream()
-                                                     .map(HeaderMatcherImpl::new)
+                                                     .map(XdsHeaderMatcher::of)
                                                      .collect(ImmutableList.toImmutableList());
         final Set<Integer> retriableStatusCodes =
                 ImmutableSet.copyOf(retryPolicy.getRetriableStatusCodesList());
@@ -151,7 +151,7 @@ final class RetryStateFactory {
 
     private static RetryStateImpl createRetryState(RequestHeaders requestHeaders,
                                                    RetryStateImpl defaultRetryState,
-                                                   List<HeaderMatcherImpl> retriableRequestHeadersMatchers) {
+                                                   List<XdsHeaderMatcher> retriableRequestHeadersMatchers) {
         Set<RetryPolicyTypes> policies = defaultRetryState.policies;
 
         policies = retryPoliciesFromRequestHeader(requestHeaders, retriableRequestHeadersMatchers, policies);
@@ -181,16 +181,16 @@ final class RetryStateFactory {
             retriableStatusCodes = builder.build();
         }
 
-        List<HeaderMatcherImpl> retriableResponseHeaderMatchers =
+        List<XdsHeaderMatcher> retriableResponseHeaderMatchers =
                 defaultRetryState.retriableResponseHeaderMatchers;
         final String retriableHeaderNames = requestHeaders.get(REQUEST_HEADER_RETRIABLE_HEADER_NAMES, "");
         if (!retriableHeaderNames.isEmpty()) {
             final String[] splitHeaderNames = retriableHeaderNames.split(",");
             final int expectedSize = splitHeaderNames.length + retriableResponseHeaderMatchers.size();
-            final ImmutableList.Builder<HeaderMatcherImpl> builder =
+            final ImmutableList.Builder<XdsHeaderMatcher> builder =
                     ImmutableList.builderWithExpectedSize(expectedSize);
             for (String headerName : splitHeaderNames) {
-                builder.add(new HeaderMatcherImpl(HeaderMatcher.newBuilder()
+                builder.add(XdsHeaderMatcher.of(HeaderMatcher.newBuilder()
                                                                .setName(headerName.trim()).build()));
             }
             builder.addAll(retriableResponseHeaderMatchers);
@@ -202,11 +202,11 @@ final class RetryStateFactory {
     }
 
     private static Set<RetryPolicyTypes> retryPoliciesFromRequestHeader(
-            RequestHeaders requestHeaders, List<HeaderMatcherImpl> retriableRequestHeadersMatchers,
+            RequestHeaders requestHeaders, List<XdsHeaderMatcher> retriableRequestHeadersMatchers,
             Set<RetryPolicyTypes> policies) {
         if (!retriableRequestHeadersMatchers.isEmpty()) {
             boolean shouldRetry = false;
-            for (HeaderMatcherImpl headerMatcher: retriableRequestHeadersMatchers) {
+            for (XdsHeaderMatcher headerMatcher: retriableRequestHeadersMatchers) {
                 if (headerMatcher.matches(requestHeaders)) {
                     shouldRetry = true;
                     break;
@@ -259,13 +259,13 @@ final class RetryStateFactory {
         private final DelegatingBackoff backoff;
         private final Set<RetryPolicyTypes> policies;
         private final Set<Integer> retriableStatusCodes;
-        private final List<HeaderMatcherImpl> retriableResponseHeaderMatchers;
+        private final List<XdsHeaderMatcher> retriableResponseHeaderMatchers;
         private final RetryDecision shouldRetry;
         private final long perTryTimeoutMillis;
 
         RetryStateImpl(RetryPolicy retryPolicy, Set<RetryPolicyTypes> policies,
                        int numRetries, Set<Integer> retriableStatusCodes,
-                       List<HeaderMatcherImpl> retriableResponseHeaderMatchers) {
+                       List<XdsHeaderMatcher> retriableResponseHeaderMatchers) {
             this.retryPolicy = retryPolicy;
             this.numRetries = numRetries;
             final RetryBackOff retryBackOff = retryPolicy.getRetryBackOff();
@@ -342,7 +342,7 @@ final class RetryStateFactory {
                 }
             }
             if (policies.contains(RetryPolicyTypes.RETRY_ON_RETRIABLE_HEADERS)) {
-                for (HeaderMatcherImpl headerMatcher : retriableResponseHeaderMatchers) {
+                for (XdsHeaderMatcher headerMatcher : retriableResponseHeaderMatchers) {
                     if (headerMatcher.matches(responseHeaders)) {
                         return shouldRetry;
                     }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteEntryMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteEntryMatcher.java
@@ -19,7 +19,6 @@ package com.linecorp.armeria.xds;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 
@@ -28,29 +27,26 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestContext;
-import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.xds.internal.XdsCommonUtil;
+import com.linecorp.armeria.xds.internal.XdsHeaderMatcher;
 import com.linecorp.armeria.xds.internal.XdsStringMatcher;
 
-import io.envoyproxy.envoy.config.route.v3.HeaderMatcher;
-import io.envoyproxy.envoy.config.route.v3.HeaderMatcher.HeaderMatchSpecifierCase;
 import io.envoyproxy.envoy.config.route.v3.QueryParameterMatcher;
 import io.envoyproxy.envoy.config.route.v3.QueryParameterMatcher.QueryParameterMatchSpecifierCase;
 import io.envoyproxy.envoy.config.route.v3.RouteMatch;
 import io.envoyproxy.envoy.config.route.v3.RouteMatch.PathSpecifierCase;
 import io.envoyproxy.envoy.type.matcher.v3.StringMatcher;
-import io.envoyproxy.envoy.type.v3.Int64Range;
 
 final class RouteEntryMatcher {
 
-    private final List<HeaderMatcherImpl> headerMatchers;
+    private final List<XdsHeaderMatcher> headerMatchers;
     private final List<QueryParamsMatcherImpl> queryParamsMatchers;
     private final PathMatcherImpl pathMatcher;
     private final RouteMatch routeMatch;
 
     RouteEntryMatcher(RouteMatch routeMatch) {
         this.routeMatch = routeMatch;
-        headerMatchers = HeaderMatcherImpl.fromHeaderMatchers(routeMatch.getHeadersList());
+        headerMatchers = XdsHeaderMatcher.of(routeMatch.getHeadersList());
         queryParamsMatchers =
                 QueryParamsMatcherImpl.fromQueryParamsMatchers(routeMatch.getQueryParametersList());
         pathMatcher = new PathMatcherImpl(routeMatch);
@@ -64,10 +60,9 @@ final class RouteEntryMatcher {
             }
         }
 
-        for (HeaderMatcherImpl headerMatcher : headerMatchers) {
-            if (!headerMatcher.matches(req)) {
-                return false;
-            }
+        if (!XdsHeaderMatcher.matchAll(headerMatchers,
+                                       req != null ? req.headers() : HttpHeaders.of())) {
+            return false;
         }
 
         if (!queryParamsMatchers.isEmpty()) {
@@ -130,91 +125,6 @@ final class RouteEntryMatcher {
 
         boolean matches(QueryParams queryParams) {
             return predicate.test(queryParams);
-        }
-    }
-
-    static class HeaderMatcherImpl {
-
-        private final Predicate<HttpHeaders> matcher;
-        private final HeaderMatcher headerMatcher;
-        private static final Joiner COMMA_JOINER = Joiner.on(",");
-
-        static List<HeaderMatcherImpl> fromHeaderMatchers(List<HeaderMatcher> headerMatchers) {
-            final ImmutableList.Builder<HeaderMatcherImpl> builder = ImmutableList.builder();
-            for (HeaderMatcher headerMatcher : headerMatchers) {
-                builder.add(new HeaderMatcherImpl(headerMatcher));
-            }
-            return builder.build();
-        }
-
-        HeaderMatcherImpl(HeaderMatcher headerMatcher) {
-            this.headerMatcher = headerMatcher;
-
-            final HeaderMatchSpecifierCase matchCase = headerMatcher.getHeaderMatchSpecifierCase();
-            switch (matchCase) {
-                case EXACT_MATCH:
-                case SAFE_REGEX_MATCH:
-                case PREFIX_MATCH:
-                case SUFFIX_MATCH:
-                case CONTAINS_MATCH:
-                    throw new IllegalArgumentException("Using deprecated field: " + matchCase +
-                                                       ". Use 'STRING_MATCH' instead.");
-                case PRESENT_MATCH:
-                case HEADERMATCHSPECIFIER_NOT_SET:
-                    final boolean presentMatch = headerMatcher.hasPresentMatch() ?
-                                                 headerMatcher.getPresentMatch() : true;
-                    matcher = headers -> {
-                        if (headerMatcher.getTreatMissingHeaderAsEmpty()) {
-                            return presentMatch;
-                        }
-                        return headers.contains(headerMatcher.getName()) == presentMatch;
-                    };
-                    break;
-                case RANGE_MATCH:
-                    matcher = headers -> {
-                        final Long value = headers.getLong(headerMatcher.getName());
-                        if (value == null) {
-                            return false;
-                        }
-                        final Int64Range rangeMatch = headerMatcher.getRangeMatch();
-                        return value >= rangeMatch.getStart() && value < rangeMatch.getEnd();
-                    };
-                    break;
-                case STRING_MATCH:
-                    final XdsStringMatcher stringMatcher =
-                            new XdsStringMatcher(headerMatcher.getStringMatch());
-                    matcher = headers -> {
-                        final List<String> allHeaders = headers.getAll(headerMatcher.getName());
-                        if (allHeaders.isEmpty()) {
-                            if (headerMatcher.getTreatMissingHeaderAsEmpty()) {
-                                return stringMatcher.match("");
-                            } else {
-                                return false;
-                            }
-                        }
-                        if (allHeaders.size() == 1) {
-                            // happy path for most cases
-                            return stringMatcher.match(allHeaders.get(0));
-                        }
-                        final String joined = COMMA_JOINER.join(allHeaders);
-                        return stringMatcher.match(joined);
-                    };
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported header matchCase: " + matchCase + '.');
-            }
-        }
-
-        boolean matches(@Nullable HttpRequest req) {
-            if (req == null) {
-                return matches(HttpHeaders.of());
-            } else {
-                return matches(req.headers());
-            }
-        }
-
-        boolean matches(HttpHeaders headers) {
-            return matcher.test(headers) != headerMatcher.getInvertMatch();
         }
     }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/XdsExtensionRegistry.java
@@ -38,6 +38,7 @@ import com.linecorp.armeria.xds.client.endpoint.StaticClusterTypeFactory;
 import com.linecorp.armeria.xds.client.endpoint.StrictDnsClusterTypeFactory;
 import com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory;
 import com.linecorp.armeria.xds.filter.CredentialInjectorFilterFactory;
+import com.linecorp.armeria.xds.filter.FaultInjectionFilterFactory;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -93,6 +94,7 @@ public final class XdsExtensionRegistry {
         // Built-in factories (registered last so they cannot be overridden)
         register(new RouterFilterFactory(), byName, byTypeUrl);
         register(new CredentialInjectorFilterFactory(), byName, byTypeUrl);
+        register(new FaultInjectionFilterFactory(), byName, byTypeUrl);
         register(new StaticClusterTypeFactory(), byName, byTypeUrl);
         register(new StrictDnsClusterTypeFactory(), byName, byTypeUrl);
         register(new PathSotwConfigSourceSubscriptionFactory(watchService, meterRegistry, meterIdPrefix),

--- a/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.filter;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
+import com.google.protobuf.util.Durations;
+
+import com.linecorp.armeria.client.DecoratingHttpClientFunction;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.xds.internal.XdsHeaderMatcher;
+
+import io.envoyproxy.envoy.extensions.filters.common.fault.v3.FaultDelay;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.FaultAbort;
+import io.envoyproxy.envoy.extensions.filters.http.fault.v3.HTTPFault;
+import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
+import io.envoyproxy.envoy.type.v3.FractionalPercent;
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * An {@link HttpFilterFactory} for the {@code envoy.filters.http.fault} filter.
+ *
+ * <p>Supports:
+ * <ul>
+ *   <li>{@code abort} — returns an HTTP error status for a percentage of requests</li>
+ *   <li>{@code delay} — adds fixed latency for a percentage of requests</li>
+ * </ul>
+ */
+@UnstableApi
+public final class FaultInjectionFilterFactory implements HttpFilterFactory {
+
+    private static final String NAME = "envoy.filters.http.fault";
+    private static final String TYPE_URL =
+            "type.googleapis.com/envoy.extensions.filters.http.fault.v3.HTTPFault";
+    private static final List<String> TYPE_URLS = ImmutableList.of(TYPE_URL);
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public List<String> typeUrls() {
+        return TYPE_URLS;
+    }
+
+    @Override
+    @Nullable
+    public XdsHttpFilter create(HttpFilter httpFilter, Any config, FactoryContext context) {
+        final HTTPFault httpFault = context.validator().unpack(config, HTTPFault.class);
+
+        final boolean hasAbort = httpFault.hasAbort() &&
+                                 httpFault.getAbort().getErrorTypeCase() ==
+                                 FaultAbort.ErrorTypeCase.HTTP_STATUS;
+        final boolean hasDelay = httpFault.hasDelay() &&
+                                 httpFault.getDelay().getFaultDelaySecifierCase() ==
+                                 FaultDelay.FaultDelaySecifierCase.FIXED_DELAY;
+
+        if (!hasAbort && !hasDelay) {
+            return null;
+        }
+
+        final int abortStatus;
+        final int abortNumerator;
+        final int abortDenominator;
+        if (hasAbort) {
+            final FaultAbort abort = httpFault.getAbort();
+            abortStatus = abort.getHttpStatus();
+            abortNumerator = abort.getPercentage().getNumerator();
+            abortDenominator = denominatorValue(abort.getPercentage());
+        } else {
+            abortStatus = 0;
+            abortNumerator = 0;
+            abortDenominator = 100;
+        }
+
+        final long delayMillis;
+        final int delayNumerator;
+        final int delayDenominator;
+        if (hasDelay) {
+            final FaultDelay delay = httpFault.getDelay();
+            delayMillis = Durations.toMillis(delay.getFixedDelay());
+            delayNumerator = delay.getPercentage().getNumerator();
+            delayDenominator = denominatorValue(delay.getPercentage());
+        } else {
+            delayMillis = 0;
+            delayNumerator = 0;
+            delayDenominator = 100;
+        }
+
+        final List<XdsHeaderMatcher> headerMatchers = XdsHeaderMatcher.of(httpFault.getHeadersList());
+
+        return new FaultInjectionXdsHttpFilter(
+                abortStatus, abortNumerator, abortDenominator,
+                delayMillis, delayNumerator, delayDenominator,
+                headerMatchers);
+    }
+
+    private static int denominatorValue(FractionalPercent percent) {
+        switch (percent.getDenominator()) {
+            case TEN_THOUSAND:
+                return 10_000;
+            case MILLION:
+                return 1_000_000;
+            default:
+                return 100;
+        }
+    }
+
+    private static boolean shouldApply(int numerator, int denominator) {
+        if (numerator <= 0) {
+            return false;
+        }
+        if (numerator >= denominator) {
+            return true;
+        }
+        return ThreadLocalRandom.current().nextInt(denominator) < numerator;
+    }
+
+    private static final class FaultInjectionXdsHttpFilter implements XdsHttpFilter {
+
+        private final int abortStatus;
+        private final int abortNumerator;
+        private final int abortDenominator;
+        private final long delayMillis;
+        private final int delayNumerator;
+        private final int delayDenominator;
+        private final List<XdsHeaderMatcher> headerMatchers;
+
+        FaultInjectionXdsHttpFilter(int abortStatus, int abortNumerator, int abortDenominator,
+                                    long delayMillis, int delayNumerator, int delayDenominator,
+                                    List<XdsHeaderMatcher> headerMatchers) {
+            this.abortStatus = abortStatus;
+            this.abortNumerator = abortNumerator;
+            this.abortDenominator = abortDenominator;
+            this.delayMillis = delayMillis;
+            this.delayNumerator = delayNumerator;
+            this.delayDenominator = delayDenominator;
+            this.headerMatchers = headerMatchers;
+        }
+
+        @Override
+        public DecoratingHttpClientFunction httpDecorator() {
+            return (delegate, ctx, req) -> {
+                if (!headersMatch(req.headers())) {
+                    return delegate.execute(ctx, req);
+                }
+                final HttpResponse faultResponse = maybeFault();
+                if (faultResponse != null) {
+                    return maybeDelay(faultResponse, ctx.eventLoop());
+                }
+                return maybeDelay(delegate.execute(ctx, req), ctx.eventLoop());
+            };
+        }
+
+        @Override
+        public DecoratingHttpServiceFunction serviceDecorator() {
+            return (delegate, ctx, req) -> {
+                if (!headersMatch(req.headers())) {
+                    return delegate.serve(ctx, req);
+                }
+                final HttpResponse faultResponse = maybeFault();
+                if (faultResponse != null) {
+                    return maybeDelay(faultResponse, ctx.eventLoop());
+                }
+                return maybeDelay(delegate.serve(ctx, req), ctx.eventLoop());
+            };
+        }
+
+        private boolean headersMatch(HttpHeaders headers) {
+            return XdsHeaderMatcher.matchAll(headerMatchers, headers);
+        }
+
+        @Nullable
+        private HttpResponse maybeFault() {
+            if (shouldApply(abortNumerator, abortDenominator)) {
+                return HttpResponse.of(HttpStatus.valueOf(abortStatus));
+            }
+            return null;
+        }
+
+        private HttpResponse maybeDelay(HttpResponse response, EventExecutor executor) {
+            if (shouldApply(delayNumerator, delayDenominator) && delayMillis > 0) {
+                return HttpResponse.delayed(response, Duration.ofMillis(delayMillis), executor);
+            }
+            return response;
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
@@ -232,7 +232,7 @@ public final class FaultInjectionFilterFactory implements HttpFilterFactory {
                     future.completeExceptionally(Exceptions.peel(e));
                 }
             }, delayMillis, TimeUnit.MILLISECONDS);
-            return HttpResponse.from(future);
+            return HttpResponse.of(future);
         }
 
         @FunctionalInterface

--- a/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/filter/FaultInjectionFilterFactory.java
@@ -18,7 +18,9 @@ package com.linecorp.armeria.xds.filter;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
@@ -30,6 +32,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
 import com.linecorp.armeria.xds.internal.XdsHeaderMatcher;
 
@@ -172,7 +175,10 @@ public final class FaultInjectionFilterFactory implements HttpFilterFactory {
                 if (faultResponse != null) {
                     return maybeDelay(faultResponse, ctx.eventLoop());
                 }
-                return maybeDelay(delegate.execute(ctx, req), ctx.eventLoop());
+                if (shouldDelay()) {
+                    return delayedDispatch(() -> delegate.execute(ctx, req), ctx.eventLoop());
+                }
+                return delegate.execute(ctx, req);
             };
         }
 
@@ -186,7 +192,10 @@ public final class FaultInjectionFilterFactory implements HttpFilterFactory {
                 if (faultResponse != null) {
                     return maybeDelay(faultResponse, ctx.eventLoop());
                 }
-                return maybeDelay(delegate.serve(ctx, req), ctx.eventLoop());
+                if (shouldDelay()) {
+                    return delayedDispatch(() -> delegate.serve(ctx, req), ctx.eventLoop());
+                }
+                return delegate.serve(ctx, req);
             };
         }
 
@@ -202,11 +211,33 @@ public final class FaultInjectionFilterFactory implements HttpFilterFactory {
             return null;
         }
 
+        private boolean shouldDelay() {
+            return shouldApply(delayNumerator, delayDenominator) && delayMillis > 0;
+        }
+
         private HttpResponse maybeDelay(HttpResponse response, EventExecutor executor) {
-            if (shouldApply(delayNumerator, delayDenominator) && delayMillis > 0) {
+            if (shouldDelay()) {
                 return HttpResponse.delayed(response, Duration.ofMillis(delayMillis), executor);
             }
             return response;
+        }
+
+        private HttpResponse delayedDispatch(
+                ThrowingSupplier dispatch, EventExecutor executor) {
+            final CompletableFuture<HttpResponse> future = new CompletableFuture<>();
+            executor.schedule(() -> {
+                try {
+                    future.complete(dispatch.get());
+                } catch (Exception e) {
+                    future.completeExceptionally(Exceptions.peel(e));
+                }
+            }, delayMillis, TimeUnit.MILLISECONDS);
+            return HttpResponse.from(future);
+        }
+
+        @FunctionalInterface
+        private interface ThrowingSupplier {
+            HttpResponse get() throws Exception;
         }
     }
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsHeaderMatcher.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/internal/XdsHeaderMatcher.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.internal;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.envoyproxy.envoy.config.route.v3.HeaderMatcher;
+import io.envoyproxy.envoy.config.route.v3.HeaderMatcher.HeaderMatchSpecifierCase;
+import io.envoyproxy.envoy.type.v3.Int64Range;
+
+/**
+ * Matches request headers against an xDS {@link HeaderMatcher}.
+ */
+public final class XdsHeaderMatcher {
+
+    private static final Joiner COMMA_JOINER = Joiner.on(",");
+
+    private final Predicate<HttpHeaders> matcher;
+    private final HeaderMatcher headerMatcher;
+
+    /**
+     * Creates a single {@link XdsHeaderMatcher} from the given proto {@link HeaderMatcher}.
+     */
+    public static XdsHeaderMatcher of(HeaderMatcher headerMatcher) {
+        return new XdsHeaderMatcher(headerMatcher);
+    }
+
+    /**
+     * Creates a list of {@link XdsHeaderMatcher}s from the given proto {@link HeaderMatcher}s.
+     */
+    public static List<XdsHeaderMatcher> of(List<HeaderMatcher> headerMatchers) {
+        if (headerMatchers.isEmpty()) {
+            return ImmutableList.of();
+        }
+        final ImmutableList.Builder<XdsHeaderMatcher> builder = ImmutableList.builder();
+        for (HeaderMatcher headerMatcher : headerMatchers) {
+            builder.add(new XdsHeaderMatcher(headerMatcher));
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns {@code true} if the given headers match all of the given matchers.
+     */
+    public static boolean matchAll(List<XdsHeaderMatcher> matchers, HttpHeaders headers) {
+        for (XdsHeaderMatcher matcher : matchers) {
+            if (!matcher.matches(headers)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private XdsHeaderMatcher(HeaderMatcher headerMatcher) {
+        this.headerMatcher = headerMatcher;
+
+        final HeaderMatchSpecifierCase matchCase = headerMatcher.getHeaderMatchSpecifierCase();
+        switch (matchCase) {
+            case EXACT_MATCH:
+            case SAFE_REGEX_MATCH:
+            case PREFIX_MATCH:
+            case SUFFIX_MATCH:
+            case CONTAINS_MATCH:
+                throw new IllegalArgumentException("Using deprecated field: " + matchCase +
+                                                   ". Use 'STRING_MATCH' instead.");
+            case PRESENT_MATCH:
+            case HEADERMATCHSPECIFIER_NOT_SET:
+                final boolean presentMatch = headerMatcher.hasPresentMatch() ?
+                                             headerMatcher.getPresentMatch() : true;
+                matcher = headers -> {
+                    if (headerMatcher.getTreatMissingHeaderAsEmpty()) {
+                        return presentMatch;
+                    }
+                    return headers.contains(headerMatcher.getName()) == presentMatch;
+                };
+                break;
+            case RANGE_MATCH:
+                matcher = headers -> {
+                    final Long value = headers.getLong(headerMatcher.getName());
+                    if (value == null) {
+                        return false;
+                    }
+                    final Int64Range rangeMatch = headerMatcher.getRangeMatch();
+                    return value >= rangeMatch.getStart() && value < rangeMatch.getEnd();
+                };
+                break;
+            case STRING_MATCH:
+                final XdsStringMatcher stringMatcher =
+                        new XdsStringMatcher(headerMatcher.getStringMatch());
+                matcher = headers -> {
+                    final List<String> allHeaders = headers.getAll(headerMatcher.getName());
+                    if (allHeaders.isEmpty()) {
+                        if (headerMatcher.getTreatMissingHeaderAsEmpty()) {
+                            return stringMatcher.match("");
+                        } else {
+                            return false;
+                        }
+                    }
+                    if (allHeaders.size() == 1) {
+                        return stringMatcher.match(allHeaders.get(0));
+                    }
+                    final String joined = COMMA_JOINER.join(allHeaders);
+                    return stringMatcher.match(joined);
+                };
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported header matchCase: " + matchCase + '.');
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given headers match this matcher.
+     */
+    public boolean matches(@Nullable HttpHeaders headers) {
+        if (headers == null) {
+            headers = HttpHeaders.of();
+        }
+        return matcher.test(headers) != headerMatcher.getInvertMatch();
+    }
+}


### PR DESCRIPTION
## Motivation:

Envoy's `envoy.filters.http.fault` filter is commonly used to inject faults (abort responses and delays) into the request path for testing resilience. Armeria's xDS integration did not support this filter, requiring users to implement fault injection manually.

## Modifications:

- Added `FaultInjectionFilterFactory` implementing the `envoy.filters.http.fault` filter with support for:
  - `abort` — returns a configured HTTP error status for a percentage of requests based on `FractionalPercent`
  - `delay` — adds fixed latency for a percentage of requests based on `FractionalPercent`
  - `headers` — conditionally applies faults only when request headers match the configured matchers
  - Both client-side (`DecoratingHttpClientFunction`) and server-side (`DecoratingHttpServiceFunction`) decorators
- Extracted `HeaderMatcherImpl` from `RouteEntryMatcher` into a shared `XdsHeaderMatcher` class in `xds.internal` so it can be reused by `RouteEntryMatcher`, `RetryStateFactory`, and `FaultInjectionFilterFactory`.
- Registered `FaultInjectionFilterFactory` as a built-in filter in `XdsExtensionRegistry`.
- Added proto definitions for `FaultDelay`, `FaultAbort`, `HTTPFault`, and `FractionalPercent`.
- Added integration tests covering abort at 100%/0%, delay latency, combined abort+delay, disabled filter passthrough, header-conditional abort, and server-side fault injection.

## Result:

- Users can configure the `envoy.filters.http.fault` filter in their xDS configuration to inject abort responses and/or delays into the request path, on both client and server side.
