### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/.github/actions/comment-build-scan.ts
+++ b/.github/actions/comment-build-scan.ts
@@ -38,7 +38,7 @@ async function main(): Promise<void> {
     if (scan.trim().length === 0) {
       continue;
     }
-    // build scan string pattern: "<job-name> https://ge.armeria.dev/xxxxxx"
+    // build scan string pattern: "<job-name> https://community.develocity.cloud/xxxxxx"
     const [jobName, scanUrl]= scan.split(" ");
     const job = jobs.find(job => job.name === jobName);
     if (job.conclusion === 'success') {

--- a/.github/workflows/gradle-enterprise-postjob.yml
+++ b/.github/workflows/gradle-enterprise-postjob.yml
@@ -1,4 +1,4 @@
-name: Upload artifacts to ge.armeria.dev
+name: Upload artifacts to community.develocity.cloud
 
 on:
   workflow_run:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Visit [the official web site](https://armeria.dev/) for more information.
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/line/armeria.svg?label=commits)](https://github.com/line/armeria/pulse)
 [![Maven Central](https://img.shields.io/maven-central/v/com.linecorp.armeria/armeria.svg?label=version)](https://search.maven.org/search?q=g:com.linecorp.armeria%20AND%20a:armeria)
 [![GitHub release date](https://img.shields.io/github/release-date/line/armeria.svg?label=release)](https://github.com/line/armeria/commits)
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.armeria.dev/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=armeria)
 
 
 > Build a reactive microservice **at your pace**, not theirs.

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,8 @@ import com.gradle.develocity.agent.gradle.scan.PublishedBuildScan
 def isCi = System.getenv("CI") != null
 
 develocity {
-    server = "https://ge.armeria.dev"
+    server = "https://community.develocity.cloud"
+    projectId = "armeria"
     buildScan {
         publishing.onlyIf { it.authenticated }
         uploadInBackground = !isCi


### PR DESCRIPTION
Motivation:

Gradle is consolidating the OSS projects it sponsors onto the **OSS Community Develocity Instance**
at <https://community.develocity.cloud>, a managed multi-tenant instance that uses Develocity's
[Project-Level Access Control](https://docs.gradle.com/develocity/2026.1/administration/access-control/project-level-access-control/)
to serve several projects at once while keeping each project's build cache data isolated.

As announced, Armeria's dedicated instance at `https://ge.armeria.dev` is being decommissioned on
**Thursday, 2026-08-27**. This PR moves Build Scan® publishing and the remote build cache over to the
community instance, under project ID `armeria`.

Modifications:

- `settings.gradle`: point `develocity.server` at `https://community.develocity.cloud` and set
  `projectId = "armeria"`, which selects this project on the multi-tenant instance.
  The `remote(develocity.buildCache)` block does not override `server`, so it follows
  `develocity.server` and needs no change.
- `README.md`: repoint the "Revved up by Develocity" badge to this project's filtered Build Scan list
  on the new instance.
- `.github/workflows/gradle-enterprise-postjob.yml`: update the workflow display name to the new host.
  No functional change — the workflow reads the host from the build, not from its own configuration.
- `.github/actions/comment-build-scan.ts`: update the build scan URL example in a comment. No
  functional change — the parser splits on whitespace and never matches on the host.

Result:

Once merged **and** the CI access key is replaced (below), Build Scans and remote build cache entries
from CI go to <https://community.develocity.cloud> instead of `ge.armeria.dev`.

## Action required: a new access key for CI

Build Scan publishing **and** remote build cache writes need a Develocity access key authorised for
the `armeria` project on the community instance. The existing `ge.armeria.dev` key will not work —
access keys are per-host.

**Step 1 — Generate the key**

1. Visit <https://community.develocity.cloud>.
2. Sign in as the CI account that has been provided for Armeria.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy the
   generated key. Keep the tab open until Step 2 is done — the key is only shown once.

**Step 2 — Update the GitHub Actions secret**

Five workflows (`actions_build.yml`, `gradle-cache-check.yml`, `e2e-chaos-tests.yml`,
`publish-release.yml` and `gradle-enterprise-postjob.yml`) already read the repository secret
`DEVELOCITY_ACCESS_KEY`. Only its **value** needs to change.

1. Open this repository's **Settings** → **Secrets and variables** → **Actions**.
2. Find the existing `DEVELOCITY_ACCESS_KEY` secret and click **Update**.
3. Set the value to the following, replacing the placeholder with the key from Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name the access key is
   silently ignored, and builds fall back to publishing nothing. This is the most common point of
   failure when onboarding, so please double-check the format.
4. Click **Update secret**.

**Step 3 — Local builds (optional, per developer)**

Maintainers who want their local builds to publish should provision a personal key. The Develocity
Gradle plugin does this in one command — it opens a browser, asks for confirmation, and writes the key
to `~/.gradle/develocity/keys.properties`:

```
./gradlew provisionDevelocityAccessKey
```

Sign out of `community.develocity.cloud` first (or use a private window) so the key is associated with
your **personal** account rather than the CI service account from Step 1.

## Accounts

User accounts for the maintainers and for the CI agent are being provided separately. If you need
accounts beyond those, you can request them via <https://forms.gle/55V2Btr2ETiY8dQ79>.

## Note on CI for this PR

This PR comes from a fork, and forks can't read this repository's secrets, so no Build Scan will be
published for it. `gradle-enterprise-postjob.yml` is additionally gated by
`if: github.repository == 'line/armeria'` and won't run at all here. That's expected and unchanged by
this PR.

If you want CI verification before merging, push this branch to a temporary branch on this repository
rather than the fork after completing Step 2 — it will pick up the secret and publish a scan.
