### PR TITLE
fix: use original response timeout in DEADLINE_EXCEEDED description

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -350,4 +350,3 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         }
     }
 }
-

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -92,9 +92,10 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         final RetryConfig<O> config = mapping.get(ctx, req);
         requireNonNull(config, "mapping.get() returned null");
 
-        final State state = new State(config, ctx.responseTimeoutMillis());
+        final long responseTimeoutMillis = ctx.responseTimeoutMillis();
+        final State state = new State(config, responseTimeoutMillis);
         ctx.setAttr(STATE, state);
-        ctx.setAttr(ORIGINAL_RESPONSE_TIMEOUT_MILLIS, ctx.responseTimeoutMillis());
+        ctx.setAttr(ORIGINAL_RESPONSE_TIMEOUT_MILLIS, responseTimeoutMillis);
         return doExecute(ctx, req);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -62,6 +62,16 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     private static final AttributeKey<State> STATE =
             AttributeKey.valueOf(AbstractRetryingClient.class, "STATE");
 
+    /**
+     * An {@link AttributeKey} to store the original response timeout millis
+     * before it gets modified by the retry logic. This is used by
+     * {@code ArmeriaClientCall} to report the originally configured timeout
+     * in the DEADLINE_EXCEEDED status description.
+     */
+    public static final AttributeKey<Long> ORIGINAL_RESPONSE_TIMEOUT_MILLIS =
+            AttributeKey.valueOf(AbstractRetryingClient.class,
+                                 "ORIGINAL_RESPONSE_TIMEOUT_MILLIS");
+
     private final RetryConfigMapping<O> mapping;
 
     @Nullable
@@ -84,6 +94,7 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
 
         final State state = new State(config, ctx.responseTimeoutMillis());
         ctx.setAttr(STATE, state);
+        ctx.setAttr(ORIGINAL_RESPONSE_TIMEOUT_MILLIS, ctx.responseTimeoutMillis());
         return doExecute(ctx, req);
     }
 
@@ -339,3 +350,4 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         }
     }
 }
+

--- a/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/AbstractRetryingClient.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.common.Response;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.TimeoutMode;
+import com.linecorp.armeria.internal.client.ClientRequestContextExtension;
 import com.linecorp.armeria.internal.client.ClientUtil;
 
 import io.netty.util.AsciiString;
@@ -62,16 +63,6 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     private static final AttributeKey<State> STATE =
             AttributeKey.valueOf(AbstractRetryingClient.class, "STATE");
 
-    /**
-     * An {@link AttributeKey} to store the original response timeout millis
-     * before it gets modified by the retry logic. This is used by
-     * {@code ArmeriaClientCall} to report the originally configured timeout
-     * in the DEADLINE_EXCEEDED status description.
-     */
-    public static final AttributeKey<Long> ORIGINAL_RESPONSE_TIMEOUT_MILLIS =
-            AttributeKey.valueOf(AbstractRetryingClient.class,
-                                 "ORIGINAL_RESPONSE_TIMEOUT_MILLIS");
-
     private final RetryConfigMapping<O> mapping;
 
     @Nullable
@@ -92,10 +83,17 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
         final RetryConfig<O> config = mapping.get(ctx, req);
         requireNonNull(config, "mapping.get() returned null");
 
-        final long responseTimeoutMillis = ctx.responseTimeoutMillis();
-        final State state = new State(config, responseTimeoutMillis);
+        final State state = new State(config, ctx.responseTimeoutMillis());
         ctx.setAttr(STATE, state);
-        ctx.setAttr(ORIGINAL_RESPONSE_TIMEOUT_MILLIS, responseTimeoutMillis);
+
+        // The response timeout of the original context is transferred to the derived contexts created for
+        // each retry attempt. Disable the timeout of the original context so that it is not triggered
+        // while retrying, and set the timeout on each derived context instead.
+        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
+        if (ctxExt != null) {
+            ctxExt.responseCancellationScheduler().cancelScheduled();
+        }
+
         return doExecute(ctx, req);
     }
 
@@ -183,21 +181,22 @@ public abstract class AbstractRetryingClient<I extends Request, O extends Respon
     }
 
     /**
-     * Resets the {@link ClientRequestContext#responseTimeoutMillis()}.
+     * Sets the response timeout of the specified {@code derivedCtx}.
      *
      * @return {@code true} if the response timeout is set, {@code false} if it can't be set due to the timeout
      */
     @SuppressWarnings("MethodMayBeStatic") // Intentionally left non-static for better user experience.
-    protected final boolean setResponseTimeout(ClientRequestContext ctx) {
+    protected final boolean setResponseTimeout(ClientRequestContext ctx, ClientRequestContext derivedCtx) {
         requireNonNull(ctx, "ctx");
+        requireNonNull(derivedCtx, "derivedCtx");
         final long responseTimeoutMillis = state(ctx).responseTimeoutMillis();
         if (responseTimeoutMillis < 0) {
             return false;
         } else if (responseTimeoutMillis == 0) {
-            ctx.clearResponseTimeout();
+            derivedCtx.clearResponseTimeout();
             return true;
         } else {
-            ctx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
+            derivedCtx.setResponseTimeoutMillis(TimeoutMode.SET_FROM_NOW, responseTimeoutMillis);
             return true;
         }
     }

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -290,11 +290,6 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             return;
         }
 
