### PR TITLE
Fix lambda-style client decorators breaking the `Unwrappable.as()` chain

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientDecoration.java
@@ -21,6 +21,12 @@ import java.util.function.Function;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.armeria.common.util.AbstractUnwrappable;
+
 /**
  * A set of {@link Function}s that transforms a {@link Client} into another.
  */
@@ -113,7 +119,8 @@ public final class ClientDecoration {
      */
     public HttpClient decorate(HttpClient client) {
         for (Function<? super HttpClient, ? extends HttpClient> decorator : decorators) {
-            client = decorator.apply(client);
+            final HttpClient previous = client;
+            client = maybeWrap(previous, decorator.apply(client));
         }
         return client;
     }
@@ -125,8 +132,33 @@ public final class ClientDecoration {
      */
     public RpcClient rpcDecorate(RpcClient client) {
         for (Function<? super RpcClient, ? extends RpcClient> decorator : rpcDecorators) {
-            client = decorator.apply(client);
+            final RpcClient previous = client;
+            client = maybeWrapRpc(previous, decorator.apply(client));
         }
         return client;
+    }
+
+    private static HttpClient maybeWrap(HttpClient previous, HttpClient decorated) {
+        if (decorated == previous || decorated instanceof AbstractUnwrappable) {
+            return decorated;
+        }
+        return new SimpleDecoratingHttpClient(previous) {
+            @Override
+            public HttpResponse execute(ClientRequestContext ctx, HttpRequest req) throws Exception {
+                return decorated.execute(ctx, req);
+            }
+        };
+    }
+
+    private static RpcClient maybeWrapRpc(RpcClient previous, RpcClient decorated) {
+        if (decorated == previous || decorated instanceof AbstractUnwrappable) {
+            return decorated;
+        }
+        return new SimpleDecoratingRpcClient(previous) {
+            @Override
+            public RpcResponse execute(ClientRequestContext ctx, RpcRequest req) throws Exception {
+                return decorated.execute(ctx, req);
+            }
+        };
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/internal/client/TailPreClient.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/TailPreClient.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.armeria.internal.client;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -58,7 +60,9 @@ public final class TailPreClient<I extends Request, O extends Response, C extend
             Function<CompletableFuture<HttpResponse>, HttpResponse> futureConverter,
             BiFunction<ClientRequestContext, Throwable, HttpResponse> errorResponseFactory) {
         final TailHttpClient tailDelegating = httpClient.as(TailHttpClient.class);
-        assert tailDelegating != null;
+        checkState(tailDelegating != null,
+                   "Failed to find TailHttpClient in the decorator chain. " +
+                   "A decorator may have been added that does not properly delegate Unwrappable.as().");
         final HttpClient rawDelegate = tailDelegating.defaultDelegate();
         final TailPreClient<HttpRequest, HttpResponse, HttpClient> tail =
                 new TailPreClient<>(httpClient, futureConverter, errorResponseFactory,
@@ -77,7 +81,9 @@ public final class TailPreClient<I extends Request, O extends Response, C extend
             Function<CompletableFuture<RpcResponse>, RpcResponse> futureConverter,
             BiFunction<ClientRequestContext, Throwable, RpcResponse> errorResponseFactory) {
         final TailRpcClient tailDelegating = rpcClient.as(TailRpcClient.class);
-        assert tailDelegating != null;
+        checkState(tailDelegating != null,
+                   "Failed to find TailRpcClient in the decorator chain. " +
+                   "A decorator may have been added that does not properly delegate Unwrappable.as().");
         final RpcClient rawDelegate = tailDelegating.defaultDelegate();
         final TailPreClient<RpcRequest, RpcResponse, RpcClient> tail =
                 new TailPreClient<>(rpcClient, futureConverter, errorResponseFactory,

--- a/core/src/test/java/com/linecorp/armeria/client/ClientDecorationTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientDecorationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+
+class ClientDecorationTest {
+
+    @Test
+    void lambdaDecorator() {
+        final BlockingWebClient client =
+                WebClient.builder()
+                         .decorator(delegate -> (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse response = client.get("http://127.0.0.1/");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void lambdaDecoratorThatDelegates() {
+        final BlockingWebClient client =
+                WebClient.builder()
+                         // inner: returns a response directly
+                         .decorator(delegate -> (ctx, req) -> HttpResponse.of("hello"))
+                         // outer: lambda that delegates to inner
+                         .decorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse response = client.get("http://127.0.0.1/");
+        assertThat(response.contentUtf8()).isEqualTo("hello");
+    }
+
+    @Test
+    void mixedLambdaAndSimpleDecoratingClient() {
+        final BlockingWebClient client =
+                WebClient.builder()
+                         // inner: lambda decorator
+                         .decorator(delegate -> (ctx, req) -> HttpResponse.of("from-lambda"))
+                         // outer: SimpleDecoratingHttpClient
+                         .decorator(delegate -> new SimpleDecoratingHttpClient(delegate) {
+                             @Override
+                             public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
+                                     throws Exception {
+                                 return unwrap().execute(ctx, req);
+                             }
+                         })
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse response = client.get("http://127.0.0.1/");
+        assertThat(response.contentUtf8()).isEqualTo("from-lambda");
+    }
+
+    @Test
+    void multipleLambdaDecorators() {
+        final BlockingWebClient client =
+                WebClient.builder()
+                         .decorator(delegate -> (ctx, req) -> HttpResponse.of("first"))
+                         .decorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                         .decorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                         .build()
+                         .blocking();
+
+        final AggregatedHttpResponse response = client.get("http://127.0.0.1/");
+        assertThat(response.contentUtf8()).isEqualTo("first");
+    }
+
+    @Test
+    void decoratorWrappingWrongDelegate() {
+        // A decorator that wraps a different client than the one passed to it.
+        // The as() chain goes through the wrong path, so TailHttpClient is not found.
+        final HttpClient other = (ctx, req) -> HttpResponse.of(HttpStatus.OK);
+        assertThatThrownBy(() -> {
+            WebClient.builder()
+                     .decorator(delegate -> new SimpleDecoratingHttpClient(other) {
+                         @Override
+                         public HttpResponse execute(ClientRequestContext ctx, HttpRequest req)
+                                 throws Exception {
+                             return unwrap().execute(ctx, req);
+                         }
+                     })
+                     .build();
+        }).isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Failed to find TailHttpClient");
+    }
+}

--- a/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/RpcClientDecorationTest.java
+++ b/thrift/thrift0.13/src/test/java/com/linecorp/armeria/client/thrift/RpcClientDecorationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.thrift;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.RpcClient;
+import com.linecorp.armeria.client.SimpleDecoratingRpcClient;
+import com.linecorp.armeria.common.RpcRequest;
+import com.linecorp.armeria.common.RpcResponse;
+
+import testing.thrift.main.HelloService;
+
+class RpcClientDecorationTest {
+
+    @Test
+    void lambdaRpcDecorator() throws TException {
+        final HelloService.Iface client =
+                ThriftClients.builder("http://127.0.0.1/")
+                             .rpcDecorator(delegate -> (ctx, req) -> RpcResponse.of("lambda"))
+                             .build(HelloService.Iface.class);
+
+        final String response = client.hello("world");
+        assertThat(response).isEqualTo("lambda");
+    }
+
+    @Test
+    void lambdaRpcDecoratorThatDelegates() throws TException {
+        final HelloService.Iface client =
+                ThriftClients.builder("http://127.0.0.1/")
+                             // inner: returns a response directly
+                             .rpcDecorator(delegate -> (ctx, req) -> RpcResponse.of("hello"))
+                             // outer: lambda that delegates to inner
+                             .rpcDecorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                             .build(HelloService.Iface.class);
+
+        final String response = client.hello("world");
+        assertThat(response).isEqualTo("hello");
+    }
+
+    @Test
+    void mixedLambdaAndSimpleDecoratingRpcClient() throws TException {
+        final HelloService.Iface client =
+                ThriftClients.builder("http://127.0.0.1/")
+                             // inner: lambda decorator
+                             .rpcDecorator(delegate -> (ctx, req) -> RpcResponse.of("from-lambda"))
+                             // outer: SimpleDecoratingRpcClient
+                             .rpcDecorator(delegate -> new SimpleDecoratingRpcClient(delegate) {
+                                 @Override
+                                 public RpcResponse execute(ClientRequestContext ctx, RpcRequest req)
+                                         throws Exception {
+                                     return unwrap().execute(ctx, req);
+                                 }
+                             })
+                             .build(HelloService.Iface.class);
+
+        final String response = client.hello("world");
+        assertThat(response).isEqualTo("from-lambda");
+    }
+
+    @Test
+    void multipleLambdaRpcDecorators() throws TException {
+        final HelloService.Iface client =
+                ThriftClients.builder("http://127.0.0.1/")
+                             .rpcDecorator(delegate -> (ctx, req) -> RpcResponse.of("first"))
+                             .rpcDecorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                             .rpcDecorator(delegate -> (ctx, req) -> delegate.execute(ctx, req))
+                             .build(HelloService.Iface.class);
+
+        final String response = client.hello("world");
+        assertThat(response).isEqualTo("first");
+    }
+
+    @Test
+    void rpcDecoratorWrappingWrongDelegate() {
+        final RpcClient other = (ctx, req) -> RpcResponse.of("other");
+        assertThatThrownBy(() -> {
+            ThriftClients.builder("http://127.0.0.1/")
+                         .rpcDecorator(delegate -> new SimpleDecoratingRpcClient(other) {
+                             @Override
+                             public RpcResponse execute(ClientRequestContext ctx, RpcRequest req)
+                                     throws Exception {
+                                 return unwrap().execute(ctx, req);
+                             }
+                         })
+                         .build(HelloService.Iface.class);
+        }).isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Failed to find TailRpcClient");
+    }
+}


### PR DESCRIPTION
Motivation:

After #6890 introduced `TailHttpClient`/`TailRpcClient` to reorder user decorators before xDS filters, `TailPreClient.of()` uses `httpClient.as(TailHttpClient.class)` to find the `TailHttpClient` at the bottom of the decorator chain. This traversal relies on `AbstractUnwrappable.as()`, which delegates to `delegate.as(type)` to walk the chain.

However, lambda-style decorators (e.g. `delegate -> (ctx, req) -> delegate.execute(ctx, req)`) return an anonymous `HttpClient` that uses the default `Unwrappable.as()`, which only checks `type.isInstance(this)` and does **not** traverse the chain. This breaks the `as()` traversal, causing an `AssertionError` at client construction time.

Modifications:

- Modified `ClientDecoration.decorate()` and `rpcDecorate()` to detect when a decorator returns a client that is not an `AbstractUnwrappable` (i.e. a lambda), and wrap it in a `SimpleDecoratingHttpClient`/`SimpleDecoratingRpcClient` that preserves the `as()` chain.
- Replaced bare `assert` statements in `TailPreClient.of()` and `ofRpc()` with explicit `checkState()` calls that throw `IllegalStateException` with a descriptive error message.
- Added `ClientDecorationTest` in the core module to verify lambda-style HTTP decorators work correctly.
- Added `RpcClientDecorationTest` in the thrift module to verify lambda-style RPC decorators work correctly.

Result:

- Users can use lambda-style `Function<HttpClient, HttpClient>` and `Function<RpcClient, RpcClient>` decorators without hitting an assertion failure.
- If a decorator wraps a different delegate than the one passed to it (breaking the `Unwrappable.as()` chain), an `IllegalStateException` with a clear message is thrown instead of a bare `AssertionError`.
