### PR TITLE
Add CallExecutor for gRPC server listener callback dispatch

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/AbstractCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/AbstractCallExecutor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.grpc;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shares the exception-routing logic between the {@link CallExecutor} implementations.
+ */
+abstract class AbstractCallExecutor implements CallExecutor {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractCallExecutor.class);
+
+    private final Consumer<? super Throwable> exceptionHandler;
+
+    AbstractCallExecutor(Consumer<? super Throwable> exceptionHandler) {
+        this.exceptionHandler = exceptionHandler;
+    }
+
+    /**
+     * Runs the task and routes any {@link Throwable} it throws to the exception handler.
+     * Never throws: a misbehaving handler is logged instead, so that a drain loop can always continue with
+     * the tasks queued behind the failed one. Otherwise those tasks would be orphaned in the queue.
+     */
+    protected final void runTask(Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable cause) {
+            try {
+                exceptionHandler.accept(cause);
+            } catch (Throwable handlerCause) {
+                logger.warn("Unexpected exception from the exception handler of {} " +
+                            "while handling an exception from a task: {}", this, cause, handlerCause);
+            }
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/AbstractCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/AbstractCallExecutor.java
@@ -21,6 +21,9 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+
 /**
  * Shares the exception-routing logic between the {@link CallExecutor} implementations.
  */
@@ -28,26 +31,37 @@ abstract class AbstractCallExecutor implements CallExecutor {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractCallExecutor.class);
 
+    private final RequestContext ctx;
     private final Consumer<? super Throwable> exceptionHandler;
 
-    AbstractCallExecutor(Consumer<? super Throwable> exceptionHandler) {
+    AbstractCallExecutor(RequestContext ctx, Consumer<? super Throwable> exceptionHandler) {
+        this.ctx = ctx;
         this.exceptionHandler = exceptionHandler;
     }
 
     /**
-     * Runs the task and routes any {@link Throwable} it throws to the exception handler.
-     * Never throws: a misbehaving handler is logged instead, so that a drain loop can always continue with
-     * the tasks queued behind the failed one. Otherwise those tasks would be orphaned in the queue.
+     * Returns the {@link RequestContext} of the call this executor belongs to.
+     */
+    protected final RequestContext ctx() {
+        return ctx;
+    }
+
+    /**
+     * Runs the task with {@link #ctx()} pushed and routes any {@link Throwable} it throws to the exception
+     * handler. A misbehaving handler is logged instead of propagating, so that a drain loop can always
+     * continue with the tasks queued behind the failed one.
      */
     protected final void runTask(Runnable task) {
-        try {
-            task.run();
-        } catch (Throwable cause) {
+        try (SafeCloseable ignored = ctx.push()) {
             try {
-                exceptionHandler.accept(cause);
-            } catch (Throwable handlerCause) {
-                logger.warn("Unexpected exception from the exception handler of {} " +
-                            "while handling an exception from a task: {}", this, cause, handlerCause);
+                task.run();
+            } catch (Throwable cause) {
+                try {
+                    exceptionHandler.accept(cause);
+                } catch (Throwable handlerCause) {
+                    logger.warn("Unexpected exception from the exception handler of {} " +
+                                "while handling an exception from a task: {}", this, cause, handlerCause);
+                }
             }
         }
     }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
@@ -46,10 +46,10 @@ import io.netty.channel.EventLoop;
 public interface CallExecutor extends Executor {
 
     /**
-     * Returns a CallExecutor that runs tasks on the EventLoop of the specified
-     * RequestContext. When called on that event loop while idle and the current
-     * context is compatible with the call's context, a task runs inline without
-     * touching the queue.
+     * Returns a {@link CallExecutor} that runs tasks on the {@link EventLoop} of the specified
+     * {@link RequestContext}. A task submitted from that event loop runs inline without touching
+     * the queue when this executor has no task running or queued and the current context is
+     * compatible with the specified context.
      */
     static CallExecutor of(RequestContext ctx, Consumer<? super Throwable> exceptionHandler) {
         return new EventLoopCallExecutor(requireNonNull(ctx, "ctx"),

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
@@ -21,12 +21,15 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
+import com.linecorp.armeria.common.RequestContext;
+
 import io.netty.channel.EventLoop;
 
 /**
  * A per-call {@link Executor} that runs the tasks of a single gRPC call one at a time.
  *
  * <ul>
+ *   <li>Every task runs with the call's {@link RequestContext} pushed.</li>
  *   <li>No two tasks run concurrently, and consecutive tasks have a happens-before relationship.</li>
  *   <li>Tasks run in the order they were enqueued, whichever thread submitted them.</li>
  *   <li>A task submitted while this executor is already running a task on the current thread is
@@ -43,26 +46,30 @@ import io.netty.channel.EventLoop;
 public interface CallExecutor extends Executor {
 
     /**
-     * Returns a {@link CallExecutor} that runs tasks on the specified {@link EventLoop}.
-     * When called on the event loop while idle, a task runs inline without touching the queue.
+     * Returns a CallExecutor that runs tasks on the EventLoop of the specified
+     * RequestContext. When called on that event loop while idle and the current
+     * context is compatible with the call's context, a task runs inline without
+     * touching the queue.
      */
-    static CallExecutor of(EventLoop eventLoop, Consumer<? super Throwable> exceptionHandler) {
-        return new EventLoopCallExecutor(requireNonNull(eventLoop, "eventLoop"),
+    static CallExecutor of(RequestContext ctx, Consumer<? super Throwable> exceptionHandler) {
+        return new EventLoopCallExecutor(requireNonNull(ctx, "ctx"),
                                          requireNonNull(exceptionHandler, "exceptionHandler"));
     }
 
     /**
-     * Returns a {@link CallExecutor} that serializes tasks on top of the specified, possibly
-     * multi-threaded, {@link Executor} such as {@code ctx.blockingTaskExecutor()}.
+     * Returns a {@link CallExecutor} that serializes the tasks of the specified {@link RequestContext} on
+     * top of the specified, possibly multi-threaded, {@link Executor} such as
+     * {@code ctx.blockingTaskExecutor()}.
      */
-    static CallExecutor sequential(Executor executor, Consumer<? super Throwable> exceptionHandler) {
-        return new SequentialCallExecutor(requireNonNull(executor, "executor"),
+    static CallExecutor sequential(RequestContext ctx, Executor executor,
+                                   Consumer<? super Throwable> exceptionHandler) {
+        return new SequentialCallExecutor(requireNonNull(ctx, "ctx"), requireNonNull(executor, "executor"),
                                           requireNonNull(exceptionHandler, "exceptionHandler"));
     }
 
     /**
-     * Returns {@code true} if the current thread is the one this executor runs its tasks on,
-     * like {@link EventLoop#inEventLoop()}.
+     * Returns whether the current thread is actively executing a task
+     * submitted to this executor.
      */
     boolean inExecutor();
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/CallExecutor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * A per-call {@link Executor} that runs the tasks of a single gRPC call one at a time.
+ *
+ * <ul>
+ *   <li>No two tasks run concurrently, and consecutive tasks have a happens-before relationship.</li>
+ *   <li>Tasks run in the order they were enqueued, whichever thread submitted them.</li>
+ *   <li>A task submitted while this executor is already running a task on the current thread is
+ *       enqueued and runs after the current task returns, on the same thread. It is neither run inline
+ *       nor handed back to the underlying executor.</li>
+ *   <li>A {@link Throwable} thrown by a task goes to the exception handler; one thrown by the handler
+ *       itself is logged. Neither stops the remaining tasks.</li>
+ *   <li>If the underlying executor rejects a submission, the task never runs and the
+ *       {@link java.util.concurrent.RejectedExecutionException} propagates, unless a drain already
+ *       running on this executor's thread took the task first, in which case it runs and
+ *       {@code execute()} returns normally.</li>
+ * </ul>
+ */
+public interface CallExecutor extends Executor {
+
+    /**
+     * Returns a {@link CallExecutor} that runs tasks on the specified {@link EventLoop}.
+     * When called on the event loop while idle, a task runs inline without touching the queue.
+     */
+    static CallExecutor of(EventLoop eventLoop, Consumer<? super Throwable> exceptionHandler) {
+        return new EventLoopCallExecutor(requireNonNull(eventLoop, "eventLoop"),
+                                         requireNonNull(exceptionHandler, "exceptionHandler"));
+    }
+
+    /**
+     * Returns a {@link CallExecutor} that serializes tasks on top of the specified, possibly
+     * multi-threaded, {@link Executor} such as {@code ctx.blockingTaskExecutor()}.
+     */
+    static CallExecutor sequential(Executor executor, Consumer<? super Throwable> exceptionHandler) {
+        return new SequentialCallExecutor(requireNonNull(executor, "executor"),
+                                          requireNonNull(exceptionHandler, "exceptionHandler"));
+    }
+
+    /**
+     * Returns {@code true} if the current thread is the one this executor runs its tasks on,
+     * like {@link EventLoop#inEventLoop()}.
+     */
+    boolean inExecutor();
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/EventLoopCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/EventLoopCallExecutor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Consumer;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * A {@link CallExecutor} that runs its tasks on an {@link EventLoop}.
+ *
+ * <p>A single queue holds every task regardless of the submitting thread, and only the event loop
+ * drains it, one drain at a time ({@code draining}). A task submitted while a drain is running on the
+ * event loop is picked up by that drain after the current task returns. When the event loop is idle and
+ * nothing is queued, the task runs inline without touching the queue.
+ */
+final class EventLoopCallExecutor extends AbstractCallExecutor {
+
+    private final EventLoop eventLoop;
+    private final Runnable drainTask = this::drain;
+
+    // Written from any thread, drained only from the event loop thread.
+    private final Queue<Runnable> queue = new ConcurrentLinkedQueue<>();
+
+    // Accessed only from the event loop thread.
+    private boolean draining;
+
+    EventLoopCallExecutor(EventLoop eventLoop, Consumer<? super Throwable> exceptionHandler) {
+        super(exceptionHandler);
+        this.eventLoop = eventLoop;
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        requireNonNull(task, "task");
+        if (!eventLoop.inEventLoop()) {
+            executeFromForeignThread(task);
+            return;
+        }
+
+        if (draining) {
+            // Reentrant; the drain running further up the stack will pick it up.
+            queue.add(task);
+            return;
+        }
+
+        if (queue.isEmpty()) {
+            // Anything a foreign thread enqueues from here on was submitted after this task, so FIFO holds.
+            draining = true;
+            try {
+                runTask(task);
+                drainQueue();
+            } finally {
+                draining = false;
+            }
+            return;
+        }
+
+        queue.add(task);
+        drain();
+    }
+
+    private void executeFromForeignThread(Runnable task) {
+        // Wrapped so that the rollback below removes exactly this submission, as Guava's SequentialExecutor
+        // does.
+        final Runnable submitted = new Runnable() {
+            @Override
+            public void run() {
+                task.run();
+            }
+
+            @Override
+            public String toString() {
+                return task.toString();
+            }
+        };
+
+        // Enqueued from this thread, not from the event loop task, so that a reentrant submission cannot
+        // overtake it.
+        queue.add(submitted);
+        try {
+            eventLoop.execute(drainTask);
+        } catch (Throwable t) {
+            // Still queued: it will never run, so rethrow. Already taken by a running drain: it ran, and only
+            // the redundant drain request was rejected.
+            if (queue.remove(submitted) || !(t instanceof RejectedExecutionException)) {
+                throw t;
+            }
+        }
+    }
+
+    @Override
+    public boolean inExecutor() {
+        return eventLoop.inEventLoop();
+    }
+
+    @VisibleForTesting
+    int pendingTasks() {
+        return queue.size();
+    }
+
+    private void drain() {
+        assert eventLoop.inEventLoop();
+        if (draining) {
+            // The drain running further up the stack will pick up whatever is queued.
+            return;
+        }
+        draining = true;
+        try {
+            drainQueue();
+        } finally {
+            draining = false;
+        }
+    }
+
+    private void drainQueue() {
+        for (;;) {
+            final Runnable next = queue.poll();
+            if (next == null) {
+                return;
+            }
+            runTask(next);
+        }
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/EventLoopCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/EventLoopCallExecutor.java
@@ -25,6 +25,9 @@ import java.util.function.Consumer;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.internal.common.RequestContextUtil;
+
 import io.netty.channel.EventLoop;
 
 /**
@@ -34,6 +37,10 @@ import io.netty.channel.EventLoop;
  * drains it, one drain at a time ({@code draining}). A task submitted while a drain is running on the
  * event loop is picked up by that drain after the current task returns. When the event loop is idle and
  * nothing is queued, the task runs inline without touching the queue.
+ *
+ * <p>Several calls share one event loop, so "on the event loop" is not enough to run inline: if another
+ * request's context is current, the submission is handed off like one from a foreign thread,
+ * so that the task runs in a fresh event loop turn with this call's context.
  */
 final class EventLoopCallExecutor extends AbstractCallExecutor {
 
@@ -46,15 +53,15 @@ final class EventLoopCallExecutor extends AbstractCallExecutor {
     // Accessed only from the event loop thread.
     private boolean draining;
 
-    EventLoopCallExecutor(EventLoop eventLoop, Consumer<? super Throwable> exceptionHandler) {
-        super(exceptionHandler);
-        this.eventLoop = eventLoop;
+    EventLoopCallExecutor(RequestContext ctx, Consumer<? super Throwable> exceptionHandler) {
+        super(ctx, exceptionHandler);
+        eventLoop = ctx.eventLoop();
     }
 
     @Override
     public void execute(Runnable task) {
         requireNonNull(task, "task");
-        if (!eventLoop.inEventLoop()) {
+        if (!eventLoop.inEventLoop() || !inCompatibleContext()) {
             executeFromForeignThread(task);
             return;
         }
@@ -82,8 +89,8 @@ final class EventLoopCallExecutor extends AbstractCallExecutor {
     }
 
     private void executeFromForeignThread(Runnable task) {
-        // Wrapped so that the rollback below removes exactly this submission, as Guava's SequentialExecutor
-        // does.
+        // Wrapped so that the rollback below removes exactly this submission,
+        // as Guava's SequentialExecutor does.
         final Runnable submitted = new Runnable() {
             @Override
             public void run() {
@@ -96,14 +103,14 @@ final class EventLoopCallExecutor extends AbstractCallExecutor {
             }
         };
 
-        // Enqueued from this thread, not from the event loop task, so that a reentrant submission cannot
-        // overtake it.
+        // Enqueued from this thread, not from the event loop task,
+        // so that a reentrant submission cannot overtake it.
         queue.add(submitted);
         try {
             eventLoop.execute(drainTask);
         } catch (Throwable t) {
-            // Still queued: it will never run, so rethrow. Already taken by a running drain: it ran, and only
-            // the redundant drain request was rejected.
+            // Still queued: it will never run, so rethrow. Already taken by a running drain:
+            // it ran, and only the redundant drain request was rejected.
             if (queue.remove(submitted) || !(t instanceof RejectedExecutionException)) {
                 throw t;
             }
@@ -112,7 +119,22 @@ final class EventLoopCallExecutor extends AbstractCallExecutor {
 
     @Override
     public boolean inExecutor() {
-        return eventLoop.inEventLoop();
+        return eventLoop.inEventLoop() && draining;
+    }
+
+    /**
+     * Whether {@link #ctx()} may be pushed on the current thread, mirroring the rule in
+     * {@code ServiceRequestContext.push()}: no context, a context without a root,
+     * this context or one of its children.
+     */
+    private boolean inCompatibleContext() {
+        final RequestContext current = RequestContext.currentOrNull();
+        if (current == null || current.root() == null) {
+            return true;
+        }
+        final RequestContext ctx = ctx();
+        return current.unwrapAll() == ctx.unwrapAll() ||
+               RequestContextUtil.equalsIgnoreWrapper(current.root(), ctx.root());
     }
 
     @VisibleForTesting

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/SequentialCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/SequentialCallExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.grpc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+/**
+ * A {@link CallExecutor} that serializes its tasks on top of a possibly multi-threaded {@link Executor},
+ * typically {@code ctx.blockingTaskExecutor()}.
+ *
+ * <p>Guava's {@link MoreExecutors#newSequentialExecutor(Executor)} already provides the queueing policy:
+ * FIFO, a reentrant submission runs after the current task on the same worker, and a rejected submission
+ * is rolled back. This class only adds {@link #inExecutor()}, which Guava has no equivalent of, and
+ * routes task exceptions to the handler instead of letting the worker swallow them.
+ */
+final class SequentialCallExecutor extends AbstractCallExecutor {
+
+    private final Executor sequentialExecutor;
+
+    /**
+     * The thread that is currently running one of our tasks, or {@code null} if none is running.
+     * Written only by the worker around each task; read from any thread by {@link #inExecutor()}.
+     */
+    @Nullable
+    private volatile Thread currentThread;
+
+    SequentialCallExecutor(Executor executor, Consumer<? super Throwable> exceptionHandler) {
+        super(exceptionHandler);
+        sequentialExecutor = MoreExecutors.newSequentialExecutor(executor);
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        requireNonNull(task, "task");
+        sequentialExecutor.execute(() -> {
+            currentThread = Thread.currentThread();
+            try {
+                runTask(task);
+            } finally {
+                currentThread = null;
+            }
+        });
+    }
+
+    @Override
+    public boolean inExecutor() {
+        return currentThread == Thread.currentThread();
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/SequentialCallExecutor.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/SequentialCallExecutor.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
 
 /**
@@ -45,8 +46,9 @@ final class SequentialCallExecutor extends AbstractCallExecutor {
     @Nullable
     private volatile Thread currentThread;
 
-    SequentialCallExecutor(Executor executor, Consumer<? super Throwable> exceptionHandler) {
-        super(exceptionHandler);
+    SequentialCallExecutor(RequestContext ctx, Executor executor,
+                           Consumer<? super Throwable> exceptionHandler) {
+        super(ctx, exceptionHandler);
         sequentialExecutor = MoreExecutors.newSequentialExecutor(executor);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -56,6 +56,7 @@ import com.linecorp.armeria.common.logging.RequestLogProperty;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.common.grpc.CallExecutor;
 import com.linecorp.armeria.internal.common.grpc.ForwardingCompressor;
 import com.linecorp.armeria.internal.common.grpc.ForwardingDecompressor;
 import com.linecorp.armeria.internal.common.grpc.GrpcLogUtil;
@@ -112,8 +113,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     private final boolean autoCompression;
 
     @VisibleForTesting
-    @Nullable
-    final Executor blockingExecutor;
+    final CallExecutor callExecutor;
     private final InternalGrpcExceptionHandler exceptionHandler;
 
     // Only set once.
@@ -173,7 +173,11 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         marshaller = new GrpcMessageMarshaller<>(alloc, serializationFormat, method, jsonMarshaller,
                                                  unsafeWrapRequestBuffers, useMethodMarshaller);
         this.unsafeWrapRequestBuffers = unsafeWrapRequestBuffers;
-        this.blockingExecutor = blockingExecutor;
+        // Listener callbacks of this call run on the blocking task executor if given, or on the event loop.
+        // The handler is only reached by a failure that escaped a task;
+        // closing the call is the only sensible reaction.
+        callExecutor = blockingExecutor != null ? CallExecutor.sequential(ctx, blockingExecutor, this::close)
+                                                : CallExecutor.of(ctx, this::close);
         defaultResponseHeaders = defaultHeaders;
         this.exceptionHandler = exceptionHandler;
 
@@ -307,18 +311,10 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
             }
 
             if (!cancelled) {
-                if (blockingExecutor != null) {
-                    blockingExecutor.execute(this::invokeOnComplete);
-                } else {
-                    invokeOnComplete();
-                }
+                callExecutor.execute(this::invokeOnComplete);
             } else {
                 this.cancelled = true;
-                if (blockingExecutor != null) {
-                    blockingExecutor.execute(this::invokeOnCancel);
-                } else {
-                    invokeOnCancel();
-                }
+                callExecutor.execute(this::invokeOnCancel);
                 // Transport error, not business logic error, so reset the stream.
                 if (!closeCalled) {
                     res.abort(statusAndMetadata.asRuntimeException());
@@ -362,11 +358,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                 GrpcUnsafeBufferUtil.storeBuffer(buf, request, ctx);
             }
 
-            if (blockingExecutor != null) {
-                blockingExecutor.execute(() -> invokeOnMessage(request, endOfStream));
-            } else {
-                invokeOnMessage(request, endOfStream);
-            }
+            callExecutor.execute(() -> invokeOnMessage(request, endOfStream));
         } catch (Throwable cause) {
             close(cause, true);
         }
@@ -376,18 +368,13 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         clientStreamClosed = true;
         if (!closeCalled) {
             maybeLogRequestContent(null);
-            if (blockingExecutor != null) {
-                blockingExecutor.execute(this::invokeHalfClose);
-            } else {
-                invokeHalfClose();
-            }
+            callExecutor.execute(this::invokeHalfClose);
         }
     }
 
     protected final void invokeOnReady() {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onReady() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
+        if (cancelled) {
+            // Do not call listener.onReady() if the call is cancelled after this task was queued.
             return;
         }
         try {
@@ -400,9 +387,12 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private void invokeOnMessage(I request, boolean halfClose) {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onMessage() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
+        if (cancelled) {
+            // Do not call listener.onMessage() if the call is cancelled after this task was queued.
+            // The listener will never see this message, so release the buffer it may be wrapping.
+            if (unsafeWrapRequestBuffers) {
+                GrpcUnsafeBufferUtil.releaseBuffer(request, ctx);
+            }
             return;
         }
         try (SafeCloseable ignored = ctx.push()) {
@@ -417,9 +407,8 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     protected final void invokeHalfClose() {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onHalfClose() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
+        if (cancelled) {
+            // Do not call listener.onHalfClose() if the call is cancelled after this task was queued.
             return;
         }
         try (SafeCloseable ignored = ctx.push()) {
@@ -662,9 +651,8 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         return cancelled;
     }
 
-    @Nullable
-    public final Executor blockingExecutor() {
-        return blockingExecutor;
+    public final CallExecutor callExecutor() {
+        return callExecutor;
     }
 
     public final EventLoop eventLoop() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/DeferredListener.java
@@ -16,30 +16,26 @@
 
 package com.linecorp.armeria.server.grpc;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.util.ArrayDeque;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.grpc.CallExecutor;
 import com.linecorp.armeria.internal.server.grpc.AbstractServerCall;
 
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
-import io.netty.util.concurrent.EventExecutor;
 
 final class DeferredListener<I> extends ServerCall.Listener<I> {
-    @Nullable
-    private final Executor blockingExecutor;
-    @Nullable
-    private final EventExecutor eventLoop;
+
+    private final CallExecutor callExecutor;
 
     // The following values are intentionally non-volatile, although the callback methods, which can be called
-    // by non-`sequentialExecutor()` thread, access the values. Because `maybeAddPendingTask()` double-checks
-    // the status of the values in the `sequentialExecutor()`.
+    // by a non-`callExecutor` thread, access the values. Because `maybeAddPendingTask()` double-checks
+    // the status of the values in the `callExecutor`.
     @Nullable
     private ArrayDeque<Consumer<Listener<I>>> pendingQueue = new ArrayDeque<>();
 
@@ -51,15 +47,9 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
         final AbstractServerCall<I, ?> armeriaServerCall = ServerCallUtil.findArmeriaServerCall(serverCall);
         checkState(armeriaServerCall != null, "Cannot use %s with a non-Armeria gRPC server. ServerCall: %s",
                    AsyncServerInterceptor.class.getName(), serverCall);
-        // As per `ServerCall.Listener`'s Javadoc, the caller should call one simultaneously. `blockingExecutor`
-        // is a sequential executor which is wrapped by `MoreExecutors.newSequentialExecutor()`. So both
-        // `blockingExecutor` and `eventLoop` guarantees the execution order.
-        blockingExecutor = armeriaServerCall.blockingExecutor();
-        if (blockingExecutor == null) {
-            eventLoop = armeriaServerCall.eventLoop();
-        } else {
-            eventLoop = null;
-        }
+        // `callExecutor` runs the tasks of this call one at a time in enqueue order, so the drain below and
+        // the callbacks queued behind it are delivered in the order they were submitted.
+        callExecutor = armeriaServerCall.callExecutor();
 
         listenerFuture.handleAsync((delegate, cause) -> {
             if (cause != null) {
@@ -87,7 +77,7 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
                 pendingQueue = null;
             }
             return null;
-        }, sequentialExecutor());
+        }, callExecutor);
     }
 
     @Override
@@ -125,11 +115,12 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
             return;
         }
 
-        if (eventLoop != null && eventLoop.inEventLoop()) {
+        if (callExecutor.inExecutor()) {
+            // Appending in place keeps this callback ahead of anything queued behind the current task.
             addPendingTask(task);
         } else {
-            // It is unavoidable to reschedule the task to ensure the execution order.
-            sequentialExecutor().execute(() -> {
+            // A foreign thread cannot touch the pending queue; re-check on the executor.
+            callExecutor.execute(() -> {
                 if (callClosed) {
                     return;
                 }
@@ -149,9 +140,5 @@ final class DeferredListener<I> extends ServerCall.Listener<I> {
 
     private boolean shouldBePending() {
         return delegate == null;
-    }
-
-    private Executor sequentialExecutor() {
-        return firstNonNull(eventLoop, blockingExecutor);
     }
 }

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/FramedGrpcService.java
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.ExchangeType;
 import com.linecorp.armeria.common.HttpRequest;
@@ -57,7 +56,6 @@ import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.GrpcHeaderNames;
 import com.linecorp.armeria.common.logging.RequestLogProperty;
-import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.armeria.internal.common.grpc.InternalGrpcExceptionHandler;
 import com.linecorp.armeria.internal.common.grpc.MetadataUtil;
@@ -296,7 +294,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         final Executor blockingExecutor;
         if (useBlockingTaskExecutor || registry.needToUseBlockingTaskExecutor(methodDef)) {
             ctx.setAttr(GRPC_USE_BLOCKING_EXECUTOR, true);
-            blockingExecutor = MoreExecutors.newSequentialExecutor(ctx.blockingTaskExecutor());
+            blockingExecutor = ctx.blockingTaskExecutor();
         } else {
             ctx.setAttr(GRPC_USE_BLOCKING_EXECUTOR, false);
             blockingExecutor = null;
@@ -304,13 +302,7 @@ final class FramedGrpcService extends AbstractHttpService implements GrpcService
         final AbstractServerCall<I, O> call = newServerCall(simpleMethodName, methodDef, ctx, req,
                                                             res, resFuture, serializationFormat,
                                                             blockingExecutor);
-        if (blockingExecutor != null) {
-            blockingExecutor.execute(() -> startCall(methodDef, ctx, req, methodDescriptor, call));
-        } else {
-            try (SafeCloseable ignored = ctx.push()) {
-                startCall(methodDef, ctx, req, methodDescriptor, call);
-            }
-        }
+        call.callExecutor().execute(() -> startCall(methodDef, ctx, req, methodDescriptor, call));
     }
 
     private static <I, O> void startCall(ServerMethodDefinition<I, O> methodDef, ServiceRequestContext ctx,

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -163,12 +163,7 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
                     // Invoke onReady() only when server can send multiple messages.
                     res.whenConsumed().thenRun(() -> {
                         if (!isCloseCalled() && pendingMessagesUpdater.decrementAndGet(this) == 0) {
-                            final Executor blockingExecutor = blockingExecutor();
-                            if (blockingExecutor != null) {
-                                blockingExecutor.execute(this::invokeOnReady);
-                            } else {
-                                invokeOnReady();
-                            }
+                            callExecutor().execute(this::invokeOnReady);
                         }
                     });
                 }

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
@@ -40,10 +40,15 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
 import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
 
 class CallExecutorTest {
 
@@ -70,7 +75,7 @@ class CallExecutorTest {
     @Test
     void sequential_tasksNeverRunConcurrentlyAndKeepPerProducerOrder() throws Exception {
         final List<Throwable> errors = new CopyOnWriteArrayList<>();
-        final CallExecutor executor = CallExecutor.sequential(pool, errors::add);
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, errors::add);
 
         final int producers = 4;
         final int perProducer = 200;
@@ -121,7 +126,7 @@ class CallExecutorTest {
 
     @Test
     void sequential_reentrantTaskRunsAfterCurrentTaskOnTheSameThread() throws Exception {
-        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, t -> {});
         final List<String> events = new CopyOnWriteArrayList<>();
         final AtomicReference<Thread> outerThread = new AtomicReference<>();
         final AtomicReference<Thread> innerThread = new AtomicReference<>();
@@ -146,7 +151,7 @@ class CallExecutorTest {
 
     @Test
     void sequential_reentrantTaskDoesNotOvertakeAlreadyQueuedTasks() throws Exception {
-        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, t -> {});
         final List<String> events = new CopyOnWriteArrayList<>();
         final CountDownLatch aStarted = new CountDownLatch(1);
         final CountDownLatch bQueued = new CountDownLatch(1);
@@ -179,7 +184,7 @@ class CallExecutorTest {
 
     @Test
     void sequential_inExecutorIsTrueOnlyWhileRunningATask() throws Exception {
-        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, t -> {});
         final CompletableFuture<Boolean> insideTask = new CompletableFuture<>();
 
         assertThat(executor.inExecutor()).isFalse();
@@ -190,7 +195,7 @@ class CallExecutorTest {
 
     @Test
     void sequential_secondTaskDoesNotStartWhileFirstIsRunning() throws Exception {
-        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, t -> {});
         final CountDownLatch firstStarted = new CountDownLatch(1);
         final CountDownLatch releaseFirst = new CountDownLatch(1);
         final AtomicBoolean firstFinished = new AtomicBoolean();
@@ -225,7 +230,7 @@ class CallExecutorTest {
             delegateCalls.incrementAndGet();
             pool.execute(task);
         };
-        final CallExecutor executor = CallExecutor.sequential(countingDelegate, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), countingDelegate, t -> {});
         final CompletableFuture<Void> done = new CompletableFuture<>();
 
         executor.execute(() -> {
@@ -241,7 +246,7 @@ class CallExecutorTest {
     void sequential_inExecutorIsFalseAgainAfterExecuteReturnsOnDirectExecutor() {
         // With a direct delegate the task runs synchronously on the calling thread, so this is the only
         // way to observe from the same thread that the "current thread" bookkeeping is reset afterwards.
-        final CallExecutor executor = CallExecutor.sequential(MoreExecutors.directExecutor(), t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), MoreExecutors.directExecutor(), t -> {});
         final AtomicBoolean insideTask = new AtomicBoolean();
 
         executor.execute(() -> insideTask.set(executor.inExecutor()));
@@ -254,7 +259,7 @@ class CallExecutorTest {
     void sequential_rejectedSubmissionNeverRunsAndPropagates() {
         final ExecutorService deadPool = Executors.newSingleThreadExecutor();
         deadPool.shutdownNow();
-        final CallExecutor executor = CallExecutor.sequential(deadPool, t -> {});
+        final CallExecutor executor = CallExecutor.sequential(ctx(), deadPool, t -> {});
         final AtomicBoolean ran = new AtomicBoolean();
 
         assertThatThrownBy(() -> executor.execute(() -> ran.set(true)))
@@ -266,7 +271,7 @@ class CallExecutorTest {
     void sequential_throwingExceptionHandlerDoesNotOrphanQueuedTasks() throws Exception {
         // The handler throwing an Error is the harshest case: without isolation it would kill the worker
         // and leave the already-queued task behind forever.
-        final CallExecutor executor = CallExecutor.sequential(pool, t -> {
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, t -> {
             throw new Error("handler failed");
         });
         final CountDownLatch firstStarted = new CountDownLatch(1);
@@ -292,7 +297,7 @@ class CallExecutorTest {
     @Test
     void sequential_exceptionIsReportedAndLaterTasksStillRun() throws Exception {
         final List<Throwable> errors = new CopyOnWriteArrayList<>();
-        final CallExecutor executor = CallExecutor.sequential(pool, errors::add);
+        final CallExecutor executor = CallExecutor.sequential(ctx(), pool, errors::add);
         final CompletableFuture<Void> secondRan = new CompletableFuture<>();
         final RuntimeException boom = new RuntimeException("boom");
 
@@ -311,7 +316,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_runsInlineWhenCalledOnTheEventLoopWhileIdle() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {});
         final CompletableFuture<Boolean> ranBeforeExecuteReturned = new CompletableFuture<>();
 
         eventLoop.get().execute(() -> {
@@ -325,7 +330,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_reentrantTaskRunsAfterCurrentTaskInsteadOfNesting() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {});
         final List<String> events = new CopyOnWriteArrayList<>();
         final CompletableFuture<List<String>> afterOuterExecute = new CompletableFuture<>();
 
@@ -345,7 +350,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_reentrantTasksKeepSubmissionOrder() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {});
         final List<String> events = new CopyOnWriteArrayList<>();
         final CompletableFuture<Void> done = new CompletableFuture<>();
 
@@ -365,7 +370,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_reentrantTaskDoesNotOvertakeTaskQueuedByForeignThread() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {});
         final List<String> events = new CopyOnWriteArrayList<>();
         final CountDownLatch aStarted = new CountDownLatch(1);
         final CountDownLatch bQueued = new CountDownLatch(1);
@@ -398,7 +403,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_foreignThreadSubmissionRunsOnTheEventLoop() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {});
         final CompletableFuture<Boolean> ranOnEventLoop = new CompletableFuture<>();
 
         // The test thread is not the event loop.
@@ -409,20 +414,11 @@ class CallExecutorTest {
     }
 
     @Test
-    void eventLoop_inExecutorIsTrueOnTheEventLoop() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
-        final CompletableFuture<Boolean> insideTask = new CompletableFuture<>();
-
-        executor.execute(() -> insideTask.complete(executor.inExecutor()));
-        assertThat(insideTask.get(10, TimeUnit.SECONDS)).isTrue();
-    }
-
-    @Test
     void eventLoop_rejectedForeignSubmissionNeverRunsAndLeavesNoResidue() throws Exception {
         final DefaultEventLoop deadLoop = new DefaultEventLoop();
         deadLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
         final EventLoopCallExecutor executor =
-                (EventLoopCallExecutor) CallExecutor.of(deadLoop, t -> {});
+                (EventLoopCallExecutor) CallExecutor.of(ctxOn(deadLoop), t -> {});
         final AtomicBoolean ran = new AtomicBoolean();
 
         assertThatThrownBy(() -> executor.execute(() -> ran.set(true)))
@@ -439,7 +435,7 @@ class CallExecutorTest {
         // instead of reporting a rejection the caller might retry.
         final InterceptingEventLoop loop = new InterceptingEventLoop();
         try {
-            final CallExecutor executor = CallExecutor.of(loop, t -> {});
+            final CallExecutor executor = CallExecutor.of(ctxOn(loop), t -> {});
             final CountDownLatch aStarted = new CountDownLatch(1);
             final CountDownLatch releaseA = new CountDownLatch(1);
             final CompletableFuture<Void> fRan = new CompletableFuture<>();
@@ -475,7 +471,7 @@ class CallExecutorTest {
 
     @Test
     void eventLoop_throwingExceptionHandlerDoesNotOrphanQueuedTasks() throws Exception {
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), t -> {
             throw new Error("handler failed");
         });
         final CompletableFuture<Void> reentrantRan = new CompletableFuture<>();
@@ -491,7 +487,7 @@ class CallExecutorTest {
     @Test
     void eventLoop_exceptionIsReportedAndDrainContinues() throws Exception {
         final List<Throwable> errors = new CopyOnWriteArrayList<>();
-        final CallExecutor executor = CallExecutor.of(eventLoop.get(), errors::add);
+        final CallExecutor executor = CallExecutor.of(ctxOn(eventLoop.get()), errors::add);
         final CompletableFuture<Void> reentrantRan = new CompletableFuture<>();
         final RuntimeException boom = new RuntimeException("boom");
 
@@ -502,6 +498,89 @@ class CallExecutorTest {
 
         reentrantRan.get(10, TimeUnit.SECONDS);
         assertThat(errors).containsExactly(boom);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Request context: every task runs with the call's context, and a call's executor never runs a
+    // task inline under another request's context.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void eventLoop_inlineTaskRunsWithTheCallContext() throws Exception {
+        final ServiceRequestContext ctx = ctxOn(eventLoop.get());
+        final CallExecutor executor = CallExecutor.of(ctx, t -> {});
+        final CompletableFuture<RequestContext> seen = new CompletableFuture<>();
+
+        // Raw event loop, no context pushed: the task still runs inline, and still sees its own context.
+        eventLoop.get().execute(() -> executor.execute(() -> seen.complete(RequestContext.currentOrNull())));
+
+        assertThat(seen.get(10, TimeUnit.SECONDS)).isSameAs(ctx);
+    }
+
+    @Test
+    void eventLoop_submissionUnderAnotherRequestContextIsNotRunInline() throws Exception {
+        // Two calls share one physical event loop. While a task of call A runs with A's context pushed,
+        // it submits to B's executor (e.g. by completing B's listener future). B's task must not run
+        // inline under A's context; it runs later with B's context.
+        final EventLoop loop = eventLoop.get();
+        final ServiceRequestContext ctxA = ctxOn(loop);
+        final ServiceRequestContext ctxB = ctxOn(loop);
+        final CallExecutor executorB = CallExecutor.of(ctxB, t -> {});
+        final AtomicBoolean bRan = new AtomicBoolean();
+        final CompletableFuture<Boolean> ranInlineUnderA = new CompletableFuture<>();
+        final CompletableFuture<RequestContext> seenByB = new CompletableFuture<>();
+
+        ctxA.eventLoop().execute(() -> {                // ContextAwareEventLoop: A's context is pushed here
+            executorB.execute(() -> {
+                bRan.set(true);
+                seenByB.complete(RequestContext.currentOrNull());
+            });
+            ranInlineUnderA.complete(bRan.get());
+        });
+
+        assertThat(ranInlineUnderA.get(10, TimeUnit.SECONDS)).isFalse();
+        assertThat(seenByB.get(10, TimeUnit.SECONDS)).isSameAs(ctxB);
+    }
+
+    @Test
+    void eventLoop_inExecutorIsTrueOnlyInsideThisExecutorsTask() throws Exception {
+        final EventLoop loop = eventLoop.get();
+        final CallExecutor executorA = CallExecutor.of(ctxOn(loop), t -> {});
+        final CallExecutor executorB = CallExecutor.of(ctxOn(loop), t -> {});
+        final CompletableFuture<Boolean> onLoopOutsideAnyTask = new CompletableFuture<>();
+        final CompletableFuture<Boolean> insideOwnTask = new CompletableFuture<>();
+        final CompletableFuture<Boolean> insideOtherCallsTask = new CompletableFuture<>();
+
+        loop.execute(() -> {
+            onLoopOutsideAnyTask.complete(executorA.inExecutor());
+            executorA.execute(() -> {
+                insideOwnTask.complete(executorA.inExecutor());
+                insideOtherCallsTask.complete(executorB.inExecutor());
+            });
+        });
+
+        assertThat(onLoopOutsideAnyTask.get(10, TimeUnit.SECONDS)).isFalse();
+        assertThat(insideOwnTask.get(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(insideOtherCallsTask.get(10, TimeUnit.SECONDS)).isFalse();
+    }
+
+    @Test
+    void sequential_taskRunsWithTheCallContext() throws Exception {
+        final ServiceRequestContext ctx = ctx();
+        final CallExecutor executor = CallExecutor.sequential(ctx, pool, t -> {});
+        final CompletableFuture<RequestContext> seen = new CompletableFuture<>();
+
+        executor.execute(() -> seen.complete(RequestContext.currentOrNull()));
+
+        assertThat(seen.get(10, TimeUnit.SECONDS)).isSameAs(ctx);
+    }
+
+    private static ServiceRequestContext ctx() {
+        return ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+    }
+
+    private static ServiceRequestContext ctxOn(EventLoop loop) {
+        return ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).eventLoop(loop).build();
     }
 
     /**

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
@@ -44,6 +44,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.testing.BlockingUtils;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
 
@@ -379,12 +380,8 @@ class CallExecutorTest {
         eventLoop.get().execute(() -> executor.execute(() -> {
             events.add("A:start");
             aStarted.countDown();
-            try {
-                // Block the event loop briefly until the test thread has queued B from outside.
-                bQueued.await(10, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+            // Block the event loop briefly until the test thread has queued B from outside.
+            BlockingUtils.blockingRun(() -> bQueued.await(10, TimeUnit.SECONDS));
             // Reentrant submission while B (from a foreign thread) is already queued: X must run after B.
             executor.execute(() -> {
                 events.add("X");
@@ -444,11 +441,7 @@ class CallExecutorTest {
             // A holds the event loop inside a running drain.
             loop.execute(() -> executor.execute(() -> {
                 aStarted.countDown();
-                try {
-                    releaseA.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
+                BlockingUtils.blockingRun(() -> releaseA.await(10, TimeUnit.SECONDS));
             }));
             assertThat(aStarted.await(10, TimeUnit.SECONDS)).isTrue();
 

--- a/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/common/grpc/CallExecutorTest.java
@@ -1,0 +1,530 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.internal.common.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.testing.junit5.common.EventLoopExtension;
+
+import io.netty.channel.DefaultEventLoop;
+
+class CallExecutorTest {
+
+    @RegisterExtension
+    static final EventLoopExtension eventLoop = new EventLoopExtension();
+
+    private static ExecutorService pool;
+
+    @BeforeAll
+    static void startPool() {
+        pool = Executors.newFixedThreadPool(4);
+    }
+
+    @AfterAll
+    static void stopPool() {
+        pool.shutdownNow();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Sequential variant: serializes tasks on top of a multi-threaded executor
+    // (the `useBlockingTaskExecutor` mode).
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void sequential_tasksNeverRunConcurrentlyAndKeepPerProducerOrder() throws Exception {
+        final List<Throwable> errors = new CopyOnWriteArrayList<>();
+        final CallExecutor executor = CallExecutor.sequential(pool, errors::add);
+
+        final int producers = 4;
+        final int perProducer = 200;
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final AtomicInteger running = new AtomicInteger();
+        final AtomicBoolean overlapped = new AtomicBoolean();
+        final CountDownLatch done = new CountDownLatch(producers * perProducer);
+
+        final List<Thread> threads = new ArrayList<>();
+        for (int p = 0; p < producers; p++) {
+            final int producer = p;
+            final Thread t = new Thread(() -> {
+                for (int i = 0; i < perProducer; i++) {
+                    final int seq = i;
+                    executor.execute(() -> {
+                        if (running.incrementAndGet() != 1) {
+                            overlapped.set(true);
+                        }
+                        events.add(producer + ":" + seq);
+                        running.decrementAndGet();
+                        done.countDown();
+                    });
+                }
+            });
+            threads.add(t);
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+        assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(overlapped).isFalse();
+        assertThat(errors).isEmpty();
+        // Submission order from each single producer thread must be preserved.
+        for (int p = 0; p < producers; p++) {
+            final String prefix = p + ":";
+            int expected = 0;
+            for (String e : events) {
+                if (e.startsWith(prefix)) {
+                    assertThat(e).isEqualTo(prefix + expected);
+                    expected++;
+                }
+            }
+            assertThat(expected).isEqualTo(perProducer);
+        }
+    }
+
+    @Test
+    void sequential_reentrantTaskRunsAfterCurrentTaskOnTheSameThread() throws Exception {
+        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final AtomicReference<Thread> outerThread = new AtomicReference<>();
+        final AtomicReference<Thread> innerThread = new AtomicReference<>();
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            events.add("A:start");
+            outerThread.set(Thread.currentThread());
+            // Reentrant submission: must NOT run inline here.
+            executor.execute(() -> {
+                events.add("X");
+                innerThread.set(Thread.currentThread());
+                done.complete(null);
+            });
+            events.add("A:end");
+        });
+
+        done.get(10, TimeUnit.SECONDS);
+        assertThat(events).containsExactly("A:start", "A:end", "X");
+        assertThat(innerThread.get()).isSameAs(outerThread.get());
+    }
+
+    @Test
+    void sequential_reentrantTaskDoesNotOvertakeAlreadyQueuedTasks() throws Exception {
+        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final CountDownLatch aStarted = new CountDownLatch(1);
+        final CountDownLatch bQueued = new CountDownLatch(1);
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            events.add("A:start");
+            aStarted.countDown();
+            try {
+                // Wait until the test thread has queued B behind us.
+                bQueued.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            // Reentrant submission while B is already queued: X must run after B.
+            executor.execute(() -> {
+                events.add("X");
+                done.complete(null);
+            });
+            events.add("A:end");
+        });
+
+        assertThat(aStarted.await(10, TimeUnit.SECONDS)).isTrue();
+        executor.execute(() -> events.add("B"));
+        bQueued.countDown();
+
+        done.get(10, TimeUnit.SECONDS);
+        assertThat(events).containsExactly("A:start", "A:end", "B", "X");
+    }
+
+    @Test
+    void sequential_inExecutorIsTrueOnlyWhileRunningATask() throws Exception {
+        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CompletableFuture<Boolean> insideTask = new CompletableFuture<>();
+
+        assertThat(executor.inExecutor()).isFalse();
+        executor.execute(() -> insideTask.complete(executor.inExecutor()));
+        assertThat(insideTask.get(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(executor.inExecutor()).isFalse();
+    }
+
+    @Test
+    void sequential_secondTaskDoesNotStartWhileFirstIsRunning() throws Exception {
+        final CallExecutor executor = CallExecutor.sequential(pool, t -> {});
+        final CountDownLatch firstStarted = new CountDownLatch(1);
+        final CountDownLatch releaseFirst = new CountDownLatch(1);
+        final AtomicBoolean firstFinished = new AtomicBoolean();
+        final CompletableFuture<Boolean> firstFinishedWhenSecondStarted = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            firstStarted.countDown();
+            try {
+                releaseFirst.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            firstFinished.set(true);
+        });
+        assertThat(firstStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+        // Submitted from another thread while the first task is held. The pool has idle threads, so an
+        // executor that did not serialize would start it right away and it would observe the first task
+        // as still running.
+        executor.execute(() -> firstFinishedWhenSecondStarted.complete(firstFinished.get()));
+        releaseFirst.countDown();
+
+        assertThat(firstFinishedWhenSecondStarted.get(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void sequential_reentrantSubmissionDoesNotRescheduleToTheDelegate() throws Exception {
+        // "Does not perform rescheduling": a reentrant submission must be picked up by the worker that is
+        // already running, not handed back to the delegate executor as a new task.
+        final AtomicInteger delegateCalls = new AtomicInteger();
+        final Executor countingDelegate = task -> {
+            delegateCalls.incrementAndGet();
+            pool.execute(task);
+        };
+        final CallExecutor executor = CallExecutor.sequential(countingDelegate, t -> {});
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            executor.execute(() -> {});
+            executor.execute(() -> done.complete(null));
+        });
+
+        done.get(10, TimeUnit.SECONDS);
+        assertThat(delegateCalls).hasValue(1);
+    }
+
+    @Test
+    void sequential_inExecutorIsFalseAgainAfterExecuteReturnsOnDirectExecutor() {
+        // With a direct delegate the task runs synchronously on the calling thread, so this is the only
+        // way to observe from the same thread that the "current thread" bookkeeping is reset afterwards.
+        final CallExecutor executor = CallExecutor.sequential(MoreExecutors.directExecutor(), t -> {});
+        final AtomicBoolean insideTask = new AtomicBoolean();
+
+        executor.execute(() -> insideTask.set(executor.inExecutor()));
+
+        assertThat(insideTask).isTrue();
+        assertThat(executor.inExecutor()).isFalse();
+    }
+
+    @Test
+    void sequential_rejectedSubmissionNeverRunsAndPropagates() {
+        final ExecutorService deadPool = Executors.newSingleThreadExecutor();
+        deadPool.shutdownNow();
+        final CallExecutor executor = CallExecutor.sequential(deadPool, t -> {});
+        final AtomicBoolean ran = new AtomicBoolean();
+
+        assertThatThrownBy(() -> executor.execute(() -> ran.set(true)))
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(ran).isFalse();
+    }
+
+    @Test
+    void sequential_throwingExceptionHandlerDoesNotOrphanQueuedTasks() throws Exception {
+        // The handler throwing an Error is the harshest case: without isolation it would kill the worker
+        // and leave the already-queued task behind forever.
+        final CallExecutor executor = CallExecutor.sequential(pool, t -> {
+            throw new Error("handler failed");
+        });
+        final CountDownLatch firstStarted = new CountDownLatch(1);
+        final CountDownLatch secondQueued = new CountDownLatch(1);
+        final CompletableFuture<Void> secondRan = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            firstStarted.countDown();
+            try {
+                secondQueued.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            throw new RuntimeException("task failed");
+        });
+        assertThat(firstStarted.await(10, TimeUnit.SECONDS)).isTrue();
+        executor.execute(() -> secondRan.complete(null));
+        secondQueued.countDown();
+
+        secondRan.get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void sequential_exceptionIsReportedAndLaterTasksStillRun() throws Exception {
+        final List<Throwable> errors = new CopyOnWriteArrayList<>();
+        final CallExecutor executor = CallExecutor.sequential(pool, errors::add);
+        final CompletableFuture<Void> secondRan = new CompletableFuture<>();
+        final RuntimeException boom = new RuntimeException("boom");
+
+        executor.execute(() -> {
+            throw boom;
+        });
+        executor.execute(() -> secondRan.complete(null));
+
+        secondRan.get(10, TimeUnit.SECONDS);
+        assertThat(errors).containsExactly(boom);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Event loop variant: runs on the request's event loop (the default mode).
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void eventLoop_runsInlineWhenCalledOnTheEventLoopWhileIdle() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CompletableFuture<Boolean> ranBeforeExecuteReturned = new CompletableFuture<>();
+
+        eventLoop.get().execute(() -> {
+            final AtomicBoolean ran = new AtomicBoolean();
+            executor.execute(() -> ran.set(true));
+            ranBeforeExecuteReturned.complete(ran.get());
+        });
+
+        assertThat(ranBeforeExecuteReturned.get(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void eventLoop_reentrantTaskRunsAfterCurrentTaskInsteadOfNesting() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final CompletableFuture<List<String>> afterOuterExecute = new CompletableFuture<>();
+
+        eventLoop.get().execute(() -> {
+            executor.execute(() -> {
+                events.add("A:start");
+                executor.execute(() -> events.add("X"));
+                events.add("A:end");
+            });
+            // The reentrant task must have been drained before the outer execute() returned.
+            afterOuterExecute.complete(new ArrayList<>(events));
+        });
+
+        assertThat(afterOuterExecute.get(10, TimeUnit.SECONDS))
+                .containsExactly("A:start", "A:end", "X");
+    }
+
+    @Test
+    void eventLoop_reentrantTasksKeepSubmissionOrder() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        eventLoop.get().execute(() -> {
+            executor.execute(() -> {
+                events.add("A:start");
+                executor.execute(() -> events.add("B"));
+                executor.execute(() -> events.add("X"));
+                events.add("A:end");
+            });
+            done.complete(null);
+        });
+
+        done.get(10, TimeUnit.SECONDS);
+        assertThat(events).containsExactly("A:start", "A:end", "B", "X");
+    }
+
+    @Test
+    void eventLoop_reentrantTaskDoesNotOvertakeTaskQueuedByForeignThread() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final List<String> events = new CopyOnWriteArrayList<>();
+        final CountDownLatch aStarted = new CountDownLatch(1);
+        final CountDownLatch bQueued = new CountDownLatch(1);
+        final CompletableFuture<Void> done = new CompletableFuture<>();
+
+        eventLoop.get().execute(() -> executor.execute(() -> {
+            events.add("A:start");
+            aStarted.countDown();
+            try {
+                // Block the event loop briefly until the test thread has queued B from outside.
+                bQueued.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            // Reentrant submission while B (from a foreign thread) is already queued: X must run after B.
+            executor.execute(() -> {
+                events.add("X");
+                done.complete(null);
+            });
+            events.add("A:end");
+        }));
+
+        assertThat(aStarted.await(10, TimeUnit.SECONDS)).isTrue();
+        executor.execute(() -> events.add("B"));
+        bQueued.countDown();
+
+        done.get(10, TimeUnit.SECONDS);
+        assertThat(events).containsExactly("A:start", "A:end", "B", "X");
+    }
+
+    @Test
+    void eventLoop_foreignThreadSubmissionRunsOnTheEventLoop() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CompletableFuture<Boolean> ranOnEventLoop = new CompletableFuture<>();
+
+        // The test thread is not the event loop.
+        assertThat(executor.inExecutor()).isFalse();
+        executor.execute(() -> ranOnEventLoop.complete(eventLoop.get().inEventLoop()));
+
+        assertThat(ranOnEventLoop.get(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void eventLoop_inExecutorIsTrueOnTheEventLoop() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {});
+        final CompletableFuture<Boolean> insideTask = new CompletableFuture<>();
+
+        executor.execute(() -> insideTask.complete(executor.inExecutor()));
+        assertThat(insideTask.get(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void eventLoop_rejectedForeignSubmissionNeverRunsAndLeavesNoResidue() throws Exception {
+        final DefaultEventLoop deadLoop = new DefaultEventLoop();
+        deadLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        final EventLoopCallExecutor executor =
+                (EventLoopCallExecutor) CallExecutor.of(deadLoop, t -> {});
+        final AtomicBoolean ran = new AtomicBoolean();
+
+        assertThatThrownBy(() -> executor.execute(() -> ran.set(true)))
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(ran).isFalse();
+        // Failure atomicity: a rejected task must not linger in the queue where a later drain could run it.
+        assertThat(executor.pendingTasks()).isZero();
+    }
+
+    @Test
+    void eventLoop_rejectionAfterRunningDrainTookTheTaskIsTreatedAsSuccess() throws Exception {
+        // The other half of failure atomicity: if the event loop rejects the drain request only after a drain
+        // that was already running has taken the task, the task did run, so execute() must return normally
+        // instead of reporting a rejection the caller might retry.
+        final InterceptingEventLoop loop = new InterceptingEventLoop();
+        try {
+            final CallExecutor executor = CallExecutor.of(loop, t -> {});
+            final CountDownLatch aStarted = new CountDownLatch(1);
+            final CountDownLatch releaseA = new CountDownLatch(1);
+            final CompletableFuture<Void> fRan = new CompletableFuture<>();
+            final AtomicInteger fRuns = new AtomicInteger();
+
+            // A holds the event loop inside a running drain.
+            loop.execute(() -> executor.execute(() -> {
+                aStarted.countDown();
+                try {
+                    releaseA.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+            assertThat(aStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+            // When the foreign submission asks the loop to drain: release A so that the running drain takes F,
+            // wait until F actually ran, and only then reject the drain request.
+            loop.rejectNextExecute(() -> {
+                releaseA.countDown();
+                fRan.join();
+            });
+            executor.execute(() -> {
+                fRuns.incrementAndGet();
+                fRan.complete(null);
+            });
+
+            assertThat(fRuns).hasValue(1);
+        } finally {
+            loop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        }
+    }
+
+    @Test
+    void eventLoop_throwingExceptionHandlerDoesNotOrphanQueuedTasks() throws Exception {
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), t -> {
+            throw new Error("handler failed");
+        });
+        final CompletableFuture<Void> reentrantRan = new CompletableFuture<>();
+
+        executor.execute(() -> {
+            executor.execute(() -> reentrantRan.complete(null));
+            throw new RuntimeException("task failed");
+        });
+
+        reentrantRan.get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void eventLoop_exceptionIsReportedAndDrainContinues() throws Exception {
+        final List<Throwable> errors = new CopyOnWriteArrayList<>();
+        final CallExecutor executor = CallExecutor.of(eventLoop.get(), errors::add);
+        final CompletableFuture<Void> reentrantRan = new CompletableFuture<>();
+        final RuntimeException boom = new RuntimeException("boom");
+
+        executor.execute(() -> {
+            executor.execute(() -> reentrantRan.complete(null));
+            throw boom;
+        });
+
+        reentrantRan.get(10, TimeUnit.SECONDS);
+        assertThat(errors).containsExactly(boom);
+    }
+
+    /**
+     * An event loop whose next {@code execute()} can be made to run a hook and then reject.
+     */
+    private static final class InterceptingEventLoop extends DefaultEventLoop {
+
+        @Nullable
+        private volatile Runnable beforeReject;
+
+        void rejectNextExecute(Runnable beforeReject) {
+            this.beforeReject = beforeReject;
+        }
+
+        @Override
+        public void execute(Runnable task) {
+            final Runnable hook = beforeReject;
+            if (hook != null) {
+                beforeReject = null;
+                hook.run();
+                throw new RejectedExecutionException("intercepted");
+            }
+            super.execute(task);
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCallTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.util.IdentityHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,12 +29,16 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.google.protobuf.ByteString;
+
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.FilteredHttpRequest;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.unsafe.grpc.GrpcUnsafeBufferUtil;
 
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -43,6 +48,8 @@ import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import io.netty.buffer.ByteBuf;
+import testing.grpc.Messages.Payload;
 import testing.grpc.Messages.StreamingInputCallRequest;
 import testing.grpc.Messages.StreamingInputCallResponse;
 import testing.grpc.TestServiceGrpc;
@@ -58,6 +65,7 @@ class AbstractServerCallTest {
             final GrpcService grpcService =
                     GrpcService.builder()
                                .useBlockingTaskExecutor(true)
+                               .unsafeWrapRequestBuffers(true)
                                .useClientTimeoutHeader(false)
                                .addService(ServerInterceptors.intercept(
                                        new FooTestServiceImpl(),
@@ -79,14 +87,20 @@ class AbstractServerCallTest {
                     protected void beforeSubscribe(Subscriber<? super HttpObject> subscriber,
                                                    Subscription subscription) {
                         // This is called right before
-                        // blockingExecutor.execute(() -> invokeOnMessage(request, endOfStream));
+                        // callExecutor.execute(() -> invokeOnMessage(request, endOfStream));
                         // in AbstractServerCall.
-                        // https://github.com/line/armeria/blob/0960d091bfc7f350c17e68f57cc627de584b9705/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java#L363
                         final ServerCall<?, ?> serverCall = serverCallCaptor.get();
                         assertThat(serverCall).isInstanceOf(AbstractServerCall.class);
-                        ((AbstractServerCall<?, ?>) serverCall).blockingExecutor.execute(() -> {
+                        ((AbstractServerCall<?, ?>) serverCall).callExecutor.execute(() -> {
                             // invokeOnMessage is not called until the request is cancelled.
                             await().until(serverCall::isCancelled);
+                            // The request message was deframed and its buffer stored in the meantime.
+                            await().until(() -> {
+                                final IdentityHashMap<Object, ByteBuf> buffers =
+                                        ctx.attr(GrpcUnsafeBufferUtil.BUFFERS);
+                                return buffers != null && !buffers.isEmpty();
+                            });
+                            storedBuffer.set(ctx.attr(GrpcUnsafeBufferUtil.BUFFERS).values().iterator().next());
                             // Now, AbstractServerCall.invokeOnMessage() is called and it doesn't call
                             // listener.onMessage() because the request is cancelled.
                         });
@@ -98,6 +112,7 @@ class AbstractServerCallTest {
                     }
                 };
                 ctx.updateRequest(newReq);
+                ctxCaptor.set(ctx);
                 return delegate.serve(ctx, newReq);
             });
             sb.requestTimeoutMillis(100);
@@ -105,6 +120,8 @@ class AbstractServerCallTest {
     };
 
     private static final AtomicBoolean isOnNextCalled = new AtomicBoolean();
+    private static final AtomicReference<ServiceRequestContext> ctxCaptor = new AtomicReference<>();
+    private static final AtomicReference<ByteBuf> storedBuffer = new AtomicReference<>();
 
     @Test
     void onMessageIsNotCalledWhenRequestCancelled() throws InterruptedException {
@@ -124,12 +141,23 @@ class AbstractServerCallTest {
                     public void onCompleted() {
                     }
                 });
-        streamingInputCallRequestStreamObserver.onNext(StreamingInputCallRequest.newBuilder().build());
+        streamingInputCallRequestStreamObserver.onNext(
+                StreamingInputCallRequest.newBuilder()
+                                         .setPayload(Payload.newBuilder()
+                                                            .setBody(ByteString.copyFromUtf8("payload")))
+                                         .build());
         assertThatThrownBy(future::get).hasCauseInstanceOf(StatusRuntimeException.class)
                                        .hasMessageContaining("CANCELLED");
         // Sleep additional 1 second to make sure that the onNext() is not called.
         Thread.sleep(1000);
         assertThat(isOnNextCalled).isFalse();
+
+        // The skipped message must release the buffer it wrapped, exactly once.
+        await().untilAsserted(() -> {
+            assertThat(storedBuffer.get()).isNotNull();
+            assertThat(storedBuffer.get().refCnt()).isZero();
+            assertThat(ctxCaptor.get().attr(GrpcUnsafeBufferUtil.BUFFERS)).isEmpty();
+        });
     }
 
     private static class FooTestServiceImpl extends TestServiceGrpc.TestServiceImplBase {

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/DeferredListenerTest.java
@@ -24,13 +24,13 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpMethod;
@@ -72,11 +72,9 @@ class DeferredListenerTest {
         }
         assertListenerEvents(serverCall, eventLoop);
 
-        final Executor blockingExecutor =
-                MoreExecutors.newSequentialExecutor(CommonPools.blockingTaskExecutor());
         final UnaryServerCall<SimpleRequest, SimpleResponse> blockingServerCall =
-                newServerCall(eventLoop, blockingExecutor);
-        assertListenerEvents(blockingServerCall, blockingExecutor);
+                newServerCall(eventLoop, CommonPools.blockingTaskExecutor());
+        assertListenerEvents(blockingServerCall, blockingServerCall.callExecutor());
     }
 
     private static void assertListenerEvents(ServerCall<SimpleRequest, SimpleResponse> serverCall,
@@ -105,8 +103,77 @@ class DeferredListenerTest {
                 .containsExactly("onMessage", "onReady", "onHalfClose", "onComplete", "onCancel");
     }
 
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void pendingMessageIsNotOvertakenByLaterMessage(boolean blocking) throws Exception {
+        // Listener future still pending. Queue: [onMessage(m1) running] [drain] [onMessage(m2)].
+        // m1 must keep its place ahead of m2 even though it arrived before the delegate was set.
+        final UnaryServerCall<SimpleRequest, SimpleResponse> call = newServerCall(blocking);
+        final Executor executor = call.callExecutor();
+        final TestListener testListener = new TestListener();
+        final CompletableFuture<ServerCall.Listener<SimpleRequest>> future = new CompletableFuture<>();
+        final DeferredListener<SimpleRequest> listener = new DeferredListener<>(call, future);
+        final SimpleRequest m1 = SimpleRequest.newBuilder().setResponseSize(1).build();
+        final SimpleRequest m2 = SimpleRequest.newBuilder().setResponseSize(2).build();
+        final CountDownLatch m1Started = new CountDownLatch(1);
+        final CountDownLatch m2Queued = new CountDownLatch(1);
+
+        executor.execute(() -> {
+            m1Started.countDown();
+            try {
+                m2Queued.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            listener.onMessage(m1);
+        });
+        assertThat(m1Started.await(10, TimeUnit.SECONDS)).isTrue();
+        future.complete(testListener);                      // drain task queued behind the running task
+        executor.execute(() -> listener.onMessage(m2));
+        m2Queued.countDown();
+
+        await().untilAsserted(() -> assertThat(testListener.messages).hasSize(2));
+        assertThat(testListener.messages).containsExactly(m1, m2);
+    }
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void pendingMessageIsDeliveredBeforeLaterTerminalCallback(boolean blocking) throws Exception {
+        // Same shape, but the task queued behind the drain is a terminal callback.
+        final UnaryServerCall<SimpleRequest, SimpleResponse> call = newServerCall(blocking);
+        final Executor executor = call.callExecutor();
+        final TestListener testListener = new TestListener();
+        final CompletableFuture<ServerCall.Listener<SimpleRequest>> future = new CompletableFuture<>();
+        final DeferredListener<SimpleRequest> listener = new DeferredListener<>(call, future);
+        final SimpleRequest m1 = SimpleRequest.newBuilder().setResponseSize(1).build();
+        final CountDownLatch m1Started = new CountDownLatch(1);
+        final CountDownLatch completeQueued = new CountDownLatch(1);
+
+        executor.execute(() -> {
+            m1Started.countDown();
+            try {
+                completeQueued.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            listener.onMessage(m1);
+        });
+        assertThat(m1Started.await(10, TimeUnit.SECONDS)).isTrue();
+        future.complete(testListener);
+        executor.execute(listener::onComplete);
+        completeQueued.countDown();
+
+        await().untilAsserted(() -> assertThat(testListener.events).hasSize(2));
+        assertThat(testListener.events).containsExactly("onMessage", "onComplete");
+    }
+
     private static void executeAndAwait(Executor executor, Runnable task) {
         CompletableFuture.runAsync(task, executor).join();
+    }
+
+    private static UnaryServerCall<SimpleRequest, SimpleResponse> newServerCall(boolean blocking) {
+        return newServerCall(CommonPools.workerGroup().next(),
+                             blocking ? CommonPools.blockingTaskExecutor() : null);
     }
 
     private static UnaryServerCall<SimpleRequest, SimpleResponse> newServerCall(
@@ -127,10 +194,14 @@ class DeferredListenerTest {
     private static class TestListener extends ServerCall.Listener<SimpleRequest> {
 
         final List<String> events = new CopyOnWriteArrayList<>();
+        final List<SimpleRequest> messages = new CopyOnWriteArrayList<>();
 
         @Override
         public void onMessage(SimpleRequest message) {
             events.add("onMessage");
+            if (message != null) {
+                messages.add(message);
+            }
         }
 
         @Override


### PR DESCRIPTION
Related: #6241 #6938

Motivation:

#6241 proposes moving gRPC request and response serialization to the `blockingTaskExecutor` when `GrpcServiceBuilder#useBlockingTaskExecutor(true)` is enabled.

As discussed in the issue, the per-call executor comes first. This PR introduces it and routes listener callback dispatch through it. Moving request deserialization and response serialization is intentionally left to follow-up PRs.

The executor provides sequential execution and avoids resubmission to the underlying executor on reentry. Reentrant tasks use a queue-and-drain trampoline, similar to gRPC's `SynchronizationContext`: they run after the current task returns, on the same thread, without another executor handoff. This also preserves FIFO ordering.

Modifications:

- Add `CallExecutor`, which executes tasks for a single gRPC call sequentially with the call's `RequestContext` pushed.
  - `EventLoopCallExecutor` runs an idle task inline when the current context is compatible, and uses a per-call queue for reentrant submissions.
  - `SequentialCallExecutor` wraps Guava's `MoreExecutors.newSequentialExecutor()` for blocking execution.
- Route gRPC call startup and listener callback dispatch in `FramedGrpcService`, `AbstractServerCall`, `StreamingServerCall`, and `DeferredListener` through the per-call executor.
- Add `CallExecutor#inExecutor()` so `DeferredListener` can determine whether it may update its pending queue directly.
- Release an unsafe-wrapped request buffer when a queued `onMessage` callback is skipped after cancellation.
- Add tests for sequential execution, reentry, ordering, request-context propagation, rejection, deferred listener ordering, and cancelled-buffer cleanup.

Result:

- Both EventLoop and blocking modes use the same per-call run-to-completion semantics.
- The normal non-blocking path remains inline when the executor is idle.
- A reentrant callback on the non-blocking path now runs after the current callback returns instead of running as a nested invocation. It is not resubmitted to the EventLoop and does not switch threads.
- No supported public API changes.
- This PR does not move serialization yet; #6241 remains open for the follow-up PRs.