### PR TITLE
Add xDS request header mutation support

### DIFF
--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HeaderMutationTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/HeaderMutationTest.java
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsHttpPreprocessor;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+
+class HeaderMutationTest {
+
+    @RegisterExtension
+    static final ServerExtension echoServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> {
+                final StringBuilder body = new StringBuilder();
+                req.headers().forEach((name, value) -> {
+                    if (name.toString().startsWith("x-")) {
+                        body.append(name).append('=').append(value).append('\n');
+                    }
+                });
+                return HttpResponse.of(body.toString());
+            });
+            sb.http(0);
+        }
+    };
+
+    @Test
+    void routeHeaderAddAndRemove() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-added
+                        value: route-value
+                    request_headers_to_remove: ["x-to-remove"]
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-to-remove", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-added=route-value");
+                assertThat(res.contentUtf8()).doesNotContain("x-to-remove");
+            });
+        }
+    }
+
+    @Test
+    void multiLevelOrdering_defaultFlagOff() {
+        // Default (most_specific_header_mutations_wins=false):
+        // Applied order: Route → VHost → RouteConfig (last writer wins → RouteConfig)
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                request_headers_to_add:
+                - header:
+                    key: x-level
+                    value: from-rc
+                  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  request_headers_to_add:
+                  - header:
+                      key: x-level
+                      value: from-vhost
+                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-level
+                        value: from-route
+                      append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.get("/");
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8().trim()).isEqualTo("x-level=from-rc");
+            });
+        }
+    }
+
+    @Test
+    void multiLevelOrdering_mostSpecificWins() {
+        // most_specific_header_mutations_wins=true:
+        // Applied order: RouteConfig → VHost → Route (last writer wins → Route)
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                most_specific_header_mutations_wins: true
+                request_headers_to_add:
+                - header:
+                    key: x-level
+                    value: from-rc
+                  append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  request_headers_to_add:
+                  - header:
+                      key: x-level
+                      value: from-vhost
+                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-level
+                        value: from-route
+                      append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.get("/");
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8().trim()).isEqualTo("x-level=from-route");
+            });
+        }
+    }
+
+    @Test
+    void weightedClusterHeaderMutation() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      weighted_clusters:
+                        clusters:
+                        - name: cluster1
+                          weight: 100
+                          request_headers_to_add:
+                          - header:
+                              key: x-wc
+                              value: from-wc
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.get("/");
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-wc=from-wc");
+            });
+        }
+    }
+
+    @Test
+    void appendIfExistsOrAdd() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-test
+                        value: appended
+                      append_action: APPEND_IF_EXISTS_OR_ADD
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-test", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-test=original");
+                assertThat(res.contentUtf8()).contains("x-test=appended");
+            });
+        }
+    }
+
+    @Test
+    void addIfAbsent() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-test
+                        value: new-value
+                      append_action: ADD_IF_ABSENT
+                    - header:
+                        key: x-new
+                        value: added
+                      append_action: ADD_IF_ABSENT
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                // x-test already exists → ADD_IF_ABSENT skips
+                // x-new does not exist → ADD_IF_ABSENT adds
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-test", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-test=original");
+                assertThat(res.contentUtf8()).doesNotContain("x-test=new-value");
+                assertThat(res.contentUtf8()).contains("x-new=added");
+            });
+        }
+    }
+
+    @Test
+    void overwriteIfExistsOrAdd() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-test
+                        value: overwritten
+                      append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-test", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-test=overwritten");
+                assertThat(res.contentUtf8()).doesNotContain("x-test=original");
+            });
+        }
+    }
+
+    @Test
+    void overwriteIfExists() {
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_add:
+                    - header:
+                        key: x-existing
+                        value: overwritten
+                      append_action: OVERWRITE_IF_EXISTS
+                    - header:
+                        key: x-absent
+                        value: should-not-appear
+                      append_action: OVERWRITE_IF_EXISTS
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                // x-existing is present → replaced
+                // x-absent is not present → NOT added
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-existing", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-existing=overwritten");
+                assertThat(res.contentUtf8()).doesNotContain("x-absent");
+            });
+        }
+    }
+
+    @Test
+    void removeBeforeAddWithinLevel() {
+        // Within a single level, removes happen before adds.
+        // Removing x-test then adding x-test=new-value should result in x-test=new-value.
+        final Bootstrap bootstrap = bootstrap("""
+                name: local_route
+                virtual_hosts:
+                - name: vhost1
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      prefix: /
+                    route:
+                      cluster: cluster1
+                    request_headers_to_remove: ["x-test"]
+                    request_headers_to_add:
+                    - header:
+                        key: x-test
+                        value: new-value
+                """);
+
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             XdsHttpPreprocessor preprocessor =
+                     XdsHttpPreprocessor.ofListener("listener1", xdsBootstrap)) {
+            final BlockingWebClient client = WebClient.of(preprocessor).blocking();
+            await().untilAsserted(() -> {
+                final AggregatedHttpResponse res = client.execute(
+                        HttpRequest.of(RequestHeaders.of(HttpMethod.GET, "/",
+                                                         "x-test", "original")));
+                assertThat(res.status()).isEqualTo(HttpStatus.OK);
+                assertThat(res.contentUtf8()).contains("x-test=new-value");
+                assertThat(res.contentUtf8()).doesNotContain("x-test=original");
+            });
+        }
+    }
+
+    private Bootstrap bootstrap(String routeConfig) {
+        final String address = echoServer.httpSocketAddress().getHostString();
+        final int port = echoServer.httpPort();
+        //language=YAML
+        final String yaml = """
+                static_resources:
+                  listeners:
+                  - name: listener1
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                %s\
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                  - name: cluster1
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster1
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: %s
+                                port_value: %d
+                """.formatted(routeConfig.indent(10), address, port);
+        return XdsResourceReader.fromYaml(yaml, Bootstrap.class);
+    }
+}

