### PR TITLE
Support `transport_socket_match_criteria` for xDS health checks

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HealthCheckTransportSocketMatchTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HealthCheckTransportSocketMatchTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
+import com.linecorp.armeria.testing.junit5.server.SelfSignedCertificateExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.SnapshotWatcher;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+
+class HealthCheckTransportSocketMatchTest {
+
+    @RegisterExtension
+    static final XdsCertificateExtension serverCert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    static final XdsCertificateExtension wrongCert =
+            new XdsCertificateExtension(new SelfSignedCertificateExtension("127.0.0.1"));
+
+    @RegisterExtension
+    static final ServerExtension tlsServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.tls(serverCert.tlsKeyPair());
+            sb.service("/monitor/healthcheck", HealthCheckService.builder().build());
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    private static XdsLoadBalancer pollLoadBalancer(ListenerRoot root, String clusterName) {
+        final AtomicReference<XdsLoadBalancer> lbRef = new AtomicReference<>();
+        final SnapshotWatcher<ListenerSnapshot> watcher = (newSnapshot, t) -> {
+            final ClusterSnapshot clusterSnapshot =
+                    newSnapshot.routeSnapshot().virtualHostSnapshots().get(0).routeEntries().get(0)
+                               .clusterSnapshot();
+            if (clusterSnapshot != null && clusterName.equals(clusterSnapshot.xdsResource().name())) {
+                lbRef.set(clusterSnapshot.loadBalancer());
+            }
+        };
+        root.addSnapshotWatcher(watcher);
+        await().untilAsserted(() -> assertThat(lbRef.get()).isNotNull());
+        return lbRef.get();
+    }
+
+    @Test
+    void healthCheckUsesMatchedTransportSocket() throws Exception {
+        final String correctCa = base64Cert(serverCert.certificateFile());
+        final String wrongCa = base64Cert(wrongCert.certificateFile());
+
+        //language=YAML
+        final String bootstrapYaml =
+                """
+                static_resources:
+                  listeners:
+                  - name: listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                .v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: cluster
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  clusters:
+                  - name: cluster
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                    transport_socket:
+                      name: envoy.transport_sockets.tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.UpstreamTlsContext
+                        common_tls_context:
+                          validation_context:
+                            trusted_ca:
+                              inline_bytes: %s
+                    transport_socket_matches:
+                    - name: health_check_tls
+                      match:
+                        health_check: "true"
+                      transport_socket:
+                        name: envoy.transport_sockets.tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.UpstreamTlsContext
+                          common_tls_context:
+                            validation_context:
+                              trusted_ca:
+                                inline_bytes: %s
+                    health_checks:
+                    - http_health_check:
+                        path: /monitor/healthcheck
+                      timeout: 5s
+                      interval: 10s
+                      unhealthy_threshold: 1
+                      healthy_threshold: 1
+                      transport_socket_match_criteria:
+                        health_check: "true"
+                """.formatted(tlsServer.httpsPort(), wrongCa, correctCa);
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(bootstrapYaml);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             ListenerRoot root = xdsBootstrap.listenerRoot("listener")) {
+            final XdsLoadBalancer loadBalancer = pollLoadBalancer(root, "cluster");
+            final List<Integer> healthyPorts =
+                    loadBalancer.hostSets().get(0).healthyHostsEndpointGroup().endpoints()
+                                .stream().map(Endpoint::port).collect(Collectors.toList());
+            assertThat(healthyPorts).containsExactly(tlsServer.httpsPort());
+
+            final ClientRequestContext ctx =
+                    ClientRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+            final Endpoint endpoint = loadBalancer.selectNow(ctx);
+            assertThat(endpoint).isNotNull();
+            assertThat(endpoint.port()).isEqualTo(tlsServer.httpsPort());
+        }
+    }
+
+    @Test
+    void healthCheckFailsWithoutMatchCriteria() throws Exception {
+        final String wrongCa = base64Cert(wrongCert.certificateFile());
+        final String correctCa = base64Cert(serverCert.certificateFile());
+
+        //language=YAML
+        final String bootstrapYaml =
+                """
+                static_resources:
+                  listeners:
+                  - name: listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager\
+                .v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: cluster
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                  clusters:
+                  - name: cluster
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                    transport_socket:
+                      name: envoy.transport_sockets.tls
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.UpstreamTlsContext
+                        common_tls_context:
+                          validation_context:
+                            trusted_ca:
+                              inline_bytes: %s
+                    transport_socket_matches:
+                    - name: health_check_tls
+                      match:
+                        health_check: "true"
+                      transport_socket:
+                        name: envoy.transport_sockets.tls
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.transport_sockets\
+                .tls.v3.UpstreamTlsContext
+                          common_tls_context:
+                            validation_context:
+                              trusted_ca:
+                                inline_bytes: %s
+                    health_checks:
+                    - http_health_check:
+                        path: /monitor/healthcheck
+                      timeout: 5s
+                      interval: 10s
+                      unhealthy_threshold: 1
+                      healthy_threshold: 1
+                """.formatted(tlsServer.httpsPort(), wrongCa, correctCa);
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(bootstrapYaml);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             ListenerRoot root = xdsBootstrap.listenerRoot("listener")) {
+            final XdsLoadBalancer loadBalancer = pollLoadBalancer(root, "cluster");
+            // Without transport_socket_match_criteria, the health check uses the default
+            // transport socket which has the wrong CA certificate, so the TLS handshake
+            // fails and the endpoint remains unhealthy.
+            assertThat(loadBalancer.hostSets().get(0).healthyHostsEndpointGroup().endpoints())
+                    .isEmpty();
+        }
+    }
+
+    private static String base64Cert(File certFile) throws Exception {
+        return Base64.getEncoder().encodeToString(Files.readAllBytes(certFile.toPath()));
+    }
+}

