### PR TITLE
Add jitter to maximum connection age

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -867,6 +867,22 @@ public final class ClientFactoryBuilder implements TlsSetters {
     }
 
     /**
+     * Sets the jitter rate applied to the maximum connection age. The effective max connection age is chosen
+     * uniformly at random for each connection between
+     * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
+     * {@code maxConnectionAge}. The default is {@code 0.0}, which disables jitter. This option has no effect
+     * when the max connection age is disabled.
+     *
+     * @param maxConnectionAgeJitterRate the jitter rate between {@code 0.0} and {@code 1.0}, inclusive
+     * @throws IllegalArgumentException if the specified {@code maxConnectionAgeJitterRate} is less than
+     *                                  {@code 0.0} or greater than {@code 1.0}
+     */
+    public ClientFactoryBuilder maxConnectionAgeJitterRate(double maxConnectionAgeJitterRate) {
+        option(ClientFactoryOptions.MAX_CONNECTION_AGE_JITTER_RATE, maxConnectionAgeJitterRate);
+        return this;
+    }
+
+    /**
      * Sets the maximum allowed number of requests that can be sent through one connection.
      * This option is disabled by default, which means unlimited.
      *

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryBuilder.java
@@ -877,6 +877,7 @@ public final class ClientFactoryBuilder implements TlsSetters {
      * @throws IllegalArgumentException if the specified {@code maxConnectionAgeJitterRate} is less than
      *                                  {@code 0.0} or greater than {@code 1.0}
      */
