### PR TITLE
Fix NPE in Http1ObjectEncoder.doWriteReset() when pendingWritesMap is sparse

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1ObjectEncoder.java
@@ -356,6 +356,10 @@ public abstract class Http1ObjectEncoder implements HttpObjectEncoder {
                     new ClosedSessionException("An HTTP/1 connection has been reset: " + error);
             for (int i = minClosedId; i <= maxIdWithPendingWrites; i++) {
                 final PendingWrites pendingWrites = pendingWritesMap.remove(i);
+                if (pendingWrites == null) {
+                    // pendingWritesMap is sparse — not every ID in the range has an entry.
+                    continue;
+                }
                 for (;;) {
                     final Entry<HttpObject, ChannelPromise> e = pendingWrites.poll();
                     if (e == null) {

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -133,4 +133,57 @@ class Http1PipelineTest {
               .hasCauseInstanceOf(ClosedSessionException.class);
         }
     }
+
+    /**
+     * Regression test for the NPE in {@code Http1ObjectEncoder.doWriteReset()}.
+     *
+     * <p>{@code doWriteReset()} iterates over a contiguous range of request IDs
+     * ({@code minClosedId..maxIdWithPendingWrites}) to fail pending writes when a reset occurs.
+     * However, {@code pendingWritesMap} is <em>sparse</em> — only IDs that actually had out-of-order
+     * writes queued are stored. Previously, iterating over a gap ID returned {@code null} from the map,
+     * and calling {@code .poll()} on it caused a {@link NullPointerException}.
+     */
+    @Test
+    void resetShouldNotNpeWhenPendingWritesMapIsSparse() {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .useHttp1Pipelining(true)
+                                                  .build()) {
+            final WebClient client = WebClient.builder(server.uri(SessionProtocol.H1C))
+                                              .factory(factory)
+                                              .build();
+
+            // Pipeline 3 requests on the same connection:
+            //   id=1  /slow          – held open, forcing later responses to queue in pendingWritesMap
+            //   id=2  /length-limit  – violates the request size limit, triggering a connection reset
+            // The gap between the IDs that do and do not have pending-write entries is what previously
+            // caused the NPE.
+            final CompletableFuture<ResponseEntity<String>> slow =
+                    RestClient.of(client).get("/slow").execute(ResponseAs.string());
+
+            final StreamWriter<HttpData> stream = StreamMessage.streaming();
+            final HttpResponse limitResponse =
+                    client.prepare()
+                          .post("/length-limit")
+                          .content(MediaType.PLAIN_TEXT, stream)
+                          .execute();
+            final SplitHttpResponse splitLimit = limitResponse.split();
+
+            // Wait until the server has sent the initial 200 OK headers for /length-limit.
+            assertThat(splitLimit.headers().join().status()).isEqualTo(HttpStatus.OK);
+
+            // Exceed the request size limit → ContentTooLargeException → doWriteReset().
+            stream.write(HttpData.ofUtf8(Strings.repeat("x", 101)));
+            stream.close();
+
+            // The body of the length-limit response must fail with ClosedSessionException,
+            // NOT a NullPointerException from the sparse-map iteration in doWriteReset().
+            assertThatThrownBy(() -> splitLimit.body().collect().join())
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(ClosedSessionException.class);
+
+            // The slow request must also terminate cleanly (connection was closed).
+            assertThatThrownBy(slow::join)
+                    .isInstanceOf(CompletionException.class);
+        }
+    }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -20,14 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -50,11 +49,16 @@ import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.SplitHttpResponse;
+import com.linecorp.armeria.common.logging.RequestLog;
+import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.stream.StreamWriter;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.testing.server.ServiceRequestContextCaptor;
 
 class Http1PipelineTest {
+
+    private static final CompletableFuture<Void> emptyResponseTrigger = new CompletableFuture<>();
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -82,19 +86,14 @@ class Http1PipelineTest {
                   return writer;
               });
 
-            // A service that never writes any response headers — used in the sparse-map
-            // regression test so that doWriteReset() is called for an ID that has no
-            // entry in pendingWritesMap, creating a gap in the iteration range.
-            sb.route()
-              .path("/never-respond")
-              .requestTimeoutMillis(0)
-              .build((ctx, req) -> {
-                  // Return a future that resolves only when the request context is cancelled.
-                  // The connection reset from another pipelined request will cancel this context.
-                  final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
-                  ctx.whenRequestCancelling().thenRun(() -> f.cancel(true));
-                  return HttpResponse.of(f);
-              });
+            // A service that completes its response stream without writing any response headers when
+            // 'emptyResponseTrigger' is completed, so that the stream is reset via 'writeReset()'
+            // while 'pendingWritesMap' has no entry for its request ID.
+            sb.service("/empty", (ctx, req) -> {
+                final HttpResponseWriter writer = HttpResponse.streaming();
+                emptyResponseTrigger.thenRunAsync(writer::close, ctx.eventLoop());
+                return writer;
+            });
         }
     };
 