--- a/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
@@ -453,5 +453,6 @@ message HealthCheck {
   // :ref:`transport socket matches <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket_matches>`,
   // the cluster's :ref:`transport socket <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket>`
   // will be used for health check socket configuration.
+  option (armeria.xds.supported.field) = 23;
   google.protobuf.Struct transport_socket_match_criteria = 23;
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/DefaultXdsLoadBalancerFactory.java
@@ -139,7 +139,8 @@ final class DefaultXdsLoadBalancerFactory implements XdsLoadBalancerFactory {
                                                                       transportSocket, transportSocketMatches);
                         final EndpointGroup staticGroup = EndpointGroup.of(endpoints);
                         final EndpointGroup healthChecked = XdsEndpointUtil.maybeHealthChecked(
-                                staticGroup, clusterXdsResource.resource());
+                                staticGroup, clusterXdsResource.resource(), transportSocket,
+                                transportSocketMatches);
                         return XdsEndpointUtil.endpointGroupToStream(healthChecked)
                                               .map(resolved -> new ResolvedEndpoints(
                                                       snapshot, resolved));

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsEndpointUtil.java
@@ -24,8 +24,10 @@ import java.util.List;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.DomainSocketAddress;
 import com.linecorp.armeria.internal.common.util.IpAddrUtil;
 import com.linecorp.armeria.xds.TransportSocketMatchSnapshot;
