### PR TITLE
saml: Avoid NPE when LogoutRequest has no Issuer

### DIFF
--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -176,18 +176,27 @@ final class SamlSingleLogoutFunction implements SamlServiceFunction {
 
     private SamlIdentityProviderConfig validateAndGetIdPConfig(LogoutRequest logoutRequest,
                                                                String endpointUri) {
-        final Issuer issuerElement = logoutRequest.getIssuer();
-        final String issuer = issuerElement != null ? issuerElement.getValue() : null;
+        final Issuer issuerObject = logoutRequest.getIssuer();
+        if (issuerObject == null) {
+            throw new InvalidSamlRequestException(
+                    "no issuer found from the logout request: " + logoutRequest.getID());
+        }
+
+        final String issuer = issuerObject.getValue();
         if (issuer == null) {
-            throw new InvalidSamlRequestException("no issuer found from the logout request: " +
-                                                  logoutRequest.getID());
+            throw new InvalidSamlRequestException(
+                    "no issuer found from the logout request: " + logoutRequest.getID());
         }
+
         if (!endpointUri.equals(logoutRequest.getDestination())) {
-            throw new InvalidSamlRequestException("unexpected destination: " + logoutRequest.getDestination());
+            throw new InvalidSamlRequestException(
+                    "unexpected destination: " + logoutRequest.getDestination());
         }
+
         final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
         if (config == null) {
-            throw new InvalidSamlRequestException("unexpected identity provider: " + issuer);
+            throw new InvalidSamlRequestException(
+                    "unexpected identity provider: " + issuer);
         }
         return config;
     }

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -175,21 +175,31 @@ final class SamlSingleLogoutFunction implements SamlServiceFunction {
     }
 
     private SamlIdentityProviderConfig validateAndGetIdPConfig(LogoutRequest logoutRequest,
-                                                               String endpointUri) {
-        final String issuer = logoutRequest.getIssuer().getValue();
-        if (issuer == null) {
-            throw new InvalidSamlRequestException("no issuer found from the logout request: " +
-                                                  logoutRequest.getID());
-        }
-        if (!endpointUri.equals(logoutRequest.getDestination())) {
-            throw new InvalidSamlRequestException("unexpected destination: " + logoutRequest.getDestination());
-        }
-        final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
-        if (config == null) {
-            throw new InvalidSamlRequestException("unexpected identity provider: " + issuer);
-        }
-        return config;
+                                                           String endpointUri) {
+    final Issuer issuerObject = logoutRequest.getIssuer();
+    if (issuerObject == null) {
+        throw new InvalidSamlRequestException(
+                "no issuer found from the logout request: " + logoutRequest.getID());
     }
+
+    final String issuer = issuerObject.getValue();
+    if (issuer == null) {
+        throw new InvalidSamlRequestException(
+                "no issuer found from the logout request: " + logoutRequest.getID());
+    }
+
+    if (!endpointUri.equals(logoutRequest.getDestination())) {
+        throw new InvalidSamlRequestException(
+                "unexpected destination: " + logoutRequest.getDestination());
+    }
+
+    final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
+    if (config == null) {
+        throw new InvalidSamlRequestException(
+                "unexpected identity provider: " + issuer);
+    }
+    return config;
+}
 
     private LogoutResponse createLogoutResponse(LogoutRequest logoutRequest,
                                                 String statusCode) {

--- a/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
+++ b/saml/src/main/java/com/linecorp/armeria/server/saml/SamlSingleLogoutFunction.java
@@ -175,31 +175,22 @@ final class SamlSingleLogoutFunction implements SamlServiceFunction {
     }
 
     private SamlIdentityProviderConfig validateAndGetIdPConfig(LogoutRequest logoutRequest,
-                                                           String endpointUri) {
-    final Issuer issuerObject = logoutRequest.getIssuer();
-    if (issuerObject == null) {
-        throw new InvalidSamlRequestException(
-                "no issuer found from the logout request: " + logoutRequest.getID());
+                                                               String endpointUri) {
+        final Issuer issuerElement = logoutRequest.getIssuer();
+        final String issuer = issuerElement != null ? issuerElement.getValue() : null;
+        if (issuer == null) {
+            throw new InvalidSamlRequestException("no issuer found from the logout request: " +
+                                                  logoutRequest.getID());
+        }
+        if (!endpointUri.equals(logoutRequest.getDestination())) {
+            throw new InvalidSamlRequestException("unexpected destination: " + logoutRequest.getDestination());
+        }
+        final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
+        if (config == null) {
+            throw new InvalidSamlRequestException("unexpected identity provider: " + issuer);
+        }
+        return config;
     }
-
-    final String issuer = issuerObject.getValue();
-    if (issuer == null) {
-        throw new InvalidSamlRequestException(
-                "no issuer found from the logout request: " + logoutRequest.getID());
-    }
-
-    if (!endpointUri.equals(logoutRequest.getDestination())) {
-        throw new InvalidSamlRequestException(
-                "unexpected destination: " + logoutRequest.getDestination());
-    }
-
-    final SamlIdentityProviderConfig config = idpConfigs.get(issuer);
-    if (config == null) {
-        throw new InvalidSamlRequestException(
-                "unexpected identity provider: " + issuer);
-    }
-    return config;
-}
 
     private LogoutResponse createLogoutResponse(LogoutRequest logoutRequest,
                                                 String statusCode) {

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -587,8 +587,11 @@ class SamlServiceProviderTest {
 
         logoutRequest.setIssuer(null);
 
-        final AggregatedHttpResponse res = sendViaHttpPostBindingProtocol("/saml/slo/post", SAML_REQUEST,
-                                                                          logoutRequest, idpCredential);
+        final AggregatedHttpResponse res =
+                sendViaHttpPostBindingProtocol("/saml/slo/post",
+                                               SAML_REQUEST,
+                                               logoutRequest,
+                                               idpCredential);
 
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -580,6 +580,23 @@ class SamlServiceProviderTest {
     }
 
     @Test
+    void shouldNotConsumeLogoutRequestWithoutIssuer_HttpPost() throws Exception {
+    final LogoutRequest logoutRequest =
+            getLogoutRequest("http://" + spHostname + ':' + server.httpPort() + "/saml/slo/post",
+                             "http://idp.example.com/post");
+
+    logoutRequest.setIssuer(null);
+
+    final AggregatedHttpResponse res =
+            sendViaHttpPostBindingProtocol("/saml/slo/post",
+                                          SAML_REQUEST,
+                                          logoutRequest,
+                                          idpCredential);
+
+    assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     void shouldConsumeLogoutRequest_HttpRedirect() throws Exception {
         final LogoutRequest logoutRequest =
                 getLogoutRequest("http://" + spHostname + ':' + server.httpPort() + "/saml/slo/redirect",

--- a/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
+++ b/saml/src/test/java/com/linecorp/armeria/server/saml/SamlServiceProviderTest.java
@@ -581,19 +581,16 @@ class SamlServiceProviderTest {
 
     @Test
     void shouldNotConsumeLogoutRequestWithoutIssuer_HttpPost() throws Exception {
-    final LogoutRequest logoutRequest =
-            getLogoutRequest("http://" + spHostname + ':' + server.httpPort() + "/saml/slo/post",
-                             "http://idp.example.com/post");
+        final LogoutRequest logoutRequest =
+                getLogoutRequest("http://" + spHostname + ':' + server.httpPort() + "/saml/slo/post",
+                                 "http://idp.example.com/post");
 
-    logoutRequest.setIssuer(null);
+        logoutRequest.setIssuer(null);
 
-    final AggregatedHttpResponse res =
-            sendViaHttpPostBindingProtocol("/saml/slo/post",
-                                          SAML_REQUEST,
-                                          logoutRequest,
-                                          idpCredential);
+        final AggregatedHttpResponse res = sendViaHttpPostBindingProtocol("/saml/slo/post", SAML_REQUEST,
+                                                                          logoutRequest, idpCredential);
 
-    assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test


### PR DESCRIPTION
## Motivation

A `LogoutRequest` without an `Issuer` currently results in an internal server error (500)
due to a `NullPointerException` during request processing.

According to the SAML protocol, a missing `Issuer` is an invalid request and should be
treated as a client error rather than causing an unexpected server failure.

## Modifications

- Handle a missing `Issuer` in `LogoutRequest` validation.
- Reject the request with `InvalidSamlRequestException` instead of allowing a
  `NullPointerException` to propagate.
- Add a regression test to verify that a `LogoutRequest` without an `Issuer`
  returns `400 Bad Request`.

## Result

Malformed logout requests are now rejected gracefully with `400 Bad Request`
instead of returning `500 Internal Server Error`.