@@ -155,73 +154,58 @@ class Http1PipelineTest {
     }
 
     /**
-     * Regression test for the NPE in {@link com.linecorp.armeria.internal.common.Http1ObjectEncoder}
-     * {@code doWriteReset()} when {@code pendingWritesMap} is sparse.
+     * Regression test for the {@link NullPointerException} that was thrown by
+     * {@code Http1ObjectEncoder.doWriteReset()} when {@code pendingWritesMap} is sparse.
      *
-     * <p>{@code doWriteReset()} iterates IDs {@code [minClosedId, maxIdWithPendingWrites]} to fail
-     * pending writes. The map is <em>sparse</em>: only out-of-order request IDs that went through
-     * the encoder's {@code write()} path have entries. Iterating a gap ID (one that never wrote
-     * anything before the reset) returned {@code null}, and the subsequent {@code .poll()} call
-     * threw a {@link NullPointerException}.
-     *
-     * <p>Scenario (3 pipelined requests on one connection):
+     * <p>{@code doWriteReset()} iterates over the IDs in {@code [minClosedId, maxIdWithPendingWrites]}
+     * to fail the pending writes, but the map contains entries only for the IDs whose responses were
+     * queued out of order. The following scenario makes the range contain an ID without an entry:
      * <ol>
-     *   <li>id=1 {@code /slow}         – holds the write-turn, so ids 2 and 3 queue in pendingWritesMap</li>
-     *   <li>id=2 {@code /never-respond} – handler never writes a response header → <strong>no entry</strong>
-     *                                    in pendingWritesMap at id=2; connection reset eventually closes it</li>
-     *   <li>id=3 {@code /length-limit}  – writes 200 OK → pendingWritesMap[3]; overflow triggers
-     *                                    doWriteReset(3); after connection reset minClosedId becomes 2
-     *                                    (because the cancel from /never-respond propagates), so the
-     *                                    iteration range [2, 3] includes the gap at id=2</li>
+     *   <li>id=1 {@code /slow} - holds the write turn so that the other responses are queued.</li>
+     *   <li>id=2 {@code /empty} - completes its response stream without writing any headers, which
+     *       resets the stream via {@code writeReset(2)} while {@code pendingWritesMap} has no entry
+     *       for id=2.</li>
+     *   <li>id=3 {@code /fast} - responds immediately so that its response is queued at id=3.</li>
      * </ol>
+     * {@code doWriteReset(2)} then iterates over {@code [2, 3]} and must skip id=2.
      */
     @Test
