### PR TITLE
Run gRPC serialization and deserialization on the appropriate threads

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -282,10 +282,18 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     protected abstract void doClose(ServerStatusAndMetadata statusAndMetadata);
 
+    /**
+     * Invoked once when the listener is closed, i.e. when the call is complete or cancelled, right before
+     * {@code onComplete()} or {@code onCancel()} is delivered to the listener, so that a subclass can
+     * release the resources which were prepared for a response but never written.
+     */
+    protected void onListenerClosed() {}
+
     protected final void closeListener(ServerStatusAndMetadata statusAndMetadata) {
         final boolean cancelled = statusAndMetadata.shouldCancel();
         if (!listenerClosed) {
             listenerClosed = true;
+            onListenerClosed();
 
             if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_CONTENT)) {
                 // Failed to deserialize a message into a request
@@ -496,14 +504,18 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     @Override
     public void sendHeaders(Metadata metadata) {
+        // Decide the compressor and build the response headers on the caller's thread, because
+        // `sendMessage()` serializes and compresses a message on the caller's thread, which may happen
+        // before the event loop runs `doSendHeaders()`.
+        final ResponseHeaders headers = buildResponseHeaders(metadata);
         if (ctx.eventLoop().inEventLoop()) {
-            doSendHeaders(metadata);
+            doSendHeaders(headers);
         } else {
-            ctx.eventLoop().execute(() -> doSendHeaders(metadata));
+            ctx.eventLoop().execute(() -> doSendHeaders(headers));
         }
     }
 
-    private void doSendHeaders(Metadata metadata) {
+    private void doSendHeaders(ResponseHeaders headers) {
         if (isCancelled()) {
             // call was already closed by a client or a timeout scheduler.
             return;
@@ -511,6 +523,13 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         checkState(responseHeaders == null, "sendHeaders already called");
         checkState(!closeCalled, "call is closed");
 
+        // https://github.com/grpc/proposal/blob/4c4a06d95eb1e7d3d7d84c4c9505a99f2a721db9/A6-client-retries.md#L263
+        // gRPC servers should delay the Response-Headers until the first response message or
+        // until the application code chooses to send headers.
+        responseHeaders = headers;
+    }
+
+    private ResponseHeaders buildResponseHeaders(Metadata metadata) {
         final Compressor oldCompressor = compressor;
         if (messageCompression && !clientAcceptEncoding.isEmpty()) {
             final List<String> acceptedEncodings =
@@ -560,11 +579,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                 }
             });
         }
-
-        // https://github.com/grpc/proposal/blob/4c4a06d95eb1e7d3d7d84c4c9505a99f2a721db9/A6-client-retries.md#L263
-        // gRPC servers should delay the Response-Headers until the first response message or
-        // until the application code chooses to send headers.
-        responseHeaders = headers;
+        return headers;
     }
 
     protected final HttpData toPayload(O message) throws IOException {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -380,7 +380,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     private void deserializeAndInvokeOnMessage(DeframedMessage message, boolean endOfStream) {
         if (shouldSkipRequestCallback()) {
-            // Skip cancelled calls and messages queued before a previous message failed.
             message.close();
             return;
         }
@@ -424,7 +423,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     protected final void invokeOnReady() {
         if (shouldSkipRequestCallback()) {
-            // Skip cancelled calls and callbacks queued before request message processing failed.
             return;
         }
         try {
@@ -450,7 +448,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     protected final void invokeHalfClose() {
         if (shouldSkipRequestCallback()) {
-            // Skip cancelled calls and callbacks queued before request message processing failed.
             return;
         }
         try (SafeCloseable ignored = ctx.push()) {
@@ -462,6 +459,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private boolean shouldSkipRequestCallback() {
+        // Skip cancelled calls and callbacks queued before request message processing failed.
         return cancelled || (blockingExecutor != null && requestMessageProcessingFailed);
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -411,8 +411,8 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         clientStreamClosed = true;
         if (!closeCalled) {
             if (!messageReceived) {
-                // If a message was received, its request content is logged when it is deserialized,
-                // which may happen later than this on `blockingTaskExecutor`.
+                // If a message was received, log its content during deserialization, which may still
+                // be pending on the blocking executor.
                 maybeLogRequestContent(null);
             }
             if (blockingExecutor != null) {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -329,9 +329,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     public void onRequestMessage(DeframedMessage message, boolean endOfStream) {
         try {
-            final I request;
-            final ByteBuf buf = message.buf();
-
             boolean success = false;
             try {
                 // Special case for unary calls.
@@ -354,28 +351,54 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                 }
             }
 
-            final boolean grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
-            request = marshaller.deserializeRequest(message, grpcWebText);
-            maybeLogRequestContent(request);
-
-            if (unsafeWrapRequestBuffers && buf != null && !grpcWebText) {
-                GrpcUnsafeBufferUtil.storeBuffer(buf, request, ctx);
-            }
-
+            // Deserialize the message on the thread that invokes the listener, so that the event loop
+            // is not occupied by deserialization (and decompression) when `blockingTaskExecutor` is used.
             if (blockingExecutor != null) {
-                blockingExecutor.execute(() -> invokeOnMessage(request, endOfStream));
+                blockingExecutor.execute(() -> deserializeAndInvokeOnMessage(message, endOfStream));
             } else {
-                invokeOnMessage(request, endOfStream);
+                deserializeAndInvokeOnMessage(message, endOfStream);
             }
         } catch (Throwable cause) {
             close(cause, true);
         }
     }
 
+    private void deserializeAndInvokeOnMessage(DeframedMessage message, boolean endOfStream) {
+        if (blockingExecutor != null && cancelled) {
+            // Do not deserialize the message if the call is cancelled after
+            // this task was scheduled to blockingTaskExecutor.
+            message.close();
+            return;
+        }
+
+        final I request;
+        try {
+            final ByteBuf buf = message.buf();
+            final boolean grpcWebText = GrpcSerializationFormats.isGrpcWebText(serializationFormat);
+            // `deserializeRequest()` releases the buffer (unless `unsafeWrapRequestBuffers` is enabled)
+            // or closes the stream, even if it fails.
+            request = marshaller.deserializeRequest(message, grpcWebText);
+            maybeLogRequestContent(request);
+
+            if (unsafeWrapRequestBuffers && buf != null && !grpcWebText) {
+                GrpcUnsafeBufferUtil.storeBuffer(buf, request, ctx);
+            }
+        } catch (Throwable cause) {
+            close(cause, true);
+            return;
+        }
+
+        invokeOnMessage(request, endOfStream);
+    }
+
     protected final void onRequestComplete() {
         clientStreamClosed = true;
         if (!closeCalled) {
-            maybeLogRequestContent(null);
+            if (!messageReceived) {
+                // If a message was received, its request content is logged when it is deserialized,
+                // which may happen later than this on `blockingTaskExecutor`.
+                maybeLogRequestContent(null);
+            }
             if (blockingExecutor != null) {
                 blockingExecutor.execute(this::invokeHalfClose);
             } else {
@@ -400,11 +423,6 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private void invokeOnMessage(I request, boolean halfClose) {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onMessage() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
-            return;
-        }
         try (SafeCloseable ignored = ctx.push()) {
             assert listener != null;
             listener.onMessage(request);

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -362,7 +363,12 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
             // Deserialize the message on the thread that invokes the listener, so that the event loop
             // is not occupied by deserialization (and decompression) when `blockingTaskExecutor` is used.
             if (blockingExecutor != null) {
-                blockingExecutor.execute(() -> deserializeAndInvokeOnMessage(message, endOfStream));
+                try {
+                    blockingExecutor.execute(() -> deserializeAndInvokeOnMessage(message, endOfStream));
+                } catch (RejectedExecutionException cause) {
+                    message.close();
+                    throw cause;
+                }
             } else {
                 deserializeAndInvokeOnMessage(message, endOfStream);
             }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -380,8 +380,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     private void deserializeAndInvokeOnMessage(DeframedMessage message, boolean endOfStream) {
         if (shouldSkipRequestCallback()) {
-            // Do not deserialize the message if the call is cancelled or a previous message failed after
-            // this task was scheduled to blockingTaskExecutor.
+            // Skip cancelled calls and messages queued before a previous message failed.
             message.close();
             return;
         }
@@ -425,8 +424,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     protected final void invokeOnReady() {
         if (shouldSkipRequestCallback()) {
-            // Do not call listener.onReady() if the call is cancelled or request message processing failed
-            // after this task was scheduled to blockingTaskExecutor.
+            // Skip cancelled calls and callbacks queued before request message processing failed.
             return;
         }
         try {
@@ -452,8 +450,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
 
     protected final void invokeHalfClose() {
         if (shouldSkipRequestCallback()) {
-            // Do not call listener.onHalfClose() if the call is cancelled or request message processing failed
-            // after this task was scheduled to blockingTaskExecutor.
+            // Skip cancelled calls and callbacks queued before request message processing failed.
             return;
         }
         try (SafeCloseable ignored = ctx.push()) {
@@ -465,7 +462,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private boolean shouldSkipRequestCallback() {
-        return blockingExecutor != null && (cancelled || requestMessageProcessingFailed);
+        return cancelled || (blockingExecutor != null && requestMessageProcessingFailed);
     }
 
     private void invokeOnComplete() {

--- a/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/server/grpc/AbstractServerCall.java
@@ -136,6 +136,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     private volatile boolean cancelled;
     private volatile boolean clientStreamClosed;
     private volatile boolean listenerClosed;
+    private volatile boolean requestMessageProcessingFailed;
     private boolean closeCalled;
 
     protected AbstractServerCall(HttpRequest req,
@@ -378,8 +379,8 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     private void deserializeAndInvokeOnMessage(DeframedMessage message, boolean endOfStream) {
-        if (blockingExecutor != null && cancelled) {
-            // Do not deserialize the message if the call is cancelled after
+        if (shouldSkipRequestCallback()) {
+            // Do not deserialize the message if the call is cancelled or a previous message failed after
             // this task was scheduled to blockingTaskExecutor.
             message.close();
             return;
@@ -398,6 +399,7 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
                 GrpcUnsafeBufferUtil.storeBuffer(buf, request, ctx);
             }
         } catch (Throwable cause) {
+            requestMessageProcessingFailed = true;
             close(cause, true);
             return;
         }
@@ -422,9 +424,9 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     protected final void invokeOnReady() {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onReady() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
+        if (shouldSkipRequestCallback()) {
+            // Do not call listener.onReady() if the call is cancelled or request message processing failed
+            // after this task was scheduled to blockingTaskExecutor.
             return;
         }
         try {
@@ -449,9 +451,9 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
     }
 
     protected final void invokeHalfClose() {
-        if (blockingExecutor != null && cancelled) {
-            // Do not call listener.onHalfClose() if the call is cancelled after
-            // this task was scheduled to blockingTaskExecutor.
+        if (shouldSkipRequestCallback()) {
+            // Do not call listener.onHalfClose() if the call is cancelled or request message processing failed
+            // after this task was scheduled to blockingTaskExecutor.
             return;
         }
         try (SafeCloseable ignored = ctx.push()) {
@@ -460,6 +462,10 @@ public abstract class AbstractServerCall<I, O> extends ServerCall<I, O> {
         } catch (Throwable t) {
             close(t);
         }
+    }
+
+    private boolean shouldSkipRequestCallback() {
+        return blockingExecutor != null && (cancelled || requestMessageProcessingFailed);
     }
 
     private void invokeOnComplete() {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.reactivestreams.Subscriber;
@@ -145,7 +146,13 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
         if (ctx.eventLoop().inEventLoop()) {
             doSendMessage(message, payload);
         } else {
-            ctx.eventLoop().execute(() -> doSendMessage(message, payload));
+            try {
+                ctx.eventLoop().execute(() -> doSendMessage(message, payload));
+            } catch (RejectedExecutionException cause) {
+                payload.close();
+                pendingMessagesUpdater.decrementAndGet(this);
+                throw cause;
+            }
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
+import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponseWriter;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -132,25 +133,41 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
     @Override
     public void sendMessage(O message) {
         pendingMessagesUpdater.incrementAndGet(this);
+        // Serialize and compress the message on the caller's thread so that the event loop is not
+        // occupied by serialization.
+        final HttpData payload;
+        try {
+            payload = toPayload(message);
+        } catch (Throwable e) {
+            close(e, true);
+            return;
+        }
         if (ctx.eventLoop().inEventLoop()) {
-            doSendMessage(message);
+            doSendMessage(message, payload);
         } else {
-            ctx.eventLoop().execute(() -> doSendMessage(message));
+            ctx.eventLoop().execute(() -> doSendMessage(message, payload));
         }
     }
 
-    private void doSendMessage(O message) {
+    private void doSendMessage(O message, HttpData payload) {
         if (isCancelled()) {
             // call was already closed by a client or a timeout scheduler
+            payload.close();
             return;
         }
         final ResponseHeaders responseHeaders = responseHeaders();
-        checkState(responseHeaders != null, "sendHeaders has not been called");
-        checkState(!isCloseCalled(), "call is closed");
+        try {
+            checkState(responseHeaders != null, "sendHeaders has not been called");
+            checkState(!isCloseCalled(), "call is closed");
+        } catch (IllegalStateException e) {
+            payload.close();
+            throw e;
+        }
 
         if (firstResponse == null) {
             // Write the response headers when the first response is received.
             if (!res.tryWrite(responseHeaders)) {
+                payload.close();
                 maybeCancel();
                 return;
             }
@@ -158,7 +175,8 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
         }
 
         try {
-            if (res.tryWrite(toPayload(message))) {
+            // `res` releases `payload` by itself if `tryWrite()` returns false or throws.
+            if (res.tryWrite(payload)) {
                 if (!method.getType().serverSendsOneMessage()) {
                     // Invoke onReady() only when server can send multiple messages.
                     res.whenConsumed().thenRun(() -> {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/StreamingServerCall.java
@@ -134,8 +134,8 @@ final class StreamingServerCall<I, O> extends AbstractServerCall<I, O>
     @Override
     public void sendMessage(O message) {
         pendingMessagesUpdater.incrementAndGet(this);
-        // Serialize and compress the message on the caller's thread so that the event loop is not
-        // occupied by serialization.
+        // Serialize and compress the message on the caller's thread before handing the payload
+        // to the event loop.
         final HttpData payload;
         try {
             payload = toPayload(message);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -211,7 +211,6 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
                 assert responseHeaders != null;
                 assert responseMessage != null;
                 if (responseFailure != null) {
-                    // `sendMessage()` failed to serialize the response.
                     Exceptions.throwUnsafely(responseFailure);
                 }
                 assert responsePayload != null;

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 import com.linecorp.armeria.common.AggregationOptions;
 import com.linecorp.armeria.common.HttpData;
@@ -135,7 +136,12 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
         if (ctx.eventLoop().inEventLoop()) {
             doSendMessage(message, payload);
         } else {
-            ctx.eventLoop().execute(() -> doSendMessage(message, payload));
+            try {
+                ctx.eventLoop().execute(() -> doSendMessage(message, payload));
+            } catch (RejectedExecutionException cause) {
+                payload.close();
+                throw cause;
+            }
         }
     }
 

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -128,15 +128,14 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
 
     @Override
     public void sendMessage(O message) {
-        // Serialize and compress the message on the caller's thread so that the event loop is not
-        // occupied by serialization.
+        // Serialize and compress the message on the caller's thread before handing the payload
+        // to the event loop.
         final HttpData payload;
         try {
             payload = toPayload(message);
         } catch (Throwable e) {
-            // Report the failure when the call is closed, as it was reported when the message was serialized
-            // in `doClose()`. Closing the call here instead would let `close(Status.OK)` from the service
-            // preempt an asynchronous exception handler and complete the call with a wrong status.
+            // Defer reporting until `doClose()` so that `close(Status.OK)` from the service cannot
+            // overtake an asynchronous exception handler and complete the call with the wrong status.
             if (ctx.eventLoop().inEventLoop()) {
                 doFailSendMessage(message, e);
             } else {

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.SerializationFormat;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.internal.common.grpc.GrpcLogUtil;
 import com.linecorp.armeria.internal.common.grpc.InternalGrpcExceptionHandler;
 import com.linecorp.armeria.internal.server.grpc.AbstractServerCall;
@@ -67,6 +68,9 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
     // The serialized `responseMessage`. Released by `onListenerClosed()` if it was not written.
     @Nullable
     private HttpData responsePayload;
+    // The cause of the serialization failure of `responseMessage`, if any. Reported by `doClose()`.
+    @Nullable
+    private Throwable responseFailure;
 
     UnaryServerCall(HttpRequest req, MethodDescriptor<I, O> method, String simpleMethodName,
                     CompressorRegistry compressorRegistry, DecompressorRegistry decompressorRegistry,
@@ -130,7 +134,14 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
         try {
             payload = toPayload(message);
         } catch (Throwable e) {
-            close(e, true);
+            // Report the failure when the call is closed, as it was reported when the message was serialized
+            // in `doClose()`. Closing the call here instead would let `close(Status.OK)` from the service
+            // preempt an asynchronous exception handler and complete the call with a wrong status.
+            if (ctx.eventLoop().inEventLoop()) {
+                doFailSendMessage(message, e);
+            } else {
+                ctx.eventLoop().execute(() -> doFailSendMessage(message, e));
+            }
             return;
         }
         if (ctx.eventLoop().inEventLoop()) {
@@ -163,6 +174,18 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
         responsePayload = payload;
     }
 
+    private void doFailSendMessage(O message, Throwable cause) {
+        if (isCancelled()) {
+            // call was already closed by a client or a timeout scheduler
+            return;
+        }
+        checkState(responseHeaders() != null, "sendHeaders has not been called");
+        checkState(responseMessage == null, "responseMessage is set already");
+        checkState(!isCloseCalled(), "call is closed");
+        responseMessage = message;
+        responseFailure = cause;
+    }
+
     @Override
     protected void onListenerClosed() {
         if (responsePayload != null) {
@@ -188,6 +211,10 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
             if (status.isOk()) {
                 assert responseHeaders != null;
                 assert responseMessage != null;
+                if (responseFailure != null) {
+                    // `sendMessage()` failed to serialize the response.
+                    Exceptions.throwUnsafely(responseFailure);
+                }
                 assert responsePayload != null;
                 final HttpData responseBody = responsePayload;
                 final HttpObject responseTrailers = responseTrailers(ctx, status, metadata, false);

--- a/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
+++ b/grpc/src/main/java/com/linecorp/armeria/server/grpc/UnaryServerCall.java
@@ -63,6 +63,9 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
     // Only set once.
     @Nullable
     private O responseMessage;
+    // The serialized `responseMessage`. Released by `onListenerClosed()` if it was not written.
+    @Nullable
+    private HttpData responsePayload;
 
     UnaryServerCall(HttpRequest req, MethodDescriptor<I, O> method, String simpleMethodName,
                     CompressorRegistry compressorRegistry, DecompressorRegistry decompressorRegistry,
@@ -120,22 +123,47 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
 
     @Override
     public void sendMessage(O message) {
+        // Serialize and compress the message on the caller's thread so that the event loop is not
+        // occupied by serialization.
+        final HttpData payload;
+        try {
+            payload = toPayload(message);
+        } catch (Throwable e) {
+            close(e, true);
+            return;
+        }
         if (ctx.eventLoop().inEventLoop()) {
-            doSendMessage(message);
+            doSendMessage(message, payload);
         } else {
-            ctx.eventLoop().execute(() -> doSendMessage(message));
+            ctx.eventLoop().execute(() -> doSendMessage(message, payload));
         }
     }
 
-    private void doSendMessage(O message) {
+    private void doSendMessage(O message, HttpData payload) {
         if (isCancelled()) {
             // call was already closed by a client or a timeout scheduler
+            payload.close();
             return;
         }
-        checkState(responseHeaders() != null, "sendHeaders has not been called");
-        checkState(responseMessage == null, "responseMessage is set already");
-        checkState(!isCloseCalled(), "call is closed");
+        try {
+            checkState(responseHeaders() != null, "sendHeaders has not been called");
+            checkState(responseMessage == null, "responseMessage is set already");
+            checkState(!isCloseCalled(), "call is closed");
+        } catch (IllegalStateException e) {
+            payload.close();
+            throw e;
+        }
         responseMessage = message;
+        responsePayload = payload;
+    }
+
+    @Override
+    protected void onListenerClosed() {
+        if (responsePayload != null) {
+            // The call was closed without writing the response, e.g. cancelled or failed.
+            responsePayload.close();
+            responsePayload = null;
+        }
     }
 
     @Override
@@ -154,9 +182,12 @@ final class UnaryServerCall<I, O> extends AbstractServerCall<I, O> {
             if (status.isOk()) {
                 assert responseHeaders != null;
                 assert responseMessage != null;
-                final HttpData responseBody = toPayload(responseMessage);
-
+                assert responsePayload != null;
+                final HttpData responseBody = responsePayload;
                 final HttpObject responseTrailers = responseTrailers(ctx, status, metadata, false);
+                // From here, the payload is owned by the response or consumed by `aggregateData()`.
+                // If an exception was raised above, `onListenerClosed()` releases it.
+                responsePayload = null;
                 if (responseTrailers instanceof HttpData) {
                     // gRPC-Web encodes response trailers as response body.
                     final HttpData httpData =

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncGrpcExceptionHandlerTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/AsyncGrpcExceptionHandlerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.grpc.GrpcClients;
 import com.linecorp.armeria.common.ContentTooLargeException;
@@ -43,6 +46,7 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import testing.grpc.Messages.Payload;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
 import testing.grpc.Messages.StreamingOutputCallRequest;
@@ -347,6 +351,82 @@ class AsyncGrpcExceptionHandlerTest {
         }
     };
 
+    // The two servers below verify that a unary response which fails to serialize in `sendMessage()`
+    // is reported with the status produced by the asynchronous handler, even though the service calls
+    // `onCompleted()` right after `onNext()`, i.e. before the asynchronous handler completes.
+
+    private static final CountDownLatch blockingServiceCompleted = new CountDownLatch(1);
+
+    @RegisterExtension
+    static final ServerExtension serverWithFailingResponseSerialization = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final GrpcExceptionHandlerFunction asyncHandler = new GrpcExceptionHandlerFunction() {
+                @Override
+                public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause,
+                                              Metadata metadata) {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Status> applyAsync(RequestContext ctx, Status status,
+                                                            Throwable cause, Metadata metadata) {
+                    // A completed future is enough on the event loop, because the continuation is
+                    // always scheduled to the event loop asynchronously.
+                    return UnmodifiableFuture.completedFuture(
+                            Status.RESOURCE_EXHAUSTED.withDescription("large-response-async-handled")
+                                                     .withCause(cause));
+                }
+            };
+            sb.requestTimeoutMillis(5000)
+              .service(GrpcService.builder()
+                                  .addService(new LargeResponseService(null))
+                                  .maxResponseMessageLength(1000)
+                                  .exceptionHandler(asyncHandler)
+                                  .build());
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension blockingServerWithFailingResponseSerialization = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final GrpcExceptionHandlerFunction asyncHandler = new GrpcExceptionHandlerFunction() {
+                @Override
+                public @Nullable Status apply(RequestContext ctx, Status status, Throwable cause,
+                                              Metadata metadata) {
+                    return null;
+                }
+
+                @Override
+                public CompletableFuture<Status> applyAsync(RequestContext ctx, Status status,
+                                                            Throwable cause, Metadata metadata) {
+                    // Complete the future only after the service has called `onCompleted()`, so that
+                    // the handler is guaranteed to be still pending when the service closes the call.
+                    final CompletableFuture<Status> future = new CompletableFuture<>();
+                    ASYNC_EXECUTOR.execute(() -> {
+                        try {
+                            blockingServiceCompleted.await(10, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        future.complete(Status.RESOURCE_EXHAUSTED
+                                                .withDescription("large-response-async-handled")
+                                                .withCause(cause));
+                    });
+                    return future;
+                }
+            };
+            sb.requestTimeoutMillis(5000)
+              .service(GrpcService.builder()
+                                  .addService(new LargeResponseService(blockingServiceCompleted))
+                                  .maxResponseMessageLength(1000)
+                                  .useBlockingTaskExecutor(true)
+                                  .exceptionHandler(asyncHandler)
+                                  .build());
+        }
+    };
+
     @Test
     void asyncHandlerReturnsCustomStatus() {
         final TestServiceBlockingStub client =
@@ -482,6 +562,30 @@ class AsyncGrpcExceptionHandlerTest {
         assertThat(streamingHandlerInvocations).hasValue(1);
     }
 
+    @Test
+    void asyncHandlerStatusIsUsedWhenResponseSerializationFails() {
+        assertLargeResponseAsyncHandled(serverWithFailingResponseSerialization);
+    }
+
+    @Test
+    void asyncHandlerStatusIsUsedWhenResponseSerializationFailsOnBlockingTaskExecutor() {
+        assertLargeResponseAsyncHandled(blockingServerWithFailingResponseSerialization);
+    }
+
+    private static void assertLargeResponseAsyncHandled(ServerExtension server) {
+        final TestServiceBlockingStub client =
+                GrpcClients.newClient(server.httpUri(), TestServiceBlockingStub.class);
+        final SimpleRequest request = SimpleRequest.newBuilder()
+                                                   .setResponseSize(1001)
+                                                   .build();
+        // The response exceeds `maxResponseMessageLength`, so `sendMessage()` fails to frame it.
+        assertThatThrownBy(() -> client.unaryCall(request))
+                .isInstanceOfSatisfying(StatusRuntimeException.class, e -> {
+                    assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.RESOURCE_EXHAUSTED);
+                    assertThat(e.getStatus().getDescription()).isEqualTo("large-response-async-handled");
+                });
+    }
+
     private static class ErrorThrowingService extends TestServiceImplBase {
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
@@ -504,6 +608,30 @@ class AsyncGrpcExceptionHandlerTest {
         @Override
         public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
             throw ContentTooLargeException.get();
+        }
+    }
+
+    private static class LargeResponseService extends TestServiceImplBase {
+
+        @Nullable
+        private final CountDownLatch completed;
+
+        LargeResponseService(@Nullable CountDownLatch completed) {
+            this.completed = completed;
+        }
+
+        @Override
+        public void unaryCall(SimpleRequest request, StreamObserver<SimpleResponse> responseObserver) {
+            final SimpleResponse response =
+                    SimpleResponse.newBuilder()
+                                  .setPayload(Payload.newBuilder().setBody(
+                                          ByteString.copyFrom(new byte[request.getResponseSize()])))
+                                  .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+            if (completed != null) {
+                completed.countDown();
+            }
         }
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.server.grpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.io.InputStream;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.grpc.GrpcClients;
+import com.linecorp.armeria.common.FilteredHttpRequest;
+import com.linecorp.armeria.common.HttpObject;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.server.grpc.AbstractServerCall;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.StreamObserver;
+import io.netty.buffer.AbstractByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import testing.grpc.Messages.ResponseParameters;
+import testing.grpc.Messages.SimpleRequest;
+import testing.grpc.Messages.SimpleResponse;
+import testing.grpc.Messages.StreamingOutputCallRequest;
+import testing.grpc.Messages.StreamingOutputCallResponse;
+import testing.grpc.TestServiceGrpc;
+import testing.grpc.TestServiceGrpc.TestServiceBlockingStub;
+import testing.grpc.TestServiceGrpc.TestServiceStub;
+
+/**
+ * Verifies which thread performs request deserialization and response serialization.
+ */
+class GrpcSerdeExecutorTest {
+
+    private static final AtomicReference<Thread> requestParseThread = new AtomicReference<>();
+    private static final AtomicInteger requestParseCount = new AtomicInteger();
+    private static final AtomicReference<Thread> handlerThread = new AtomicReference<>();
+
+    private static final TrackingAllocator cancellingServerAllocator = new TrackingAllocator();
+
+    // Non-empty messages, because an empty message is not deserialized through the marshaller.
+    private static final SimpleRequest UNARY_REQUEST =
+            SimpleRequest.newBuilder().setResponseSize(1).build();
+    private static final StreamingOutputCallRequest BIDI_REQUEST =
+            StreamingOutputCallRequest.newBuilder()
+                                      .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
+                                      .build();
+
+    @RegisterExtension
+    static final ServerExtension blockingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(recordingService())
+                                  .useMethodMarshaller(true)
+                                  .useBlockingTaskExecutor(true)
+                                  .build());
+        }
+    };
+
+    @RegisterExtension
+    static final ServerExtension eventLoopServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(GrpcService.builder()
+                                  .addService(recordingService())
+                                  .useMethodMarshaller(true)
+                                  .build());
+        }
+    };
+
+    /**
+     * A blocking server whose per-call blocking executor is stalled until the request is cancelled by
+     * the request timeout, so that the deserialization task runs only after the cancellation.
+     */
+    @RegisterExtension
+    static final ServerExtension cancellingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final AtomicReference<ServerCall<?, ?>> serverCallCaptor = new AtomicReference<>();
+            sb.service(GrpcService.builder()
+                                  .addService(ServerInterceptors.intercept(
+                                          recordingService(), new ServerInterceptor() {
+                                              @Override
+                                              public <I, O> Listener<I> interceptCall(
+                                                      ServerCall<I, O> call, Metadata headers,
+                                                      ServerCallHandler<I, O> next) {
+                                                  serverCallCaptor.set(call);
+                                                  return next.startCall(call, headers);
+                                              }
+                                          }))
+                                  .useMethodMarshaller(true)
+                                  .useBlockingTaskExecutor(true)
+                                  // Otherwise, the client's `grpc-timeout` overrides the request timeout.
+                                  .useClientTimeoutHeader(false)
+                                  .build());
+            sb.decorator((delegate, ctx, req) -> {
+                final HttpRequest stalled = new FilteredHttpRequest(req) {
+                    @Override
+                    protected void beforeSubscribe(Subscriber<? super HttpObject> subscriber,
+                                                   Subscription subscription) {
+                        // Called right before the request body is subscribed, i.e. after `startCall()` and
+                        // before the first message is deframed. Stall the sequential blocking executor so
+                        // that the deserialization task is queued behind and runs after the cancellation.
+                        final ServerCall<?, ?> serverCall = serverCallCaptor.get();
+                        assertThat(serverCall).isInstanceOf(AbstractServerCall.class);
+                        ((AbstractServerCall<?, ?>) serverCall).blockingExecutor().execute(() -> {
+                            await().until(serverCall::isCancelled);
+                        });
+                    }
+
+                    @Override
+                    protected HttpObject filter(HttpObject obj) {
+                        return obj;
+                    }
+                };
+                ctx.updateRequest(stalled);
+                return delegate.serve(ctx, stalled);
+            });
+            sb.childChannelOption(ChannelOption.ALLOCATOR, cancellingServerAllocator);
+            sb.requestTimeoutMillis(200);
+        }
+    };
+
+    @BeforeEach
+    void reset() {
+        requestParseThread.set(null);
+        requestParseCount.set(0);
+        handlerThread.set(null);
+        cancellingServerAllocator.allocated.clear();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void requestIsDeserializedOnBlockingTaskExecutor(boolean unary) throws Exception {
+        final ServiceRequestContext ctx = call(blockingServer, unary);
+
+        assertThat(requestParseCount).hasPositiveValue();
+        final Thread parseThread = requestParseThread.get();
+        assertThat(parseThread).isNotNull();
+        assertThat(ctx.eventLoop().inEventLoop(parseThread)).isFalse();
+        assertThat(parseThread).isSameAs(handlerThread.get());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void requestIsDeserializedOnEventLoopWithoutBlockingTaskExecutor(boolean unary) throws Exception {
+        final ServiceRequestContext ctx = call(eventLoopServer, unary);
+
+        assertThat(requestParseCount).hasPositiveValue();
+        final Thread parseThread = requestParseThread.get();
+        assertThat(parseThread).isNotNull();
+        assertThat(ctx.eventLoop().inEventLoop(parseThread)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void requestIsNotDeserializedAfterCancellation(boolean unary) throws Exception {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            assertThatThrownBy(() -> call(cancellingServer, factory, unary))
+                    .isInstanceOf(StatusRuntimeException.class);
+        }
+
+        // The request body buffers must be released even though the deserialization task ran after
+        // the cancellation ...
+        await().untilAsserted(() -> assertThat(cancellingServerAllocator.allocated)
+                .allSatisfy(buf -> assertThat(buf.refCnt()).isZero()));
+        // ... and the message must not have been deserialized.
+        assertThat(requestParseCount).hasValue(0);
+    }
+
+    private static ServiceRequestContext call(ServerExtension server, boolean unary) throws Exception {
+        return call(server, ClientFactory.ofDefault(), unary);
+    }
+
+    private static ServiceRequestContext call(ServerExtension server, ClientFactory factory,
+                                              boolean unary) throws Exception {
+        if (unary) {
+            final TestServiceBlockingStub client =
+                    GrpcClients.builder(server.httpUri())
+                               .factory(factory)
+                               .build(TestServiceBlockingStub.class);
+            client.unaryCall(UNARY_REQUEST);
+        } else {
+            final TestServiceStub client =
+                    GrpcClients.builder(server.httpUri())
+                               .factory(factory)
+                               .build(TestServiceStub.class);
+            final CompletableFuture<Void> completion = new CompletableFuture<>();
+            final StreamObserver<StreamingOutputCallRequest> requestObserver =
+                    client.fullDuplexCall(new StreamObserver<StreamingOutputCallResponse>() {
+                        @Override
+                        public void onNext(StreamingOutputCallResponse value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            completion.completeExceptionally(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            completion.complete(null);
+                        }
+                    });
+            requestObserver.onNext(BIDI_REQUEST);
+            requestObserver.onNext(BIDI_REQUEST);
+            requestObserver.onCompleted();
+            try {
+                completion.get(10, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                throw (Exception) e.getCause();
+            }
+        }
+        return server.requestContextCaptor().take();
+    }
+
+    /**
+     * Binds {@code UnaryCall} and {@code FullDuplexCall} with marshallers which record the thread that
+     * performs the deserialization, and handlers which record the thread that receives the request.
+     */
+    private static ServerServiceDefinition recordingService() {
+        final MethodDescriptor<SimpleRequest, SimpleResponse> unaryMethod =
+                recording(TestServiceGrpc.getUnaryCallMethod());
+        final MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> bidiMethod =
+                recording(TestServiceGrpc.getFullDuplexCallMethod());
+
+        return ServerServiceDefinition
+                .builder(TestServiceGrpc.SERVICE_NAME)
+                .addMethod(unaryMethod, ServerCalls.asyncUnaryCall((request, responseObserver) -> {
+                    handlerThread.set(Thread.currentThread());
+                    responseObserver.onNext(SimpleResponse.getDefaultInstance());
+                    responseObserver.onCompleted();
+                }))
+                .addMethod(bidiMethod, ServerCalls.asyncBidiStreamingCall(
+                        responseObserver -> new StreamObserver<StreamingOutputCallRequest>() {
+                            @Override
+                            public void onNext(StreamingOutputCallRequest value) {
+                                handlerThread.set(Thread.currentThread());
+                                responseObserver.onNext(StreamingOutputCallResponse.getDefaultInstance());
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {}
+
+                            @Override
+                            public void onCompleted() {
+                                responseObserver.onCompleted();
+                            }
+                        }))
+                .build();
+    }
+
+    private static <I, O> MethodDescriptor<I, O> recording(MethodDescriptor<I, O> method) {
+        return method.toBuilder()
+                     .setRequestMarshaller(new RecordingMarshaller<>(method.getRequestMarshaller()))
+                     .build();
+    }
+
+    private static final class RecordingMarshaller<T> implements PrototypeMarshaller<T> {
+
+        private final PrototypeMarshaller<T> delegate;
+
+        RecordingMarshaller(Marshaller<T> delegate) {
+            this.delegate = (PrototypeMarshaller<T>) delegate;
+        }
+
+        @Nullable
+        @Override
+        public T getMessagePrototype() {
+            return delegate.getMessagePrototype();
+        }
+
+        @Override
+        public Class<T> getMessageClass() {
+            return delegate.getMessageClass();
+        }
+
+        @Override
+        public InputStream stream(T value) {
+            return delegate.stream(value);
+        }
+
+        @Override
+        public T parse(InputStream stream) {
+            requestParseThread.set(Thread.currentThread());
+            requestParseCount.incrementAndGet();
+            return delegate.parse(stream);
+        }
+    }
+
+    /**
+     * An unpooled allocator which remembers every buffer it allocated, so that a test can verify that all
+     * of them were released. Unpooled buffers are not recycled, so a released buffer stays at zero.
+     */
+    private static final class TrackingAllocator extends AbstractByteBufAllocator {
+
+        private final UnpooledByteBufAllocator delegate = new UnpooledByteBufAllocator(true);
+        final Queue<ByteBuf> allocated = new ConcurrentLinkedQueue<>();
+
+        TrackingAllocator() {
+            super(true);
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.heapBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.directBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+
+        private ByteBuf track(ByteBuf buf) {
+            allocated.add(buf);
+            return buf;
+        }
+    }
+}

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
@@ -94,10 +94,7 @@ class GrpcSerdeExecutorTest {
 
     private static final String CALLER_THREAD_NAME = "serde-caller";
 
-    /**
-     * The thread from which the services below send their responses, so that a test can tell whether
-     * a response was serialized on the thread that called {@code sendMessage()}.
-     */
+    // Sends responses from a dedicated thread to verify where serialization runs.
     private static final Executor caller =
             Executors.newSingleThreadExecutor(r -> new Thread(r, CALLER_THREAD_NAME));
 
@@ -585,11 +582,7 @@ class GrpcSerdeExecutorTest {
         return server.requestContextCaptor().take();
     }
 
-    /**
-     * Binds {@code UnaryCall} and {@code FullDuplexCall} with marshallers which record the threads that
-     * perform the (de)serialization, and handlers which record the thread that receives the request and
-     * send the responses from the {@link #caller} thread.
-     */
+    // Records request processing threads and sends responses from `caller`.
     private static ServerServiceDefinition recordingService() {
         final MethodDescriptor<SimpleRequest, SimpleResponse> unaryMethod =
                 recording(TestServiceGrpc.getUnaryCallMethod());

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
@@ -24,17 +24,23 @@ import java.io.InputStream;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
+
+import com.google.protobuf.ByteString;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.grpc.GrpcClients;
@@ -43,10 +49,13 @@ import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.internal.server.grpc.AbstractServerCall;
+import com.linecorp.armeria.internal.testing.BlockingUtils;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 
+import io.grpc.Codec;
+import io.grpc.DecompressorRegistry;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.MethodDescriptor.Marshaller;
@@ -57,13 +66,17 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
 import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelOption;
+import testing.grpc.Messages.Payload;
 import testing.grpc.Messages.ResponseParameters;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
@@ -78,19 +91,40 @@ import testing.grpc.TestServiceGrpc.TestServiceStub;
  */
 class GrpcSerdeExecutorTest {
 
+    private static final String CALLER_THREAD_NAME = "serde-caller";
+
+    /**
+     * The thread from which the services below send their responses, so that a test can tell whether
+     * a response was serialized on the thread that called {@code sendMessage()}.
+     */
+    private static final Executor caller =
+            Executors.newSingleThreadExecutor(r -> new Thread(r, CALLER_THREAD_NAME));
+
     private static final AtomicReference<Thread> requestParseThread = new AtomicReference<>();
     private static final AtomicInteger requestParseCount = new AtomicInteger();
+    private static final AtomicReference<Thread> responseStreamThread = new AtomicReference<>();
     private static final AtomicReference<Thread> handlerThread = new AtomicReference<>();
+    private static final AtomicReference<CompletableFuture<Void>> requestReceived = new AtomicReference<>();
 
     private static final TrackingAllocator cancellingServerAllocator = new TrackingAllocator();
+    private static final TrackingAllocator leakServerAllocator = new TrackingAllocator();
 
-    // Non-empty messages, because an empty message is not deserialized through the marshaller.
+    // Non-empty messages, because an empty message is not (de)serialized through the marshaller.
     private static final SimpleRequest UNARY_REQUEST =
             SimpleRequest.newBuilder().setResponseSize(1).build();
+    private static final SimpleResponse UNARY_RESPONSE =
+            SimpleResponse.newBuilder()
+                          .setPayload(Payload.newBuilder().setBody(ByteString.copyFromUtf8("response")))
+                          .build();
     private static final StreamingOutputCallRequest BIDI_REQUEST =
             StreamingOutputCallRequest.newBuilder()
                                       .addResponseParameters(ResponseParameters.newBuilder().setSize(1))
                                       .build();
+    private static final StreamingOutputCallResponse BIDI_RESPONSE =
+            StreamingOutputCallResponse.newBuilder()
+                                       .setPayload(Payload.newBuilder()
+                                                          .setBody(ByteString.copyFromUtf8("response")))
+                                       .build();
 
     @RegisterExtension
     static final ServerExtension blockingServer = new ServerExtension() {
@@ -168,12 +202,106 @@ class GrpcSerdeExecutorTest {
         }
     };
 
+    /**
+     * A blocking server which enables gzip compression and then blocks the event loop until the first
+     * response has been sent, so that the response is serialized before the event loop processes
+     * {@code sendHeaders()}.
+     */
+    @RegisterExtension
+    static final ServerExtension compressingServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final MethodDescriptor<SimpleRequest, SimpleResponse> unaryMethod =
+                    recording(TestServiceGrpc.getUnaryCallMethod());
+            final ServerServiceDefinition service =
+                    ServerServiceDefinition
+                            .builder(TestServiceGrpc.SERVICE_NAME)
+                            .addMethod(unaryMethod, ServerCalls.asyncUnaryCall((request, rawObserver) -> {
+                                final ServerCallStreamObserver<SimpleResponse> observer =
+                                        (ServerCallStreamObserver<SimpleResponse>) rawObserver;
+                                final ServiceRequestContext ctx = ServiceRequestContext.current();
+                                observer.setCompression("gzip");
+
+                                final CountDownLatch latch = new CountDownLatch(1);
+                                ctx.eventLoop().execute(() -> BlockingUtils.blockingRun(
+                                        () -> latch.await(10, TimeUnit.SECONDS)));
+                                try {
+                                    // Sends the headers and the message back to back.
+                                    observer.onNext(UNARY_RESPONSE);
+                                } finally {
+                                    latch.countDown();
+                                }
+                                observer.onCompleted();
+                            }))
+                            .build();
+            sb.service(GrpcService.builder()
+                                  .addService(service)
+                                  .useMethodMarshaller(true)
+                                  .useBlockingTaskExecutor(true)
+                                  .build());
+        }
+    };
+
+    /**
+     * A blocking server whose services discard a response after {@code sendMessage()}: the unary service
+     * fails the call after sending a message, and the bidi service sends a message after the client
+     * cancelled the call.
+     */
+    @RegisterExtension
+    static final ServerExtension leakServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            final MethodDescriptor<SimpleRequest, SimpleResponse> unaryMethod =
+                    recording(TestServiceGrpc.getUnaryCallMethod());
+            final MethodDescriptor<StreamingOutputCallRequest, StreamingOutputCallResponse> bidiMethod =
+                    recording(TestServiceGrpc.getFullDuplexCallMethod());
+            final ServerServiceDefinition service =
+                    ServerServiceDefinition
+                            .builder(TestServiceGrpc.SERVICE_NAME)
+                            .addMethod(unaryMethod, ServerCalls.asyncUnaryCall((request, responseObserver) -> {
+                                responseObserver.onNext(UNARY_RESPONSE);
+                                responseObserver.onError(Status.INTERNAL.asRuntimeException());
+                            }))
+                            .addMethod(bidiMethod, ServerCalls.asyncBidiStreamingCall(rawObserver -> {
+                                final ServerCallStreamObserver<StreamingOutputCallResponse> observer =
+                                        (ServerCallStreamObserver<StreamingOutputCallResponse>) rawObserver;
+                                // Without an `onCancelHandler`, the stub marks the observer as cancelled when
+                                // `onCancel()` is delivered and `onNext()` throws instead of sending.
+                                observer.setOnCancelHandler(() -> {});
+                                return new StreamObserver<StreamingOutputCallRequest>() {
+                                    @Override
+                                    public void onNext(StreamingOutputCallRequest value) {
+                                        requestReceived.get().complete(null);
+                                        await().until(observer::isCancelled);
+                                        observer.onNext(BIDI_RESPONSE);
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {}
+
+                                    @Override
+                                    public void onCompleted() {}
+                                };
+                            }))
+                            .build();
+            sb.service(GrpcService.builder()
+                                  .addService(service)
+                                  .useMethodMarshaller(true)
+                                  .useBlockingTaskExecutor(true)
+                                  .build());
+            sb.childChannelOption(ChannelOption.ALLOCATOR, leakServerAllocator);
+        }
+    };
+
     @BeforeEach
     void reset() {
         requestParseThread.set(null);
         requestParseCount.set(0);
+        responseStreamThread.set(null);
         handlerThread.set(null);
+        requestReceived.set(new CompletableFuture<>());
         cancellingServerAllocator.allocated.clear();
+        leakServerAllocator.allocated.clear();
     }
 
     @ParameterizedTest
@@ -213,6 +341,90 @@ class GrpcSerdeExecutorTest {
                 .allSatisfy(buf -> assertThat(buf.refCnt()).isZero()));
         // ... and the message must not have been deserialized.
         assertThat(requestParseCount).hasValue(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void responseIsSerializedOnCallerThreadWithBlockingTaskExecutor(boolean unary) throws Exception {
+        call(blockingServer, unary);
+
+        assertThat(responseStreamThread.get()).isNotNull()
+                                              .extracting(Thread::getName)
+                                              .isEqualTo(CALLER_THREAD_NAME);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void responseIsSerializedOnCallerThreadWithoutBlockingTaskExecutor(boolean unary) throws Exception {
+        call(eventLoopServer, unary);
+
+        assertThat(responseStreamThread.get()).isNotNull()
+                                              .extracting(Thread::getName)
+                                              .isEqualTo(CALLER_THREAD_NAME);
+    }
+
+    @Test
+    void compressionIsNegotiatedBeforeResponseIsSerialized() {
+        // The client does not accept gzip, so the server must not compress the response even though the
+        // service requested it. The service serializes the response before the event loop processes
+        // `sendHeaders()`, so the negotiation must happen on the caller's thread.
+        final TestServiceBlockingStub client =
+                GrpcClients.builder(compressingServer.httpUri())
+                           .decompressorRegistry(DecompressorRegistry.emptyInstance()
+                                                                     .with(Codec.Identity.NONE, false))
+                           .build(TestServiceBlockingStub.class);
+
+        assertThat(client.unaryCall(UNARY_REQUEST)).isEqualTo(UNARY_RESPONSE);
+    }
+
+    @Test
+    void unaryResponseIsReleasedWhenCallFailsAfterSendMessage() throws Exception {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            assertThatThrownBy(() -> call(leakServer, factory, true))
+                    .isInstanceOf(StatusRuntimeException.class);
+        }
+
+        assertThat(responseStreamThread.get()).isNotNull();
+        await().untilAsserted(() -> assertThat(leakServerAllocator.allocated)
+                .allSatisfy(buf -> assertThat(buf.refCnt()).isZero()));
+    }
+
+    @Test
+    void streamingResponseIsReleasedWhenSentAfterCancellation() throws Exception {
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            final TestServiceStub client =
+                    GrpcClients.builder(leakServer.httpUri())
+                               .factory(factory)
+                               .build(TestServiceStub.class);
+            final CompletableFuture<Void> completion = new CompletableFuture<>();
+            final ClientCallStreamObserver<StreamingOutputCallRequest> requestObserver =
+                    (ClientCallStreamObserver<StreamingOutputCallRequest>) client.fullDuplexCall(
+                            new StreamObserver<StreamingOutputCallResponse>() {
+                                @Override
+                                public void onNext(StreamingOutputCallResponse value) {}
+
+                                @Override
+                                public void onError(Throwable t) {
+                                    completion.completeExceptionally(t);
+                                }
+
+                                @Override
+                                public void onCompleted() {
+                                    completion.complete(null);
+                                }
+                            });
+            requestObserver.onNext(BIDI_REQUEST);
+            requestReceived.get().get(10, TimeUnit.SECONDS);
+            requestObserver.cancel("cancelled by the test", null);
+            assertThatThrownBy(() -> completion.get(10, TimeUnit.SECONDS))
+                    .hasCauseInstanceOf(StatusRuntimeException.class);
+
+            // Wait until the service sent the message after the cancellation.
+            await().until(() -> responseStreamThread.get() != null);
+        }
+
+        await().untilAsserted(() -> assertThat(leakServerAllocator.allocated)
+                .allSatisfy(buf -> assertThat(buf.refCnt()).isZero()));
     }
 
     private static ServiceRequestContext call(ServerExtension server, boolean unary) throws Exception {
@@ -261,8 +473,9 @@ class GrpcSerdeExecutorTest {
     }
 
     /**
-     * Binds {@code UnaryCall} and {@code FullDuplexCall} with marshallers which record the thread that
-     * performs the deserialization, and handlers which record the thread that receives the request.
+     * Binds {@code UnaryCall} and {@code FullDuplexCall} with marshallers which record the threads that
+     * perform the (de)serialization, and handlers which record the thread that receives the request and
+     * send the responses from the {@link #caller} thread.
      */
     private static ServerServiceDefinition recordingService() {
         final MethodDescriptor<SimpleRequest, SimpleResponse> unaryMethod =
@@ -274,15 +487,17 @@ class GrpcSerdeExecutorTest {
                 .builder(TestServiceGrpc.SERVICE_NAME)
                 .addMethod(unaryMethod, ServerCalls.asyncUnaryCall((request, responseObserver) -> {
                     handlerThread.set(Thread.currentThread());
-                    responseObserver.onNext(SimpleResponse.getDefaultInstance());
-                    responseObserver.onCompleted();
+                    caller.execute(() -> {
+                        responseObserver.onNext(UNARY_RESPONSE);
+                        responseObserver.onCompleted();
+                    });
                 }))
                 .addMethod(bidiMethod, ServerCalls.asyncBidiStreamingCall(
                         responseObserver -> new StreamObserver<StreamingOutputCallRequest>() {
                             @Override
                             public void onNext(StreamingOutputCallRequest value) {
                                 handlerThread.set(Thread.currentThread());
-                                responseObserver.onNext(StreamingOutputCallResponse.getDefaultInstance());
+                                caller.execute(() -> responseObserver.onNext(BIDI_RESPONSE));
                             }
 
                             @Override
@@ -290,7 +505,7 @@ class GrpcSerdeExecutorTest {
 
                             @Override
                             public void onCompleted() {
-                                responseObserver.onCompleted();
+                                caller.execute(responseObserver::onCompleted);
                             }
                         }))
                 .build();
@@ -299,9 +514,14 @@ class GrpcSerdeExecutorTest {
     private static <I, O> MethodDescriptor<I, O> recording(MethodDescriptor<I, O> method) {
         return method.toBuilder()
                      .setRequestMarshaller(new RecordingMarshaller<>(method.getRequestMarshaller()))
+                     .setResponseMarshaller(new RecordingMarshaller<>(method.getResponseMarshaller()))
                      .build();
     }
 
+    /**
+     * Records the thread which calls {@link #parse(InputStream)} (request deserialization on the server)
+     * and {@link #stream(Object)} (response serialization on the server).
+     */
     private static final class RecordingMarshaller<T> implements PrototypeMarshaller<T> {
 
         private final PrototypeMarshaller<T> delegate;
@@ -323,6 +543,7 @@ class GrpcSerdeExecutorTest {
 
         @Override
         public InputStream stream(T value) {
+            responseStreamThread.set(Thread.currentThread());
             return delegate.stream(value);
         }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.armeria.server.grpc;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -223,7 +224,9 @@ class GrpcSerdeExecutorTest {
                         // that the deserialization task is queued behind and runs after the cancellation.
                         final ServerCall<?, ?> serverCall = serverCallCaptor.get();
                         assertThat(serverCall).isInstanceOf(AbstractServerCall.class);
-                        ((AbstractServerCall<?, ?>) serverCall).blockingExecutor().execute(() -> {
+                        final Executor blockingExecutor = requireNonNull(
+                                ((AbstractServerCall<?, ?>) serverCall).blockingExecutor(), "blockingExecutor");
+                        blockingExecutor.execute(() -> {
                             await().until(serverCall::isCancelled);
                         });
                     }
@@ -433,7 +436,9 @@ class GrpcSerdeExecutorTest {
             final ServerCall<?, ?> call = blockingServerCall.get();
             assertThat(call).isInstanceOf(AbstractServerCall.class);
             final CountDownLatch blockingTasksDrained = new CountDownLatch(1);
-            ((AbstractServerCall<?, ?>) call).blockingExecutor().execute(blockingTasksDrained::countDown);
+            final Executor blockingExecutor = requireNonNull(
+                    ((AbstractServerCall<?, ?>) call).blockingExecutor(), "blockingExecutor");
+            blockingExecutor.execute(blockingTasksDrained::countDown);
             parseRelease.countDown();
             assertThat(blockingTasksDrained.await(10, TimeUnit.SECONDS)).isTrue();
             assertThat(requestHalfClosed.get()).isNotDone();

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcSerdeExecutorTest.java
@@ -105,6 +105,13 @@ class GrpcSerdeExecutorTest {
     private static final AtomicReference<Thread> responseStreamThread = new AtomicReference<>();
     private static final AtomicReference<Thread> handlerThread = new AtomicReference<>();
     private static final AtomicReference<CompletableFuture<Void>> requestReceived = new AtomicReference<>();
+    private static final AtomicReference<CompletableFuture<Void>> requestHalfClosed = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> requestParseStarted = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> requestParseRelease = new AtomicReference<>();
+    private static final AtomicReference<RuntimeException> requestParseFailure = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> requestCompleteStarted = new AtomicReference<>();
+    private static final AtomicReference<CountDownLatch> requestCompleteRelease = new AtomicReference<>();
+    private static final AtomicReference<ServerCall<?, ?>> blockingServerCall = new AtomicReference<>();
 
     private static final TrackingAllocator cancellingServerAllocator = new TrackingAllocator();
     private static final TrackingAllocator leakServerAllocator = new TrackingAllocator();
@@ -131,10 +138,42 @@ class GrpcSerdeExecutorTest {
         @Override
         protected void configure(ServerBuilder sb) {
             sb.service(GrpcService.builder()
-                                  .addService(recordingService())
+                                  .addService(ServerInterceptors.intercept(
+                                          recordingService(), new ServerInterceptor() {
+                                              @Override
+                                              public <I, O> Listener<I> interceptCall(
+                                                      ServerCall<I, O> call, Metadata headers,
+                                                      ServerCallHandler<I, O> next) {
+                                                  blockingServerCall.set(call);
+                                                  return next.startCall(call, headers);
+                                              }
+                                          }))
                                   .useMethodMarshaller(true)
                                   .useBlockingTaskExecutor(true)
                                   .build());
+            sb.decorator((delegate, ctx, req) -> {
+                final HttpRequest observed = new FilteredHttpRequest(req) {
+                    @Override
+                    protected void beforeComplete(Subscriber<? super HttpObject> subscriber) {
+                        final CountDownLatch started = requestCompleteStarted.get();
+                        if (started != null) {
+                            ctx.eventLoop().execute(() -> {
+                                started.countDown();
+                                final CountDownLatch release = requestCompleteRelease.get();
+                                assert release != null;
+                                BlockingUtils.blockingRun(() -> release.await(10, TimeUnit.SECONDS));
+                            });
+                        }
+                    }
+
+                    @Override
+                    protected HttpObject filter(HttpObject obj) {
+                        return obj;
+                    }
+                };
+                ctx.updateRequest(observed);
+                return delegate.serve(ctx, observed);
+            });
         }
     };
 
@@ -300,6 +339,13 @@ class GrpcSerdeExecutorTest {
         responseStreamThread.set(null);
         handlerThread.set(null);
         requestReceived.set(new CompletableFuture<>());
+        requestHalfClosed.set(new CompletableFuture<>());
+        requestParseStarted.set(null);
+        requestParseRelease.set(null);
+        requestParseFailure.set(null);
+        requestCompleteStarted.set(null);
+        requestCompleteRelease.set(null);
+        blockingServerCall.set(null);
         cancellingServerAllocator.allocated.clear();
         leakServerAllocator.allocated.clear();
     }
@@ -341,6 +387,68 @@ class GrpcSerdeExecutorTest {
                 .allSatisfy(buf -> assertThat(buf.refCnt()).isZero()));
         // ... and the message must not have been deserialized.
         assertThat(requestParseCount).hasValue(0);
+    }
+
+    @Test
+    void halfCloseIsNotInvokedAfterRequestDeserializationFails() throws Exception {
+        final CountDownLatch parseStarted = new CountDownLatch(1);
+        final CountDownLatch parseRelease = new CountDownLatch(1);
+        final CountDownLatch completeStarted = new CountDownLatch(1);
+        final CountDownLatch completeRelease = new CountDownLatch(1);
+        requestParseStarted.set(parseStarted);
+        requestParseRelease.set(parseRelease);
+        requestParseFailure.set(Status.INTERNAL.withDescription("request deserialization failed")
+                                               .asRuntimeException());
+        requestCompleteStarted.set(completeStarted);
+        requestCompleteRelease.set(completeRelease);
+
+        try (ClientFactory factory = ClientFactory.builder().build()) {
+            final TestServiceStub client =
+                    GrpcClients.builder(blockingServer.httpUri())
+                               .factory(factory)
+                               .build(TestServiceStub.class);
+            final CompletableFuture<Void> completion = new CompletableFuture<>();
+            final StreamObserver<StreamingOutputCallRequest> requestObserver =
+                    client.fullDuplexCall(new StreamObserver<StreamingOutputCallResponse>() {
+                        @Override
+                        public void onNext(StreamingOutputCallResponse value) {}
+
+                        @Override
+                        public void onError(Throwable t) {
+                            completion.completeExceptionally(t);
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            completion.complete(null);
+                        }
+                    });
+            requestObserver.onNext(BIDI_REQUEST);
+            assertThat(parseStarted.await(10, TimeUnit.SECONDS)).isTrue();
+            requestObserver.onCompleted();
+            // Wait until onRequestComplete() queues invokeHalfClose(), and then keep the event loop blocked
+            // so that it cannot process the close requested by the failing deserialization task.
+            assertThat(completeStarted.await(10, TimeUnit.SECONDS)).isTrue();
+
+            final ServerCall<?, ?> call = blockingServerCall.get();
+            assertThat(call).isInstanceOf(AbstractServerCall.class);
+            final CountDownLatch blockingTasksDrained = new CountDownLatch(1);
+            ((AbstractServerCall<?, ?>) call).blockingExecutor().execute(blockingTasksDrained::countDown);
+            parseRelease.countDown();
+            assertThat(blockingTasksDrained.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(requestHalfClosed.get()).isNotDone();
+
+            completeRelease.countDown();
+            assertThatThrownBy(() -> completion.get(10, TimeUnit.SECONDS))
+                    .isInstanceOfSatisfying(ExecutionException.class, cause ->
+                            assertThat(cause.getCause())
+                                    .isInstanceOfSatisfying(StatusRuntimeException.class, statusCause ->
+                                            assertThat(statusCause.getStatus().getCode())
+                                                    .isEqualTo(Status.Code.INTERNAL)));
+        } finally {
+            parseRelease.countDown();
+            completeRelease.countDown();
+        }
     }
 
     @ParameterizedTest
@@ -505,6 +613,7 @@ class GrpcSerdeExecutorTest {
 
                             @Override
                             public void onCompleted() {
+                                requestHalfClosed.get().complete(null);
                                 caller.execute(responseObserver::onCompleted);
                             }
                         }))
@@ -551,6 +660,17 @@ class GrpcSerdeExecutorTest {
         public T parse(InputStream stream) {
             requestParseThread.set(Thread.currentThread());
             requestParseCount.incrementAndGet();
+            final CountDownLatch parseStarted = requestParseStarted.get();
+            if (parseStarted != null) {
+                parseStarted.countDown();
+                final CountDownLatch parseRelease = requestParseRelease.get();
+                assert parseRelease != null;
+                BlockingUtils.blockingRun(() -> parseRelease.await(10, TimeUnit.SECONDS));
+            }
+            final RuntimeException failure = requestParseFailure.get();
+            if (failure != null) {
+                throw failure;
+            }
             return delegate.parse(stream);
         }
     }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
@@ -211,7 +211,8 @@ class StreamingServerCallTest {
 
         assertThatThrownBy(() -> rejectingCall.sendMessage(SimpleResponse.getDefaultInstance()))
                 .isInstanceOf(RejectedExecutionException.class);
-        assertThat(allocator.allocated).allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
+        assertThat(allocator.allocated).isNotEmpty()
+                                       .allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
         assertThat(rejectingCall.isReady()).isTrue();
     }
 

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/StreamingServerCallTest.java
@@ -19,9 +19,11 @@ package com.linecorp.armeria.server.grpc;
 import static com.linecorp.armeria.internal.common.grpc.TestServiceImpl.EXTRA_HEADER_KEY;
 import static com.linecorp.armeria.internal.common.grpc.TestServiceImpl.EXTRA_HEADER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -71,8 +74,11 @@ import io.grpc.Metadata.Key;
 import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.Status;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.EventLoop;
 import io.netty.util.AsciiString;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
@@ -188,6 +194,25 @@ class StreamingServerCallTest {
         assertThat(call.isCancelled()).isFalse();
         completionFuture.completeExceptionally(ClosedSessionException.get());
         await().untilAsserted(() -> assertThat(call.isCancelled()).isTrue());
+    }
+
+    @Test
+    void responsePayloadIsReleasedWhenEventLoopRejects() {
+        final TrackingAllocator allocator = new TrackingAllocator();
+        final EventLoop rejectingEventLoop = mock(EventLoop.class);
+        doThrow(new RejectedExecutionException()).when(rejectingEventLoop).execute(any(Runnable.class));
+        final ServiceRequestContext rejectingCtx =
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
+                                     .eventLoop(rejectingEventLoop)
+                                     .alloc(allocator)
+                                     .build();
+        final StreamingServerCall<SimpleRequest, SimpleResponse> rejectingCall =
+                newServerCall(res, rejectingCtx, false);
+
+        assertThatThrownBy(() -> rejectingCall.sendMessage(SimpleResponse.getDefaultInstance()))
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(allocator.allocated).allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
+        assertThat(rejectingCall.isReady()).isTrue();
     }
 
     @Test
@@ -355,6 +380,11 @@ class StreamingServerCallTest {
 
     private StreamingServerCall<SimpleRequest, SimpleResponse> newServerCall(HttpResponseWriter response,
                                                                              boolean unsafeWrapRequestBuffers) {
+        return newServerCall(response, ctx, unsafeWrapRequestBuffers);
+    }
+
+    private static StreamingServerCall<SimpleRequest, SimpleResponse> newServerCall(
+            HttpResponseWriter response, ServiceRequestContext ctx, boolean unsafeWrapRequestBuffers) {
         return new StreamingServerCall<>(
                 HttpRequest.of(HttpMethod.GET, "/"),
                 TestServiceGrpc.getUnaryCallMethod(),
@@ -375,5 +405,35 @@ class StreamingServerCallTest {
                 /* blockingExecutor */ null,
                 false,
                 false);
+    }
+
+    private static final class TrackingAllocator extends AbstractByteBufAllocator {
+
+        private final UnpooledByteBufAllocator delegate = new UnpooledByteBufAllocator(true);
+        private final List<ByteBuf> allocated = new ArrayList<>();
+
+        TrackingAllocator() {
+            super(true);
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.heapBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.directBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+
+        private ByteBuf track(ByteBuf buf) {
+            allocated.add(buf);
+            return buf;
+        }
     }
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -55,6 +55,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.grpc.GrpcExceptionHandlerFunction;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
 import com.linecorp.armeria.common.grpc.protocol.DeframedMessage;
@@ -136,6 +137,19 @@ class UnaryServerCallTest {
     }
 
     @Test
+    void messageReadAfterCancellation() {
+        res.abort();
+        await().untilAsserted(() -> verify(listener).onCancel());
+
+        final ByteBuf buf = GrpcTestUtil.requestByteBuf();
+        call.onRequestMessage(new DeframedMessage(buf, 0), true);
+
+        verify(listener, never()).onMessage(any());
+        verify(listener, never()).onHalfClose();
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
     void messageRead_notWrappedByteBuf() {
         final ByteBuf buf = GrpcTestUtil.requestByteBuf();
         call.onRequestMessage(new DeframedMessage(buf, 0), true);
@@ -201,7 +215,8 @@ class UnaryServerCallTest {
 
         assertThatThrownBy(() -> rejectingCall.sendMessage(SimpleResponse.getDefaultInstance()))
                 .isInstanceOf(RejectedExecutionException.class);
-        assertThat(allocator.allocated).allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
+        assertThat(allocator.allocated).isNotEmpty()
+                                       .allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
     }
 
     @Test
@@ -412,7 +427,7 @@ class UnaryServerCallTest {
 
     private static UnaryServerCall<SimpleRequest, SimpleResponse> newServerCall(
             HttpResponse response, CompletableFuture<HttpResponse> resFuture,
-            ServiceRequestContext ctx, boolean unsafeWrapRequestBuffers, Executor blockingExecutor) {
+            ServiceRequestContext ctx, boolean unsafeWrapRequestBuffers, @Nullable Executor blockingExecutor) {
         return new UnaryServerCall<>(
                 HttpRequest.of(HttpMethod.GET, "/"),
                 TestServiceGrpc.getUnaryCallMethod(),

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/UnaryServerCallTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -31,6 +32,8 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -69,8 +72,11 @@ import io.grpc.Metadata.Key;
 import io.grpc.ServerCall.Listener;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.EventLoop;
 import io.netty.util.AsciiString;
 import testing.grpc.Messages.SimpleRequest;
 import testing.grpc.Messages.SimpleResponse;
@@ -159,6 +165,43 @@ class UnaryServerCallTest {
                                                   0), true);
 
         verify(listener, never()).onMessage(any());
+    }
+
+    @Test
+    void requestMessageIsReleasedWhenBlockingExecutorRejects() {
+        final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+        final HttpResponse response = HttpResponse.of(responseFuture);
+        final Executor rejectingExecutor = task -> {
+            throw new RejectedExecutionException();
+        };
+        final UnaryServerCall<SimpleRequest, SimpleResponse> rejectingCall =
+                newServerCall(response, responseFuture, ctx, false, rejectingExecutor);
+        rejectingCall.setListener(listener);
+        final ByteBuf buf = GrpcTestUtil.requestByteBuf();
+
+        rejectingCall.onRequestMessage(new DeframedMessage(buf, 0), true);
+
+        assertThat(buf.refCnt()).isZero();
+    }
+
+    @Test
+    void responsePayloadIsReleasedWhenEventLoopRejects() {
+        final TrackingAllocator allocator = new TrackingAllocator();
+        final EventLoop rejectingEventLoop = mock(EventLoop.class);
+        doThrow(new RejectedExecutionException()).when(rejectingEventLoop).execute(any(Runnable.class));
+        final ServiceRequestContext rejectingCtx =
+                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.POST, "/"))
+                                     .eventLoop(rejectingEventLoop)
+                                     .alloc(allocator)
+                                     .build();
+        final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+        final HttpResponse response = HttpResponse.of(responseFuture);
+        final UnaryServerCall<SimpleRequest, SimpleResponse> rejectingCall =
+                newServerCall(response, responseFuture, rejectingCtx, false, null);
+
+        assertThatThrownBy(() -> rejectingCall.sendMessage(SimpleResponse.getDefaultInstance()))
+                .isInstanceOf(RejectedExecutionException.class);
+        assertThat(allocator.allocated).allSatisfy(buf -> assertThat(buf.refCnt()).isZero());
     }
 
     @Test
@@ -364,6 +407,12 @@ class UnaryServerCallTest {
             HttpResponse response,
             CompletableFuture<HttpResponse> resFuture,
             boolean unsafeWrapRequestBuffers) {
+        return newServerCall(response, resFuture, ctx, unsafeWrapRequestBuffers, null);
+    }
+
+    private static UnaryServerCall<SimpleRequest, SimpleResponse> newServerCall(
+            HttpResponse response, CompletableFuture<HttpResponse> resFuture,
+            ServiceRequestContext ctx, boolean unsafeWrapRequestBuffers, Executor blockingExecutor) {
         return new UnaryServerCall<>(
                 HttpRequest.of(HttpMethod.GET, "/"),
                 TestServiceGrpc.getUnaryCallMethod(),
@@ -382,9 +431,39 @@ class UnaryServerCallTest {
                                .contentType(GrpcSerializationFormats.PROTO.mediaType())
                                .build(),
                 exceptionHandler,
-                /* blockingExecutor */ null,
+                blockingExecutor,
                 /* autoCompress */ false,
                 /* useMethodMarshaller */ false,
                 /* enableEnvoyHttp1Bridge */ false);
+    }
+
+    private static final class TrackingAllocator extends AbstractByteBufAllocator {
+
+        private final UnpooledByteBufAllocator delegate = new UnpooledByteBufAllocator(true);
+        private final List<ByteBuf> allocated = new ArrayList<>();
+
+        TrackingAllocator() {
+            super(true);
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.heapBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            return track(delegate.directBuffer(initialCapacity, maxCapacity));
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+
+        private ByteBuf track(ByteBuf buf) {
+            allocated.add(buf);
+            return buf;
+        }
     }
 }


### PR DESCRIPTION
Motivation:

gRPC request deserialization and response serialization run on the event loop, even when `useBlockingTaskExecutor(true)` is configured. This leaves potentially expensive serialization and compression work on the event loop.

Modifications:

- Deserialize requests on the listener callback executor, including decompression.
- Serialize, frame, and compress responses on the thread calling `sendMessage()`.
- Negotiate response compression before scheduling header processing on the event loop.
- Skip queued request callbacks after deserialization fails.
- Preserve asynchronous exception handling for unary response serialization failures.
- Add tests for thread selection, compression negotiation, resource cleanup, and failure handling.

Result:

Closes #6241. Request deserialization follows the listener callback executor, and response serialization runs on the `sendMessage()` caller's thread.