--- a/xds-api/src/main/proto/envoy/config/core/v3/base.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/base.proto
@@ -448,23 +448,28 @@ message HeaderValueOption {
     // - Duplicate header added in the ``HeaderMap`` for other headers.
     //
     // If the header doesn't exist then this will add new header with specified key and value.
+    option (armeria.xds.supported.enum_value) = 0;
     APPEND_IF_EXISTS_OR_ADD = 0;
 
     // This action will add the header if it doesn't already exist. If the header
     // already exists then this will be a no-op.
+    option (armeria.xds.supported.enum_value) = 1;
     ADD_IF_ABSENT = 1;
 
     // This action will overwrite the specified value by discarding any existing values if
     // the header already exists. If the header doesn't exist then this will add the header
     // with specified key and value.
+    option (armeria.xds.supported.enum_value) = 2;
     OVERWRITE_IF_EXISTS_OR_ADD = 2;
 
     // This action will overwrite the specified value by discarding any existing values if
     // the header already exists. If the header doesn't exist then this will be no-op.
+    option (armeria.xds.supported.enum_value) = 3;
     OVERWRITE_IF_EXISTS = 3;
   }
 
   // Header name/value pair that this option applies to.
+  option (armeria.xds.supported.field) = 1;
   HeaderValue header = 1 [(validate.rules).message = {required: true}];
 
   // Should the value be appended? If true (default), the value is appended to
@@ -483,10 +488,12 @@ message HeaderValueOption {
   // or to only add this header if it's absent.
   // Value defaults to :ref:`APPEND_IF_EXISTS_OR_ADD
   // <envoy_v3_api_enum_value_config.core.v3.HeaderValueOption.HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD>`.
+  option (armeria.xds.supported.field) = 3;
   HeaderAppendAction append_action = 3 [(validate.rules).enum = {defined_only: true}];
 
   // Is the header value allowed to be empty? If false (default), custom headers with empty values are dropped,
   // otherwise they are added.
+  option (armeria.xds.supported.field) = 4;
   bool keep_empty_value = 4;
 }
 