-    void resetDoesNotNpeWhenPendingWritesMapIsSparse() throws IOException {
-        // Use a raw socket so all three requests are sent in a single burst before the server
-        // can respond to any of them. This ensures they all get distinct pipelined IDs on the
-        // same connection and that id=1 (/slow) holds the write-turn while ids 2 and 3 queue.
+    void resetShouldNotThrowNpeWhenPendingWritesMapIsSparse() throws Exception {
+        // Use a raw socket to pipeline the three requests on a single connection in a single burst.
         try (Socket socket = new Socket()) {
             socket.connect(server.httpSocketAddress());
             socket.setSoTimeout(10_000);
 
             final PrintWriter out = new PrintWriter(socket.getOutputStream(), false);
-
-            // id=1: /slow — 3-second delay; keeps currentId=1 so all later responses queue
-            out.print("GET /slow HTTP/1.1\r\n");
-            out.print("Host: 127.0.0.1\r\n");
-            out.print("\r\n");
-
-            // id=2: /never-respond — handler never writes headers → no pendingWritesMap entry at id=2
-            out.print("GET /never-respond HTTP/1.1\r\n");
-            out.print("Host: 127.0.0.1\r\n");
-            out.print("\r\n");
-
-            // id=3: /length-limit — writes 200 OK (queued at id=3) then overflows → doWriteReset(3)
-            //        After the connection reset, the cancel propagates to /never-respond which means
-            //        minClosedId is updated to cover id=2 as well, producing the gap [2, 3].
-            final String overBody = Strings.repeat("x", 101);
-            out.print("POST /length-limit HTTP/1.1\r\n");
-            out.print("Host: 127.0.0.1\r\n");
-            out.print("Content-Type: text/plain\r\n");
-            out.print("Content-Length: " + overBody.length() + "\r\n");
-            out.print("\r\n");
-            out.print(overBody);
+            out.print("GET /slow HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+            out.print("GET /empty HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+            out.print("GET /fast HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
             out.flush();
 
-            // Read until the connection is closed by the server.
-            // We only assert that we get *some* valid response (200 OK for /slow) and that
-            // the connection then closes cleanly — i.e. no NullPointerException causes the
-            // server to crash before sending any bytes.
-            final InputStream is = socket.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-            final StringBuilder received = new StringBuilder();
-            String line;
-            while ((line = reader.readLine()) != null) {
-                received.append(line).append('\n');
-            }
-            // At minimum we should receive the HTTP/1.1 status line for /slow
-            // confirming the server did not crash (NPE) before writing anything.
-            assertThat(received.toString()).contains("HTTP/1.1");
+            final ServiceRequestContextCaptor captor = server.requestContextCaptor();
+            final ServiceRequestContext slowCtx = captor.take();
+            final ServiceRequestContext emptyCtx = captor.take();
+            final ServiceRequestContext fastCtx = captor.take();
+            assertThat(slowCtx.path()).isEqualTo("/slow");
+            assertThat(emptyCtx.path()).isEqualTo("/empty");
+            assertThat(fastCtx.path()).isEqualTo("/fast");
+
+            // Wait until the '/fast' response is queued in 'pendingWritesMap' and then let '/empty'
+            // complete its response stream without headers, which triggers 'doWriteReset(2)'.
+            fastCtx.log().whenAvailable(RequestLogProperty.RESPONSE_HEADERS).get(10, TimeUnit.SECONDS);
+            emptyResponseTrigger.complete(null);
+
+            // The reset must fail the queued '/fast' response with a ClosedSessionException.
+            // Before the fix, the NPE aborted the iteration so that the queued response was
+            // never failed and this log never completed.
+            final RequestLog fastLog = fastCtx.log().whenComplete().get(10, TimeUnit.SECONDS);
+            assertThat(fastLog.responseCause()).isInstanceOf(ClosedSessionException.class);
+
+            // The failed write closes the connection cleanly because the queued responses cannot
+            // be written to an HTTP/1 connection anymore.
+            final BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            assertThat(reader.readLine()).isNull();
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/Http1PipelineTest.java
@@ -19,6 +19,12 @@ package com.linecorp.armeria.server;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -74,6 +80,20 @@ class Http1PipelineTest {
                       writer.close();
                   });
                   return writer;
+              });
+
+            // A service that never writes any response headers — used in the sparse-map
+            // regression test so that doWriteReset() is called for an ID that has no
+            // entry in pendingWritesMap, creating a gap in the iteration range.
+            sb.route()
+              .path("/never-respond")
+              .requestTimeoutMillis(0)
+              .build((ctx, req) -> {
+                  // Return a future that resolves only when the request context is cancelled.
+                  // The connection reset from another pipelined request will cancel this context.
+                  final CompletableFuture<HttpResponse> f = new CompletableFuture<>();
+                  ctx.whenRequestCancelling().thenRun(() -> f.cancel(true));
+                  return HttpResponse.of(f);
               });
         }
     };
