### PR TITLE
Complete channel acquisition before rethrowing fatal errors

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -56,6 +56,7 @@ import com.linecorp.armeria.common.logging.ClientConnectionTimingsBuilder;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.AsyncCloseableSupport;
 import com.linecorp.armeria.common.util.DomainSocketAddress;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.client.HttpSession;
 import com.linecorp.armeria.internal.client.PooledChannel;
 import com.linecorp.armeria.internal.common.ConnectionEventListener;
@@ -550,8 +551,15 @@ final class HttpChannelPool implements AsyncCloseable {
                 }
                 promise.completeExceptionally(UnprocessedRequestException.of(throwable));
             }
-        } catch (Exception e) {
-            promise.completeExceptionally(UnprocessedRequestException.of(e));
+        } catch (Throwable t) {
+            Throwable cause = t;
+            try {
+                cause = UnprocessedRequestException.of(t);
+            } catch (Throwable ignored) {
+                // Use the original cause if creating an UnprocessedRequestException fails.
+            }
+            promise.completeExceptionally(cause);
+            Exceptions.throwIfFatal(t);
         }
     }
 

--- a/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
+++ b/core/src/main/java/com/linecorp/armeria/client/HttpChannelPool.java
@@ -552,13 +552,11 @@ final class HttpChannelPool implements AsyncCloseable {
                 promise.completeExceptionally(UnprocessedRequestException.of(throwable));
             }
         } catch (Throwable t) {
-            Throwable cause = t;
-            try {
-                cause = UnprocessedRequestException.of(t);
-            } catch (Throwable ignored) {
-                // Use the original cause if creating an UnprocessedRequestException fails.
-            }
-            promise.completeExceptionally(cause);
+            // Complete the promise before rethrowing, so that a fatal error cannot leave the request
+            // pending forever. The cause is not wrapped with UnprocessedRequestException here because
+            // HttpClientDelegate already does that for every acquisition failure, and wrapping could
+            // fail for the same reason the original attempt did.
+            promise.completeExceptionally(t);
             Exceptions.throwIfFatal(t);
         }
     }

--- a/core/src/test/java/com/linecorp/armeria/client/HttpClientFactoryTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/HttpClientFactoryTest.java
@@ -21,20 +21,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.net.SocketAddress;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.endpoint.dns.TestDnsServer;
+import com.linecorp.armeria.client.proxy.ProxyConfig;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.logging.ClientConnectionTimings;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
+import com.linecorp.armeria.internal.client.PooledChannel;
 import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
@@ -43,6 +52,9 @@ import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DatagramDnsQuery;
 import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.resolver.dns.DnsServerAddressStreamProvider;
@@ -62,6 +74,81 @@ class HttpClientFactoryTest {
             });
         }
     };
+
+    @ParameterizedTest
+    @MethodSource("fatalErrors")
+    void fatalErrorDuringChannelAcquisitionDoesNotLeaveRequestPending(Error fatalError) {
+        try (ClientFactory clientFactory = newFailingClientFactory(throwingOnToString(fatalError))) {
+            final CompletableFuture<AggregatedHttpResponse> response =
+                    WebClient.builder(server.httpUri())
+                             .factory(clientFactory)
+                             .build()
+                             .get("/")
+                             .aggregate();
+
+            await().until(response::isDone);
+            assertThat(response).isCompletedExceptionally();
+        }
+    }
+
+    private static Stream<Error> fatalErrors() {
+        return Stream.of(new StackOverflowError(), new NoClassDefFoundError());
+    }
+
+    @Test
+    void unwrappableFatalErrorCompletesChannelAcquisition() {
+        final Error fatalError = new StackOverflowError() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String toString() {
+                throw this;
+            }
+        };
+        try (ClientFactory clientFactory = newFailingClientFactory(throwingOnToString(fatalError))) {
+            final HttpClientFactory factory = (HttpClientFactory) clientFactory.unwrap();
+            final EventLoop eventLoop = clientFactory.eventLoopGroup().next();
+            final HttpChannelPool pool = factory.pool(eventLoop);
+            final CompletableFuture<CompletableFuture<PooledChannel>> acquisitionFutureFuture =
+                    new CompletableFuture<>();
+            eventLoop.execute(() -> acquisitionFutureFuture.complete(
+                    pool.acquireLater(SessionProtocol.H1C, SerializationFormat.NONE,
+                                      new HttpChannelPool.PoolKey(server.httpEndpoint(), ProxyConfig.direct(),
+                                                                  null, null),
+                                      ClientConnectionTimings.builder())));
+            final CompletableFuture<PooledChannel> acquisitionFuture = acquisitionFutureFuture.join();
+
+            await().until(acquisitionFuture::isDone);
+            assertThat(acquisitionFuture).isCompletedExceptionally();
+        }
+    }
+
+    private static Throwable throwingOnToString(Error error) {
+        return new Throwable() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public String toString() {
+                throw error;
+            }
+        };
+    }
+
+    private static ClientFactory newFailingClientFactory(Throwable connectFailure) {
+        return ClientFactory.builder()
+                            .option(ClientFactoryOptions.CHANNEL_PIPELINE_CUSTOMIZER, pipeline -> {
+                                pipeline.addLast(new ChannelOutboundHandlerAdapter() {
+                                    @Override
+                                    public void connect(ChannelHandlerContext ctx,
+                                                        SocketAddress remoteAddress,
+                                                        SocketAddress localAddress,
+                                                        ChannelPromise promise) {
+                                        ctx.executor().execute(() -> promise.setFailure(connectFailure));
+                                    }
+                                });
+                            })
+                            .build();
+    }
 
     @Test
     void numConnections() {


### PR DESCRIPTION
Motivation:

`HttpChannelPool.notifyConnect()` caught only `Exception`. A fatal `Error` raised while handling a completed connection attempt could therefore escape before the channel acquisition promise was completed, leaving the request pending indefinitely.

Modifications:

- Catch `Throwable` at the asynchronous connection-acquisition boundary.
- Complete the acquisition promise before rethrowing fatal errors.
- Add regression coverage for `StackOverflowError`, `NoClassDefFoundError`, and wrapper-construction failure.

Result:

- Requests no longer remain pending when these fatal errors occur during channel acquisition.
- Armeria still rethrows fatal errors after promise completion.
- Verified with `HttpClientFactoryTest` and the core Checkstyle tasks.