-        if (!setResponseTimeout(ctx)) {
-            handleException(ctx, rootReqDuplicator, future, ResponseTimeoutException.get(), initialAttempt);
-            return;
-        }
-
         final HttpRequest duplicateReq;
         if (initialAttempt) {
             duplicateReq = rootReqDuplicator.duplicate();
@@ -309,6 +304,11 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             derivedCtx = newDerivedContext(ctx, duplicateReq, ctx.rpcRequest(), initialAttempt);
         } catch (Throwable t) {
             handleException(ctx, rootReqDuplicator, future, t, initialAttempt);
+            return;
+        }
+
+        if (!setResponseTimeout(ctx, derivedCtx)) {
+            handleException(ctx, rootReqDuplicator, future, ResponseTimeoutException.get(), initialAttempt);
             return;
         }
 

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -308,7 +308,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         }
 
         if (!setResponseTimeout(ctx, derivedCtx)) {
-            handleException(ctx, rootReqDuplicator, future, ResponseTimeoutException.get(), initialAttempt);
+            handleException(ctx, derivedCtx, rootReqDuplicator, future,
+                            ResponseTimeoutException.get(), initialAttempt);
             return;
         }
 
@@ -316,7 +317,8 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
         if (!initialAttempt) {
             final boolean shouldRetry = config.retryLimiter().shouldRetry(derivedCtx);
             if (!shouldRetry) {
-                handleException(ctx, rootReqDuplicator, future, RetryLimitedException.of(), initialAttempt);
+                handleException(ctx, derivedCtx, rootReqDuplicator, future,
+                                RetryLimitedException.of(), initialAttempt);
                 return;
             }
         }
@@ -530,6 +532,14 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             ctx.logBuilder().endRequest(cause);
         }
         ctx.logBuilder().endResponse(cause);
+    }
+
+    private static void handleException(ClientRequestContext ctx, ClientRequestContext derivedCtx,
+                                        @Nullable HttpRequestDuplicator rootReqDuplicator,
+                                        CompletableFuture<HttpResponse> future, Throwable cause,
+                                        boolean endRequestLog) {
+        derivedCtx.cancel(cause);
+        handleException(ctx, rootReqDuplicator, future, cause, endRequestLog);
     }
 
     private void handleRetryDecision(@Nullable RetryDecision decision, ClientRequestContext ctx,

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -158,12 +158,12 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
                     "the response returned to the client has been cancelled"), initialAttempt);
             return;
         }
-        if (!setResponseTimeout(ctx)) {
+        final ClientRequestContext derivedCtx = newDerivedContext(ctx, null, req, initialAttempt);
+
+        if (!setResponseTimeout(ctx, derivedCtx)) {
             handleException(ctx, future, ResponseTimeoutException.get(), initialAttempt);
             return;
         }
-
-        final ClientRequestContext derivedCtx = newDerivedContext(ctx, null, req, initialAttempt);
 
         if (!initialAttempt) {
             derivedCtx.mutateAdditionalRequestHeaders(

--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingRpcClient.java
@@ -161,7 +161,7 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
         final ClientRequestContext derivedCtx = newDerivedContext(ctx, null, req, initialAttempt);
 
         if (!setResponseTimeout(ctx, derivedCtx)) {
-            handleException(ctx, future, ResponseTimeoutException.get(), initialAttempt);
+            handleException(ctx, derivedCtx, future, ResponseTimeoutException.get(), initialAttempt);
             return;
         }
 
@@ -174,7 +174,8 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
         if (!initialAttempt) {
             final boolean shouldRetry = config.retryLimiter().shouldRetry(derivedCtx);
             if (!shouldRetry) {
-                handleException(ctx, future, UnprocessedRequestException.of(RetryLimitedException.of()),
+                handleException(ctx, derivedCtx, future,
+                                UnprocessedRequestException.of(RetryLimitedException.of()),
                                 initialAttempt);
                 return;
             }
@@ -247,5 +248,12 @@ public final class RetryingRpcClient extends AbstractRetryingClient<RpcRequest, 
             ctx.logBuilder().endRequest(cause);
         }
         ctx.logBuilder().endResponse(cause);
+    }
+
+    private static void handleException(ClientRequestContext ctx, ClientRequestContext derivedCtx,
+                                        CompletableFuture<RpcResponse> future, Throwable cause,
+                                        boolean endRequestLog) {
+        derivedCtx.cancel(cause);
+        handleException(ctx, future, cause, endRequestLog);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -660,4 +660,3 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         return simpleMethodName;
     }
 }
-

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -39,7 +39,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpPreClient;
-import com.linecorp.armeria.client.retry.AbstractRetryingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
@@ -556,16 +555,8 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         }
 
         if (status.getCode() == Code.DEADLINE_EXCEEDED) {
-            final long timeoutMillis;
-            final Long originalTimeout =
-                    ctx.attr(AbstractRetryingClient.ORIGINAL_RESPONSE_TIMEOUT_MILLIS).get();
-            if (originalTimeout != null && originalTimeout > 0) {
-                timeoutMillis = originalTimeout;
-            } else {
-                timeoutMillis = ctx.responseTimeoutMillis();
-            }
             status = status.augmentDescription("deadline exceeded after " +
-                                               MILLISECONDS.toNanos(timeoutMillis) + "ns.");
+                                               MILLISECONDS.toNanos(ctx.responseTimeoutMillis()) + "ns.");
         }
 
         final StatusAndMetadata statusAndMetadata = new StatusAndMetadata(status, metadata);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/client/grpc/ArmeriaClientCall.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.HttpPreClient;
