### PR TITLE
Fix #4997: Default AuthFailureHandler for basic auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,33 @@
+# Changes
+
+## Issue
+- Issue: #4997
+- Title: Default AuthFailureHandler for basic access authentication
+
+## Problem
+The default `AuthFailureHandler` in `AuthServiceBuilder` returned a `401 Unauthorized` response without the `WWW-Authenticate` header. This meant browsers would not prompt users for login credentials when basic access authentication was configured.
+
+## Changes Made
+- Added a `basicAuthFailureHandler` that includes `WWW-Authenticate: Basic realm="Accessing to the ..."` header.
+- Added `basicAuthAdded` flag to track if `addBasicAuth()` was called.
+- Added `failureHandlerWasSet` flag to track if `onFailure()` was called.
+- `addBasicAuth()` sets `basicAuthAdded = true`.
+- `onFailure()` sets `failureHandlerWasSet = true`.
+- `build()` selects `basicAuthFailureHandler` only when `basicAuthAdded == true` AND `failureHandlerWasSet == false`.
+- Preserves the original `failureHandler` for: OAuth1a, OAuth2, custom authorizers, and explicit `onFailure()` calls.
+
+## Implementation Details
+File changed: `core/src/main/java/com/linecorp/armeria/server/auth/AuthServiceBuilder.java`.
+
+Test added: `core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java`
+- Added endpoint `/basic-on-failure` with `addBasicAuth` + explicit `onFailure`.
+- Added `explicitOnFailureNotReplacedByBasicAuth()` regression test.
+
+## Testing
+- Existing `testBasicAuth` verifies `401` responses for failed auth.
+- `explicitOnFailureNotReplacedByBasicAuth` verifies custom handler is preserved when `addBasicAuth` is used with `onFailure()`.
+
+## Result
+- When basic access authentication is configured via `addBasicAuth()` without an explicit `onFailure()`, failed authorization responses now include `WWW-Authenticate: Basic realm="Accessing to the ..."` header, allowing browsers to prompt users for credentials.
+- Other authentication schemes (OAuth1a, OAuth2, custom) retain the original behavior with no `WWW-Authenticate` header.
+- Explicit `onFailure()` handlers are never replaced.

--- a/core/src/main/java/com/linecorp/armeria/server/auth/AuthServiceBuilder.java
+++ b/core/src/main/java/com/linecorp/armeria/server/auth/AuthServiceBuilder.java
@@ -20,10 +20,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.function.Function;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.auth.BasicToken;
 import com.linecorp.armeria.common.auth.OAuth1aToken;
@@ -46,6 +48,17 @@ public final class AuthServiceBuilder {
         }
         return HttpResponse.of(HttpStatus.UNAUTHORIZED);
     };
+    private AuthFailureHandler basicAuthFailureHandler = (delegate, ctx, req, cause) -> {
+        if (cause != null) {
+            AuthService.logger.warn("Unexpected exception during authorization.", cause);
+        }
+        return HttpResponse.of(ResponseHeaders.builder(HttpStatus.UNAUTHORIZED)
+                                          .add(HttpHeaderNames.WWW_AUTHENTICATE,
+                                               "Basic realm=\"Accessing to the ...\"")
+                                          .build());
+    };
+    private boolean basicAuthAdded;
+    private boolean failureHandlerWasSet;
     private MeterIdPrefix meterIdPrefix = new MeterIdPrefix("armeria.server.auth");
 
     /**
@@ -82,6 +95,7 @@ public final class AuthServiceBuilder {
      * Adds an HTTP basic {@link Authorizer}.
      */
     public AuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer) {
+        basicAuthAdded = true;
         return addTokenAuthorizer(AuthTokenExtractors.basic(),
                                   requireNonNull(authorizer, "authorizer"));
     }
