### PR TITLE
Only trigger the xDS workflows on main repository

### DIFF
--- a/.github/workflows/xds-sync-apis.yml
+++ b/.github/workflows/xds-sync-apis.yml
@@ -6,10 +6,11 @@ permissions:
 on:
   schedule:
     # every monday at 10:00 am (KST)
-    - cron:  '0 1 * * 1'
+    - cron: '0 1 * * 1'
 
 jobs:
   envoy-versions:
+    if: github.repository == 'line/armeria'
     uses: ./.github/workflows/xds-compare-versions.yml
 
   call-update-protobuf:
@@ -17,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
     needs: envoy-versions
-    if: ${{ needs.envoy-versions.outputs.should_update == 'true' }}
+    if: github.repository == 'line/armeria' && needs.envoy-versions.outputs.should_update == 'true'
     uses: ./.github/workflows/xds-apply-updates.yml
     with:
       target_version: ${{ needs.envoy-versions.outputs.target_version }}


### PR DESCRIPTION
Motivation:

The "Sync xDS APIs with upstream" workflow has been running on my fork for several months, and recently also failing. I think we can limit the execution to only run this workflow on the main repository.

Modifications:

- Add the missing `github.repository` check on all scheduled workflows

Result:

- The xDS API workflow only runs on `line/armeria` repository