### PR TITLE
Wait for context init before using eventLoop in WebSocketClient

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/websocket/DefaultWebSocketClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/DefaultWebSocketClient.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.ByteStreamMessage;
 import com.linecorp.armeria.common.stream.StreamMessage;
 import com.linecorp.armeria.common.websocket.WebSocket;
+import com.linecorp.armeria.internal.client.ClientRequestContextExtension;
 import com.linecorp.armeria.internal.common.DefaultSplitHttpResponse;
 import com.linecorp.armeria.internal.common.websocket.WebSocketFrameEncoder;
 import com.linecorp.armeria.internal.common.websocket.WebSocketWrapper;
@@ -106,6 +107,36 @@ final class DefaultWebSocketClient implements WebSocketClient {
             response = webClient.execute(request, requestOptions);
             ctx = captor.get();
         }
+
+        final CompletableFuture<WebSocketSession> result = new CompletableFuture<>();
+        final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
+        if (ctxExt == null) {
+            finishConnect(ctx, requestHeaders, response, outboundFuture, result);
+            return result;
+        }
+        ctxExt.whenInitialized().handle((unused, cause) -> {
+            if (cause != null) {
+                response.abort(cause);
+                outboundFuture.completeExceptionally(cause);
+                result.completeExceptionally(cause);
+                return null;
+            }
+            try {
+                finishConnect(ctx, requestHeaders, response, outboundFuture, result);
+            } catch (Throwable t) {
+                response.abort(t);
+                outboundFuture.completeExceptionally(t);
+                result.completeExceptionally(t);
+            }
+            return null;
+        });
+        return result;
+    }
+
+    private void finishConnect(ClientRequestContext ctx, RequestHeaders requestHeaders,
+                               HttpResponse response,
+                               CompletableFuture<StreamMessage<HttpData>> outboundFuture,
+                               CompletableFuture<WebSocketSession> result) {
         final SplitHttpResponse split =
                 new DefaultSplitHttpResponse(response, ctx.eventLoop(), responseHeaders -> {
                     final SessionProtocol actualSessionProtocol = actualSessionProtocol(ctx);
@@ -116,7 +147,6 @@ final class DefaultWebSocketClient implements WebSocketClient {
                     return !responseHeaders.status().isInformational();
                 });
 
-        final CompletableFuture<WebSocketSession> result = new CompletableFuture<>();
         split.headers().handle((responseHeaders, cause) -> {
             if (cause != null) {
                 fail(outboundFuture, split.body(), result, cause);
@@ -137,7 +167,6 @@ final class DefaultWebSocketClient implements WebSocketClient {
             result.complete(new WebSocketSession(ctx, responseHeaders, inbound, outboundFuture, encoder));
             return null;
         });
-        return result;
     }
 
     private RequestHeaders webSocketHeaders(String path, HttpHeaders headers) {

--- a/core/src/main/java/com/linecorp/armeria/client/websocket/DefaultWebSocketClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/websocket/DefaultWebSocketClient.java
@@ -108,19 +108,13 @@ final class DefaultWebSocketClient implements WebSocketClient {
             ctx = captor.get();
         }
 
-        final CompletableFuture<WebSocketSession> result = new CompletableFuture<>();
         final ClientRequestContextExtension ctxExt = ctx.as(ClientRequestContextExtension.class);
         if (ctxExt == null) {
-            finishConnect(ctx, requestHeaders, response, outboundFuture, result);
-            return result;
+            throw new IllegalStateException("ClientRequestContextExtension is unavailable");
         }
-        ctxExt.whenInitialized().handle((unused, cause) -> {
-            if (cause != null) {
-                response.abort(cause);
-                outboundFuture.completeExceptionally(cause);
-                result.completeExceptionally(cause);
-                return null;
-            }
+
+        final CompletableFuture<WebSocketSession> result = new CompletableFuture<>();
+        ctxExt.whenInitialized().handle((unused, unused2) -> {
             try {
                 finishConnect(ctx, requestHeaders, response, outboundFuture, result);
             } catch (Throwable t) {

--- a/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
@@ -22,10 +22,10 @@ import static org.awaitility.Awaitility.await;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
@@ -120,15 +120,20 @@ class WebSocketClientTest {
         await().until(outbound::isComplete);
     }
 
-    @Test
-    void connectWaitsForAsyncEndpointGroup() {
+    @EnumSource(value = SessionProtocol.class, names = { "H2C", "H1C" })
+    @ParameterizedTest
+    void connectWaitsForAsyncEndpointGroup(SessionProtocol sessionProtocol) {
         final DelayedEndpointGroup group = new DelayedEndpointGroup();
-        final WebSocketClient client = WebSocketClient.builder(SessionProtocol.HTTP, group).build();
+        final WebSocketClient client = WebSocketClient.builder(sessionProtocol, group).build();
         final CompletableFuture<WebSocketSession> future = client.connect("/chat");
         assertThat(future).isNotDone();
         group.set(server.httpEndpoint());
         final WebSocketSession session = future.join();
-        assertThat(session.responseHeaders().status()).isIn(HttpStatus.SWITCHING_PROTOCOLS, HttpStatus.OK);
+        if (sessionProtocol == SessionProtocol.H1C) {
+            assertThat(session.responseHeaders().status()).isSameAs(HttpStatus.SWITCHING_PROTOCOLS);
+        } else {
+            assertThat(session.responseHeaders().status()).isSameAs(HttpStatus.OK);
+        }
         session.inbound().abort();
         session.outbound().abort();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
@@ -127,7 +128,7 @@ class WebSocketClientTest {
         assertThat(future).isNotDone();
         group.set(server.httpEndpoint());
         final WebSocketSession session = future.join();
-        assertThat(session.responseHeaders().status().code()).isGreaterThanOrEqualTo(100);
+        assertThat(session.responseHeaders().status()).isIn(HttpStatus.SWITCHING_PROTOCOLS, HttpStatus.OK);
         session.inbound().abort();
         session.outbound().abort();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/websocket/WebSocketClientTest.java
@@ -22,6 +22,7 @@ import static org.awaitility.Awaitility.await;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -29,6 +30,8 @@ import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.SerializationFormat;
@@ -114,6 +117,25 @@ class WebSocketClientTest {
         assertThat(frame).isEqualTo(WebSocketFrame.ofClose(WebSocketCloseStatus.NORMAL_CLOSURE));
         inboundHandler.completionFuture().join();
         await().until(outbound::isComplete);
+    }
+
+    @Test
+    void connectWaitsForAsyncEndpointGroup() {
+        final DelayedEndpointGroup group = new DelayedEndpointGroup();
+        final WebSocketClient client = WebSocketClient.builder(SessionProtocol.HTTP, group).build();
+        final CompletableFuture<WebSocketSession> future = client.connect("/chat");
+        assertThat(future).isNotDone();
+        group.set(server.httpEndpoint());
+        final WebSocketSession session = future.join();
+        assertThat(session.responseHeaders().status().code()).isGreaterThanOrEqualTo(100);
+        session.inbound().abort();
+        session.outbound().abort();
+    }
+
+    static final class DelayedEndpointGroup extends DynamicEndpointGroup {
+        void set(Endpoint endpoint) {
+            addEndpoint(endpoint);
+        }
     }
 
     static final class WebSocketServiceEchoHandler implements WebSocketServiceHandler {


### PR DESCRIPTION
Motivation:

`WebSocketClient.connect()` calls `ctx.eventLoop()` immediately after `execute()`. When the client is backed by an `EndpointGroup` whose `selectNow()` returns `null` (service-discovery-backed groups, a cold `DynamicEndpointGroup`, etc.), the context is not initialized yet and `connect()` throws `IllegalStateException: Should call init(endpoint) before invoking this method`. A `WebClient` over the same group waits for selection.

Modifications:

- Finish the WebSocket handshake after `ClientRequestContextExtension.whenInitialized()`, as suggested on the issue.
- Throw if the client context is not a `ClientRequestContextExtension`.
- Add a regression test that connects through an initially empty `DynamicEndpointGroup` and checks a successful handshake status (101 or 200).

Result:

- Closes #6839
- `WebSocketClient.connect()` waits for async endpoint selection instead of failing immediately.

Tested:

- `./gradlew :core:test --tests com.linecorp.armeria.client.websocket.WebSocketClientTest`
- `./gradlew :core:checkstyleMain :core:checkstyleTest`