+import com.linecorp.armeria.client.retry.AbstractRetryingClient;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpRequestWriter;
@@ -555,8 +556,16 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         }
 
         if (status.getCode() == Code.DEADLINE_EXCEEDED) {
+            final long timeoutMillis;
+            final Long originalTimeout =
+                    ctx.attr(AbstractRetryingClient.ORIGINAL_RESPONSE_TIMEOUT_MILLIS).get();
+            if (originalTimeout != null && originalTimeout > 0) {
+                timeoutMillis = originalTimeout;
+            } else {
+                timeoutMillis = ctx.responseTimeoutMillis();
+            }
             status = status.augmentDescription("deadline exceeded after " +
-                                               MILLISECONDS.toNanos(ctx.responseTimeoutMillis()) + "ns.");
+                                               MILLISECONDS.toNanos(timeoutMillis) + "ns.");
         }
 
         final StatusAndMetadata statusAndMetadata = new StatusAndMetadata(status, metadata);
@@ -651,3 +660,4 @@ final class ArmeriaClientCall<I, O> extends ClientCall<I, O>
         return simpleMethodName;
     }
 }
+

--- a/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/client/grpc/GrpcClientTest.java
@@ -69,6 +69,8 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpPreprocessor;
 import com.linecorp.armeria.client.ResponseTimeoutException;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -1525,6 +1527,35 @@ class GrpcClientTest {
                 StatusRuntimeException.class, t -> {
                     assertThat(t.getStatus().getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
                     assertThat(t.getStatus().getDescription()).contains("deadline exceeded after");
+                });
+    }
+
+    @Test
+    void deadlineDescriptionWithRetryingClient() throws Exception {
+        final TestServiceStub stub =
+                GrpcClients.builder(server.httpUri())
+                           .responseTimeoutMillis(3000)
+                           .decorator(RetryingClient.builder(RetryRule.failsafe())
+                                                     .maxTotalAttempts(2)
+                                                     .newDecorator())
+                           .build(TestServiceStub.class);
+        final StreamRecorder<StreamingOutputCallResponse> responseObserver = StreamRecorder.create();
+        stub.streamingOutputCall(
+                StreamingOutputCallRequest
+                        .newBuilder()
+                        .addResponseParameters(
+                                ResponseParameters.newBuilder()
+                                                  .setIntervalUs((int) TimeUnit.SECONDS.toMicros(10)))
+                        .build(),
+                responseObserver);
+        responseObserver.awaitCompletion(operationTimeoutMillis(), TimeUnit.MILLISECONDS);
+
+        assertThat(responseObserver.getError()).isInstanceOfSatisfying(
+                StatusRuntimeException.class, t -> {
+                    assertThat(t.getStatus().getCode()).isEqualTo(Code.DEADLINE_EXCEEDED);
+                    assertThat(t.getStatus().getDescription())
+                            .contains("deadline exceeded after " +
+                                      TimeUnit.MILLISECONDS.toNanos(3000) + "ns");
                 });
     }
 


### PR DESCRIPTION
Fixes #6894

## Summary

When RetryingClient decorates a gRPC client and responseTimeoutMillis is configured, the DEADLINE_EXCEEDED status description reports a smaller timeout than the one originally configured (e.g., 2999000000ns instead of 3000000000ns).

## Root Cause

1. AbstractRetryingClient.execute() captures the configured response timeout and stores it as deadlineNanos in the State object.
2. RetryingClient.doExecute0() then calls ctx.setResponseTimeoutMillis(SET_FROM_NOW, remaining) where remaining is computed via NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()).
3. The sub-millisecond time elapsed between step 1 and step 2 is floored away by NANOSECONDS.toMillis(), so the context responseTimeoutMillis ends up as 2999 instead of 3000.
4. ArmeriaClientCall.close() builds the DEADLINE_EXCEEDED description from ctx.responseTimeoutMillis(), reporting the reduced value.

## Fix

- Store the original configured response timeout as an AttributeKey on the ClientRequestContext in AbstractRetryingClient.execute() before the timeout gets modified.
- In ArmeriaClientCall.close(), read this attribute and use the original value for the DEADLINE_EXCEEDED description, falling back to ctx.responseTimeoutMillis() when the attribute is not set (non-retry case).

## Changes

- AbstractRetryingClient: Added ORIGINAL_RESPONSE_TIMEOUT_MILLIS attribute key and set it in execute().
- ArmeriaClientCall: Read the original timeout from the context attribute for the status description.
