### PR TITLE
Mask sensitive query parameters in request logs

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/common/logging/AbstractLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/AbstractLogFormatterBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * A skeletal builder implementation for {@link LogFormatter}.
@@ -66,6 +67,7 @@ abstract class AbstractLogFormatterBuilder<SELF extends AbstractLogFormatterBuil
      * Adds the query parameters to mask in request paths before logging.
      * Query parameter names are case-sensitive. Unmasked query components are logged unchanged.
      */
+    @UnstableApi
     public SELF maskQueryParams(String... queryParams) {
         requireNonNull(queryParams, "queryParams");
         return maskQueryParams(ImmutableSet.copyOf(queryParams));
@@ -75,6 +77,7 @@ abstract class AbstractLogFormatterBuilder<SELF extends AbstractLogFormatterBuil
      * Adds the query parameters to mask in request paths before logging.
      * Query parameter names are case-sensitive. Unmasked query components are logged unchanged.
      */
+    @UnstableApi
     public SELF maskQueryParams(Iterable<String> queryParams) {
         requireNonNull(queryParams, "queryParams");
         if (queryParamsToMask == null) {
@@ -89,6 +92,7 @@ abstract class AbstractLogFormatterBuilder<SELF extends AbstractLogFormatterBuil
      * Sets the {@link QueryParamMaskingFunction} to use to mask query parameters before logging.
      * The default is {@link QueryParamMaskingFunction#of()}.
      */
+    @UnstableApi
     public SELF queryParamMaskingFunction(QueryParamMaskingFunction queryParamMaskingFunction) {
         this.queryParamMaskingFunction =
                 requireNonNull(queryParamMaskingFunction, "queryParamMaskingFunction");

--- a/core/src/main/java/com/linecorp/armeria/common/logging/AbstractLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/AbstractLogFormatterBuilder.java
@@ -18,8 +18,12 @@ package com.linecorp.armeria.common.logging;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.RequestContext;
@@ -29,6 +33,11 @@ import com.linecorp.armeria.common.annotation.Nullable;
  * A skeletal builder implementation for {@link LogFormatter}.
  */
 abstract class AbstractLogFormatterBuilder<SELF extends AbstractLogFormatterBuilder<SELF, T>, T> {
+
+    @Nullable
+    private Set<String> queryParamsToMask;
+
+    private QueryParamMaskingFunction queryParamMaskingFunction = QueryParamMaskingFunction.of();
 
     @Nullable
     private HeadersSanitizer<T> requestHeadersSanitizer;
@@ -51,6 +60,49 @@ abstract class AbstractLogFormatterBuilder<SELF extends AbstractLogFormatterBuil
     @SuppressWarnings("unchecked")
     final SELF self() {
         return (SELF) this;
+    }
+
+    /**
+     * Adds the query parameters to mask in request paths before logging.
+     * Query parameter names are case-sensitive. Unmasked query components are logged unchanged.
+     */
+    public SELF maskQueryParams(String... queryParams) {
+        requireNonNull(queryParams, "queryParams");
+        return maskQueryParams(ImmutableSet.copyOf(queryParams));
+    }
+
+    /**
+     * Adds the query parameters to mask in request paths before logging.
+     * Query parameter names are case-sensitive. Unmasked query components are logged unchanged.
+     */
+    public SELF maskQueryParams(Iterable<String> queryParams) {
+        requireNonNull(queryParams, "queryParams");
+        if (queryParamsToMask == null) {
+            queryParamsToMask = new HashSet<>();
+        }
+        queryParams.forEach(queryParam ->
+                queryParamsToMask.add(requireNonNull(queryParam, "queryParam")));
+        return self();
+    }
+
+    /**
+     * Sets the {@link QueryParamMaskingFunction} to use to mask query parameters before logging.
+     * The default is {@link QueryParamMaskingFunction#of()}.
+     */
+    public SELF queryParamMaskingFunction(QueryParamMaskingFunction queryParamMaskingFunction) {
+        this.queryParamMaskingFunction =
+                requireNonNull(queryParamMaskingFunction, "queryParamMaskingFunction");
+        return self();
+    }
+
+    final HeadersSanitizer<T> maybeWrapRequestHeadersSanitizer(
+            HeadersSanitizer<T> requestHeadersSanitizer) {
+        if (queryParamsToMask == null || queryParamsToMask.isEmpty()) {
+            return requestHeadersSanitizer;
+        }
+        return new QueryParamMaskingHeadersSanitizer<>(
+                requestHeadersSanitizer, ImmutableSet.copyOf(queryParamsToMask),
+                queryParamMaskingFunction);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/JsonLogFormatterBuilder.java
@@ -61,10 +61,12 @@ public final class JsonLogFormatterBuilder
         final ObjectMapper objectMapper = this.objectMapper;
         final HeadersSanitizer<JsonNode> defaultHeadersSanitizer =
                 defaultHeadersSanitizer(objectMapper);
+        final HeadersSanitizer<JsonNode> requestHeadersSanitizer =
+                firstNonNull(requestHeadersSanitizer(), HeadersSanitizer.ofJson());
         final BiFunction<? super RequestContext, Object, JsonNode> defaultContentSanitizer =
                 defaultSanitizer(objectMapper);
         return new JsonLogFormatter(
-                firstNonNull(requestHeadersSanitizer(), HeadersSanitizer.ofJson()),
+                maybeWrapRequestHeadersSanitizer(requestHeadersSanitizer),
                 firstNonNull(responseHeadersSanitizer(), HeadersSanitizer.ofJson()),
                 firstNonNull(requestTrailersSanitizer(), defaultHeadersSanitizer),
                 firstNonNull(responseTrailersSanitizer(), defaultHeadersSanitizer),

--- a/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingFunction.java
@@ -17,10 +17,12 @@
 package com.linecorp.armeria.common.logging;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
  * A function that masks the specified query parameter value.
  */
+@UnstableApi
 @FunctionalInterface
 public interface QueryParamMaskingFunction {
 

--- a/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingFunction.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * A function that masks the specified query parameter value.
+ */
+@FunctionalInterface
+public interface QueryParamMaskingFunction {
+
+    /**
+     * Returns the default {@link QueryParamMaskingFunction} that masks the given value with {@code ****}.
+     */
+    static QueryParamMaskingFunction of() {
+        return (name, value) -> "****";
+    }
+
+    /**
+     * Masks the specified {@code value} of the specified {@code name}.
+     * If {@code null} is returned, the specified query parameter will be removed from the log.
+     */
+    @Nullable
+    String mask(String name, String value);
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingHeadersSanitizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingHeadersSanitizer.java
@@ -49,10 +49,13 @@ final class QueryParamMaskingHeadersSanitizer<T> implements HeadersSanitizer<T> 
             return delegate.sanitize(ctx, headers);
         }
 
-        final int queryStart = path.indexOf('?') + 1;
-        if (queryStart == 0 || queryStart == path.length()) {
+        final int queryDelimiter = path.indexOf('?');
+        final int fragmentStart = path.indexOf('#');
+        if (queryDelimiter < 0 || queryDelimiter == path.length() - 1 ||
+            (fragmentStart >= 0 && fragmentStart < queryDelimiter)) {
             return delegate.sanitize(ctx, headers);
         }
+        final int queryStart = queryDelimiter + 1;
 
         final String maskedPath = maskQueryParams(path, queryStart);
         if (maskedPath == null) {

--- a/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingHeadersSanitizer.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/QueryParamMaskingHeadersSanitizer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.logging;
+
+import static com.linecorp.armeria.internal.common.PercentDecoder.decodeComponent;
+import static com.linecorp.armeria.internal.common.PercentEncoder.encodeComponent;
+
+import java.util.Set;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.util.TemporaryThreadLocals;
+
+final class QueryParamMaskingHeadersSanitizer<T> implements HeadersSanitizer<T> {
+
+    private final HeadersSanitizer<T> delegate;
+    private final Set<String> queryParamsToMask;
+    private final QueryParamMaskingFunction maskingFunction;
+
+    QueryParamMaskingHeadersSanitizer(HeadersSanitizer<T> delegate,
+                                      Set<String> queryParamsToMask,
+                                      QueryParamMaskingFunction maskingFunction) {
+        this.delegate = delegate;
+        this.queryParamsToMask = queryParamsToMask;
+        this.maskingFunction = maskingFunction;
+    }
+
+    @Nullable
+    @Override
+    public T sanitize(RequestContext ctx, HttpHeaders headers) {
+        final String path = headers.get(HttpHeaderNames.PATH);
+        if (path == null) {
+            return delegate.sanitize(ctx, headers);
+        }
+
+        final int queryStart = path.indexOf('?') + 1;
+        if (queryStart == 0 || queryStart == path.length()) {
+            return delegate.sanitize(ctx, headers);
+        }
+
+        final String maskedPath = maskQueryParams(path, queryStart);
+        if (maskedPath == null) {
+            return delegate.sanitize(ctx, headers);
+        }
+        return delegate.sanitize(
+                ctx, headers.withMutations(builder -> builder.set(HttpHeaderNames.PATH, maskedPath)));
+    }
+
+    @Nullable
+    private String maskQueryParams(String path, int queryStart) {
+        final int fragmentStart = path.indexOf('#', queryStart);
+        final int queryEnd = fragmentStart >= 0 ? fragmentStart : path.length();
+        if (queryStart == queryEnd) {
+            return null;
+        }
+
+        try (TemporaryThreadLocals tempThreadLocals = TemporaryThreadLocals.acquire()) {
+            final StringBuilder maskedQuery = tempThreadLocals.stringBuilder();
+            boolean masked = false;
+            boolean retained = false;
+            int componentStart = queryStart;
+            for (;;) {
+                int componentEnd = path.indexOf('&', componentStart);
+                if (componentEnd < 0 || componentEnd > queryEnd) {
+                    componentEnd = queryEnd;
+                }
+
+                boolean matched = false;
+                if (componentStart != componentEnd) {
+                    final int equalsPos = firstEqualsOrEnd(path, componentStart, componentEnd);
+                    final String name =
+                            decodeComponent(tempThreadLocals, path, componentStart, equalsPos);
+                    if (queryParamsToMask.contains(name)) {
+                        matched = true;
+                        masked = true;
+                        final int valueStart = equalsPos < componentEnd ? equalsPos + 1 : componentEnd;
+                        final String value =
+                                decodeComponent(tempThreadLocals, path, valueStart, componentEnd);
+                        final String maskedValue = maskingFunction.mask(name, value);
+                        if (maskedValue != null) {
+                            if (retained) {
+                                maskedQuery.append('&');
+                            }
+                            maskedQuery.append(path, componentStart, equalsPos).append('=');
+                            encodeComponent(maskedQuery, maskedValue);
+                            retained = true;
+                        }
+                    }
+                }
+
+                if (!matched) {
+                    if (retained) {
+                        maskedQuery.append('&');
+                    }
+                    maskedQuery.append(path, componentStart, componentEnd);
+                    retained = true;
+                }
+
+                if (componentEnd == queryEnd) {
+                    break;
+                }
+                componentStart = componentEnd + 1;
+            }
+
+            if (!masked) {
+                return null;
+            }
+
+            final int prefixEnd = retained ? queryStart : queryStart - 1;
+            final StringBuilder maskedPath = new StringBuilder(path.length() + 16);
+            maskedPath.append(path, 0, prefixEnd);
+            if (retained) {
+                maskedPath.append(maskedQuery);
+            }
+            return maskedPath.append(path, queryEnd, path.length()).toString();
+        }
+    }
+
+    private static int firstEqualsOrEnd(String path, int componentStart, int componentEnd) {
+        for (int i = componentStart; i < componentEnd; i++) {
+            if (path.charAt(i) == '=') {
+                return i;
+            }
+        }
+        return componentEnd;
+    }
+}

--- a/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/common/logging/TextLogFormatterBuilder.java
@@ -48,8 +48,10 @@ public final class TextLogFormatterBuilder
      * Returns a newly-created text {@link LogFormatter} based on the properties of this builder.
      */
     public LogFormatter build() {
+        final HeadersSanitizer<String> requestHeadersSanitizer =
+                firstNonNull(requestHeadersSanitizer(), HeadersSanitizer.ofText());
         return new TextLogFormatter(
-                firstNonNull(requestHeadersSanitizer(), HeadersSanitizer.ofText()),
+                maybeWrapRequestHeadersSanitizer(requestHeadersSanitizer),
                 firstNonNull(responseHeadersSanitizer(), HeadersSanitizer.ofText()),
                 firstNonNull(requestTrailersSanitizer(), defaultHeadersSanitizer()),
                 firstNonNull(responseTrailersSanitizer(), defaultHeadersSanitizer()),

--- a/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/JsonLogFormatterTest.java
@@ -107,6 +107,25 @@ class JsonLogFormatterTest {
     }
 
     @Test
+    void maskQueryParams() {
+        final LogFormatter logFormatter = LogFormatter.builderForJson()
+                                                      .maskQueryParams("token", "ssn")
+                                                      .build();
+        final HttpRequest req = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.GET, "/v1/users?token=abcdef&page=1&ssn=1234",
+                                  HttpHeaderNames.COOKIE, "Armeria=awesome"));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        final String requestLog = logFormatter.formatRequest(log);
+        assertThat(requestLog)
+                .contains("\":path\":\"/v1/users?token=****&page=1&ssn=****\"")
+                .contains("\"cookie\":\"****\"")
+                .doesNotContain("abcdef", "1234");
+    }
+
+    @Test
     void defaultSensitiveHeadersShouldBeOverridable() {
         final LogFormatter logFormatter = LogFormatter.builderForJson()
                                                       .responseHeadersSanitizer(

--- a/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
@@ -115,6 +115,128 @@ class TextLogFormatterTest {
     }
 
     @Test
+    void maskQueryParams() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token", "ssn")
+                                                      .build();
+        final HttpRequest req = HttpRequest.of(
+                RequestHeaders.of(HttpMethod.GET, "/v1/users?token=abcdef&page=1&ssn=1234",
+                                  HttpHeaderNames.COOKIE, "Armeria=awesome"));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        final String requestLog = logFormatter.formatRequest(log);
+        assertThat(requestLog).contains(":path=/v1/users?token=****&page=1&ssn=****");
+        assertThat(requestLog).contains("cookie=****");
+        assertThat(requestLog).doesNotContain("abcdef", "1234");
+    }
+
+    @Test
+    void maskDuplicateQueryParams() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET,
+                               "/search?token=first&token=&token=third&page=a%20b"));
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        final String requestLog = logFormatter.formatRequest(log);
+        assertThat(requestLog).contains(":path=/search?token=****&token=****&token=****&page=a+b");
+        assertThat(requestLog).doesNotContain("first", "third");
+    }
+
+    @Test
+    void preserveUnmaskedQueryComponents() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token", "token/id")
+                                                      .build();
+        final ServiceRequestContext ctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final DefaultRequestLog log = new DefaultRequestLog(ctx);
+        log.requestHeaders(RequestHeaders.of(
+                HttpMethod.GET,
+                "/search?token=first&token%2Fid=second&page=a%20b&x=a%2Bb#fragment"));
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains(":path=/search?token=****&token%2Fid=****&page=a%20b&x=a%2Bb#fragment")
+                .doesNotContain("first", "second");
+    }
+
+    @Test
+    void useCustomQueryParamMaskingFunction() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .queryParamMaskingFunction(
+                                                              (name, value) -> name + '-' + value.length())
+                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET, "/search?token=abcdef&page=1"));
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains(":path=/search?token=token-6&page=1");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/search?token=abcdef, /search",
+            "/search?token=abcdef&page=1, /search?page=1",
+            "/search?page=1&token=abcdef&sort=asc, /search?page=1&sort=asc"
+    })
+    void removeQueryParamWhenMaskingFunctionReturnsNull(String path, String maskedPath) {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .queryParamMaskingFunction((name, value) -> null)
+                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET, path));
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains(":path=" + maskedPath + ']')
+                .doesNotContain("abcdef");
+    }
+
+    @Test
+    void customRequestHeadersSanitizerReceivesMaskedQueryParams() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .requestHeadersSanitizer((ctx, headers) ->
+                                                              headers.get(HttpHeaderNames.PATH))
+                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET, "/search?token=abcdef&page=a%20b"));
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains("headers=/search?token=****&page=a+b");
+    }
+
+    @Test
+    void leavePathUnchangedWhenQueryParamDoesNotMatch() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .requestHeadersSanitizer((ctx, headers) ->
+                                                              headers.get(HttpHeaderNames.PATH))
+                                                      .build();
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.GET, "/search?page"));
+        final DefaultRequestLog log = (DefaultRequestLog) ctx.log();
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains("headers=/search?page}")
+                .doesNotContain("headers=/search?page=");
+    }
+
+    @Test
     void defaultSensitiveHeadersShouldBeOverridable() {
         final LogFormatter logFormatter = LogFormatter.builderForText()
                                                       .responseHeadersSanitizer(

--- a/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
+++ b/core/src/test/java/com/linecorp/armeria/common/logging/TextLogFormatterTest.java
@@ -167,6 +167,25 @@ class TextLogFormatterTest {
     }
 
     @Test
+    void doNotMaskFragmentThatContainsQueryDelimiter() {
+        final LogFormatter logFormatter = LogFormatter.builderForText()
+                                                      .maskQueryParams("token")
+                                                      .requestHeadersSanitizer((ctx, headers) ->
+                                                              headers.get(HttpHeaderNames.PATH))
+                                                      .build();
+        final ServiceRequestContext ctx =
+                ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final DefaultRequestLog log = new DefaultRequestLog(ctx);
+        log.requestHeaders(RequestHeaders.of(
+                HttpMethod.GET, "/search#fragment?token=value"));
+        log.endRequest();
+
+        assertThat(logFormatter.formatRequest(log))
+                .contains("headers=/search#fragment?token=value")
+                .doesNotContain("****");
+    }
+
+    @Test
     void useCustomQueryParamMaskingFunction() {
         final LogFormatter logFormatter = LogFormatter.builderForText()
                                                       .maskQueryParams("token")


### PR DESCRIPTION
Motivation:

`LogFormatter` currently logs sensitive query parameter values as part of the `:path` pseudo-header. Masking only selected query parameters requires users to replace the request header sanitizer and rewrite the request path themselves, which can also replace Armeria's default sensitive-header masking behavior.

Modifications:

- Add `maskQueryParams(String...)` and `maskQueryParams(Iterable<String>)` to the text and JSON log formatter builders.
- Add `QueryParamMaskingFunction` and `queryParamMaskingFunction(...)` for custom replacement or removal of selected query parameters.
- Apply query parameter masking before the existing request header sanitizer so default and custom sanitizers continue to work.
- Preserve unmasked raw query components, encoded parameter names, fragments, duplicate parameters and their order.
- Add regression tests for text and JSON formatting, duplicate parameters, custom masking and removal, raw component preservation, and sanitizer composition.

Result:

- Closes #6919.
- Applications can mask selected query parameter values in request logs without replacing Armeria's existing sensitive-header masking behavior.
