### PR TITLE
Fix out-of-order listener notification in DynamicEndpointGroup

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
+++ b/core/src/main/java/com/linecorp/armeria/common/util/AbstractListenable.java
@@ -57,7 +57,8 @@ public abstract class AbstractListenable<T> implements Listenable<T> {
         }
 
         for (Consumer<? super T> listener : updateListeners) {
-            listener.accept(latestValue);
+            final T value = latestValue();
+            listener.accept(value != null ? value : latestValue);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -28,7 +29,10 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 
 class DynamicEndpointGroupTest {
 
@@ -180,6 +184,49 @@ class DynamicEndpointGroupTest {
         // Should be allowed to set an empty list.
         dynamicEndpointGroup.setEndpoints(new ArrayList<>());
         assertThat(dynamicEndpointGroup.endpoints()).isEmpty();
+    }
+
+    @Test
+    void concurrentSetEndpointsShouldNotDeliverStaleNotification() throws Exception {
+        final DynamicEndpointGroup group = new DynamicEndpointGroup();
+        final Endpoint a = Endpoint.of("a");
+        final Endpoint b = Endpoint.of("b");
+        final Endpoint c = Endpoint.of("c");
+
+        group.setEndpoints(ImmutableList.of(a, b, c));
+
+        final AtomicInteger counter = new AtomicInteger();
+        final CountDownLatch slowListenerEntered = new CountDownLatch(1);
+        final CountDownLatch slowListenerProceed = new CountDownLatch(1);
+
+        group.addListener(endpoints -> {
+            if (counter.getAndIncrement() == 0) {
+                slowListenerEntered.countDown();
+                try {
+                    slowListenerProceed.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+
+        final ClientRequestContext ctx = ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        group.selectNow(ctx);
+
+        final Thread t1 = new Thread(() -> group.setEndpoints(ImmutableList.of(a, b)));
+        t1.start();
+
+        slowListenerEntered.await();
+
+        group.setEndpoints(ImmutableList.of(a));
+
+        slowListenerProceed.countDown();
+        t1.join();
+
+        // only a is selected
+        assertThat(group.selectNow(ctx)).isEqualTo(a);
+        assertThat(group.selectNow(ctx)).isEqualTo(a);
+        assertThat(group.selectNow(ctx)).isEqualTo(a);
     }
 
     private static void testWhenAllowEmptyEndpointsIsFalse(DynamicEndpointGroup dynamicEndpointGroup,

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -17,7 +17,6 @@ package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -222,7 +221,7 @@ class DynamicEndpointGroupTest {
         group.setEndpoints(ImmutableList.of(a));
 
         slowListenerProceed.countDown();
-        t1.join(Duration.ofSeconds(10));
+        t1.join(10_000);
 
         // only a is selected
         assertThat(group.selectNow(ctx)).isEqualTo(a);

--- a/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/endpoint/DynamicEndpointGroupTest.java
@@ -17,6 +17,7 @@ package com.linecorp.armeria.client.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -221,7 +222,7 @@ class DynamicEndpointGroupTest {
         group.setEndpoints(ImmutableList.of(a));
 
         slowListenerProceed.countDown();
-        t1.join();
+        t1.join(Duration.ofSeconds(10));
 
         // only a is selected
         assertThat(group.selectNow(ctx)).isEqualTo(a);


### PR DESCRIPTION
Motivation:

When two concurrent `setEndpoints()` calls race in `DynamicEndpointGroup`, listener notifications can be delivered out of order. `setEndpoints()` updates `this.endpoints` under `endpointsLock` but calls `notifyListeners()` after releasing the lock, passing the locally captured endpoint list. If Thread A's notification is delayed (e.g. by thread scheduling), Thread B can complete both its lock acquisition and notification first. When Thread A finally resumes, it delivers its stale endpoint list to listeners, causing the `EndpointSelector`'s load balancer to revert to an older snapshot.

This was observed in production where two `HealthCheckedEndpointGroup` health status updates arrived 1ms apart. The selector continued routing to an endpoint that had already been removed, because the older notification overwrote the newer one.

Modifications:

- Modified `AbstractListenable.notifyListeners()` to re-read the current value via `latestValue()` for each listener invocation instead of using the (potentially stale) parameter. Falls back to the parameter when `latestValue()` returns `null`, preserving behavior for subclasses that don't override it.
- Added `DynamicEndpointGroupTest.concurrentSetEndpointsShouldNotDeliverStaleNotification()` that reproduces the race by blocking the first notification with a slow listener, allowing a second `setEndpoints()` to complete, then verifying the round-robin selector only returns the latest endpoints.

Result:

- `DynamicEndpointGroup` listeners (including the internal `EndpointSelector`) will always observe the latest committed endpoint list, even under concurrent `setEndpoints()` calls. This prevents stale endpoints from being routed to after rapid health status changes.
