### PR TITLE
Release note for 1.41.1

### DIFF
--- a/site/src/content/release-notes/1.41.1.mdx
+++ b/site/src/content/release-notes/1.41.1.mdx
@@ -1,0 +1,25 @@
+---
+date: 2026-09-01
+---
+
+# v1.41.1
+
+## 🛠️ Bug fixes
+
+- Lambda-style client decorators no longer throw an `AssertionError` when a request is executed.
+  This regression was introduced in 1.41.0. #6929
+  ```java
+  WebClient.builder()
+           .decorator(delegate ->
+               (ctx, req) -> delegate.execute(ctx, req)) // 👈👈👈
+           .build();
+  ```
+
+## 🙇 Thank you
+
+<ThankYou usernames={[
+  'ikhoon',
+  'jrhee17',
+  'minwoox',
+  'trustin'
+]} />


### PR DESCRIPTION
<img width="1365" height="1117" alt="localhost_3000_release-notes_1 41 1" src="https://github.com/user-attachments/assets/3d2d296c-873c-4e13-8484-88d28ffa5ec0" />