+    @UnstableApi
     public ClientFactoryBuilder maxConnectionAgeJitterRate(double maxConnectionAgeJitterRate) {
         option(ClientFactoryOptions.MAX_CONNECTION_AGE_JITTER_RATE, maxConnectionAgeJitterRate);
         return this;

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -250,6 +250,7 @@ public final class ClientFactoryOptions
      * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
      * {@code maxConnectionAge}. This option is disabled by default.
      */
+    @UnstableApi
     public static final ClientFactoryOption<Double> MAX_CONNECTION_AGE_JITTER_RATE =
             ClientFactoryOption.define("MAX_CONNECTION_AGE_JITTER_RATE", 0.0,
                                        ClientFactoryOptions::validateMaxConnectionAgeJitterRate,
@@ -631,6 +632,7 @@ public final class ClientFactoryOptions
      * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
      * {@code maxConnectionAge}.
      */
+    @UnstableApi
     public double maxConnectionAgeJitterRate() {
         return get(MAX_CONNECTION_AGE_JITTER_RATE);
     }

--- a/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
+++ b/core/src/main/java/com/linecorp/armeria/client/ClientFactoryOptions.java
@@ -245,6 +245,17 @@ public final class ClientFactoryOptions
             ClientFactoryOption.define("MAX_CONNECTION_AGE_MILLIS", clampedDefaultMaxClientConnectionAge());
 
     /**
+     * The jitter rate applied to the client-side max connection age. The effective max connection age is
+     * chosen uniformly at random for each connection between
+     * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
+     * {@code maxConnectionAge}. This option is disabled by default.
+     */
+    public static final ClientFactoryOption<Double> MAX_CONNECTION_AGE_JITTER_RATE =
+            ClientFactoryOption.define("MAX_CONNECTION_AGE_JITTER_RATE", 0.0,
+                                       ClientFactoryOptions::validateMaxConnectionAgeJitterRate,
+                                       (oldValue, newValue) -> newValue);
+
+    /**
      * The {@link OutlierDetection} which is used to detect unhealthy connections.
      * If an unhealthy connection is detected, it is disabled and a new connection will be created.
      * This option is disabled by default.
@@ -259,6 +270,13 @@ public final class ClientFactoryOptions
             return MIN_MAX_CONNECTION_AGE_MILLIS;
         }
         return connectionAgeMillis;
+    }
+
+    private static double validateMaxConnectionAgeJitterRate(double maxConnectionAgeJitterRate) {
+        checkArgument(maxConnectionAgeJitterRate >= 0.0 && maxConnectionAgeJitterRate <= 1.0,
+                      "maxConnectionAgeJitterRate: %s (expected: >= 0.0 and <= 1.0)",
+                      maxConnectionAgeJitterRate);
+        return maxConnectionAgeJitterRate;
     }
 
     /**
@@ -605,6 +623,16 @@ public final class ClientFactoryOptions
      */
     public long maxConnectionAgeMillis() {
         return get(MAX_CONNECTION_AGE_MILLIS);
+    }
+
+    /**
+     * Returns the jitter rate applied to the client-side max connection age. The effective max connection age
+     * is chosen uniformly at random for each connection between
+     * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
+     * {@code maxConnectionAge}.
+     */
+    public double maxConnectionAgeJitterRate() {
+        return get(MAX_CONNECTION_AGE_JITTER_RATE);
     }
 
     /**

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ClientKeepAliveHandler.java
@@ -46,11 +46,11 @@ final class Http1ClientKeepAliveHandler extends Http1KeepAliveHandler {
 
     Http1ClientKeepAliveHandler(Channel channel, Http1ResponseDecoder decoder,
                                 Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
-                                boolean keepAliveOnPing) {
+                                long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
+                                int maxNumRequestsPerConnection, boolean keepAliveOnPing) {
         super(channel, "client", keepAliveTimer, idleTimeoutMillis,
-              pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection, keepAliveOnPing,
-              ConnectionEventListener.get(channel));
+              pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+              maxNumRequestsPerConnection, keepAliveOnPing, ConnectionEventListener.get(channel));
         httpSession = HttpSession.get(requireNonNull(channel, "channel"));
         this.decoder = requireNonNull(decoder, "decoder");
     }

--- a/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http1ResponseDecoder.java
@@ -78,6 +78,7 @@ final class Http1ResponseDecoder extends AbstractHttpResponseDecoder implements 
         final long idleTimeoutMillis = clientFactory.idleTimeoutMillis();
         final long pingIntervalMillis = clientFactory.pingIntervalMillis();
         final long maxConnectionAgeMillis = clientFactory.maxConnectionAgeMillis();
+        final double maxConnectionAgeJitterRate = clientFactory.maxConnectionAgeJitterRate();
         final int maxNumRequestsPerConnection = clientFactory.maxNumRequestsPerConnection();
         final boolean keepAliveOnPing = clientFactory.keepAliveOnPing();
         final boolean needsKeepAliveHandler =
@@ -91,7 +92,8 @@ final class Http1ResponseDecoder extends AbstractHttpResponseDecoder implements 
                                         ImmutableList.of(Tag.of("protocol", protocol.uriText())));
             keepAliveHandler = new Http1ClientKeepAliveHandler(
                     channel, this, keepAliveTimer, idleTimeoutMillis,
-                    pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
+                    pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+                    maxNumRequestsPerConnection,
                     keepAliveOnPing);
         } else {
             keepAliveHandler = new NoopKeepAliveHandler();

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientConnectionHandler.java
@@ -59,6 +59,7 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
         final boolean keepAliveOnPing = clientFactory.keepAliveOnPing();
         final long pingIntervalMillis = clientFactory.pingIntervalMillis();
         final long maxConnectionAgeMillis = clientFactory.maxConnectionAgeMillis();
+        final double maxConnectionAgeJitterRate = clientFactory.maxConnectionAgeJitterRate();
         final int maxNumRequestsPerConnection = clientFactory.maxNumRequestsPerConnection();
         final boolean needsKeepAliveHandler = needsKeepAliveHandler(
                 idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
@@ -72,8 +73,8 @@ final class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler 
                                     ImmutableList.of(Tag.of("protocol", protocol.uriText())));
         return new Http2ClientKeepAliveHandler(
                 channel, encoder.frameWriter(), keepAliveTimer,
-                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
-                keepAliveOnPing);
+                idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+                maxNumRequestsPerConnection, keepAliveOnPing);
     }
 
     Http2ResponseDecoder responseDecoder() {

--- a/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/client/Http2ClientKeepAliveHandler.java
@@ -28,12 +28,12 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 final class Http2ClientKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ClientKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
-                                boolean keepAliveOnPing) {
+                                long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
+                                int maxNumRequestsPerConnection, boolean keepAliveOnPing) {
 
         super(channel, frameWriter, "client", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
-              keepAliveOnPing, ConnectionEventListener.get(channel));
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+              maxNumRequestsPerConnection, keepAliveOnPing, ConnectionEventListener.get(channel));
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpClientFactory.java
@@ -100,6 +100,7 @@ final class HttpClientFactory implements ClientFactory {
     private final boolean keepAliveOnPing;
     private final long pingIntervalMillis;
     private final long maxConnectionAgeMillis;
+    private final double maxConnectionAgeJitterRate;
     private final int maxNumRequestsPerConnection;
     private final boolean useHttp2Preface;
     private final boolean useHttp2WithoutAlpn;
@@ -185,6 +186,7 @@ final class HttpClientFactory implements ClientFactory {
         proxyConfigSelector = options.proxyConfigSelector();
         http1HeaderNaming = options.http1HeaderNaming();
         maxConnectionAgeMillis = options.maxConnectionAgeMillis();
+        maxConnectionAgeJitterRate = options.maxConnectionAgeJitterRate();
         maxNumRequestsPerConnection = options.maxNumRequestsPerConnection();
         channelPipelineCustomizer = options.channelPipelineCustomizer();
         this.autoCloseConnectionPoolListener = autoCloseConnectionPoolListener;
@@ -263,6 +265,10 @@ final class HttpClientFactory implements ClientFactory {
 
     long maxConnectionAgeMillis() {
         return maxConnectionAgeMillis;
+    }
+
+    double maxConnectionAgeJitterRate() {
+        return maxConnectionAgeJitterRate;
     }
 
     int maxNumRequestsPerConnection() {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -47,8 +47,6 @@ import io.netty.channel.EventLoop;
 public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractKeepAliveHandler.class);
-    private static final long MIN_MAX_CONNECTION_AGE_NANOS = TimeUnit.SECONDS.toNanos(1);
-
     @Nullable
     private final Stopwatch stopwatch = logger.isDebugEnabled() ? Stopwatch.createUnstarted() : null;
     private final ChannelFutureListener pingWriteListener = new PingWriteListener();
@@ -169,7 +167,7 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
                 } else {
                     randomValue = ThreadLocalRandom.current().nextDouble();
                 }
-                effectiveMaxConnectionAgeNanos = jitteredMaxConnectionAgeNanos(
+                effectiveMaxConnectionAgeNanos = KeepAliveHandlerUtil.jitteredMaxConnectionAgeNanos(
                         maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
                 maxConnectionAgeDelayNanos = effectiveMaxConnectionAgeNanos;
             }
@@ -288,19 +286,6 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
     @VisibleForTesting
     final PingState state() {
         return pingState;
-    }
-
-    @VisibleForTesting
-    static long jitteredMaxConnectionAgeNanos(long maxConnectionAgeNanos,
-                                              double jitterRate, double randomValue) {
-        if (maxConnectionAgeNanos <= 0 || jitterRate == 0) {
-            return maxConnectionAgeNanos;
-        }
-
-        final long jitteredLowerBound = (long) (maxConnectionAgeNanos * (1 - jitterRate));
-        final long lowerBound = Math.min(maxConnectionAgeNanos,
-                                         Math.max(MIN_MAX_CONNECTION_AGE_NANOS, jitteredLowerBound));
-        return lowerBound + (long) ((maxConnectionAgeNanos - lowerBound) * randomValue);
     }
 
     private void cancelFutures() {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -131,13 +131,22 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
         }
         isInitialized = true;
 
-        final long connectionStartTimeNanos = System.nanoTime();
+        final long initializationTimeNanos = System.nanoTime();
+        final KeepAliveHandlerUtil.ConnectionLifespan connectionLifespan =
+                KeepAliveHandlerUtil.connectionLifespan(channel);
+        final long connectionStartTimeNanos;
+        if (connectionLifespan != null) {
+            connectionLifespan.protocolDetected();
+            connectionStartTimeNanos = connectionLifespan.connectionStartTimeNanos();
+        } else {
+            connectionStartTimeNanos = initializationTimeNanos;
+        }
         ctx.channel().closeFuture().addListener(unused -> {
             keepAliveTimer.record(System.nanoTime() - connectionStartTimeNanos, TimeUnit.NANOSECONDS);
             destroy();
         });
 
-        lastConnectionIdleTime = lastPingIdleTime = connectionStartTimeNanos;
+        lastConnectionIdleTime = lastPingIdleTime = initializationTimeNanos;
         if (connectionIdleTimeNanos > 0) {
             connectionIdleTimeout = executor().schedule(new ConnectionIdleTimeoutTask(ctx),
                                                         connectionIdleTimeNanos, TimeUnit.NANOSECONDS);
@@ -147,17 +156,26 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
                                                   pingIdleTimeNanos, TimeUnit.NANOSECONDS);
         }
         if (maxConnectionAgeNanos > 0) {
-            final double randomValue;
-            if (maxConnectionAgeJitterRate == 0) {
-                randomValue = 0;
+            final long effectiveMaxConnectionAgeNanos;
+            final long maxConnectionAgeDelayNanos;
+            if (connectionLifespan != null) {
+                effectiveMaxConnectionAgeNanos = connectionLifespan.effectiveMaxConnectionAgeNanos();
+                final long connectionAgeNanos = initializationTimeNanos - connectionStartTimeNanos;
+                maxConnectionAgeDelayNanos = Math.max(0, effectiveMaxConnectionAgeNanos - connectionAgeNanos);
             } else {
-                randomValue = ThreadLocalRandom.current().nextDouble();
+                final double randomValue;
+                if (maxConnectionAgeJitterRate == 0) {
+                    randomValue = 0;
+                } else {
+                    randomValue = ThreadLocalRandom.current().nextDouble();
+                }
+                effectiveMaxConnectionAgeNanos = jitteredMaxConnectionAgeNanos(
+                        maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
+                maxConnectionAgeDelayNanos = effectiveMaxConnectionAgeNanos;
             }
-            final long effectiveMaxConnectionAgeNanos = jitteredMaxConnectionAgeNanos(
-                    maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
             maxConnectionAgeFuture = executor().schedule(
                     new MaxConnectionAgeExceededTask(ctx, effectiveMaxConnectionAgeNanos),
-                    effectiveMaxConnectionAgeNanos, TimeUnit.NANOSECONDS);
+                    maxConnectionAgeDelayNanos, TimeUnit.NANOSECONDS);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -270,6 +270,9 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     protected abstract boolean hasRequestsInProgress(ChannelHandlerContext ctx);
 
+    /**
+     * Closes an idle connection whose effective maximum connection age has elapsed.
+     */
     protected ChannelFuture closeIdleConnectionOnMaxAge(ChannelHandlerContext ctx) {
         return ctx.channel().close();
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/AbstractKeepAliveHandler.java
@@ -19,6 +19,7 @@ package com.linecorp.armeria.internal.common;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -46,6 +47,7 @@ import io.netty.channel.EventLoop;
 public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractKeepAliveHandler.class);
+    private static final long MIN_MAX_CONNECTION_AGE_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     @Nullable
     private final Stopwatch stopwatch = logger.isDebugEnabled() ? Stopwatch.createUnstarted() : null;
@@ -54,7 +56,6 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     private final Channel channel;
     private final String name;
-    private final boolean isServer;
     private final Timer keepAliveTimer;
 
     private final long maxNumRequestsPerConnection;
@@ -76,6 +77,7 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
     @Nullable
     private ScheduledFuture<?> maxConnectionAgeFuture;
     private final long maxConnectionAgeNanos;
+    private final double maxConnectionAgeJitterRate;
     private boolean isMaxConnectionAgeExceeded;
 
     private boolean isInitialized;
@@ -90,12 +92,13 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     protected AbstractKeepAliveHandler(Channel channel, String name, Timer keepAliveTimer,
                                        long idleTimeoutMillis, long pingIntervalMillis,
-                                       long maxConnectionAgeMillis, long maxNumRequestsPerConnection,
-                                       boolean keepAliveOnPing, ConnectionEventListener listener) {
+                                       long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
+                                       long maxNumRequestsPerConnection, boolean keepAliveOnPing,
+                                       ConnectionEventListener listener) {
         this.channel = channel;
         this.name = name;
-        isServer = "server".equals(name);
         this.keepAliveTimer = keepAliveTimer;
+        this.maxConnectionAgeJitterRate = maxConnectionAgeJitterRate;
         this.maxNumRequestsPerConnection = maxNumRequestsPerConnection;
         this.keepAliveOnPing = keepAliveOnPing;
         this.listener = listener;
@@ -144,8 +147,17 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
                                                   pingIdleTimeNanos, TimeUnit.NANOSECONDS);
         }
         if (maxConnectionAgeNanos > 0) {
-            maxConnectionAgeFuture = executor().schedule(new MaxConnectionAgeExceededTask(ctx),
-                                                         maxConnectionAgeNanos, TimeUnit.NANOSECONDS);
+            final double randomValue;
+            if (maxConnectionAgeJitterRate == 0) {
+                randomValue = 0;
+            } else {
+                randomValue = ThreadLocalRandom.current().nextDouble();
+            }
+            final long effectiveMaxConnectionAgeNanos = jitteredMaxConnectionAgeNanos(
+                    maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
+            maxConnectionAgeFuture = executor().schedule(
+                    new MaxConnectionAgeExceededTask(ctx, effectiveMaxConnectionAgeNanos),
+                    effectiveMaxConnectionAgeNanos, TimeUnit.NANOSECONDS);
         }
     }
 
@@ -242,6 +254,10 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     protected abstract boolean hasRequestsInProgress(ChannelHandlerContext ctx);
 
+    protected ChannelFuture closeIdleConnectionOnMaxAge(ChannelHandlerContext ctx) {
+        return ctx.channel().close();
+    }
+
     @Nullable
     protected final Future<?> shutdownFuture() {
         return shutdownFuture;
@@ -254,6 +270,19 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
     @VisibleForTesting
     final PingState state() {
         return pingState;
+    }
+
+    @VisibleForTesting
+    static long jitteredMaxConnectionAgeNanos(long maxConnectionAgeNanos,
+                                              double jitterRate, double randomValue) {
+        if (maxConnectionAgeNanos <= 0 || jitterRate == 0) {
+            return maxConnectionAgeNanos;
+        }
+
+        final long jitteredLowerBound = (long) (maxConnectionAgeNanos * (1 - jitterRate));
+        final long lowerBound = Math.min(maxConnectionAgeNanos,
+                                         Math.max(MIN_MAX_CONNECTION_AGE_NANOS, jitteredLowerBound));
+        return lowerBound + (long) ((maxConnectionAgeNanos - lowerBound) * randomValue);
     }
 
     private void cancelFutures() {
@@ -443,8 +472,11 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
 
     private final class MaxConnectionAgeExceededTask extends AbstractKeepAliveTask {
 
-        MaxConnectionAgeExceededTask(ChannelHandlerContext ctx) {
+        private final long effectiveMaxConnectionAgeNanos;
+
+        MaxConnectionAgeExceededTask(ChannelHandlerContext ctx, long effectiveMaxConnectionAgeNanos) {
             super(ctx);
+            this.effectiveMaxConnectionAgeNanos = effectiveMaxConnectionAgeNanos;
         }
 
         @Override
@@ -453,8 +485,12 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
                 isMaxConnectionAgeExceeded = true;
 
                 // A connection exceeding the max age will be closed with:
-                // - HTTP/2 server: Sending GOAWAY frame after writing headers
-                // - HTTP/1 server: Sending 'Connection: close' header when writing headers
+                // - HTTP/2 server
+                //   - Sending GOAWAY frame after writing headers
+                //   - Or closed by this task if the connection is idle
+                // - HTTP/1 server
+                //   - Sending 'Connection: close' header when writing headers
+                //   - Or closed by this task if the connection is idle
                 // - HTTP/2 client
                 //   - Sending GOAWAY frame after receiving the end of a stream
                 //   - Or closed by this task if the connection is idle
@@ -462,11 +498,14 @@ public abstract class AbstractKeepAliveHandler implements KeepAliveHandler {
                 //   - Close the connection after fully receiving a response
                 //   - Or closed by this task if the connection is idle
 
-                if (!isServer && !hasRequestsInProgress(ctx)) {
+                logger.debug("{} A {} connection exceeded the max age: {}ns",
+                             ctx.channel(), name, effectiveMaxConnectionAgeNanos);
+
+                if (!hasRequestsInProgress(ctx)) {
                     logger.debug("{} Closing a {} connection exceeding the max age: {}ns",
-                                 ctx.channel(), name, maxConnectionAgeNanos);
+                                 ctx.channel(), name, effectiveMaxConnectionAgeNanos);
                     listener.closeHint(CloseHint.MAX_CONNECTION_AGE);
-                    ctx.channel().close();
+                    closeIdleConnectionOnMaxAge(ctx);
                 }
             } catch (Exception e) {
                 logger.warn("Unexpected error occurred while closing a connection exceeding the max age", e);

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http1KeepAliveHandler.java
@@ -22,10 +22,10 @@ import io.netty.channel.Channel;
 public abstract class Http1KeepAliveHandler extends AbstractKeepAliveHandler {
     protected Http1KeepAliveHandler(Channel channel, String name, Timer keepAliveTimer, long idleTimeoutMillis,
                                     long pingIntervalMillis, long maxConnectionAgeMillis,
-                                    long maxNumRequestsPerConnection, boolean keepAliveOnPing,
-                                    ConnectionEventListener listener) {
+                                    double maxConnectionAgeJitterRate, long maxNumRequestsPerConnection,
+                                    boolean keepAliveOnPing, ConnectionEventListener listener) {
         super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis,
-              maxNumRequestsPerConnection, keepAliveOnPing, listener);
+              maxConnectionAgeJitterRate, maxNumRequestsPerConnection, keepAliveOnPing, listener);
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandler.java
@@ -63,10 +63,12 @@ public abstract class Http2KeepAliveHandler extends AbstractKeepAliveHandler {
 
     protected Http2KeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, String name,
                                     Timer keepAliveTimer, long idleTimeoutMillis, long pingIntervalMillis,
-                                    long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
-                                    boolean keepAliveOnPing, ConnectionEventListener listener) {
+                                    long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
+                                    int maxNumRequestsPerConnection, boolean keepAliveOnPing,
+                                    ConnectionEventListener listener) {
         super(channel, name, keepAliveTimer, idleTimeoutMillis, pingIntervalMillis,
-              maxConnectionAgeMillis, maxNumRequestsPerConnection, keepAliveOnPing, listener);
+              maxConnectionAgeMillis, maxConnectionAgeJitterRate, maxNumRequestsPerConnection,
+              keepAliveOnPing, listener);
         this.channel = requireNonNull(channel, "channel");
         this.frameWriter = requireNonNull(frameWriter, "frameWriter");
     }

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
@@ -19,6 +19,8 @@ package com.linecorp.armeria.internal.common;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.annotation.Nullable;
 
 import io.netty.channel.Channel;
@@ -27,6 +29,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.ScheduledFuture;
 
 public final class KeepAliveHandlerUtil {
+
+    private static final long MIN_MAX_CONNECTION_AGE_NANOS = TimeUnit.SECONDS.toNanos(1);
 
     private static final AttributeKey<ConnectionLifespan> CONNECTION_LIFESPAN =
             AttributeKey.valueOf(KeepAliveHandlerUtil.class, "connectionLifespan");
@@ -46,7 +50,7 @@ public final class KeepAliveHandlerUtil {
         final long maxConnectionAgeNanos = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
         final double randomValue = maxConnectionAgeJitterRate == 0 ? 0 :
                                    ThreadLocalRandom.current().nextDouble();
-        final long effectiveMaxConnectionAgeNanos = AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+        final long effectiveMaxConnectionAgeNanos = jitteredMaxConnectionAgeNanos(
                 maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
         final long connectionStartTimeNanos = System.nanoTime();
         final ScheduledFuture<?> preProtocolMaxAgeFuture = channel.eventLoop().schedule(
@@ -68,6 +72,19 @@ public final class KeepAliveHandlerUtil {
     @Nullable
     static ConnectionLifespan connectionLifespan(Channel channel) {
         return channel.attr(CONNECTION_LIFESPAN).get();
+    }
+
+    @VisibleForTesting
+    static long jitteredMaxConnectionAgeNanos(long maxConnectionAgeNanos,
+                                              double jitterRate, double randomValue) {
+        if (maxConnectionAgeNanos <= 0 || jitterRate == 0) {
+            return maxConnectionAgeNanos;
+        }
+
+        final long jitteredLowerBound = (long) (maxConnectionAgeNanos * (1 - jitterRate));
+        final long lowerBound = Math.min(maxConnectionAgeNanos,
+                                         Math.max(MIN_MAX_CONNECTION_AGE_NANOS, jitteredLowerBound));
+        return lowerBound + (long) ((maxConnectionAgeNanos - lowerBound) * randomValue);
     }
 
     static final class ConnectionLifespan {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
@@ -41,6 +41,11 @@ public final class KeepAliveHandlerUtil {
                maxConnectionAgeMillis > 0 || maxNumRequestsPerConnection > 0;
     }
 
+    /**
+     * Samples the effective maximum age of the connection and schedules a pre-protocol close task.
+     * The keep-alive handler takes ownership of the remaining lifespan after protocol detection, while
+     * closing the channel before detection cancels and cleans up the task.
+     */
     public static void initializeConnectionLifespan(Channel channel, long maxConnectionAgeMillis,
                                                     double maxConnectionAgeJitterRate) {
         if (maxConnectionAgeMillis <= 0) {

--- a/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/common/KeepAliveHandlerUtil.java
@@ -16,12 +16,92 @@
 
 package com.linecorp.armeria.internal.common;
 
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import com.linecorp.armeria.common.annotation.Nullable;
+
+import io.netty.channel.Channel;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.ScheduledFuture;
+
 public final class KeepAliveHandlerUtil {
+
+    private static final AttributeKey<ConnectionLifespan> CONNECTION_LIFESPAN =
+            AttributeKey.valueOf(KeepAliveHandlerUtil.class, "connectionLifespan");
 
     public static boolean needsKeepAliveHandler(long idleTimeoutMillis, long pingIntervalMillis,
                                                 long maxConnectionAgeMillis, int maxNumRequestsPerConnection) {
         return idleTimeoutMillis > 0 || pingIntervalMillis > 0 ||
                maxConnectionAgeMillis > 0 || maxNumRequestsPerConnection > 0;
+    }
+
+    public static void initializeConnectionLifespan(Channel channel, long maxConnectionAgeMillis,
+                                                    double maxConnectionAgeJitterRate) {
+        if (maxConnectionAgeMillis <= 0) {
+            return;
+        }
+
+        final long maxConnectionAgeNanos = TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis);
+        final double randomValue = maxConnectionAgeJitterRate == 0 ? 0 :
+                                   ThreadLocalRandom.current().nextDouble();
+        final long effectiveMaxConnectionAgeNanos = AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+                maxConnectionAgeNanos, maxConnectionAgeJitterRate, randomValue);
+        final long connectionStartTimeNanos = System.nanoTime();
+        final ScheduledFuture<?> preProtocolMaxAgeFuture = channel.eventLoop().schedule(
+                (Runnable) channel::close, effectiveMaxConnectionAgeNanos, TimeUnit.NANOSECONDS);
+        final ConnectionLifespan connectionLifespan =
+                new ConnectionLifespan(connectionStartTimeNanos, effectiveMaxConnectionAgeNanos,
+                                       preProtocolMaxAgeFuture);
+        final Attribute<ConnectionLifespan> connectionLifespanAttr = channel.attr(CONNECTION_LIFESPAN);
+        if (!connectionLifespanAttr.compareAndSet(null, connectionLifespan)) {
+            connectionLifespan.cancelPreProtocolMaxAgeFuture();
+            return;
+        }
+        channel.closeFuture().addListener(unused -> {
+            connectionLifespan.cancelPreProtocolMaxAgeFuture();
+            connectionLifespanAttr.compareAndSet(connectionLifespan, null);
+        });
+    }
+
+    @Nullable
+    static ConnectionLifespan connectionLifespan(Channel channel) {
+        return channel.attr(CONNECTION_LIFESPAN).get();
+    }
+
+    static final class ConnectionLifespan {
+
+        private final long connectionStartTimeNanos;
+        private final long effectiveMaxConnectionAgeNanos;
+        @Nullable
+        private ScheduledFuture<?> preProtocolMaxAgeFuture;
+
+        ConnectionLifespan(long connectionStartTimeNanos, long effectiveMaxConnectionAgeNanos,
+                           ScheduledFuture<?> preProtocolMaxAgeFuture) {
+            this.connectionStartTimeNanos = connectionStartTimeNanos;
+            this.effectiveMaxConnectionAgeNanos = effectiveMaxConnectionAgeNanos;
+            this.preProtocolMaxAgeFuture = preProtocolMaxAgeFuture;
+        }
+
+        long connectionStartTimeNanos() {
+            return connectionStartTimeNanos;
+        }
+
+        long effectiveMaxConnectionAgeNanos() {
+            return effectiveMaxConnectionAgeNanos;
+        }
+
+        void protocolDetected() {
+            cancelPreProtocolMaxAgeFuture();
+        }
+
+        private void cancelPreProtocolMaxAgeFuture() {
+            if (preProtocolMaxAgeFuture != null) {
+                preProtocolMaxAgeFuture.cancel(false);
+                preProtocolMaxAgeFuture = null;
+            }
+        }
     }
 
     private KeepAliveHandlerUtil() {}

--- a/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/DefaultServerConfig.java
@@ -91,6 +91,7 @@ final class DefaultServerConfig implements ServerConfig {
     private final boolean keepAliveOnPing;
     private final long pingIntervalMillis;
     private final long maxConnectionAgeMillis;
+    private final double maxConnectionAgeJitterRate;
     private final long connectionDrainDurationMicros;
     private final int maxNumRequestsPerConnection;
 
@@ -145,7 +146,7 @@ final class DefaultServerConfig implements ServerConfig {
             VirtualHost defaultVirtualHost, List<VirtualHost> virtualHosts,
             EventLoopGroup workerGroup, boolean shutdownWorkerGroupOnStop, Executor startStopExecutor,
             int maxNumConnections, long idleTimeoutMillis, boolean keepAliveOnPing, long pingIntervalMillis,
-            long maxConnectionAgeMillis,
+            long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
             int maxNumRequestsPerConnection, long connectionDrainDurationMicros,
             int http2InitialConnectionWindowSize, int http2InitialStreamWindowSize,
             float http2StreamWindowUpdateRatio, long http2MaxStreamsPerConnection, int http2MaxFrameSize,
@@ -186,6 +187,7 @@ final class DefaultServerConfig implements ServerConfig {
         this.maxNumRequestsPerConnection =
                 validateNonNegative(maxNumRequestsPerConnection, "maxNumRequestsPerConnection");
         this.maxConnectionAgeMillis = maxConnectionAgeMillis;
+        this.maxConnectionAgeJitterRate = maxConnectionAgeJitterRate;
         this.connectionDrainDurationMicros = validateNonNegative(connectionDrainDurationMicros,
                                                                  "connectionDrainDurationMicros");
         this.http2InitialConnectionWindowSize = http2InitialConnectionWindowSize;
@@ -566,6 +568,11 @@ final class DefaultServerConfig implements ServerConfig {
     @Override
     public long maxConnectionAgeMillis() {
         return maxConnectionAgeMillis;
+    }
+
+    @Override
+    public double maxConnectionAgeJitterRate() {
+        return maxConnectionAgeJitterRate;
     }
 
     @Override

--- a/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http1ServerKeepAliveHandler.java
@@ -28,9 +28,9 @@ final class Http1ServerKeepAliveHandler extends Http1KeepAliveHandler {
 
     Http1ServerKeepAliveHandler(Channel channel, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long maxConnectionAgeMillis,
-                                int maxNumRequestsPerConnection) {
+                                double maxConnectionAgeJitterRate, int maxNumRequestsPerConnection) {
         super(channel, "server", keepAliveTimer, idleTimeoutMillis, /* pingIntervalMillis(unsupported) */ 0,
-              maxConnectionAgeMillis, maxNumRequestsPerConnection, false,
+              maxConnectionAgeMillis, maxConnectionAgeJitterRate, maxNumRequestsPerConnection, false,
               ConnectionEventListener.NOOP);
     }
 

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerConnectionHandler.java
@@ -67,6 +67,7 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
         final boolean keepAliveOnPing = cfg.keepAliveOnPing();
         final long pingIntervalMillis = cfg.pingIntervalMillis();
         final long maxConnectionAgeMillis = cfg.maxConnectionAgeMillis();
+        final double maxConnectionAgeJitterRate = cfg.maxConnectionAgeJitterRate();
         final int maxNumRequestsPerConnection = cfg.maxNumRequestsPerConnection();
         final boolean needsKeepAliveHandler = needsKeepAliveHandler(
                 idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection);
@@ -77,7 +78,8 @@ final class Http2ServerConnectionHandler extends AbstractHttp2ConnectionHandler 
 
         return new Http2ServerKeepAliveHandler(
                 channel, encoder.frameWriter(), keepAliveTimer, idleTimeoutMillis,
-                pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection, keepAliveOnPing);
+                pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+                maxNumRequestsPerConnection, keepAliveOnPing);
     }
 
     ServerHttp2ObjectEncoder getOrCreateResponseEncoder(ChannelHandlerContext connectionHandlerCtx) {

--- a/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
+++ b/core/src/main/java/com/linecorp/armeria/server/Http2ServerKeepAliveHandler.java
@@ -21,22 +21,30 @@ import com.linecorp.armeria.internal.common.Http2KeepAliveHandler;
 
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 
 final class Http2ServerKeepAliveHandler extends Http2KeepAliveHandler {
     Http2ServerKeepAliveHandler(Channel channel, Http2FrameWriter frameWriter, Timer keepAliveTimer,
                                 long idleTimeoutMillis, long pingIntervalMillis,
-                                long maxConnectionAgeMillis, int maxNumRequestsPerConnection,
-                                boolean keepAliveOnPing) {
+                                long maxConnectionAgeMillis, double maxConnectionAgeJitterRate,
+                                int maxNumRequestsPerConnection, boolean keepAliveOnPing) {
         super(channel, frameWriter, "server", keepAliveTimer,
-              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxNumRequestsPerConnection,
-              keepAliveOnPing, ConnectionEventListener.NOOP);
+              idleTimeoutMillis, pingIntervalMillis, maxConnectionAgeMillis, maxConnectionAgeJitterRate,
+              maxNumRequestsPerConnection, keepAliveOnPing, ConnectionEventListener.NOOP);
     }
 
     @Override
     protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
         final HttpServer server = HttpServer.get(ctx);
         return server != null && server.unfinishedRequests() != 0;
+    }
+
+    @Override
+    protected ChannelFuture closeIdleConnectionOnMaxAge(ChannelHandlerContext ctx) {
+        // Bypass Http2ServerConnectionHandler.close(), which starts a graceful drain. Because the
+        // connection is idle, it can be closed immediately at its effective max-age deadline.
+        return ctx.close();
     }
 }

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -213,6 +213,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
 
         final long idleTimeoutMillis = config.idleTimeoutMillis();
         final long maxConnectionAgeMillis = config.maxConnectionAgeMillis();
+        final double maxConnectionAgeJitterRate = config.maxConnectionAgeJitterRate();
         final int maxNumRequestsPerConnection = config.maxNumRequestsPerConnection();
         final boolean needsKeepAliveHandler =
                 needsKeepAliveHandler(idleTimeoutMillis, /* pingIntervalMillis */ 0,
@@ -223,6 +224,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             final Timer keepAliveTimer = newKeepAliveTimer(H1C);
             keepAliveHandler = new Http1ServerKeepAliveHandler(ch, keepAliveTimer, idleTimeoutMillis,
                                                                maxConnectionAgeMillis,
+                                                               maxConnectionAgeJitterRate,
                                                                maxNumRequestsPerConnection);
         } else {
             keepAliveHandler = new NoopKeepAliveHandler();
@@ -628,6 +630,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             final ChannelPipeline p = ctx.pipeline();
             final long idleTimeoutMillis = config.idleTimeoutMillis();
             final long maxConnectionAgeMillis = config.maxConnectionAgeMillis();
+            final double maxConnectionAgeJitterRate = config.maxConnectionAgeJitterRate();
             final int maxNumRequestsPerConnection = config.maxNumRequestsPerConnection();
             final boolean needsKeepAliveHandler =
                     needsKeepAliveHandler(idleTimeoutMillis, /* pingIntervalMillis */ 0,
@@ -637,6 +640,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             if (needsKeepAliveHandler) {
                 keepAliveHandler = new Http1ServerKeepAliveHandler(ch, newKeepAliveTimer(H1), idleTimeoutMillis,
                                                                    maxConnectionAgeMillis,
+                                                                   maxConnectionAgeJitterRate,
                                                                    maxNumRequestsPerConnection);
             } else {
                 keepAliveHandler = new NoopKeepAliveHandler();

--- a/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
+++ b/core/src/main/java/com/linecorp/armeria/server/HttpServerPipelineConfigurator.java
@@ -24,6 +24,7 @@ import static com.linecorp.armeria.common.SessionProtocol.H2C;
 import static com.linecorp.armeria.common.SessionProtocol.HTTP;
 import static com.linecorp.armeria.common.SessionProtocol.HTTPS;
 import static com.linecorp.armeria.common.SessionProtocol.PROXY;
+import static com.linecorp.armeria.internal.common.KeepAliveHandlerUtil.initializeConnectionLifespan;
 import static com.linecorp.armeria.internal.common.KeepAliveHandlerUtil.needsKeepAliveHandler;
 import static java.util.Objects.requireNonNull;
 
@@ -155,6 +156,9 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
         // which caches the remote address once its underlying transport returns a non-null address.
         ch.remoteAddress();
 
+        initializeConnectionLifespan(ch, config.maxConnectionAgeMillis(),
+                                     config.maxConnectionAgeJitterRate());
+
         // Disable the write buffer watermark notification because we manage backpressure by ourselves.
         ChannelUtil.disableWriterBufferWatermark(ch);
 
@@ -237,7 +241,7 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
                                                                           gracefulShutdownSupport,
                                                                           responseEncoder,
                                                                           H1C, connectionContext);
-        p.addLast(new Http2PrefaceOrHttpHandler(responseEncoder, httpServerHandler));
+        p.addLast(new Http2PrefaceOrHttpHandler(responseEncoder, httpServerHandler, idleTimeoutMillis));
         p.addLast(httpServerHandler);
     }
 
@@ -755,38 +759,41 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
     private final class Http2PrefaceOrHttpHandler extends ByteToMessageDecoder {
 
         private final ServerHttp1ObjectEncoder responseEncoder;
-        private final KeepAliveHandler keepAliveHandler;
         private final HttpServer httpServer;
+        private final long protocolDetectionIdleTimeoutMillis;
+        @Nullable
+        private ScheduledFuture<?> protocolDetectionIdleTimeoutFuture;
         @Nullable
         private String name;
 
-        Http2PrefaceOrHttpHandler(ServerHttp1ObjectEncoder responseEncoder, HttpServer httpServer) {
+        Http2PrefaceOrHttpHandler(ServerHttp1ObjectEncoder responseEncoder, HttpServer httpServer,
+                                 long protocolDetectionIdleTimeoutMillis) {
             this.responseEncoder = responseEncoder;
-            keepAliveHandler = responseEncoder.keepAliveHandler();
             this.httpServer = httpServer;
+            this.protocolDetectionIdleTimeoutMillis = protocolDetectionIdleTimeoutMillis;
         }
 
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-            keepAliveHandler.initialize(ctx);
             super.handlerAdded(ctx);
             name = ctx.name();
+            resetProtocolDetectionIdleTimeout(ctx);
         }
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            keepAliveHandler.destroy();
+            cancelProtocolDetectionIdleTimeout();
             super.channelInactive(ctx);
         }
 
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-            keepAliveHandler.onReadOrWrite();
-
             if (in.readableBytes() < 4) {
+                resetProtocolDetectionIdleTimeout(ctx);
                 return;
             }
 
+            cancelProtocolDetectionIdleTimeout();
             if (in.getInt(in.readerIndex()) == 0x50524920) { // If starts with 'PRI '
                 // Probably HTTP/2; received the HTTP/2 preface string.
                 configureHttp2(ctx);
@@ -796,6 +803,21 @@ final class HttpServerPipelineConfigurator extends ChannelInitializer<Channel> {
             }
 
             ctx.pipeline().remove(this);
+        }
+
+        private void resetProtocolDetectionIdleTimeout(ChannelHandlerContext ctx) {
+            cancelProtocolDetectionIdleTimeout();
+            if (protocolDetectionIdleTimeoutMillis > 0) {
+                protocolDetectionIdleTimeoutFuture = ctx.executor().schedule(
+                        (Runnable) ctx::close, protocolDetectionIdleTimeoutMillis, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        private void cancelProtocolDetectionIdleTimeout() {
+            if (protocolDetectionIdleTimeoutFuture != null) {
+                protocolDetectionIdleTimeoutFuture.cancel(false);
+                protocolDetectionIdleTimeoutFuture = null;
+            }
         }
 
         private void configureHttp1WithUpgrade(ChannelHandlerContext ctx) {

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -802,6 +802,7 @@ public final class ServerBuilder implements ConnectionLevelSetters, TlsSetters,
      * @throws IllegalArgumentException if the specified {@code maxConnectionAgeJitterRate} is less than
      *                                  {@code 0.0} or greater than {@code 1.0}
      */
+    @UnstableApi
     public ServerBuilder maxConnectionAgeJitterRate(double maxConnectionAgeJitterRate) {
         checkArgument(maxConnectionAgeJitterRate >= 0.0 && maxConnectionAgeJitterRate <= 1.0,
                       "maxConnectionAgeJitterRate: %s (expected: >= 0.0 and <= 1.0)",

--- a/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerBuilder.java
@@ -213,6 +213,7 @@ public final class ServerBuilder implements ConnectionLevelSetters, TlsSetters,
     private boolean keepAliveOnPing = Flags.defaultServerKeepAliveOnPing();
     private long pingIntervalMillis = Flags.defaultPingIntervalMillis();
     private long maxConnectionAgeMillis = Flags.defaultMaxServerConnectionAgeMillis();
+    private double maxConnectionAgeJitterRate;
     private long connectionDrainDurationMicros = Flags.defaultServerConnectionDrainDurationMicros();
     private int maxNumRequestsPerConnection = Flags.defaultMaxServerNumRequestsPerConnection();
     private int http2InitialConnectionWindowSize = Flags.defaultHttp2InitialConnectionWindowSize();
@@ -788,6 +789,25 @@ public final class ServerBuilder implements ConnectionLevelSetters, TlsSetters,
      */
     public ServerBuilder maxConnectionAge(Duration maxConnectionAge) {
         return maxConnectionAgeMillis(requireNonNull(maxConnectionAge, "maxConnectionAge").toMillis());
+    }
+
+    /**
+     * Sets the jitter rate applied to the maximum connection age. The effective max connection age is chosen
+     * uniformly at random for each connection between
+     * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
+     * {@code maxConnectionAge}. The default is {@code 0.0}, which disables jitter. This option has no effect
+     * when the max connection age is disabled.
+     *
+     * @param maxConnectionAgeJitterRate the jitter rate between {@code 0.0} and {@code 1.0}, inclusive
+     * @throws IllegalArgumentException if the specified {@code maxConnectionAgeJitterRate} is less than
+     *                                  {@code 0.0} or greater than {@code 1.0}
+     */
+    public ServerBuilder maxConnectionAgeJitterRate(double maxConnectionAgeJitterRate) {
+        checkArgument(maxConnectionAgeJitterRate >= 0.0 && maxConnectionAgeJitterRate <= 1.0,
+                      "maxConnectionAgeJitterRate: %s (expected: >= 0.0 and <= 1.0)",
+                      maxConnectionAgeJitterRate);
+        this.maxConnectionAgeJitterRate = maxConnectionAgeJitterRate;
+        return this;
     }
 
     /**
@@ -2648,6 +2668,7 @@ public final class ServerBuilder implements ConnectionLevelSetters, TlsSetters,
                 ports, defaultVirtualHost,
                 virtualHosts, workerGroup, shutdownWorkerGroupOnStop, startStopExecutor, maxNumConnections,
                 idleTimeoutMillis, keepAliveOnPing, pingIntervalMillis, maxConnectionAgeMillis,
+                maxConnectionAgeJitterRate,
                 maxNumRequestsPerConnection,
                 connectionDrainDurationMicros, http2InitialConnectionWindowSize,
                 http2InitialStreamWindowSize, http2StreamWindowUpdateRatio, http2MaxStreamsPerConnection,

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -170,6 +170,14 @@ public interface ServerConfig {
     long maxConnectionAgeMillis();
 
     /**
+     * Returns the jitter rate applied to the maximum allowed age of a connection. The effective max connection
+     * age is chosen uniformly at random for each connection between
+     * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
+     * {@code maxConnectionAge}.
+     */
+    double maxConnectionAgeJitterRate();
+
+    /**
      * Returns the graceful connection shutdown drain duration.
      */
     long connectionDrainDurationMicros();

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -175,6 +175,7 @@ public interface ServerConfig {
      * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
      * {@code maxConnectionAge}.
      */
+    @UnstableApi
     default double maxConnectionAgeJitterRate() {
         return 0.0;
     }

--- a/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/ServerConfig.java
@@ -175,7 +175,9 @@ public interface ServerConfig {
      * {@code max(1 second, maxConnectionAge * (1 - maxConnectionAgeJitterRate))} and
      * {@code maxConnectionAge}.
      */
-    double maxConnectionAgeJitterRate();
+    default double maxConnectionAgeJitterRate() {
+        return 0.0;
+    }
 
     /**
      * Returns the graceful connection shutdown drain duration.

--- a/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
+++ b/core/src/main/java/com/linecorp/armeria/server/UpdatableServerConfig.java
@@ -175,6 +175,11 @@ final class UpdatableServerConfig implements ServerConfig {
     }
 
     @Override
+    public double maxConnectionAgeJitterRate() {
+        return delegate.maxConnectionAgeJitterRate();
+    }
+
+    @Override
     public long connectionDrainDurationMicros() {
         return delegate.connectionDrainDurationMicros();
     }

--- a/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientFactoryBuilderTest.java
@@ -265,6 +265,43 @@ class ClientFactoryBuilderTest {
     }
 
     @Test
+    void maxConnectionAgeJitterRate() {
+        try (ClientFactory factory = ClientFactory.builder()
+                                                  .maxConnectionAgeJitterRate(0.1)
+                                                  .build()) {
+            assertThat(factory.options().maxConnectionAgeJitterRate()).isEqualTo(0.1);
+        }
+    }
+
+    @Test
+    void maxConnectionAgeJitterRateDefaultsToZero() {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            assertThat(factory.options().maxConnectionAgeJitterRate()).isZero();
+        }
+    }
+
+    @Test
+    void invalidMaxConnectionAgeJitterRate() {
+        assertThatThrownBy(() -> ClientFactory.builder().maxConnectionAgeJitterRate(-0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+        assertThatThrownBy(() -> ClientFactory.builder().maxConnectionAgeJitterRate(1.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+        assertThatThrownBy(() -> ClientFactory.builder().maxConnectionAgeJitterRate(Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+    }
+
+    @Test
+    void invalidMaxConnectionAgeJitterRateOption() {
+        assertThatThrownBy(() -> ClientFactory.builder().option(
+                ClientFactoryOptions.MAX_CONNECTION_AGE_JITTER_RATE, 1.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+    }
+
+    @Test
     void defaultTcpUserTimeoutSet() {
         assumeThat(Flags.transportType()).isEqualTo(TransportType.EPOLL);
 

--- a/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
@@ -141,7 +141,8 @@ class ClientMaxConnectionAgeTest {
                                 assertThat(value * 1000)
                                         .isBetween(MIN_CONNECTION_AGE - 300.0,
                                                    (double) (MAX_CONNECTION_AGE +
-                                                             CONNECTION_AGE_TOLERANCE));
+                                                             CONNECTION_AGE_TOLERANCE))
+                                        .isLessThan((double) MAX_CONNECTION_AGE);
                             })
                     .hasEntrySatisfying(
                             "armeria.client.connections.lifespan.percentile#value{phi=1,protocol=" +

--- a/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/ClientMaxConnectionAgeTest.java
@@ -46,6 +46,8 @@ import io.netty.util.AttributeMap;
 class ClientMaxConnectionAgeTest {
 
     private static final long MAX_CONNECTION_AGE = 2000;
+    private static final long MIN_CONNECTION_AGE = 1000;
+    private static final long CONNECTION_AGE_TOLERANCE = 1000;
 
     @RegisterExtension
     static ServerExtension server = new ServerExtension() {
@@ -105,6 +107,7 @@ class ClientMaxConnectionAgeTest {
                                                          .connectionPoolListener(connectionPoolListener)
                                                          .idleTimeoutMillis(0)
                                                          .maxConnectionAgeMillis(MAX_CONNECTION_AGE)
+                                                         .maxConnectionAgeJitterRate(1.0)
                                                          .meterRegistry(meterRegistry)
                                                          .tlsNoVerify()
                                                          .build();
@@ -136,14 +139,18 @@ class ClientMaxConnectionAgeTest {
                             scheme + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 300.0, MAX_CONNECTION_AGE + 4000.0);
+                                        .isBetween(MIN_CONNECTION_AGE - 300.0,
+                                                   (double) (MAX_CONNECTION_AGE +
+                                                             CONNECTION_AGE_TOLERANCE));
                             })
                     .hasEntrySatisfying(
                             "armeria.client.connections.lifespan.percentile#value{phi=1,protocol=" +
                             scheme + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 300.0, MAX_CONNECTION_AGE + 4000.0);
+                                        .isBetween(MIN_CONNECTION_AGE - 300.0,
+                                                   (double) (MAX_CONNECTION_AGE +
+                                                             CONNECTION_AGE_TOLERANCE));
                             })
                     .hasEntrySatisfying(
                             "armeria.client.connections.lifespan#count{protocol=" + scheme + '}',
@@ -159,6 +166,7 @@ class ClientMaxConnectionAgeTest {
                                                   .connectionPoolListener(connectionPoolListener)
                                                   .idleTimeoutMillis(0)
                                                   .maxConnectionAgeMillis(MAX_CONNECTION_AGE)
+                                                  .maxConnectionAgeJitterRate(1.0)
                                                   .tlsNoVerify()
                                                   .build()) {
             final WebClient client = WebClient.builder(server.uri(protocol))
@@ -166,9 +174,14 @@ class ClientMaxConnectionAgeTest {
                                               .responseTimeoutMillis(0)
                                               .build();
 
+            final long startNanos = System.nanoTime();
             assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
             await().untilAtomic(opened, Matchers.is(1));
-            await().untilAtomic(closed, Matchers.is(1));
+            await().atMost(Duration.ofMillis(MAX_CONNECTION_AGE + CONNECTION_AGE_TOLERANCE))
+                   .untilAtomic(closed, Matchers.is(1));
+            assertThat(Duration.ofNanos(System.nanoTime() - startNanos).toMillis())
+                    .isBetween(MIN_CONNECTION_AGE - 300,
+                               MAX_CONNECTION_AGE + CONNECTION_AGE_TOLERANCE);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/Http2KeepAliveHandlerTest.java
@@ -65,7 +65,8 @@ class Http2KeepAliveHandlerTest {
         keepAliveHandler = new Http2KeepAliveHandler(
                 channel, frameWriter, "test", NoopMeterRegistry.get().timer(""),
                 idleTimeoutMillis, pingIntervalMillis,
-                /* maxConnectionAgeMillis */ 0, /* maxNumRequestsPerConnection */ 0,
+                /* maxConnectionAgeMillis */ 0, /* maxConnectionAgeJitterRate */ 0.0,
+                /* maxNumRequestsPerConnection */ 0,
                 keepAliveOnPing, ConnectionEventListener.NOOP) {
             @Override
             protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -292,7 +292,7 @@ class KeepAliveHandlerTest {
         channel.closeFuture().addListener(unused -> closed.incrementAndGet());
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "server", keepAliveTimer, 0, 0,
-                                             500, 0.0, 0, false) {
+                                             500, 0.0, 0, false, ConnectionEventListener.NOOP) {
                     @Override
                     public boolean isHttp2() {
                         return false;

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -85,6 +85,20 @@ class KeepAliveHandlerTest {
         }).syncUninterruptibly();
     }
 
+    @Test
+    void connectionLifespanIsInitializedOnceAndClearedOnClose() {
+        KeepAliveHandlerUtil.initializeConnectionLifespan(channel, 60_000, 0.0);
+        final KeepAliveHandlerUtil.ConnectionLifespan connectionLifespan =
+                KeepAliveHandlerUtil.connectionLifespan(channel);
+        assertThat(connectionLifespan).isNotNull();
+
+        KeepAliveHandlerUtil.initializeConnectionLifespan(channel, 60_000, 0.0);
+        assertThat(KeepAliveHandlerUtil.connectionLifespan(channel)).isSameAs(connectionLifespan);
+
+        channel.close();
+        await().untilAsserted(() -> assertThat(KeepAliveHandlerUtil.connectionLifespan(channel)).isNull());
+    }
+
     @AfterEach
     void tearDown() {
         channel.finish();

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -229,7 +229,7 @@ class KeepAliveHandlerTest {
     void zeroJitterPreservesMaxConnectionAge() {
         final long maxConnectionAgeNanos = TimeUnit.SECONDS.toNanos(10);
 
-        assertThat(AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+        assertThat(KeepAliveHandlerUtil.jitteredMaxConnectionAgeNanos(
                 maxConnectionAgeNanos, 0, 0.5)).isEqualTo(maxConnectionAgeNanos);
     }
 
@@ -244,7 +244,7 @@ class KeepAliveHandlerTest {
     })
     void jitteredMaxConnectionAgeStaysWithinBounds(long maxConnectionAgeMillis, double jitterRate,
                                                     double randomValue, long expectedMillis) {
-        assertThat(AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+        assertThat(KeepAliveHandlerUtil.jitteredMaxConnectionAgeNanos(
                 TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis), jitterRate, randomValue))
                 .isEqualTo(TimeUnit.MILLISECONDS.toNanos(expectedMillis));
     }

--- a/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
+++ b/core/src/test/java/com/linecorp/armeria/internal/common/KeepAliveHandlerTest.java
@@ -95,7 +95,7 @@ class KeepAliveHandlerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
-                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0, false,
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 1000, 0, 0, 0.0, 0, false,
                                              ConnectionEventListener.NOOP) {
 
                     @Override
@@ -139,7 +139,7 @@ class KeepAliveHandlerTest {
         final Stopwatch stopwatch = Stopwatch.createStarted();
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
-                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0, false,
+                new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 1000, 0, 0.0, 0, false,
                                              ConnectionEventListener.NOOP) {
 
                     @Override
@@ -180,7 +180,7 @@ class KeepAliveHandlerTest {
         final long maxConnectionAgeMillis = 0;
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                maxConnectionAgeMillis, 0, false,
+                                                                maxConnectionAgeMillis, 0.0, 0, false,
                                                                 ConnectionEventListener.NOOP) {
             @Override
             public boolean isHttp2() {
@@ -212,11 +212,35 @@ class KeepAliveHandlerTest {
     }
 
     @Test
+    void zeroJitterPreservesMaxConnectionAge() {
+        final long maxConnectionAgeNanos = TimeUnit.SECONDS.toNanos(10);
+
+        assertThat(AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+                maxConnectionAgeNanos, 0, 0.5)).isEqualTo(maxConnectionAgeNanos);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "10000, 0.1, 0.0,  9000",
+            "10000, 0.1, 0.5,  9500",
+            "10000, 0.1, 1.0, 10000",
+            "2000,  1.0, 0.0,  1000",
+            "2000,  1.0, 0.5,  1500",
+            "1000,  1.0, 0.0,  1000",
+    })
+    void jitteredMaxConnectionAgeStaysWithinBounds(long maxConnectionAgeMillis, double jitterRate,
+                                                    double randomValue, long expectedMillis) {
+        assertThat(AbstractKeepAliveHandler.jitteredMaxConnectionAgeNanos(
+                TimeUnit.MILLISECONDS.toNanos(maxConnectionAgeMillis), jitterRate, randomValue))
+                .isEqualTo(TimeUnit.MILLISECONDS.toNanos(expectedMillis));
+    }
+
+    @Test
     void testMaxConnectionAge() throws InterruptedException {
         final long maxConnectionAgeMillis = 500;
         final AbstractKeepAliveHandler
                 keepAliveHandler = new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0, 0,
-                                                                maxConnectionAgeMillis, 0, false,
+                                                                maxConnectionAgeMillis, 0.0, 0, false,
                                                                 ConnectionEventListener.NOOP) {
             @Override
             public boolean isHttp2() {
@@ -249,6 +273,41 @@ class KeepAliveHandlerTest {
     }
 
     @Test
+    void maxConnectionAgeClosesIdleServerConnection() {
+        final AtomicInteger closed = new AtomicInteger();
+        channel.closeFuture().addListener(unused -> closed.incrementAndGet());
+        final AbstractKeepAliveHandler keepAliveHandler =
+                new AbstractKeepAliveHandler(channel, "server", keepAliveTimer, 0, 0,
+                                             500, 0.0, 0, false) {
+                    @Override
+                    public boolean isHttp2() {
+                        return false;
+                    }
+
+                    @Override
+                    public void onPingAck(long data) {}
+
+                    @Override
+                    protected ChannelFuture writePing(ChannelHandlerContext ctx) {
+                        return null;
+                    }
+
+                    @Override
+                    protected boolean pingResetsPreviousPing() {
+                        return false;
+                    }
+
+                    @Override
+                    protected boolean hasRequestsInProgress(ChannelHandlerContext ctx) {
+                        return false;
+                    }
+                };
+        keepAliveHandler.initialize(ctx);
+
+        await().untilAtomic(closed, Matchers.is(1));
+    }
+
+    @Test
     void shouldNotWritePingIfConnectionIsActive() throws InterruptedException {
         final AtomicLong lastIdleEventTime = new AtomicLong();
         final AtomicInteger pingCounter = new AtomicInteger();
@@ -256,7 +315,7 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler pingScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, 0,
-                                             pingInterval, 0, 0, false,
+                                             pingInterval, 0, 0.0, 0, false,
                                              ConnectionEventListener.NOOP) {
 
                     @Override
@@ -306,7 +365,7 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout,
-                                             0, 0, 0, false, ConnectionEventListener.NOOP) {
+                                             0, 0, 0.0, 0, false, ConnectionEventListener.NOOP) {
 
                     @Override
                     public boolean isHttp2() {
@@ -358,7 +417,8 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler idleTimeoutScheduler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout,
-                                             0, 0, 0, keepAliveOnPing, ConnectionEventListener.NOOP) {
+                                             0, 0, 0.0, 0, keepAliveOnPing,
+                                             ConnectionEventListener.NOOP) {
 
                     @Override
                     public boolean isHttp2() {
@@ -409,7 +469,8 @@ class KeepAliveHandlerTest {
 
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, 0, false, ConnectionEventListener.NOOP) {
+                                             maxConnectionAgeMillis, 0.0, 0, false,
+                                             ConnectionEventListener.NOOP) {
                     @Override
                     public boolean isHttp2() {
                         return false;
@@ -463,7 +524,8 @@ class KeepAliveHandlerTest {
         final int maxNumRequestsPerConnection = 0;
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequestsPerConnection, false,
+                                             maxConnectionAgeMillis, 0.0,
+                                             maxNumRequestsPerConnection, false,
                                              ConnectionEventListener.NOOP) {
                     @Override
                     public boolean isHttp2() {
@@ -521,7 +583,8 @@ class KeepAliveHandlerTest {
         final ChannelPromise promise = channel.newPromise();
         final AbstractKeepAliveHandler keepAliveHandler =
                 new AbstractKeepAliveHandler(channel, "test", keepAliveTimer, idleTimeout, pingInterval,
-                                             maxConnectionAgeMillis, maxNumRequestsPerConnection, false,
+                                             maxConnectionAgeMillis, 0.0,
+                                             maxNumRequestsPerConnection, false,
                                              ConnectionEventListener.NOOP) {
                     @Override
                     public boolean isHttp2() {

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -708,6 +708,11 @@ class ServerBuilderTest {
     }
 
     @Test
+    void maxConnectionAgeJitterRateIsBackwardCompatible() throws NoSuchMethodException {
+        assertThat(ServerConfig.class.getMethod("maxConnectionAgeJitterRate").isDefault()).isTrue();
+    }
+
+    @Test
     void invalidMaxConnectionAgeJitterRate() {
         assertThatThrownBy(() -> Server.builder().maxConnectionAgeJitterRate(-0.1))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerBuilderTest.java
@@ -687,6 +687,40 @@ class ServerBuilderTest {
     }
 
     @Test
+    void maxConnectionAgeJitterRate() {
+        final ServerConfig config = Server.builder()
+                                          .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                                          .maxConnectionAgeJitterRate(0.1)
+                                          .build()
+                                          .config();
+
+        assertThat(config.maxConnectionAgeJitterRate()).isEqualTo(0.1);
+    }
+
+    @Test
+    void maxConnectionAgeJitterRateDefaultsToZero() {
+        final ServerConfig config = Server.builder()
+                                          .service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK))
+                                          .build()
+                                          .config();
+
+        assertThat(config.maxConnectionAgeJitterRate()).isZero();
+    }
+
+    @Test
+    void invalidMaxConnectionAgeJitterRate() {
+        assertThatThrownBy(() -> Server.builder().maxConnectionAgeJitterRate(-0.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+        assertThatThrownBy(() -> Server.builder().maxConnectionAgeJitterRate(1.1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+        assertThatThrownBy(() -> Server.builder().maxConnectionAgeJitterRate(Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("expected: >= 0.0 and <= 1.0");
+    }
+
+    @Test
     void defaultTcpUserTimeoutApplied() {
         assumeThat(Flags.transportType()).isEqualTo(TransportType.EPOLL);
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -54,7 +54,9 @@ import io.netty.util.AttributeMap;
 
 class ServerMaxConnectionAgeTest {
 
-    private static final long MAX_CONNECTION_AGE = 1000;
+    private static final long MAX_CONNECTION_AGE = 1500;
+    private static final long MIN_CONNECTION_AGE = 1000;
+    private static final long CONNECTION_AGE_TOLERANCE = 1000;
     private static MeterRegistry meterRegistry;
 
     @RegisterExtension
@@ -66,8 +68,9 @@ class ServerMaxConnectionAgeTest {
             sb.tlsSelfSigned();
             sb.idleTimeoutMillis(0);
             sb.requestTimeoutMillis(0);
-            sb.connectionDrainDuration(Duration.ofMillis(10));
+            sb.connectionDrainDuration(Duration.ofSeconds(3));
             sb.maxConnectionAgeMillis(MAX_CONNECTION_AGE);
+            sb.maxConnectionAgeJitterRate(1.0);
             meterRegistry = new SimpleMeterRegistry();
             sb.meterRegistry(meterRegistry);
             sb.service("/", (ctx, req) -> HttpResponse.of(OK));
@@ -160,12 +163,12 @@ class ServerMaxConnectionAgeTest {
                                           .responseTimeoutMillis(0)
                                           .build();
 
-        while (closed.get() < maxClosedConnection) {
+        for (int i = 0; i < maxClosedConnection; i++) {
             final HttpResponse response = client.get("/");
             assertThat(response.aggregate().join().status()).isEqualTo(OK);
             response.whenComplete().join();
-            final int closed = this.closed.get();
-            assertThat(opened).hasValueBetween(closed, closed + 1);
+            await().untilAtomic(opened, Matchers.is(i + 1));
+            await().untilAtomic(closed, Matchers.is(i + 1));
         }
 
         await().untilAsserted(() -> {
@@ -175,14 +178,18 @@ class ServerMaxConnectionAgeTest {
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
+                                        .isBetween(MIN_CONNECTION_AGE - 200.0,
+                                                   (double) (MAX_CONNECTION_AGE +
+                                                             CONNECTION_AGE_TOLERANCE));
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
                             protocol.uriText() + '}',
                             value -> {
                                 assertThat(value * 1000)
-                                        .isBetween(MAX_CONNECTION_AGE - 200.0, MAX_CONNECTION_AGE + 3000.0);
+                                        .isBetween(MIN_CONNECTION_AGE - 200.0,
+                                                   (double) (MAX_CONNECTION_AGE +
+                                                             CONNECTION_AGE_TOLERANCE));
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan#count{protocol=" + protocol.uriText() + '}',
@@ -284,9 +291,14 @@ class ServerMaxConnectionAgeTest {
         try (ClientFactory factory = newClientFactory(false)) {
             final WebClient client = newWebClient(factory, server.uri(protocol));
 
+            final long startNanos = System.nanoTime();
             assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
             await().untilAtomic(opened, Matchers.is(1));
-            await().untilAtomic(closed, Matchers.is(1));
+            await().atMost(Duration.ofMillis(MAX_CONNECTION_AGE + CONNECTION_AGE_TOLERANCE))
+                   .untilAtomic(closed, Matchers.is(1));
+            assertThat(Duration.ofNanos(System.nanoTime() - startNanos).toMillis())
+                    .isBetween(MIN_CONNECTION_AGE - 200,
+                               MAX_CONNECTION_AGE + CONNECTION_AGE_TOLERANCE);
         }
     }
 

--- a/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/ServerMaxConnectionAgeTest.java
@@ -22,10 +22,12 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -180,7 +182,8 @@ class ServerMaxConnectionAgeTest {
                                 assertThat(value * 1000)
                                         .isBetween(MIN_CONNECTION_AGE - 200.0,
                                                    (double) (MAX_CONNECTION_AGE +
-                                                             CONNECTION_AGE_TOLERANCE));
+                                                             CONNECTION_AGE_TOLERANCE))
+                                        .isLessThan((double) MAX_CONNECTION_AGE);
                             })
                     .hasEntrySatisfying(
                             "armeria.server.connections.lifespan.percentile#value{phi=1,protocol=" +
@@ -268,6 +271,55 @@ class ServerMaxConnectionAgeTest {
                         .hasValue(1);
             });
         }
+    }
+
+    @CsvSource({ "H2C", "H2" })
+    @ParameterizedTest
+    void activeHttp2RequestCompletesAfterMaxConnectionAge(SessionProtocol protocol) {
+        try (ClientFactory factory = newClientFactory(false)) {
+            final WebClient client = newWebClient(factory, server.uri(protocol));
+
+            assertThat(client.get("/slow").aggregate().join().contentUtf8()).isEqualTo("Disconnect");
+            await().untilAtomic(closed, Matchers.is(1));
+        }
+    }
+
+    @Test
+    void directH2cRecordsOnlyH2cConnectionLifespan() {
+        try (ClientFactory factory = newClientFactory(false)) {
+            final WebClient client = newWebClient(factory, server.uri(SessionProtocol.H2C));
+            assertThat(client.get("/").aggregate().join().status()).isEqualTo(OK);
+        }
+
+        await().untilAsserted(() ->
+                assertThat(MoreMeters.measureAll(meterRegistry))
+                        .containsEntry("armeria.server.connections.lifespan#count{protocol=h2c}", 1.0)
+                        .containsEntry("armeria.server.connections.lifespan#count{protocol=h1c}", 0.0));
+    }
+
+    @Test
+    void maxConnectionAgeIncludesProtocolDetection() throws Exception {
+        final long startNanos = System.nanoTime();
+        try (Socket socket = new Socket("127.0.0.1", server.httpPort())) {
+            socket.setSoTimeout((int) (MAX_CONNECTION_AGE + CONNECTION_AGE_TOLERANCE));
+            final OutputStream out = socket.getOutputStream();
+            final byte[] fragmentedMethod = { 'G', 'E', 'T' };
+            for (int i = 0; i < fragmentedMethod.length; i++) {
+                out.write(fragmentedMethod[i]);
+                out.flush();
+                if (i < fragmentedMethod.length - 1) {
+                    Thread.sleep(450);
+                }
+            }
+            out.write(" / HTTP/1.1\r\nHost: localhost\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+
+            while (socket.getInputStream().read() != -1) {
+                // Drain the response until the max-age deadline closes the connection.
+            }
+        }
+        assertThat(Duration.ofNanos(System.nanoTime() - startNanos).toMillis())
+                .isLessThan(MAX_CONNECTION_AGE + 300);
     }
 
     @CsvSource({ "H1C", "H2C" })


### PR DESCRIPTION
Motivation:

A fixed maximum connection age can cause many client or server connections created at similar times to expire together. Per-connection jitter spreads those expirations and reduces synchronized reconnect spikes while preserving the configured maximum as a hard upper bound.

Modifications:

- Add `maxConnectionAgeJitterRate(double)` to `ClientFactoryBuilder` and `ServerBuilder`.
- Randomize each effective maximum connection age downward within the configured range, with a one-second lower bound.
- Keep jitter disabled by default and validate rates within `[0.0, 1.0]`.
- Apply the behavior consistently to HTTP/1 and HTTP/2 clients and servers.
- Add builder, keep-alive, and client/server integration coverage and document the option in the release notes.

Result:

- Users can spread connection expiration by configuring a jitter rate without allowing connections to outlive `maxConnectionAge`.