### PR TITLE
Register TLS certificate metrics once per ClientFactory

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/common/SslContextFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/SslContextFactory.java
@@ -20,8 +20,10 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.ClientTlsSpec;
@@ -48,6 +50,14 @@ public final class SslContextFactory {
 
     private final Map<AbstractTlsSpec, SslContextHolder> cache = new HashMap<>();
     private final Map<SslContext, AbstractTlsSpec> reverseCache = new HashMap<>();
+    // Certificate metrics are shared across all cached contexts that register the exact same meters
+    // (same certificates and meter ID prefix). Without this, two contexts that differ only in an
+    // attribute irrelevant to the meter identity - e.g. ALPN protocols - would each bind an identical
+    // set of gauges, producing "Gauge already registered" warnings and, worse, unregistering the
+    // shared gauges as soon as the first of them is released. See
+    // https://github.com/line/armeria/issues/6734
+    private final Map<CertificateMetricsKey, CertificateMetricsHolder> certificateMetrics =
+            new HashMap<>();
 
     private final MeterRegistry meterRegistry;
     @Nullable
@@ -99,7 +109,7 @@ public final class SslContextFactory {
     }
 
     private SslContextHolder toContextHolder(AbstractTlsSpec tlsSpec, SslContext sslContext) {
-        CloseableMeterBinder meterBinder = null;
+        CertificateMetricsKey meterKey = null;
         final ImmutableList.Builder<X509Certificate> certsBuilder = ImmutableList.builder();
         final TlsKeyPair keyPair = tlsSpec.tlsKeyPair();
         if (keyPair != null) {
@@ -109,10 +119,28 @@ public final class SslContextFactory {
                 certsBuilder.addAll(tlsSpec.trustedCertificates()).build();
         if (!certs.isEmpty()) {
             final MeterIdPrefix meterIdPrefix = meterIdPrefix(tlsSpec);
-            meterBinder = MoreMeterBinders.certificateMetrics(certs, meterIdPrefix);
-            meterBinder.bindTo(meterRegistry);
+            meterKey = new CertificateMetricsKey(certs, meterIdPrefix);
+            // Bind the certificate metrics only once per unique meter identity, and retain a
+            // reference so they are unbound only after the last context using them is released.
+            final CertificateMetricsHolder metricsHolder =
+                    certificateMetrics.computeIfAbsent(meterKey, key -> {
+                        final CloseableMeterBinder meterBinder =
+                                MoreMeterBinders.certificateMetrics(key.certificates, key.meterIdPrefix);
+                        meterBinder.bindTo(meterRegistry);
+                        return new CertificateMetricsHolder(meterBinder);
+                    });
+            metricsHolder.retain();
         }
-        return new SslContextHolder(sslContext, meterBinder);
+        return new SslContextHolder(sslContext, meterKey);
+    }
+
+    private void releaseCertificateMetrics(CertificateMetricsKey meterKey) {
+        final CertificateMetricsHolder metricsHolder = certificateMetrics.get(meterKey);
+        assert metricsHolder != null : "certificate metrics not found for: " + meterKey;
+        if (metricsHolder.release()) {
+            certificateMetrics.remove(meterKey);
+            metricsHolder.meterBinder.close();
+        }
     }
 
     public void release(SslContext sslContext) {
@@ -127,6 +155,10 @@ public final class SslContextFactory {
                 assert removed == contextHolder;
                 reverseCache.remove(sslContext);
                 contextHolder.destroy();
+                final CertificateMetricsKey meterKey = contextHolder.meterKey();
+                if (meterKey != null) {
+                    releaseCertificateMetrics(meterKey);
+                }
             }
         } finally {
             lock.unlock();
@@ -157,16 +189,21 @@ public final class SslContextFactory {
     private static final class SslContextHolder {
         private final SslContext sslContext;
         @Nullable
-        private final CloseableMeterBinder meterBinder;
+        private final CertificateMetricsKey meterKey;
         private long refCnt;
 
-        SslContextHolder(SslContext sslContext, @Nullable CloseableMeterBinder meterBinder) {
+        SslContextHolder(SslContext sslContext, @Nullable CertificateMetricsKey meterKey) {
             this.sslContext = sslContext;
-            this.meterBinder = meterBinder;
+            this.meterKey = meterKey;
         }
 
         SslContext sslContext() {
             return sslContext;
+        }
+
+        @Nullable
+        CertificateMetricsKey meterKey() {
+            return meterKey;
         }
 
         void retain() {
@@ -180,10 +217,71 @@ public final class SslContextFactory {
         }
 
         void destroy() {
-            if (meterBinder != null) {
-                meterBinder.close();
-            }
             ReferenceCountUtil.release(sslContext);
+        }
+    }
+
+    /**
+     * Identifies the certificate metrics registered for a set of certificates under a
+     * {@link MeterIdPrefix}. Two {@link AbstractTlsSpec}s that yield an equal key register an
+     * identical set of gauges, so they must share a single {@link CertificateMetricsHolder}.
+     */
+    private static final class CertificateMetricsKey {
+        private final List<X509Certificate> certificates;
+        private final MeterIdPrefix meterIdPrefix;
+
+        CertificateMetricsKey(List<X509Certificate> certificates, MeterIdPrefix meterIdPrefix) {
+            this.certificates = certificates;
+            this.meterIdPrefix = meterIdPrefix;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CertificateMetricsKey)) {
+                return false;
+            }
+            final CertificateMetricsKey that = (CertificateMetricsKey) o;
+            return certificates.equals(that.certificates) &&
+                   meterIdPrefix.equals(that.meterIdPrefix);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(certificates, meterIdPrefix);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("certificates", certificates)
+                              .add("meterIdPrefix", meterIdPrefix)
+                              .toString();
+        }
+    }
+
+    /**
+     * A reference-counted {@link CloseableMeterBinder} shared by all cached contexts that register the
+     * same certificate metrics.
+     */
+    private static final class CertificateMetricsHolder {
+        private final CloseableMeterBinder meterBinder;
+        private long refCnt;
+
+        CertificateMetricsHolder(CloseableMeterBinder meterBinder) {
+            this.meterBinder = meterBinder;
+        }
+
+        void retain() {
+            refCnt++;
+        }
+
+        boolean release() {
+            refCnt--;
+            assert refCnt >= 0 : "refCount: " + refCnt;
+            return refCnt == 0;
         }
     }
 }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientCertificateMetricsTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.assertj.core.api.AbstractDoubleAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.metric.MeterIdPrefix;
@@ -41,6 +42,9 @@ import com.linecorp.armeria.server.ServerTlsCertificateMetricsTest;
 import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -84,6 +88,43 @@ class ClientCertificateMetricsTest {
                         .isEqualTo(1);
             });
             assertThat(res.aggregate().join().status().code()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void shouldRegisterCertificateMetricsOncePerClientFactory() {
+        // See https://github.com/line/armeria/issues/6734
+        // A ClientFactory internally creates several SslContexts that differ only in their ALPN
+        // protocols but share the same certificate metrics. The metrics must be registered only once,
+        // otherwise Micrometer logs a "Gauge has been already registered" warning and the shared
+        // gauges are unregistered as soon as the first context is released.
+        final Logger micrometerLogger =
+                (Logger) LoggerFactory.getLogger("io.micrometer.core.instrument.MeterRegistry");
+        final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+        logAppender.start();
+        micrometerLogger.addAppender(logAppender);
+        try {
+            final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+            try (ClientFactory factory = ClientFactory.builder()
+                                                      .tls(certificate.tlsKeyPair())
+                                                      .meterRegistry(meterRegistry)
+                                                      .build()) {
+                assertThat(meterRegistry.find("armeria.client.tls.certificate.validity").gauges())
+                        .hasSize(1);
+                assertThat(meterRegistry.find("armeria.client.tls.certificate.validity.days").gauges())
+                        .hasSize(1);
+            }
+            assertThat(logAppender.list)
+                    .withFailMessage("Certificate metrics were registered more than once: %s",
+                                     logAppender.list)
+                    .noneMatch(event -> {
+                        final String message = event.getFormattedMessage();
+                        return message.contains("already registered") &&
+                               message.contains("armeria.client.tls.certificate.validity");
+                    });
+        } finally {
+            micrometerLogger.detachAppender(logAppender);
+            logAppender.stop();
         }
     }
 


### PR DESCRIPTION
## Motivation

Building a `ClientFactory` with TLS emits duplicate Micrometer gauge warnings, even when the factory uses an isolated `MeterRegistry`:

```
WARN i.m.c.i.MeterRegistry - This Gauge has been already registered
(MeterId{name='armeria.client.tls.certificate.validity', tags=[tag(hostname=<cert-cn>)]}),
the registration will be ignored.
```

As diagnosed in #6734, `BootstrapSslContexts` creates one `ClientTlsSpec` per `SessionProtocol.httpsValues()` (`HTTPS`, `H1`, `H2`). These collapse into distinct cache entries that differ only in their ALPN protocols but carry **identical certificates and meter ID prefix**, so `SslContextFactory.toContextHolder(...)` binds the same `CertificateMetrics` gauges more than once.

Beyond the warning this is a correctness bug: each context's `CloseableMeterBinder` closing task calls `registry.remove(...)` on the **same** gauges, so releasing the first context unregisters the certificate metrics that the remaining live contexts still rely on.

## Modifications

- `SslContextFactory` now shares a single **reference-counted** `CertificateMetrics` binder across all cached contexts that register the same meters, keyed on `(certificates, meterIdPrefix)`.
- The binder is bound once when the first such context is created and unbound only after the last one is released; `SslContextHolder` now carries the meter key instead of its own binder.
- Added a regression test that builds a `ClientFactory` on a `SimpleMeterRegistry` and asserts the certificate gauges are registered exactly once with no duplicate-registration warning.

## Result

- Closes #6734.
- No more "Gauge has been already registered" warnings when building a `ClientFactory` (or server) with TLS, and the certificate metrics stay registered for as long as any context using them is alive.
