### PR TITLE
Fix ClientFactory leak in KubernetesEndpointGroup watches

### DIFF
--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClient.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClient.java
@@ -52,16 +52,35 @@ final class ArmeriaHttpClient
     private final WebClient webClient;
     private final ArmeriaWebSocketClient webSocketClient;
 
+    /**
+     * Creates a root client that owns the shared close state and WebSocket transport.
+     */
     ArmeriaHttpClient(ArmeriaHttpClientBuilder armeriaHttpClientBuilder, WebClient webClient) {
-        super(armeriaHttpClientBuilder, new AtomicBoolean());
+        this(armeriaHttpClientBuilder, webClient, new ArmeriaWebSocketClient(armeriaHttpClientBuilder),
+             new AtomicBoolean());
+    }
+
+    /**
+     * Creates a client that shares the given resources with its root / sibling clients.
+     * Derived clients created via {@link #newBuilder()} must share {@code closed} and
+     * {@code webSocketClient} so that WebSocket {@code ClientFactory} instances created for
+     * watches are closed when the root client is closed (see issue #6805).
+     */
+    ArmeriaHttpClient(ArmeriaHttpClientBuilder armeriaHttpClientBuilder, WebClient webClient,
+                      ArmeriaWebSocketClient webSocketClient, AtomicBoolean closed) {
+        super(armeriaHttpClientBuilder, closed);
         this.webClient = webClient;
-        webSocketClient = new ArmeriaWebSocketClient(armeriaHttpClientBuilder);
+        this.webSocketClient = webSocketClient;
     }
 
     @Override
     public void doClose() {
         webClient.options().factory().close();
         webSocketClient.close();
+    }
+
+    ArmeriaWebSocketClient getWebSocketClient() {
+        return webSocketClient;
     }
 
     @Override

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientBuilder.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientBuilder.java
@@ -55,10 +55,6 @@ final class ArmeriaHttpClientBuilder extends StandardHttpClientBuilder<
     @Override
     public HttpClient build() {
         if (client != null) {
-            // Share close state, HTTP client, and WebSocket transport with the root client so that
-            // ClientFactory instances created for watches are released when the root is closed.
-            // Matches fabric8 JDK/Jetty clients; without this, each derived client builds its own
-            // WebSocket ClientFactory that is never closed (LEAK / #6805).
             return new ArmeriaHttpClient(this, client.getWebClient(), client.getWebSocketClient(),
                                          client.getClosed());
         }

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientBuilder.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientBuilder.java
@@ -55,7 +55,12 @@ final class ArmeriaHttpClientBuilder extends StandardHttpClientBuilder<
     @Override
     public HttpClient build() {
         if (client != null) {
-            return new ArmeriaHttpClient(this, client.getWebClient());
+            // Share close state, HTTP client, and WebSocket transport with the root client so that
+            // ClientFactory instances created for watches are released when the root is closed.
+            // Matches fabric8 JDK/Jetty clients; without this, each derived client builds its own
+            // WebSocket ClientFactory that is never closed (LEAK / #6805).
+            return new ArmeriaHttpClient(this, client.getWebClient(), client.getWebSocketClient(),
+                                         client.getClosed());
         }
 
         final WebClientBuilder clientBuilder = WebClient.builder();

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
@@ -135,10 +135,6 @@ final class ArmeriaWebSocketClient implements SafeCloseable {
         }
     }
 
-    /**
-     * Returns the underlying {@link WebSocketClient}, or {@code null} if it has not been created yet.
-     * Package-private for tests that inspect shared lifecycle with derived clients.
-     */
     @Nullable
     WebSocketClient webSocketClientOrNull() {
         return webSocketClient;

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
@@ -27,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Strings;
 
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.websocket.WebSocketClient;
 import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
@@ -137,16 +136,12 @@ final class ArmeriaWebSocketClient implements SafeCloseable {
     }
 
     /**
-     * Returns the {@link ClientFactory} used by the underlying {@link WebSocketClient}, or
-     * {@code null} if the WebSocket client has not been created yet.
+     * Returns the underlying {@link WebSocketClient}, or {@code null} if it has not been created yet.
+     * Package-private for tests that inspect shared lifecycle with derived clients.
      */
     @Nullable
-    ClientFactory clientFactoryOrNull() {
-        final WebSocketClient webSocketClient = this.webSocketClient;
-        if (webSocketClient == null) {
-            return null;
-        }
-        return webSocketClient.options().factory();
+    WebSocketClient webSocketClientOrNull() {
+        return webSocketClient;
     }
 
     private static WebSocketUpgradeResponse newUpgradeResponse(StandardHttpRequest request,

--- a/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
+++ b/kubernetes/src/main/java/com/linecorp/armeria/client/kubernetes/ArmeriaWebSocketClient.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.RequestOptions;
 import com.linecorp.armeria.client.websocket.WebSocketClient;
 import com.linecorp.armeria.client.websocket.WebSocketClientBuilder;
@@ -133,6 +134,19 @@ final class ArmeriaWebSocketClient implements SafeCloseable {
         if (webSocketClient != null) {
             webSocketClient.options().factory().close();
         }
+    }
+
+    /**
+     * Returns the {@link ClientFactory} used by the underlying {@link WebSocketClient}, or
+     * {@code null} if the WebSocket client has not been created yet.
+     */
+    @Nullable
+    ClientFactory clientFactoryOrNull() {
+        final WebSocketClient webSocketClient = this.webSocketClient;
+        if (webSocketClient == null) {
+            return null;
+        }
+        return webSocketClient.options().factory();
     }
 
     private static WebSocketUpgradeResponse newUpgradeResponse(StandardHttpRequest request,

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
@@ -144,6 +144,7 @@ class ArmeriaHttpClientTest {
         // Closing the root (as KubernetesClient.close() does) must close the shared WebSocket factory.
         root.close();
         assertThat(derived.isClosed()).isTrue();
+        wsFactory.whenClosed().get(10, TimeUnit.SECONDS);
         assertThat(wsFactory.isClosed()).isTrue();
     }
 

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.linecorp.armeria.client.ClientFactory;
+
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.http.AsyncBody;
 import io.fabric8.kubernetes.client.http.HttpClient;
@@ -94,6 +96,53 @@ class ArmeriaHttpClientTest {
     void testMultipleClosure() {
         client.getHttpClient().close();
         client.getHttpClient().close(); // additional close should be no-op
+    }
+
+    /**
+     * Derived clients (used when tagging RequestConfig, and similar) must share the WebSocket
+     * ClientFactory with the root client. Otherwise each watch creates a factory that is never
+     * closed when only the root {@link KubernetesClient} is closed (#6805).
+     */
+    @Test
+    void derivedClientSharesWebSocketFactoryLifecycle() throws Exception {
+        final HttpClient root = client.getHttpClient();
+        final HttpClient derived = root.newBuilder().tag("request-config-tag").build();
+
+        assertThat(root).isInstanceOf(ArmeriaHttpClient.class);
+        assertThat(derived).isInstanceOf(ArmeriaHttpClient.class);
+        final ArmeriaHttpClient rootImpl = (ArmeriaHttpClient) root;
+        final ArmeriaHttpClient derivedImpl = (ArmeriaHttpClient) derived;
+
+        assertThat(derivedImpl.getClosed()).isSameAs(rootImpl.getClosed());
+        assertThat(derivedImpl.getWebSocketClient()).isSameAs(rootImpl.getWebSocketClient());
+        assertThat(derivedImpl.getWebClient()).isSameAs(rootImpl.getWebClient());
+
+        server.expect().withPath("/derived-ws")
+              .andUpgradeToWebSocket()
+              .open()
+              .done().always();
+
+        // Watches open WebSockets on derived clients; that lazily builds a dedicated ClientFactory.
+        final CompletableFuture<Boolean> opened = new CompletableFuture<>();
+        derived.newWebSocketBuilder()
+               .uri(URI.create(webSocketMasterUrl() + "derived-ws"))
+               .buildAsync(new Listener() {
+                   @Override
+                   public void onOpen(WebSocket webSocket) {
+                       opened.complete(true);
+                   }
+               })
+               .get(10, TimeUnit.SECONDS);
+        assertThat(opened.get(10, TimeUnit.SECONDS)).isTrue();
+
+        final ClientFactory wsFactory = derivedImpl.getWebSocketClient().clientFactoryOrNull();
+        assertThat(wsFactory).isNotNull();
+        assertThat(wsFactory.isClosed()).isFalse();
+
+        // Closing the root (as KubernetesClient.close() does) must close the shared WebSocket factory.
+        root.close();
+        assertThat(derived.isClosed()).isTrue();
+        assertThat(wsFactory.isClosed()).isTrue();
     }
 
     @Test

--- a/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
+++ b/kubernetes/src/test/java/com/linecorp/armeria/client/kubernetes/ArmeriaHttpClientTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.websocket.WebSocketClient;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.http.AsyncBody;
@@ -135,8 +136,9 @@ class ArmeriaHttpClientTest {
                .get(10, TimeUnit.SECONDS);
         assertThat(opened.get(10, TimeUnit.SECONDS)).isTrue();
 
-        final ClientFactory wsFactory = derivedImpl.getWebSocketClient().clientFactoryOrNull();
-        assertThat(wsFactory).isNotNull();
+        final WebSocketClient wsClient = derivedImpl.getWebSocketClient().webSocketClientOrNull();
+        assertThat(wsClient).isNotNull();
+        final ClientFactory wsFactory = wsClient.options().factory();
         assertThat(wsFactory.isClosed()).isFalse();
 
         // Closing the root (as KubernetesClient.close() does) must close the shared WebSocket factory.


### PR DESCRIPTION
Motivation:

`KubernetesEndpointGroup` watches open WebSockets through fabric8's derived
`HttpClient`s (e.g. tagged with `RequestConfig`). Armeria's derived
`ArmeriaHttpClient` did not share the close flag or WebSocket transport with
the root client (unlike fabric8's JDK/Jetty adapters). Each derived client
built its own WebSocket `ClientFactory`, which was never closed when the root
`KubernetesClient` was closed, producing:

```
LEAK: ClientFactory.release() was not called before it's garbage-collected.
```

Stack traces point at `ArmeriaWebSocketClient.webSocketClient()` via
`KubernetesEndpointGroup.doWatchService` (#6805).

Modifications:

- Share `AtomicBoolean closed`, `WebClient`, and `ArmeriaWebSocketClient` when
  building a derived `ArmeriaHttpClient` from `ArmeriaHttpClientBuilder`.
- Package-private helpers to inspect shared WebSocket `ClientFactory` lifecycle.
- Regression test: open WebSocket on a derived client, close root, assert the
  shared WebSocket `ClientFactory` is closed.

Result:

- Fixes #6805.
- Closing the root Kubernetes/HTTP client releases WebSocket ClientFactories
  created for watches on derived clients.