@@ -90,6 +104,7 @@ public final class AuthServiceBuilder {
      * Adds an HTTP basic {@link Authorizer} for the given {@code header}.
      */
     public AuthServiceBuilder addBasicAuth(Authorizer<? super BasicToken> authorizer, CharSequence header) {
+        basicAuthAdded = true;
         return addTokenAuthorizer(new BasicTokenExtractor(requireNonNull(header, "header")),
                                   requireNonNull(authorizer, "authorizer"));
     }
@@ -152,6 +167,7 @@ public final class AuthServiceBuilder {
      */
     public AuthServiceBuilder onFailure(AuthFailureHandler failureHandler) {
         this.failureHandler = requireNonNull(failureHandler, "failureHandler");
+        this.failureHandlerWasSet = true;
         return this;
     }
 
@@ -183,13 +199,17 @@ public final class AuthServiceBuilder {
      * Returns a newly-created {@link AuthService} based on the {@link Authorizer}s added to this builder.
      */
     public AuthService build(HttpService delegate) {
+        final AuthFailureHandler usedFailureHandler =
+                basicAuthAdded && !failureHandlerWasSet ? basicAuthFailureHandler : failureHandler;
         return new AuthService(requireNonNull(delegate, "delegate"), authorizer(),
-                               successHandler, failureHandler, meterIdPrefix);
+                               successHandler, usedFailureHandler, meterIdPrefix);
     }
 
     private AuthService build(HttpService delegate, Authorizer<HttpRequest> authorizer) {
+        final AuthFailureHandler usedFailureHandler =
+                basicAuthAdded && !failureHandlerWasSet ? basicAuthFailureHandler : failureHandler;
         return new AuthService(requireNonNull(delegate, "delegate"), authorizer,
-                               successHandler, failureHandler, meterIdPrefix);
+                               successHandler, usedFailureHandler, meterIdPrefix);
     }
 
     /**

--- a/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
+++ b/core/src/test/java/com/linecorp/armeria/server/auth/AuthServiceTest.java
@@ -122,6 +122,17 @@ class AuthServiceTest {
                                            .newDecorator())
                       .decorate(LoggingService.newDecorator()));
 
+            // Auth with Basic + explicit onFailure (explicit handler must NOT be replaced)
+            sb.service(
+                    "/basic-on-failure",
+                    ok.decorate(AuthService.builder()
+                                           .addBasicAuth(httpBasicAuthorizer)
+                                           .onFailure((delegate2, ctx2, req2, cause2) -> {
+                                               return HttpResponse.of(HttpStatus.FORBIDDEN);
+                                           })
+                                           .newDecorator())
+                      .decorate(LoggingService.newDecorator()));
+
             // Auth with OAuth1a
             final Authorizer<OAuth1aToken> oAuth1aAuthorizer = (ctx, token) ->
                     completedFuture("dummy_signature".equals(token.signature()) &&
@@ -264,6 +275,18 @@ class AuthServiceTest {
                     basicGetRequest("/basic", AuthToken.ofBasic("choco", "pangyo"),
                                     AUTHORIZATION))) {
                 assertThat(res.getCode()).isEqualTo(401);
+            }
+        }
+    }
+
+    @Test
+    void explicitOnFailureNotReplacedByBasicAuth() throws Exception {
+        // Explicit onFailure set with addBasicAuth must be preserved (not replaced by Basic handler).
+        try (CloseableHttpClient hc = HttpClients.createMinimal()) {
+            try (CloseableHttpResponse res = hc.execute(
+                    new HttpGet(server.httpUri() + "/basic-on-failure"))) {
+                assertThat(res.getCode()).isEqualTo(403); // custom handler returns FORBIDDEN
+                assertThat(res.getHeader("WWW-Authenticate")).isNull(); // custom handler doesn't add it
             }
         }
     }


### PR DESCRIPTION
Closes #4997.

- Updates the default AuthFailureHandler in AuthServiceBuilder to include the WWW-Authenticate header when basic auth is configured.
- Adds CHANGES.md documenting the fix.