### PR TITLE
Generate the Athenz xDS protos with java_multiple_files

### DIFF
--- a/xds-api/src/main/proto/armeria/xds/athenz/athenz_access_token.proto
+++ b/xds-api/src/main/proto/armeria/xds/athenz/athenz_access_token.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package jp.co.lycorp.ftd.athenz.v1;
 
+option java_multiple_files = true;
+
 import "validate/validate.proto";
 import "envoy/type/matcher/v3/string.proto";
 import "armeria/xds/supported.proto";

--- a/xds-api/src/main/proto/armeria/xds/athenz/athenz_filter_config.proto
+++ b/xds-api/src/main/proto/armeria/xds/athenz/athenz_filter_config.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package armeria.xds.athenz;
 
 option java_package = "com.linecorp.armeria.xds.athenz";
+option java_multiple_files = true;
 
 import "validate/validate.proto";
 import "armeria/xds/supported.proto";

--- a/xds-api/src/main/proto/armeria/xds/supported.proto
+++ b/xds-api/src/main/proto/armeria/xds/supported.proto
@@ -3,6 +3,10 @@ package armeria.xds;
 
 option java_package = "com.linecorp.armeria.xds.api";
 option java_outer_classname = "SupportedFieldProto";
+// Intentionally NOT java_multiple_files: the only message here, `supported`, is a lowercase namespacing
+// holder for the option extensions (so usage reads as `(armeria.xds.supported.field)`), not a real data
+// message. Emitting it with java_multiple_files would produce a non-idiomatic top-level lowercase
+// `supported` class, so keep it nested under the SupportedFieldProto outer class.
 
 import "google/protobuf/descriptor.proto";
 

--- a/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/AccessTokenConstraintFilterFactory.java
+++ b/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/AccessTokenConstraintFilterFactory.java
@@ -38,7 +38,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.athenz.AccessCheckStatus;
 import com.linecorp.armeria.server.athenz.AthenzAuthorizer;
 import com.linecorp.armeria.server.athenz.AthenzPolicyConfig;
-import com.linecorp.armeria.xds.athenz.AthenzFilterConfig.AccessTokenConstraintConfig;
+import com.linecorp.armeria.xds.athenz.AccessTokenConstraintConfig;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
@@ -47,12 +47,12 @@ import com.linecorp.armeria.xds.stream.SnapshotStream;
 import com.linecorp.armeria.xds.stream.Subscription;
 
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.AccessTokenConstraint;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.AssertionMappingRule;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.EndpointAttribute;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.EndpointAttribute.AttributeCase;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.EndpointAttributeMatch;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.WellKnownEndpointAttribute;
+import jp.co.lycorp.ftd.athenz.v1.AccessTokenConstraint;
+import jp.co.lycorp.ftd.athenz.v1.AssertionMappingRule;
+import jp.co.lycorp.ftd.athenz.v1.EndpointAttribute;
+import jp.co.lycorp.ftd.athenz.v1.EndpointAttribute.AttributeCase;
+import jp.co.lycorp.ftd.athenz.v1.EndpointAttributeMatch;
+import jp.co.lycorp.ftd.athenz.v1.WellKnownEndpointAttribute;
 
 final class AccessTokenConstraintFilterFactory implements HttpFilterFactory {
 

--- a/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/AccessTokenTargetFilterFactory.java
+++ b/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/AccessTokenTargetFilterFactory.java
@@ -31,14 +31,14 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.xds.athenz.AthenzFilterConfig.AccessTokenTargetConfig;
+import com.linecorp.armeria.xds.athenz.AccessTokenTargetConfig;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
 
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.AccessTokenTarget;
+import jp.co.lycorp.ftd.athenz.v1.AccessTokenTarget;
 
 final class AccessTokenTargetFilterFactory implements HttpFilterFactory {
 

--- a/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/MappingTemplate.java
+++ b/xds-athenz/src/main/java/com/linecorp/armeria/xds/filter/athenz/MappingTemplate.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.server.ServiceRequestContext;
 
-import jp.co.lycorp.ftd.athenz.v1.AthenzAccessToken.MappingString;
+import jp.co.lycorp.ftd.athenz.v1.MappingString;
 
 /**
  * Pre-parsed template from a {@link MappingString}.


### PR DESCRIPTION
Motivation:

The Armeria xDS protos follow the java_multiple_files convention (as do the gRPC, example and benchmark modules), but the Athenz protos added in #6853 were missing it, so their messages were generated as nested classes under an outer wrapper.

Modifications:

- Add `option java_multiple_files = true;` to armeria/xds/athenz/athenz_filter_config.proto and armeria/xds/athenz/athenz_access_token.proto, so each message is generated as a top-level class.

Result:

- Athenz xDS message classes are now top-level, matching the convention.