@@ -135,55 +155,73 @@ class Http1PipelineTest {
     }
 
     /**
-     * Regression test for the NPE in {@code Http1ObjectEncoder.doWriteReset()}.
+     * Regression test for the NPE in {@link com.linecorp.armeria.internal.common.Http1ObjectEncoder}
+     * {@code doWriteReset()} when {@code pendingWritesMap} is sparse.
      *
-     * <p>{@code doWriteReset()} iterates over a contiguous range of request IDs
-     * ({@code minClosedId..maxIdWithPendingWrites}) to fail pending writes when a reset occurs.
-     * However, {@code pendingWritesMap} is <em>sparse</em> — only IDs that actually had out-of-order
-     * writes queued are stored. Previously, iterating over a gap ID returned {@code null} from the map,
-     * and calling {@code .poll()} on it caused a {@link NullPointerException}.
+     * <p>{@code doWriteReset()} iterates IDs {@code [minClosedId, maxIdWithPendingWrites]} to fail
+     * pending writes. The map is <em>sparse</em>: only out-of-order request IDs that went through
+     * the encoder's {@code write()} path have entries. Iterating a gap ID (one that never wrote
+     * anything before the reset) returned {@code null}, and the subsequent {@code .poll()} call
+     * threw a {@link NullPointerException}.
+     *
+     * <p>Scenario (3 pipelined requests on one connection):
+     * <ol>
+     *   <li>id=1 {@code /slow}         – holds the write-turn, so ids 2 and 3 queue in pendingWritesMap</li>
+     *   <li>id=2 {@code /never-respond} – handler never writes a response header → <strong>no entry</strong>
+     *                                    in pendingWritesMap at id=2; connection reset eventually closes it</li>
+     *   <li>id=3 {@code /length-limit}  – writes 200 OK → pendingWritesMap[3]; overflow triggers
+     *                                    doWriteReset(3); after connection reset minClosedId becomes 2
+     *                                    (because the cancel from /never-respond propagates), so the
+     *                                    iteration range [2, 3] includes the gap at id=2</li>
+     * </ol>
      */
     @Test
-    void resetShouldNotNpeWhenPendingWritesMapIsSparse() {
-        try (ClientFactory factory = ClientFactory.builder()
-                                                  .useHttp1Pipelining(true)
-                                                  .build()) {
-            final WebClient client = WebClient.builder(server.uri(SessionProtocol.H1C))
-                                              .factory(factory)
-                                              .build();
+    void resetDoesNotNpeWhenPendingWritesMapIsSparse() throws IOException {
+        // Use a raw socket so all three requests are sent in a single burst before the server
+        // can respond to any of them. This ensures they all get distinct pipelined IDs on the
+        // same connection and that id=1 (/slow) holds the write-turn while ids 2 and 3 queue.
+        try (Socket socket = new Socket()) {
+            socket.connect(server.httpSocketAddress());
+            socket.setSoTimeout(10_000);
 
-            // Pipeline 3 requests on the same connection:
-            //   id=1  /slow          – held open, forcing later responses to queue in pendingWritesMap
-            //   id=2  /length-limit  – violates the request size limit, triggering a connection reset
-            // The gap between the IDs that do and do not have pending-write entries is what previously
-            // caused the NPE.
-            final CompletableFuture<ResponseEntity<String>> slow =
-                    RestClient.of(client).get("/slow").execute(ResponseAs.string());
+            final PrintWriter out = new PrintWriter(socket.getOutputStream(), false);
 
-            final StreamWriter<HttpData> stream = StreamMessage.streaming();
-            final HttpResponse limitResponse =
-                    client.prepare()
-                          .post("/length-limit")
-                          .content(MediaType.PLAIN_TEXT, stream)
-                          .execute();
-            final SplitHttpResponse splitLimit = limitResponse.split();
+            // id=1: /slow — 3-second delay; keeps currentId=1 so all later responses queue
+            out.print("GET /slow HTTP/1.1\r\n");
+            out.print("Host: 127.0.0.1\r\n");
+            out.print("\r\n");
 
-            // Wait until the server has sent the initial 200 OK headers for /length-limit.
-            assertThat(splitLimit.headers().join().status()).isEqualTo(HttpStatus.OK);
+            // id=2: /never-respond — handler never writes headers → no pendingWritesMap entry at id=2
+            out.print("GET /never-respond HTTP/1.1\r\n");
+            out.print("Host: 127.0.0.1\r\n");
+            out.print("\r\n");
 
-            // Exceed the request size limit → ContentTooLargeException → doWriteReset().
-            stream.write(HttpData.ofUtf8(Strings.repeat("x", 101)));
-            stream.close();
+            // id=3: /length-limit — writes 200 OK (queued at id=3) then overflows → doWriteReset(3)
+            //        After the connection reset, the cancel propagates to /never-respond which means
+            //        minClosedId is updated to cover id=2 as well, producing the gap [2, 3].
+            final String overBody = Strings.repeat("x", 101);
+            out.print("POST /length-limit HTTP/1.1\r\n");
+            out.print("Host: 127.0.0.1\r\n");
+            out.print("Content-Type: text/plain\r\n");
+            out.print("Content-Length: " + overBody.length() + "\r\n");
+            out.print("\r\n");
+            out.print(overBody);
+            out.flush();
 
-            // The body of the length-limit response must fail with ClosedSessionException,
-            // NOT a NullPointerException from the sparse-map iteration in doWriteReset().
-            assertThatThrownBy(() -> splitLimit.body().collect().join())
-                    .isInstanceOf(CompletionException.class)
-                    .hasCauseInstanceOf(ClosedSessionException.class);
-
-            // The slow request must also terminate cleanly (connection was closed).
-            assertThatThrownBy(slow::join)
-                    .isInstanceOf(CompletionException.class);
+            // Read until the connection is closed by the server.
+            // We only assert that we get *some* valid response (200 OK for /slow) and that
+            // the connection then closes cleanly — i.e. no NullPointerException causes the
+            // server to crash before sending any bytes.
+            final InputStream is = socket.getInputStream();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            final StringBuilder received = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                received.append(line).append('\n');
+            }
+            // At minimum we should receive the HTTP/1.1 status line for /slow
+            // confirming the server did not crash (NPE) before writing anything.
+            assertThat(received.toString()).contains("HTTP/1.1");
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerHttp1ObjectEncoderTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.armeria.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,11 +30,20 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.common.ClosedSessionException;
+import com.linecorp.armeria.common.Http1HeaderNaming;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.internal.common.NoopKeepAliveHandler;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http2.Http2Error;
 
 class ServerHttp1ObjectEncoderTest {
 
@@ -68,6 +78,30 @@ class ServerHttp1ObjectEncoderTest {
                 }
                 assertThat(line.toLowerCase()).doesNotContain(transferEncoding);
             }
+        }
+    }
+
+    @Test
+    void resetShouldSkipIdsWithoutPendingWrites() {
+        final EmbeddedChannel ch = new EmbeddedChannel();
+        try {
+            final ServerHttp1ObjectEncoder encoder = new ServerHttp1ObjectEncoder(
+                    ch, SessionProtocol.H1C, new NoopKeepAliveHandler(), Http1HeaderNaming.ofDefault());
+
+            // The request whose ID is 1 did not respond yet, so the response whose ID is 4 is queued
+            // in pendingWritesMap. The IDs 2 and 3 have no entries in the map.
+            final ChannelFuture queued =
+                    encoder.writeHeaders(4, 1, ResponseHeaders.of(HttpStatus.OK), false, HttpMethod.GET);
+            assertThat(queued.isDone()).isFalse();
+
+            // Resetting the ID 2 iterates over the range [2, 4] which contains the IDs 2 and 3 that
+            // have no pending writes; they must be skipped instead of raising an NPE.
+            assertThatCode(() -> encoder.writeReset(2, 1, Http2Error.CANCEL)).doesNotThrowAnyException();
+
+            assertThat(queued.isDone()).isTrue();
+            assertThat(queued.cause()).isInstanceOf(ClosedSessionException.class);
+        } finally {
+            ch.finishAndReleaseAll();
         }
     }
 }


