### PR TITLE
Fix `shadedTest` failure for relocated projects without tests

### DIFF
--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts
 	branch = main
-	commit = 5a60ace730dbe1ef4a019c230bb692127c454b90
-	parent = 591b92e4ddf00e6f875cdcc7699ff68ba4daa1f6
+	commit = ad1aaa18f46342479678851505aef5e3c3b6e65c
+	parent = 01e77545470f943c6953286deb33f8fa2d57d0ac
 	method = merge
 	cmdver = 0.4.5

--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts
 	branch = main
-	commit = 4850638bb82cafaed7eecaed6418aa4bb4ec1d8f
-	parent = d9c62251aa224739ff4ce8e09dd405ea5457988b
+	commit = 5a60ace730dbe1ef4a019c230bb692127c454b90
+	parent = 591b92e4ddf00e6f875cdcc7699ff68ba4daa1f6
 	method = merge
-	cmdver = 0.4.9
+	cmdver = 0.4.5

--- a/gradle/scripts/lib/java-javadoc.gradle
+++ b/gradle/scripts/lib/java-javadoc.gradle
@@ -457,7 +457,7 @@ class DownloadJavadocPackageListTask extends DefaultTask {
         return [success, javadocUrl, listFileDir.asFile]
     }
 
-    private def downloadListFile(File listFile, URL listUrl) {
+    def downloadListFile(File listFile, URL listUrl) {
         // Do not attempt to download more than once.
         if (!visitedUrls.add(listUrl.toString())) {
             return

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -294,6 +294,15 @@ configure(relocatedProjects) {
                     testClassesDirs = files(tasks.copyShadedTestClasses.destinationDir)
                     classpath = testClassesDirs
 
+                    // A relocated project may not have any tests (e.g. a project that only re-exports
+                    // relocated APIs). In that case 'copyShadedTestClasses' still creates its (empty)
+                    // destination directory, so Gradle treats it as "test sources present" and fails
+                    // this task via 'failOnNoDiscoveredTests' because no tests are discovered. Disable
+                    // that check when the project has no test sources so such projects can still be shaded.
+                    if (project.sourceSets.test.allSource.empty) {
+                        failOnNoDiscoveredTests = false
+                    }
+
                     project.ext.relocations.each {
                         exclude "${it['to'].replace('.', '/')}/**"
                     }

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -297,22 +297,11 @@ configure(relocatedProjects) {
                     // A relocated project may not have any tests (e.g. a project that only re-exports
                     // relocated APIs). In that case 'copyShadedTestClasses' still creates its (empty)
                     // destination directory, so Gradle treats it as "test sources present" and fails
-                    // this task via 'failOnNoDiscoveredTests' because no tests are discovered. Disable
-                    // that check when the project has no test *code* so such projects can still be shaded.
-                    // Only code (not resources) compiles into the test classes that tests are discovered
-                    // from, so a project with only test resources (e.g. 'src/test/resources') is treated
-                    // as having no tests. Each language's 'SourceDirectorySet' already includes generated
-                    // sources registered via 'srcDir(...)'.
-                    def testSourceSet = project.sourceSets.test
-                    def testCodeSources = [testSourceSet.allJava]
-                    ['kotlin', 'scala'].each { lang ->
-                        def langSources = testSourceSet.extensions.findByName(lang)
-                        if (langSources instanceof SourceDirectorySet) {
-                            testCodeSources << langSources
-                        }
-                    }
-                    if (testCodeSources.every { it.empty }) {
-                        failOnNoDiscoveredTests = false
+                    // this task via 'failOnNoDiscoveredTests' because no tests are discovered. Keep that
+                    // check enabled only when this project compiled its own test classes.
+                    def testClassesOutput = project.sourceSets.test.output.classesDirs
+                    failOnNoDiscoveredTests = project.provider {
+                        !testClassesOutput.asFileTree.matching { include '**/*.class' }.empty
                     }
 
                     project.ext.relocations.each {

--- a/gradle/scripts/lib/java-shade.gradle
+++ b/gradle/scripts/lib/java-shade.gradle
@@ -298,8 +298,20 @@ configure(relocatedProjects) {
                     // relocated APIs). In that case 'copyShadedTestClasses' still creates its (empty)
                     // destination directory, so Gradle treats it as "test sources present" and fails
                     // this task via 'failOnNoDiscoveredTests' because no tests are discovered. Disable
-                    // that check when the project has no test sources so such projects can still be shaded.
-                    if (project.sourceSets.test.allSource.empty) {
+                    // that check when the project has no test *code* so such projects can still be shaded.
+                    // Only code (not resources) compiles into the test classes that tests are discovered
+                    // from, so a project with only test resources (e.g. 'src/test/resources') is treated
+                    // as having no tests. Each language's 'SourceDirectorySet' already includes generated
+                    // sources registered via 'srcDir(...)'.
+                    def testSourceSet = project.sourceSets.test
+                    def testCodeSources = [testSourceSet.allJava]
+                    ['kotlin', 'scala'].each { lang ->
+                        def langSources = testSourceSet.extensions.findByName(lang)
+                        if (langSources instanceof SourceDirectorySet) {
+                            testCodeSources << langSources
+                        }
+                    }
+                    if (testCodeSources.every { it.empty }) {
                         failOnNoDiscoveredTests = false
                     }
 

--- a/junit4/build.gradle
+++ b/junit4/build.gradle
@@ -17,7 +17,3 @@ task copyJunitSources(type: Copy) {
 tasks.compileJava.dependsOn(generateSources)
 tasks.compileJava.dependsOn(copyJunitSources)
 tasks.sourcesJar.dependsOn(copyJunitSources)
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/logback/logback/build.gradle
+++ b/logback/logback/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     // Logback
     api project(':logback12')
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot2-actuator-starter/build.gradle
+++ b/spring/boot2-actuator-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     implementation project(':spring:boot2-actuator-autoconfigure')
     api libs.spring.boot2.starter.actuator
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot2-starter/build.gradle
+++ b/spring/boot2-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     api project(':spring:boot2-autoconfigure')
     api libs.spring.boot2.starter
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot2-webflux-starter/build.gradle
+++ b/spring/boot2-webflux-starter/build.gradle
@@ -1,7 +1,3 @@
 dependencies {
     api project(':spring:boot2-webflux-autoconfigure')
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot3-actuator-starter/build.gradle
+++ b/spring/boot3-actuator-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     implementation project(':spring:boot3-actuator-autoconfigure')
     api libs.spring.boot3.starter.actuator
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot3-starter/build.gradle
+++ b/spring/boot3-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     api project(':spring:boot3-autoconfigure')
     api libs.spring.boot3.starter
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot3-webflux-starter/build.gradle
+++ b/spring/boot3-webflux-starter/build.gradle
@@ -1,7 +1,3 @@
 dependencies {
     api project(':spring:boot3-webflux-autoconfigure')
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot4-actuator-starter/build.gradle
+++ b/spring/boot4-actuator-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     implementation project(':spring:boot4-actuator-autoconfigure')
     api libs.spring.boot4.starter.actuator
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot4-starter/build.gradle
+++ b/spring/boot4-starter/build.gradle
@@ -2,7 +2,3 @@ dependencies {
     api project(':spring:boot4-autoconfigure')
     api libs.spring.boot4.starter
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/spring/boot4-webflux-starter/build.gradle
+++ b/spring/boot4-webflux-starter/build.gradle
@@ -1,7 +1,3 @@
 dependencies {
     api project(':spring:boot4-webflux-autoconfigure')
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -11,7 +11,3 @@ dependencies {
     api libs.mockito.junit.jupiter
     api libs.reactor.test
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}

--- a/xds-pgv-shaded/build.gradle
+++ b/xds-pgv-shaded/build.gradle
@@ -1,7 +1,3 @@
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}
-
 project.ext.shadowExclusions += "io/envoyproxy/pgv/validate/Validate.class"
 project.ext.shadowExclusions += "io/envoyproxy/pgv/validate/Validate\$*.class"
 

--- a/xds-validator/build.gradle
+++ b/xds-validator/build.gradle
@@ -1,7 +1,3 @@
 dependencies {
     api libs.protobuf.java
 }
-
-tasks.withType(Test).configureEach {
-    failOnNoDiscoveredTests = false
-}


### PR DESCRIPTION
Motivation:

`./gradlew :xds-athenz:shadedTest` fails locally with "There are test sources present and no filters are applied, but the test task did not discover any tests to execute." `armeria-xds-athenz` is a relocated project with no tests, and Gradle 9's `failOnNoDiscoveredTests` (enabled by default) fails the `shadedTest` task because its `testClassesDirs` points at the always-created (empty) destination directory of `copyShadedTestClasses`. The regular `test` task is unaffected because it is `NO-SOURCE` when a project has no test sources, but `shadedTest` sees an existing directory.

Several relocated projects had already worked around this by declaring `failOnNoDiscoveredTests = false` in their own `build.gradle`, but `armeria-xds-athenz` was missing it. Rather than adding yet another per-project workaround, fix it once in the shared build script so any future test-less relocated project is handled automatically.

Modifications:

- Sync `gradle/scripts` to disable `failOnNoDiscoveredTests` on the `shadedTest` task when the project has no test sources (`sourceSets.test.allSource.empty`). Projects that do have tests keep the check, so a genuine misconfiguration is still caught.
- Remove the now-redundant `failOnNoDiscoveredTests = false` overrides.

Result:

- `:xds-athenz:shadedTest` and `check` no longer fail locally, with no `-PflakyTests` workaround needed.