--- a/xds-api/src/main/proto/envoy/config/route/v3/route.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route.proto
@@ -76,11 +76,13 @@ message RouteConfiguration {
   // :ref:`envoy_v3_api_msg_config.route.v3.RouteAction`. For more information, including details on
   // header value syntax, see the documentation on :ref:`custom request headers
   // <config_http_conn_man_headers_custom_request_headers>`.
+  option (armeria.xds.supported.field) = 6;
   repeated core.v3.HeaderValueOption request_headers_to_add = 6
       [(validate.rules).repeated = {max_items: 1000}];
 
   // Specifies a list of HTTP headers that should be removed from each request
   // routed by the HTTP connection manager.
+  option (armeria.xds.supported.field) = 8;
   repeated string request_headers_to_remove = 8 [
     (validate.rules).repeated = {items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}}
   ];
@@ -91,6 +93,7 @@ message RouteConfiguration {
   // This order can be reversed by setting this field to true. In other words, most specific level mutation
   // is evaluated last.
   //
+  option (armeria.xds.supported.field) = 10;
   bool most_specific_header_mutations_wins = 10;
 
   // An optional boolean that specifies whether the clusters that the route

--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -123,11 +123,13 @@ message VirtualHost {
   // enclosing :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration`. For more information, including
   // details on header value syntax, see the documentation on :ref:`custom request headers
   // <config_http_conn_man_headers_custom_request_headers>`.
+  option (armeria.xds.supported.field) = 7;
   repeated core.v3.HeaderValueOption request_headers_to_add = 7
       [(validate.rules).repeated = {max_items: 1000}];
 
   // Specifies a list of HTTP headers that should be removed from each request
   // handled by this virtual host.
+  option (armeria.xds.supported.field) = 13;
   repeated string request_headers_to_remove = 13 [(validate.rules).repeated = {
     items {string {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}}
   }];
@@ -356,11 +358,13 @@ message Route {
   // :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration`. For more information, including details on
   // header value syntax, see the documentation on :ref:`custom request headers
   // <config_http_conn_man_headers_custom_request_headers>`.
+  option (armeria.xds.supported.field) = 9;
   repeated core.v3.HeaderValueOption request_headers_to_add = 9
       [(validate.rules).repeated = {max_items: 1000}];
 
   // Specifies a list of HTTP headers that should be removed from each request
   // matching this route.
+  option (armeria.xds.supported.field) = 12;
   repeated string request_headers_to_remove = 12 [(validate.rules).repeated = {
     items {string {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}}
   }];
@@ -500,11 +504,13 @@ message WeightedCluster {
     // :ref:`envoy_v3_api_msg_config.route.v3.RouteConfiguration`. For more information, including details on
     // header value syntax, see the documentation on :ref:`custom request headers
     // <config_http_conn_man_headers_custom_request_headers>`.
+    option (armeria.xds.supported.field) = 4;
     repeated core.v3.HeaderValueOption request_headers_to_add = 4
         [(validate.rules).repeated = {max_items: 1000}];
 
     // Specifies a list of HTTP headers that should be removed from each request when
     // this cluster is selected through the enclosing :ref:`envoy_v3_api_msg_config.route.v3.RouteAction`.
+    option (armeria.xds.supported.field) = 9;
     repeated string request_headers_to_remove = 9 [(validate.rules).repeated = {
       items {string {well_known_regex: HTTP_HEADER_NAME strict: false}}
     }];

--- a/xds/src/main/java/com/linecorp/armeria/xds/DefaultRouteCluster.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/DefaultRouteCluster.java
@@ -33,15 +33,18 @@ final class DefaultRouteCluster implements RouteCluster {
 
     private final ClusterSnapshot clusterSnapshot;
     private final Metadata metadataMatch;
+    private final RequestHeadersMutator requestHeadersMutator;
     private final HttpClient httpClient;
     private final RpcClient rpcClient;
 
     DefaultRouteCluster(ClusterSnapshot clusterSnapshot, Metadata metadataMatch,
+                        RequestHeadersMutator requestHeadersMutator,
                         @Nullable ClientDecoration retryDecoration,
                         ClientDecoration downstreamDecoration,
                         ClientDecoration upstreamDecoration) {
         this.clusterSnapshot = requireNonNull(clusterSnapshot, "clusterSnapshot");
         this.metadataMatch = requireNonNull(metadataMatch, "metadataMatch");
+        this.requestHeadersMutator = requireNonNull(requestHeadersMutator, "requestHeadersMutator");
         httpClient = FilterUtil.buildHttpClient(retryDecoration, downstreamDecoration, upstreamDecoration);
         rpcClient = FilterUtil.buildRpcClient(retryDecoration, downstreamDecoration, upstreamDecoration);
     }
@@ -64,6 +67,11 @@ final class DefaultRouteCluster implements RouteCluster {
     @Override
     public RpcClient rpcClient() {
         return rpcClient;
+    }
+
+    @Override
+    public RequestHeadersMutator requestHeadersMutator() {
+        return requestHeadersMutator;
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutation.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutation.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+
+import io.envoyproxy.envoy.config.core.v3.HeaderValueOption;
+
+final class RequestHeadersMutation implements RequestHeadersMutator {
+
+    static final RequestHeadersMutation EMPTY =
+            new RequestHeadersMutation(Collections.emptyList(), Collections.emptyList());
+
+    private final List<HeaderValueOption> headersToAdd;
+    private final List<String> headersToRemove;
+
+    private RequestHeadersMutation(List<HeaderValueOption> headersToAdd, List<String> headersToRemove) {
+        this.headersToAdd = headersToAdd;
+        this.headersToRemove = headersToRemove;
+    }
+
+    static RequestHeadersMutation of(List<HeaderValueOption> toAdd, List<String> toRemove) {
+        if (toAdd.isEmpty() && toRemove.isEmpty()) {
+            return EMPTY;
+        }
+        return new RequestHeadersMutation(toAdd, toRemove);
+    }
+
+    boolean isEmpty() {
+        return headersToAdd.isEmpty() && headersToRemove.isEmpty();
+    }
+
+    @Override
+    public RequestHeaders apply(RequestHeaders original) {
+        if (isEmpty()) {
+            return original;
+        }
+        final RequestHeadersBuilder builder = original.toBuilder();
+        applyTo(builder);
+        return builder.build();
+    }
+
+    void applyTo(RequestHeadersBuilder builder) {
+        for (String name : headersToRemove) {
+            builder.remove(name);
+        }
+        for (HeaderValueOption option : headersToAdd) {
+            final String key = option.getHeader().getKey();
+            final String value = option.getHeader().getValue();
+
+            if (value.isEmpty() && !option.getKeepEmptyValue()) {
+                continue;
+            }
+
+            switch (option.getAppendAction()) {
+                case APPEND_IF_EXISTS_OR_ADD:
+                    builder.add(key, value);
+                    break;
+                case ADD_IF_ABSENT:
+                    if (!builder.contains(key)) {
+                        builder.add(key, value);
+                    }
+                    break;
+                case OVERWRITE_IF_EXISTS_OR_ADD:
+                    builder.set(key, value);
+                    break;
+                case OVERWRITE_IF_EXISTS:
+                    if (builder.contains(key)) {
+                        builder.set(key, value);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutationChain.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutationChain.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.RequestHeadersBuilder;
+
+final class RequestHeadersMutationChain implements RequestHeadersMutator {
+
+    static final RequestHeadersMutationChain EMPTY = new RequestHeadersMutationChain(ImmutableList.of(), false);
+
+    private final List<RequestHeadersMutation> mutations;
+    private final boolean mostSpecificWins;
+
+    private RequestHeadersMutationChain(List<RequestHeadersMutation> mutations, boolean mostSpecificWins) {
+        this.mutations = mutations;
+        this.mostSpecificWins = mostSpecificWins;
+    }
+
+    static RequestHeadersMutationChain of(RequestHeadersMutation routeConfig, RequestHeadersMutation vhost,
+                                          RequestHeadersMutation route, boolean mostSpecificWins) {
+        if (routeConfig.isEmpty() && vhost.isEmpty() && route.isEmpty()) {
+            return EMPTY;
+        }
+        final ImmutableList<RequestHeadersMutation> mutations;
+        if (mostSpecificWins) {
+            mutations = ImmutableList.of(routeConfig, vhost, route);
+        } else {
+            mutations = ImmutableList.of(route, vhost, routeConfig);
+        }
+        return new RequestHeadersMutationChain(mutations, mostSpecificWins);
+    }
+
+    RequestHeadersMutationChain append(RequestHeadersMutation mutation) {
+        if (mutation.isEmpty() && mutations.isEmpty()) {
+            return EMPTY;
+        }
+        final ImmutableList.Builder<RequestHeadersMutation> builder = ImmutableList.builder();
+        if (mostSpecificWins) {
+            builder.addAll(mutations);
+            builder.add(mutation);
+        } else {
+            builder.add(mutation);
+            builder.addAll(mutations);
+        }
+        return new RequestHeadersMutationChain(builder.build(), mostSpecificWins);
+    }
+
+    private boolean isEmpty() {
+        for (RequestHeadersMutation mutation : mutations) {
+            if (!mutation.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public RequestHeaders apply(RequestHeaders original) {
+        if (isEmpty()) {
+            return original;
+        }
+        final RequestHeadersBuilder builder = original.toBuilder();
+        for (RequestHeadersMutation mutation : mutations) {
+            mutation.applyTo(builder);
+        }
+        return builder.build();
+    }
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutator.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RequestHeadersMutator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds;
+
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.annotation.UnstableApi;
+
+/**
+ * Applies xDS request header mutations to {@link RequestHeaders}.
+ */
+@UnstableApi
+public interface RequestHeadersMutator {
+
+    /**
+     * Applies header mutations to the given {@link RequestHeaders}.
+     */
+    RequestHeaders apply(RequestHeaders original);
+}

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteCluster.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteCluster.java
@@ -48,4 +48,9 @@ public interface RouteCluster {
      * Returns the pre-built {@link RpcClient} chain for this route.
      */
     RpcClient rpcClient();
+
+    /**
+     * Returns the {@link RequestHeadersMutator} for mutating request headers.
+     */
+    RequestHeadersMutator requestHeadersMutator();
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteClusterFactory.java
@@ -42,14 +42,17 @@ final class RouteClusterFactory {
     private final Map<String, Any> routeFilterConfigs;
     @Nullable
     private final ClientDecoration retryDecoration;
+    private final RequestHeadersMutationChain mutationChain;
 
     RouteClusterFactory(SubscriptionContext context, HcmContext hcmContext,
                         Map<String, Any> routeFilterConfigs,
-                        @Nullable ClientDecoration retryDecoration) {
+                        @Nullable ClientDecoration retryDecoration,
+                        RequestHeadersMutationChain mutationChain) {
         this.context = context;
         this.hcmContext = hcmContext;
         this.routeFilterConfigs = routeFilterConfigs;
         this.retryDecoration = retryDecoration;
+        this.mutationChain = mutationChain;
     }
 
     SnapshotStream<RouteClusterResolver> resolve(Route route) {
@@ -73,8 +76,9 @@ final class RouteClusterFactory {
         return SnapshotStream.combineLatest(
                 clusterStream, downstreamStream, upstreamStream,
                 (cs, down, up) -> {
-                    return RouteClusterResolver.ofSingle(new DefaultRouteCluster(cs, routeMetadataMatch,
-                                                                                 retryDecoration, down, up));
+                    return RouteClusterResolver.ofSingle(
+                            new DefaultRouteCluster(cs, routeMetadataMatch, mutationChain, retryDecoration,
+                                                    down, up));
                 });
     }
 
@@ -103,6 +107,7 @@ final class RouteClusterFactory {
                     clusterStream, downstreamStream, upstreamStream,
                     (clusterSnapshot, downstreamFilters, upstreamFilter) -> {
                         return new WeightedClusterSnapshot(clusterSnapshot, weight, mergedMetadata,
+                                                           clusterWeight, mutationChain,
                                                            retryDecoration, downstreamFilters, upstreamFilter);
                     }));
         }

--- a/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RouteStream.java
@@ -190,8 +190,23 @@ final class RouteStream extends RefCountedStream<RouteSnapshot> {
             final ClientDecoration retryDecoration =
                     FilterUtil.buildRetryDecoration(effectiveRetryPolicy);
 
+            final RequestHeadersMutation rcMutation = RequestHeadersMutation.of(
+                    routeResource.resource().getRequestHeadersToAddList(),
+                    routeResource.resource().getRequestHeadersToRemoveList());
+            final RequestHeadersMutation vhMutation = RequestHeadersMutation.of(
+                    vhostResource.resource().getRequestHeadersToAddList(),
+                    vhostResource.resource().getRequestHeadersToRemoveList());
+            final RequestHeadersMutation rtMutation = RequestHeadersMutation.of(
+                    route.getRequestHeadersToAddList(),
+                    route.getRequestHeadersToRemoveList());
+            final boolean mostSpecificWins =
+                    routeResource.resource().getMostSpecificHeaderMutationsWins();
+            final RequestHeadersMutationChain headerMutationChain =
+                    RequestHeadersMutationChain.of(rcMutation, vhMutation, rtMutation, mostSpecificWins);
+
             final SnapshotStream<RouteClusterResolver> routeResolverStream =
-                    new RouteClusterFactory(context, hcmContext, filterConfigs, retryDecoration)
+                    new RouteClusterFactory(context, hcmContext, filterConfigs, retryDecoration,
+                                            headerMutationChain)
                             .resolve(route);
             final SnapshotStream<HttpService> httpServiceStream = hcmContext.server(filterConfigs);
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/WeightedClusterSnapshot.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/WeightedClusterSnapshot.java
@@ -42,16 +42,22 @@ public final class WeightedClusterSnapshot implements RouteCluster, Weighted {
     private final ClusterSnapshot clusterSnapshot;
     private final int weight;
     private final Metadata metadataMatch;
+    private final RequestHeadersMutator requestHeadersMutator;
     private final HttpClient httpClient;
     private final RpcClient rpcClient;
 
     WeightedClusterSnapshot(ClusterSnapshot clusterSnapshot, int weight, Metadata metadataMatch,
+                            ClusterWeight clusterWeight, RequestHeadersMutationChain baseMutationChain,
                             @Nullable ClientDecoration retryDecoration,
                             ClientDecoration downstreamDecoration,
                             ClientDecoration upstreamDecoration) {
         this.clusterSnapshot = requireNonNull(clusterSnapshot, "clusterSnapshot");
         this.weight = weight;
         this.metadataMatch = requireNonNull(metadataMatch, "metadataMatch");
+        final RequestHeadersMutation wcMutation = RequestHeadersMutation.of(
+                clusterWeight.getRequestHeadersToAddList(),
+                clusterWeight.getRequestHeadersToRemoveList());
+        requestHeadersMutator = baseMutationChain.append(wcMutation);
         httpClient = FilterUtil.buildHttpClient(retryDecoration, downstreamDecoration, upstreamDecoration);
         rpcClient = FilterUtil.buildRpcClient(retryDecoration, downstreamDecoration, upstreamDecoration);
     }
@@ -88,6 +94,11 @@ public final class WeightedClusterSnapshot implements RouteCluster, Weighted {
     @Override
     public RpcClient rpcClient() {
         return rpcClient;
+    }
+
+    @Override
+    public RequestHeadersMutator requestHeadersMutator() {
+        return requestHeadersMutator;
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/RouterFilterFactory.java
@@ -16,17 +16,23 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;
 
+import com.linecorp.armeria.client.DecoratingHttpClientFunction;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.armeria.server.DecoratingHttpServiceFunction;
+import com.linecorp.armeria.xds.RouteCluster;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.filter.HttpFilterFactory;
 import com.linecorp.armeria.xds.filter.XdsHttpFilter;
 import com.linecorp.armeria.xds.internal.DelegatingHttpService;
+import com.linecorp.armeria.xds.internal.XdsCommonUtil;
 
 import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpFilter;
@@ -95,6 +101,20 @@ public final class RouterFilterFactory implements HttpFilterFactory {
          */
         public Router router() {
             return router;
+        }
+
+        @Override
+        public DecoratingHttpClientFunction httpDecorator() {
+            return (delegate, ctx, req) -> {
+                final RouteCluster routeCluster = ctx.attr(XdsCommonUtil.ROUTE_CLUSTER);
+                checkState(routeCluster != null, "No RouteCluster found in the ctx (%s).", ctx);
+                final RequestHeaders mutated = routeCluster.requestHeadersMutator().apply(req.headers());
+                if (mutated != req.headers()) {
+                    req = req.withHeaders(mutated);
+                    ctx.updateRequest(req);
+                }
+                return delegate.execute(ctx, req);
+            };
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Armeria's xDS client doesn't support `request_headers_to_add` and `request_headers_to_remove` configured at all levels (RouteConfiguration, VirtualHost, Route, WeightedCluster.ClusterWeight).

Modifications:

- Added `RequestHeadersMutator` public interface with a single `apply(RequestHeaders)` method
- Added `RequestHeadersMutation` (package-private) that parses `HeaderValueOption` entries and applies all four `HeaderAppendAction` semantics: `APPEND_IF_EXISTS_OR_ADD`, `ADD_IF_ABSENT`, `OVERWRITE_IF_EXISTS_OR_ADD`, `OVERWRITE_IF_EXISTS`
- Added `RequestHeadersMutationChain` (package-private) that composes mutations from multiple xDS levels (RouteConfiguration, VirtualHost, Route, WeightedCluster) with ordering controlled by `most_specific_header_mutations_wins`
- Added `requestHeadersMutator()` to `RouteCluster` interface, implemented in `DefaultRouteCluster` and `WeightedClusterSnapshot`
- Modified `RouteStream` to parse header mutation fields from RouteConfiguration, VirtualHost, and Route protos and build a `RequestHeadersMutationChain`
- Modified `RouteClusterFactory` to pass the chain through to route cluster construction, including per-WeightedCluster mutations
- Modified `RouterFilterFactory` to apply header mutations as an HTTP decorator before forwarding
- Added `supported.field` / `supported.enum_value` proto annotations for `HeaderValueOption`, `HeaderAppendAction`, and the `request_headers_to_add`/`request_headers_to_remove`/`most_specific_header_mutations_wins` fields across RouteConfiguration, VirtualHost, Route, and ClusterWeight
- Added `HeaderMutationTest` integration test covering all append actions, multi-level ordering, `keep_empty_value`, and `most_specific_header_mutations_wins`

Result:

- `request_headers_to_add` and `request_headers_to_remove` are now applied at RouteConfiguration, VirtualHost, Route, and WeightedCluster levels
- Within each level, removals are applied before additions
- Cross-level ordering respects `most_specific_header_mutations_wins` (default off: RouteConfig → VHost → Route → WCluster; on: WCluster → Route → VHost → RouteConfig)
- Header mutations are applied to both HTTP and RPC clients via the `httpClientCustomizer` path