@@ -43,18 +45,39 @@ import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
 
 final class XdsEndpointUtil {
 
-    static EndpointGroup maybeHealthChecked(EndpointGroup delegate, Cluster cluster) {
+    static EndpointGroup maybeHealthChecked(EndpointGroup delegate, Cluster cluster,
+                                            TransportSocketSnapshot transportSocket,
+                                            List<TransportSocketMatchSnapshot> transportSocketMatches) {
         if (!cluster.getHealthChecksList().isEmpty()) {
             // multiple health-checks aren't supported
             final HealthCheck healthCheck = cluster.getHealthChecksList().get(0);
             if (healthCheck.hasHttpHealthCheck()) {
                 final HttpHealthCheck httpHealthCheck = healthCheck.getHttpHealthCheck();
-                return new XdsHealthCheckedEndpointGroupBuilder(delegate, cluster, httpHealthCheck)
+                final ClientTlsSpec healthCheckTlsSpec =
+                        resolveHealthCheckTlsSpec(healthCheck, transportSocket, transportSocketMatches);
+                return new XdsHealthCheckedEndpointGroupBuilder(delegate, cluster, httpHealthCheck,
+                                                                healthCheckTlsSpec)
                         .healthCheckedEndpointPredicate(Predicates.alwaysTrue())
                         .build();
             }
         }
         return delegate;
+    }
+
+    @Nullable
+    private static ClientTlsSpec resolveHealthCheckTlsSpec(
+            HealthCheck healthCheck,
+            TransportSocketSnapshot defaultTransportSocket,
+            List<TransportSocketMatchSnapshot> transportSocketMatches) {
+        if (healthCheck.hasTransportSocketMatchCriteria()) {
+            final TransportSocketMatchSnapshot matched =
+                    TransportSocketMatchUtil.selectMatch(transportSocketMatches,
+                                                         healthCheck.getTransportSocketMatchCriteria());
+            if (matched != null) {
+                return matched.transportSocket().clientTlsSpec();
+            }
+        }
+        return defaultTransportSocket.clientTlsSpec();
     }
 
     static List<Endpoint> convertLoadAssignment(

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHealthCheckedEndpointGroupBuilder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHealthCheckedEndpointGroupBuilder.java
@@ -23,12 +23,14 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.client.ClientTlsSpec;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.healthcheck.AbstractHealthCheckedEndpointGroupBuilder;
 import com.linecorp.armeria.client.endpoint.healthcheck.HealthCheckerContext;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.SessionProtocol;
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.AsyncCloseable;
 import com.linecorp.armeria.common.util.DomainSocketAddress;
 import com.linecorp.armeria.internal.client.endpoint.healthcheck.DefaultHttpHealthChecker;
@@ -45,12 +47,23 @@ final class XdsHealthCheckedEndpointGroupBuilder
 
     private final Cluster cluster;
     private final HttpHealthCheck httpHealthCheck;
+    @Nullable
+    private final ClientTlsSpec healthCheckTlsSpec;
 
     XdsHealthCheckedEndpointGroupBuilder(EndpointGroup delegate, Cluster cluster,
-                                         HttpHealthCheck httpHealthCheck) {
+                                         HttpHealthCheck httpHealthCheck,
+                                         @Nullable ClientTlsSpec healthCheckTlsSpec) {
         super(delegate);
         this.cluster = cluster;
         this.httpHealthCheck = httpHealthCheck;
+        this.healthCheckTlsSpec = healthCheckTlsSpec;
+        if (healthCheckTlsSpec != null) {
+            final ClientTlsSpec tlsSpec = healthCheckTlsSpec;
+            withClientOptions(opts -> opts.decorator((delegate1, ctx, req) -> {
+                ctx.setClientTlsSpec(tlsSpec);
+                return delegate1.execute(ctx, req);
+            }));
+        }
     }
 
     @Override
@@ -68,7 +81,7 @@ final class XdsHealthCheckedEndpointGroupBuilder
             final DefaultHttpHealthChecker checker =
                     new DefaultHttpHealthChecker(ctx, endpoint(healthCheckConfig, ctx.originalEndpoint()),
                                                  path, httpMethod(httpHealthCheck) == HttpMethod.GET,
-                                                 protocol(cluster), host);
+                                                 SessionProtocol.HTTP, host);
             checker.start();
             return checker;
         };
@@ -82,16 +95,6 @@ final class XdsHealthCheckedEndpointGroupBuilder
             return HttpMethod.GET;
         }
         return method;
-    }
-
-    private static SessionProtocol protocol(Cluster cluster) {
-        // Not using httpHealthCheck.getCodecClientType() because
-        // HTTP[S] covers both HTTP/1 and HTTP/2.
-        if (EndpointUtil.isTls(cluster)) {
-            return SessionProtocol.HTTPS;
-        } else {
-            return SessionProtocol.HTTP;
-        }
     }
 
     private static Endpoint endpoint(HealthCheckConfig healthCheckConfig, Endpoint endpoint) {


### PR DESCRIPTION
Motivation:

When a cluster uses `transport_socket_matches` with separate TLS configurations (e.g., a different CA for health checks vs data traffic), the health checker needs to select the correct transport socket based on `HealthCheck.transport_socket_match_criteria`. Previously, the health checker always used the cluster-level transport socket, which could cause TLS handshake failures when the health check endpoint requires a different certificate.

Modifications:

- Added `supported.field = 23` annotation for `transport_socket_match_criteria` in `health_check.proto`.
- Updated `XdsEndpointUtil.maybeHealthChecked()` to accept `TransportSocketSnapshot` and `List<TransportSocketMatchSnapshot>` and resolve the correct `ClientTlsSpec` for health checks via `resolveHealthCheckTlsSpec()`.
- Updated `XdsHealthCheckedEndpointGroupBuilder` to accept a `@Nullable ClientTlsSpec` for the health check TLS configuration, applying it as a decorator when present. Replaced the static `protocol(Cluster)` method with `ClientTlsSpec`-based protocol selection (`SessionProtocol.HTTP` by default, `HTTPS` when TLS spec is set via the decorator).
- Updated `DefaultXdsLoadBalancerFactory` to pass transport socket info to `maybeHealthChecked()`.
- Added `HealthCheckTransportSocketMatchTest` integration test verifying that health checks use the matched transport socket and fail without match criteria.

Result:

- Health checks now correctly select the transport socket specified by `transport_socket_match_criteria`, enabling separate TLS configurations for health check and data traffic.