### PR DESCRIPTION
Motivation:

When an HTTP/1 connection is reset during pipelined request handling,
`Http1ObjectEncoder.doWriteReset()` iterates over a contiguous range of
request IDs `[minClosedId, maxIdWithPendingWrites]` to fail any pending
pipelined writes with a `ClosedSessionException`.

However, `pendingWritesMap` is **sparse** — it only contains entries for
request IDs whose response arrived out-of-order and needed to be queued
behind the currently-active request. IDs that had already been written (or
were never queued) have no entry in the map.

The loop called `pendingWritesMap.remove(i)` for every integer `i` in the
range, then immediately called `.poll()` on the result — even when `remove`
returned `null` for a gap ID — causing a `NullPointerException`.

Modifications:

- `Http1ObjectEncoder`: Added a `null` guard after `pendingWritesMap.remove(i)` in
  `doWriteReset()`. When a gap ID has no entry in the sparse map, the loop now
  `continue`s instead of dereferencing `null`.
- `Http1PipelineTest`: Added regression test `resetShouldNotNpeWhenPendingWritesMapIsSparse()`
  that pipelines a slow request and a size-limit-violating request on the same connection,
  triggers a reset, and verifies the result is a `ClosedSessionException` and not a
  `NullPointerException`.

Result:

- A `NullPointerException` that occurred during HTTP/1 connection reset when the pipelined
  `pendingWritesMap` had gaps in its request-ID range is now fixed.
- All pending pipelined responses in the range are correctly failed with `ClosedSessionException`.
