### PR TITLE
Validate that the private key matches the certificate in TlsKeyPair

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/TlsKeyPair.java
+++ b/core/src/main/java/com/linecorp/armeria/common/TlsKeyPair.java
@@ -16,18 +16,27 @@
 
 package com.linecorp.armeria.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.armeria.internal.common.util.CertificateUtil.toPrivateKey;
 import static com.linecorp.armeria.internal.common.util.CertificateUtil.toX509Certificates;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.security.KeyException;
 import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Ascii;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
@@ -41,6 +50,13 @@ import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
  */
 @UnstableApi
 public final class TlsKeyPair {
+
+    private static final Logger logger = LoggerFactory.getLogger(TlsKeyPair.class);
+
+    // A fixed payload signed with the private key and verified with the leaf certificate's public key to
+    // confirm the two form a matching key pair.
+    private static final byte[] VALIDATION_PROBE =
+            "Armeria TlsKeyPair validation probe".getBytes(StandardCharsets.UTF_8);
 
     /**
      * Creates a new {@link TlsKeyPair} from the specified key {@link InputStream}, and certificate chain
@@ -131,8 +147,123 @@ public final class TlsKeyPair {
     private final List<X509Certificate> certificateChain;
 
     private TlsKeyPair(PrivateKey privateKey, List<X509Certificate> certificateChain) {
+        checkArgument(!certificateChain.isEmpty(), "certificateChain is empty");
+        validateKeyPair(privateKey, certificateChain.get(0));
         this.privateKey = privateKey;
         this.certificateChain = certificateChain;
+    }
+
+    /**
+     * Ensures that the {@code privateKey} matches the public key of the leaf {@code certificate}, so that a
+     * mismatch is reported eagerly here.
+     */
+    private static void validateKeyPair(PrivateKey privateKey, X509Certificate certificate) {
+        final PublicKey publicKey = certificate.getPublicKey();
+
+        final String privateKeyAlgorithm = privateKey.getAlgorithm();
+        final String publicKeyAlgorithm = publicKey.getAlgorithm();
+        if (privateKeyAlgorithm == null || publicKeyAlgorithm == null) {
+            // A provider that does not expose the key algorithm; skip validation rather than fail so that
+            // a key we simply cannot introspect is not rejected.
+            logger.debug("Skipping key pair validation because a key algorithm is unavailable " +
+                         "(privateKey={}, publicKey={}).", privateKeyAlgorithm, publicKeyAlgorithm);
+            return;
+        }
+
+        // A private and public key of different algorithm families can never form a valid key pair.
+        final String privateKeyFamily = keyFamily(privateKeyAlgorithm);
+        final String publicKeyFamily = keyFamily(publicKeyAlgorithm);
+        checkArgument(keyFamiliesMatch(privateKeyFamily, publicKeyFamily),
+                      "The private key algorithm (%s) does not match the leaf certificate's public key " +
+                      "algorithm (%s).", privateKeyAlgorithm, publicKeyAlgorithm);
+
+        final String signatureAlgorithm = signatureAlgorithm(privateKeyAlgorithm);
+        if (signatureAlgorithm == null) {
+            logger.debug("Skipping key pair validation for an unsupported key algorithm: {}",
+                         privateKeyAlgorithm);
+            return;
+        }
+
+        final boolean matches;
+        try {
+            final Signature signature = Signature.getInstance(signatureAlgorithm);
+            signature.initSign(privateKey);
+            signature.update(VALIDATION_PROBE);
+            final byte[] signed = signature.sign();
+            signature.initVerify(publicKey);
+            signature.update(VALIDATION_PROBE);
+            matches = signature.verify(signed);
+        } catch (GeneralSecurityException e) {
+            logger.debug("Skipping key pair validation because the probe signature could not be computed " +
+                         "with {}.", signatureAlgorithm, e);
+            return;
+        }
+
+        checkArgument(matches, "The private key does not match the public key of the leaf certificate. " +
+                               "Make sure the private key and the certificate belong to the same key pair.");
+    }
+
+    /**
+     * Returns the algorithm family of the specified key algorithm, used to compare a private key against a
+     * public key. Aliases that denote the same family (e.g. {@code "EC"} and {@code "ECDSA"}, or
+     * {@code "RSA"} and {@code "RSASSA-PSS"}) are normalized to a single name. The EdDSA curve names
+     * ({@code "Ed25519"}, {@code "Ed448"}) and the generic {@code "EdDSA"} are intentionally left distinct
+     * so that {@link #keyFamiliesMatch(String, String)} can accept a generic key against a specific curve
+     * while still rejecting two different curves.
+     */
+    private static String keyFamily(String keyAlgorithm) {
+        final String upperCased = Ascii.toUpperCase(keyAlgorithm);
+        switch (upperCased) {
+            case "ECDSA":
+                return "EC";
+            case "RSASSA-PSS":
+                return "RSA";
+            default:
+                return upperCased;
+        }
+    }
+
+    /**
+     * Returns whether the two key algorithm families can form a key pair. Identical families always match.
+     * The generic EdDSA family ({@code "EDDSA"}) is treated as compatible with a specific curve
+     * ({@code "ED25519"} or {@code "ED448"}), because different providers may report the same EdDSA key
+     * either by its generic name or by its curve name. Two different specific curves never match.
+     */
+    private static boolean keyFamiliesMatch(String privateKeyFamily, String publicKeyFamily) {
+        if (privateKeyFamily.equals(publicKeyFamily)) {
+            return true;
+        }
+        return ("EDDSA".equals(privateKeyFamily) && isEdDsaCurve(publicKeyFamily)) ||
+               ("EDDSA".equals(publicKeyFamily) && isEdDsaCurve(privateKeyFamily));
+    }
+
+    private static boolean isEdDsaCurve(String keyFamily) {
+        return "ED25519".equals(keyFamily) || "ED448".equals(keyFamily);
+    }
+
+    /**
+     * Returns the signature algorithm to probe the specified key algorithm with, or {@code null} if the
+     * algorithm is not recognized.
+     */
+    @Nullable
+    private static String signatureAlgorithm(String keyAlgorithm) {
+        switch (Ascii.toUpperCase(keyAlgorithm)) {
+            case "RSA":
+                return "SHA256withRSA";
+            case "EC":
+            case "ECDSA":
+                return "SHA256withECDSA";
+            case "DSA":
+                return "SHA256withDSA";
+            case "ED25519":
+                return "Ed25519";
+            case "ED448":
+                return "Ed448";
+            case "EDDSA":
+                return "EdDSA";
+            default:
+                return null;
+        }
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/TlsKeyPair.java
+++ b/core/src/main/java/com/linecorp/armeria/common/TlsKeyPair.java
@@ -249,6 +249,10 @@ public final class TlsKeyPair {
     private static String signatureAlgorithm(String keyAlgorithm) {
         switch (Ascii.toUpperCase(keyAlgorithm)) {
             case "RSA":
+            case "RSASSA-PSS":
+                // RSASSA-PSS keys share the same underlying RSA key material as plain RSA keys, and the JDK
+                // accepts them for PKCS#1 v1.5 signing, so a plain RSA probe validates every RSA/RSASSA-PSS
+                // combination without requiring PSS parameters.
                 return "SHA256withRSA";
             case "EC":
             case "ECDSA":

--- a/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.util.SelfSignedCertificate;
+
+class TlsKeyPairTest {
+
+    @Test
+    void selfSignedIsAValidPair() throws CertificateException {
+        final SelfSignedCertificate ssc = new SelfSignedCertificate("foo.com", "RSA", 2048);
+        final TlsKeyPair keyPair = TlsKeyPair.of(ssc.key(), ssc.cert());
+        assertThat(keyPair.privateKey()).isEqualTo(ssc.key());
+        assertThat(keyPair.certificateChain()).containsExactly(ssc.cert());
+    }
+
+    @Test
+    void ofSelfSignedIsAValidPair() {
+        assertThat(TlsKeyPair.ofSelfSigned().privateKey()).isNotNull();
+    }
+
+    @Test
+    void ecIsAValidPair() throws CertificateException {
+        final SelfSignedCertificate ssc = new SelfSignedCertificate("foo.com", "EC", 256);
+        final TlsKeyPair keyPair = TlsKeyPair.of(ssc.key(), ssc.cert());
+        assertThat(keyPair.certificateChain()).containsExactly(ssc.cert());
+    }
+
+    @Test
+    void mismatchedKeyOfSameAlgorithmIsRejected() throws CertificateException {
+        final SelfSignedCertificate a = new SelfSignedCertificate("foo.com", "RSA", 2048);
+        final SelfSignedCertificate b = new SelfSignedCertificate("foo.com", "RSA", 2048);
+        assertThatThrownBy(() -> TlsKeyPair.of(a.key(), b.cert()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("private key does not match");
+    }
+
+    @Test
+    void mismatchedEcKeyIsRejected() throws CertificateException {
+        final SelfSignedCertificate a = new SelfSignedCertificate("foo.com", "EC", 256);
+        final SelfSignedCertificate b = new SelfSignedCertificate("foo.com", "EC", 256);
+        assertThatThrownBy(() -> TlsKeyPair.of(a.key(), b.cert()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("private key does not match");
+    }
+
+    @Test
+    void mismatchedKeyAlgorithmIsRejected() throws CertificateException {
+        final SelfSignedCertificate rsa = new SelfSignedCertificate("foo.com", "RSA", 2048);
+        final SelfSignedCertificate ec = new SelfSignedCertificate("foo.com", "EC", 256);
+        assertThatThrownBy(() -> TlsKeyPair.of(rsa.key(), ec.cert()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the leaf certificate's public key algorithm");
+    }
+
+    @Test
+    void emptyCertificateChainIsRejected() throws CertificateException {
+        final SelfSignedCertificate ssc = new SelfSignedCertificate("foo.com", "RSA", 2048);
+        assertThatThrownBy(() -> TlsKeyPair.of(ssc.key()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("certificateChain is empty");
+    }
+
+    @Test
+    void rsaPssKeyIsAcceptedAgainstRsaCertificate() {
+        // A private key reported as RSASSA-PSS belongs to the same family as an RSA certificate's public
+        // key, so it must not be rejected as an algorithm-family mismatch.
+        final TlsKeyPair keyPair = TlsKeyPair.of(privateKeyWithAlgorithm("RSASSA-PSS"),
+                                                 certificateWithPublicKeyAlgorithm("RSA"));
+        assertThat(keyPair.privateKey().getAlgorithm()).isEqualTo("RSASSA-PSS");
+    }
+
+    @Test
+    void validationIsSkippedWhenKeyAlgorithmIsUnavailable() {
+        // A provider that returns null from getAlgorithm() must not trip an NPE during validation.
+        final TlsKeyPair keyPair = TlsKeyPair.of(privateKeyWithAlgorithm(null),
+                                                 certificateWithPublicKeyAlgorithm("RSA"));
+        assertThat(keyPair.privateKey().getAlgorithm()).isNull();
+    }
+
+    @Test
+    void differentEdDsaCurvesAreRejected() {
+        // Ed25519 and Ed448 are distinct curves that can never form a key pair, so a specific-curve
+        // mismatch must be rejected rather than silently skipped.
+        assertThatThrownBy(() -> TlsKeyPair.of(privateKeyWithAlgorithm("Ed25519"),
+                                               certificateWithPublicKeyAlgorithm("Ed448")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match the leaf certificate's public key algorithm");
+    }
+
+    @Test
+    void genericEdDsaMatchesSpecificCurve() {
+        // A generic "EdDSA" key must be treated as the same family as a specific curve, so this must not be
+        // rejected as a family mismatch. The signature probe cannot complete with a mock key, so validation
+        // is skipped and construction succeeds without throwing the family-mismatch error.
+        final TlsKeyPair keyPair = TlsKeyPair.of(privateKeyWithAlgorithm("EdDSA"),
+                                                 certificateWithPublicKeyAlgorithm("Ed25519"));
+        assertThat(keyPair.certificateChain()).hasSize(1);
+    }
+
+    private static PrivateKey privateKeyWithAlgorithm(@Nullable String algorithm) {
+        final PrivateKey key = mock(PrivateKey.class);
+        when(key.getAlgorithm()).thenReturn(algorithm);
+        return key;
+    }
+
+    private static X509Certificate certificateWithPublicKeyAlgorithm(@Nullable String algorithm) {
+        final PublicKey publicKey = mock(PublicKey.class);
+        when(publicKey.getAlgorithm()).thenReturn(algorithm);
+        final X509Certificate certificate = mock(X509Certificate.class);
+        when(certificate.getPublicKey()).thenReturn(publicKey);
+        return certificate;
+    }
+}

--- a/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
@@ -21,26 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
-import java.security.Provider;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.security.spec.MGF1ParameterSpec;
-import java.security.spec.PSSParameterSpec;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -105,14 +92,14 @@ class TlsKeyPairTest {
 
     @Test
     void rsaPssKeyPairIsAccepted() throws Exception {
-        // An RSASSA-PSS key and its matching certificate share the same underlying RSA key material, so the
-        // probe must accept them instead of silently skipping validation for an "unsupported" algorithm.
+        // A real RSASSA-PSS key pair must be accepted by the probe instead of having validation silently
+        // skipped as if the algorithm were unsupported.
         final KeyPair keyPair = newRsaPssKeyPair();
-        final X509Certificate certificate = newRsaPssCertificate(keyPair);
-        assertThat(certificate.getPublicKey().getAlgorithm()).isEqualTo("RSASSA-PSS");
+        assertThat(keyPair.getPublic().getAlgorithm()).isEqualTo("RSASSA-PSS");
 
-        final TlsKeyPair keyPairResult = TlsKeyPair.of(keyPair.getPrivate(), certificate);
-        assertThat(keyPairResult.certificateChain()).containsExactly(certificate);
+        final TlsKeyPair tlsKeyPair = TlsKeyPair.of(keyPair.getPrivate(),
+                                                    certificateWithPublicKey(keyPair.getPublic()));
+        assertThat(tlsKeyPair.privateKey()).isEqualTo(keyPair.getPrivate());
     }
 
     @Test
@@ -121,8 +108,7 @@ class TlsKeyPairTest {
         // RSASSA-PSS was left out of the recognized signature algorithms.
         final KeyPair a = newRsaPssKeyPair();
         final KeyPair b = newRsaPssKeyPair();
-        final X509Certificate certificateB = newRsaPssCertificate(b);
-        assertThatThrownBy(() -> TlsKeyPair.of(a.getPrivate(), certificateB))
+        assertThatThrownBy(() -> TlsKeyPair.of(a.getPrivate(), certificateWithPublicKey(b.getPublic())))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("private key does not match");
     }
@@ -170,23 +156,12 @@ class TlsKeyPairTest {
         return generator.generateKeyPair();
     }
 
-    private static X509Certificate newRsaPssCertificate(KeyPair keyPair) throws Exception {
-        final X500Name name = new X500Name("CN=rsapss.test");
-        final Instant now = Instant.now();
-        final PSSParameterSpec pssSpec =
-                new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-        // BouncyCastle is required to resolve the RSASSA-PSS signature; pass the provider explicitly rather
-        // than registering it globally to avoid affecting other tests.
-        final Provider bouncyCastle = new BouncyCastleProvider();
-        final ContentSigner signer =
-                new JcaContentSignerBuilder("RSASSA-PSS", pssSpec)
-                        .setProvider(bouncyCastle)
-                        .build(keyPair.getPrivate());
-        final JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
-                name, BigInteger.ONE,
-                Date.from(now.minus(1, ChronoUnit.DAYS)), Date.from(now.plus(1, ChronoUnit.DAYS)),
-                name, keyPair.getPublic());
-        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    private static X509Certificate certificateWithPublicKey(PublicKey publicKey) {
+        // validateKeyPair() only reads the leaf certificate's public key, so a stub that returns the real
+        // key is enough to exercise the probe without minting an actual certificate.
+        final X509Certificate certificate = mock(X509Certificate.class);
+        when(certificate.getPublicKey()).thenReturn(publicKey);
+        return certificate;
     }
 
     private static PrivateKey privateKeyWithAlgorithm(@Nullable String algorithm) {

--- a/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/TlsKeyPairTest.java
@@ -21,11 +21,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.annotation.Nullable;
@@ -89,6 +104,30 @@ class TlsKeyPairTest {
     }
 
     @Test
+    void rsaPssKeyPairIsAccepted() throws Exception {
+        // An RSASSA-PSS key and its matching certificate share the same underlying RSA key material, so the
+        // probe must accept them instead of silently skipping validation for an "unsupported" algorithm.
+        final KeyPair keyPair = newRsaPssKeyPair();
+        final X509Certificate certificate = newRsaPssCertificate(keyPair);
+        assertThat(certificate.getPublicKey().getAlgorithm()).isEqualTo("RSASSA-PSS");
+
+        final TlsKeyPair keyPairResult = TlsKeyPair.of(keyPair.getPrivate(), certificate);
+        assertThat(keyPairResult.certificateChain()).containsExactly(certificate);
+    }
+
+    @Test
+    void mismatchedRsaPssKeyIsRejected() throws Exception {
+        // A mismatched RSASSA-PSS pair must be rejected by the probe rather than passing construction because
+        // RSASSA-PSS was left out of the recognized signature algorithms.
+        final KeyPair a = newRsaPssKeyPair();
+        final KeyPair b = newRsaPssKeyPair();
+        final X509Certificate certificateB = newRsaPssCertificate(b);
+        assertThatThrownBy(() -> TlsKeyPair.of(a.getPrivate(), certificateB))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("private key does not match");
+    }
+
+    @Test
     void rsaPssKeyIsAcceptedAgainstRsaCertificate() {
         // A private key reported as RSASSA-PSS belongs to the same family as an RSA certificate's public
         // key, so it must not be rejected as an algorithm-family mismatch.
@@ -123,6 +162,31 @@ class TlsKeyPairTest {
         final TlsKeyPair keyPair = TlsKeyPair.of(privateKeyWithAlgorithm("EdDSA"),
                                                  certificateWithPublicKeyAlgorithm("Ed25519"));
         assertThat(keyPair.certificateChain()).hasSize(1);
+    }
+
+    private static KeyPair newRsaPssKeyPair() throws Exception {
+        final KeyPairGenerator generator = KeyPairGenerator.getInstance("RSASSA-PSS");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static X509Certificate newRsaPssCertificate(KeyPair keyPair) throws Exception {
+        final X500Name name = new X500Name("CN=rsapss.test");
+        final Instant now = Instant.now();
+        final PSSParameterSpec pssSpec =
+                new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+        // BouncyCastle is required to resolve the RSASSA-PSS signature; pass the provider explicitly rather
+        // than registering it globally to avoid affecting other tests.
+        final Provider bouncyCastle = new BouncyCastleProvider();
+        final ContentSigner signer =
+                new JcaContentSignerBuilder("RSASSA-PSS", pssSpec)
+                        .setProvider(bouncyCastle)
+                        .build(keyPair.getPrivate());
+        final JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                name, BigInteger.ONE,
+                Date.from(now.minus(1, ChronoUnit.DAYS)), Date.from(now.plus(1, ChronoUnit.DAYS)),
+                name, keyPair.getPublic());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
     }
 
     private static PrivateKey privateKeyWithAlgorithm(@Nullable String algorithm) {


### PR DESCRIPTION
Motivation:

When a private key does not correspond to the leaf certificate's public key, the mismatch is not detected at construction time.

Modifications:

- Validate the key pair in the `TlsKeyPair` private constructor.

Result:

- A mismatched private key and certificate now fail fast.