### PR TITLE
Add xDS `expected_statuses` support for health checks

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/healthcheck/DefaultHttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/healthcheck/DefaultHttpHealthChecker.java
@@ -20,6 +20,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.IntPredicate;
 
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -69,6 +70,7 @@ public final class DefaultHttpHealthChecker implements HttpHealthChecker {
     private final String authority;
     private final String path;
     private final boolean useGet;
+    private final IntPredicate expectedStatuses;
     private boolean wasHealthy;
     private int maxLongPollingSeconds;
     private int pingIntervalSeconds;
@@ -76,8 +78,17 @@ public final class DefaultHttpHealthChecker implements HttpHealthChecker {
     private HttpResponse lastResponse;
     private final AsyncCloseableSupport closeable = AsyncCloseableSupport.of(this::closeAsync);
 
+    private static final IntPredicate DEFAULT_EXPECTED_STATUSES =
+            statusCode -> HttpStatusClass.valueOf(statusCode) == HttpStatusClass.SUCCESS;
+
     public DefaultHttpHealthChecker(HealthCheckerContext ctx, Endpoint endpoint, String path, boolean useGet,
                                     SessionProtocol protocol, @Nullable String host) {
+        this(ctx, endpoint, path, useGet, protocol, host, DEFAULT_EXPECTED_STATUSES);
+    }
+
+    public DefaultHttpHealthChecker(HealthCheckerContext ctx, Endpoint endpoint, String path, boolean useGet,
+                                    SessionProtocol protocol, @Nullable String host,
+                                    IntPredicate expectedStatuses) {
         this.ctx = ctx;
         webClient = WebClient.builder(protocol, endpoint)
                              .options(ctx.clientOptions())
@@ -86,6 +97,7 @@ public final class DefaultHttpHealthChecker implements HttpHealthChecker {
         authority = host != null ? host : endpoint.authority();
         this.path = path;
         this.useGet = useGet;
+        this.expectedStatuses = expectedStatuses;
     }
 
     public void start() {
@@ -213,34 +225,28 @@ public final class DefaultHttpHealthChecker implements HttpHealthChecker {
 
                 final HttpStatus status = headers.status();
                 final HttpStatusClass statusClass = status.codeClass();
-                switch (statusClass) {
-                    case INFORMATIONAL:
-                        maybeSchedulePingCheck();
-                        break;
-                    case SERVER_ERROR:
-                        receivedExpectedResponse = true;
-                        break;
-                    case SUCCESS:
-                        isHealthy = true;
-                        receivedExpectedResponse = true;
-                        break;
-                    default:
-                        if (status == HttpStatus.NOT_MODIFIED) {
-                            isHealthy = wasHealthy;
-                            receivedExpectedResponse = true;
-                        } else {
-                            // Do not use long polling on an unexpected status for safety.
-                            maxLongPollingSeconds = 0;
+                if (statusClass == HttpStatusClass.INFORMATIONAL) {
+                    maybeSchedulePingCheck();
+                } else if (statusClass == HttpStatusClass.SERVER_ERROR) {
+                    receivedExpectedResponse = true;
+                } else if (status == HttpStatus.NOT_MODIFIED) {
+                    isHealthy = wasHealthy;
+                    receivedExpectedResponse = true;
+                } else if (expectedStatuses.test(status.code())) {
+                    isHealthy = true;
+                    receivedExpectedResponse = true;
+                } else {
+                    // Do not use long polling on an unexpected status for safety.
+                    maxLongPollingSeconds = 0;
 
-                            if (statusClass == HttpStatusClass.CLIENT_ERROR) {
-                                logger.warn("{} Unexpected 4xx health check response: {} A 4xx response " +
-                                            "generally indicates a misconfiguration of the client. " +
-                                            "Did you happen to forget to configure the {}'s client options?",
-                                            reqCtx, headers, HealthCheckedEndpointGroup.class.getSimpleName());
-                            } else {
-                                logger.warn("{} Unexpected health check response: {}", reqCtx, headers);
-                            }
-                        }
+                    if (statusClass == HttpStatusClass.CLIENT_ERROR) {
+                        logger.warn("{} Unexpected 4xx health check response: {} A 4xx response " +
+                                    "generally indicates a misconfiguration of the client. " +
+                                    "Did you happen to forget to configure the {}'s client options?",
+                                    reqCtx, headers, HealthCheckedEndpointGroup.class.getSimpleName());
+                    } else {
+                        logger.warn("{} Unexpected health check response: {}", reqCtx, headers);
+                    }
                 }
             } finally {
                 subscription.request(1);

--- a/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/healthcheck/DefaultHttpHealthChecker.java
+++ b/core/src/main/java/com/linecorp/armeria/internal/client/endpoint/healthcheck/DefaultHttpHealthChecker.java
@@ -227,13 +227,13 @@ public final class DefaultHttpHealthChecker implements HttpHealthChecker {
                 final HttpStatusClass statusClass = status.codeClass();
                 if (statusClass == HttpStatusClass.INFORMATIONAL) {
                     maybeSchedulePingCheck();
-                } else if (statusClass == HttpStatusClass.SERVER_ERROR) {
-                    receivedExpectedResponse = true;
                 } else if (status == HttpStatus.NOT_MODIFIED) {
                     isHealthy = wasHealthy;
                     receivedExpectedResponse = true;
                 } else if (expectedStatuses.test(status.code())) {
                     isHealthy = true;
+                    receivedExpectedResponse = true;
+                } else if (statusClass == HttpStatusClass.SERVER_ERROR) {
                     receivedExpectedResponse = true;
                 } else {
                     // Do not use long polling on an unexpected status for safety.

--- a/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ExpectedStatusesTest.java
+++ b/it/xds-client/src/test/java/com/linecorp/armeria/xds/it/ExpectedStatusesTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.xds.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.armeria.xds.ClusterSnapshot;
+import com.linecorp.armeria.xds.ListenerRoot;
+import com.linecorp.armeria.xds.ListenerSnapshot;
+import com.linecorp.armeria.xds.SnapshotWatcher;
+import com.linecorp.armeria.xds.XdsBootstrap;
+import com.linecorp.armeria.xds.client.endpoint.XdsLoadBalancer;
+
+import io.envoyproxy.envoy.config.bootstrap.v3.Bootstrap;
+
+class ExpectedStatusesTest {
+
+    // Server that returns 200 on health check
+    @RegisterExtension
+    static final ServerExtension healthyServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+            sb.service("/health", (ctx, req) -> HttpResponse.of(HttpStatus.OK));
+        }
+    };
+
+    // Server that returns 404 on health check
+    @RegisterExtension
+    static final ServerExtension notFoundServer = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.http(0);
+            sb.service("/", (ctx, req) -> HttpResponse.of(200));
+            sb.service("/health", (ctx, req) -> HttpResponse.of(HttpStatus.NOT_FOUND));
+        }
+    };
+
+    @Test
+    void withExpectedStatuses_nonStandardStatusIsHealthy() {
+        // expected_statuses includes both [200,201) and [404,405), so both servers should be healthy
+        //language=YAML
+        final String yaml = """
+                static_resources:
+                  listeners:
+                  - name: listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: cluster1
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                  - name: cluster1
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster1
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                    health_checks:
+                    - http_health_check:
+                        path: /health
+                        expected_statuses:
+                        - start: 200
+                          end: 201
+                        - start: 404
+                          end: 419
+                      timeout: 5s
+                      interval: 10s
+                      unhealthy_threshold: 1
+                      healthy_threshold: 1
+                """.formatted(healthyServer.httpPort(), notFoundServer.httpPort());
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(yaml);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             ListenerRoot root = xdsBootstrap.listenerRoot("listener")) {
+            final XdsLoadBalancer loadBalancer = pollLoadBalancer(root, "cluster1");
+            // Both servers should be healthy
+            await().untilAsserted(() -> {
+                assertThat(loadBalancer.hostSets().get(0).healthyHostsEndpointGroup().endpoints()
+                                       .stream().map(Endpoint::port).collect(Collectors.toSet()))
+                        .containsExactlyInAnyOrder(healthyServer.httpPort(), notFoundServer.httpPort());
+            });
+        }
+    }
+
+    @Test
+    void withoutExpectedStatuses_nonStandardStatusIsUnhealthy() {
+        // No expected_statuses: default behavior (2xx = healthy).
+        // The notFoundServer returns 404, which is not 2xx, so it should be unhealthy.
+        //language=YAML
+        final String yaml = """
+                static_resources:
+                  listeners:
+                  - name: listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: cluster1
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                  - name: cluster1
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster1
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                    health_checks:
+                    - http_health_check:
+                        path: /health
+                      timeout: 5s
+                      interval: 10s
+                      unhealthy_threshold: 1
+                      healthy_threshold: 1
+                """.formatted(healthyServer.httpPort(), notFoundServer.httpPort());
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(yaml);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             ListenerRoot root = xdsBootstrap.listenerRoot("listener")) {
+            final XdsLoadBalancer loadBalancer = pollLoadBalancer(root, "cluster1");
+            // Only the 200-returning server should be healthy
+            await().untilAsserted(() -> {
+                assertThat(loadBalancer.hostSets().get(0).healthyHostsEndpointGroup().endpoints()
+                                       .stream().map(Endpoint::port).collect(Collectors.toSet()))
+                        .containsExactly(healthyServer.httpPort());
+            });
+        }
+    }
+
+    @Test
+    void expectedStatusesRange() {
+        // expected_statuses with a range [400, 500) — only 4xx are healthy.
+        // healthyServer returns 200 (not in range) → unhealthy
+        // notFoundServer returns 404 (in range) → healthy
+        //language=YAML
+        final String yaml = """
+                static_resources:
+                  listeners:
+                  - name: listener
+                    api_listener:
+                      api_listener:
+                        "@type": type.googleapis.com/envoy.extensions.filters.network\
+                .http_connection_manager.v3.HttpConnectionManager
+                        stat_prefix: http
+                        route_config:
+                          name: local_route
+                          virtual_hosts:
+                          - name: local_service
+                            domains: ["*"]
+                            routes:
+                            - match:
+                                prefix: /
+                              route:
+                                cluster: cluster1
+                        http_filters:
+                        - name: envoy.filters.http.router
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.http\
+                .router.v3.Router
+                  clusters:
+                  - name: cluster1
+                    type: STATIC
+                    load_assignment:
+                      cluster_name: cluster1
+                      endpoints:
+                      - lb_endpoints:
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                        - endpoint:
+                            address:
+                              socket_address:
+                                address: 127.0.0.1
+                                port_value: %d
+                    health_checks:
+                    - http_health_check:
+                        path: /health
+                        expected_statuses:
+                        - start: 400
+                          end: 500
+                      timeout: 5s
+                      interval: 10s
+                      unhealthy_threshold: 1
+                      healthy_threshold: 1
+                """.formatted(healthyServer.httpPort(), notFoundServer.httpPort());
+
+        final Bootstrap bootstrap = XdsResourceReader.fromYaml(yaml);
+        try (XdsBootstrap xdsBootstrap = XdsBootstrap.of(bootstrap);
+             ListenerRoot root = xdsBootstrap.listenerRoot("listener")) {
+            final XdsLoadBalancer loadBalancer = pollLoadBalancer(root, "cluster1");
+            // Only the teapot server (404) should be healthy
+            await().untilAsserted(() -> {
+                assertThat(loadBalancer.hostSets().get(0).healthyHostsEndpointGroup().endpoints()
+                                       .stream().map(Endpoint::port).collect(Collectors.toSet()))
+                        .containsExactly(notFoundServer.httpPort());
+            });
+        }
+    }
+
+    private static XdsLoadBalancer pollLoadBalancer(ListenerRoot root, String clusterName) {
+        final AtomicReference<XdsLoadBalancer> lbRef = new AtomicReference<>();
+        final SnapshotWatcher<ListenerSnapshot> watcher = (newSnapshot, t) -> {
+            final ClusterSnapshot clusterSnapshot =
+                    newSnapshot.routeSnapshot().virtualHostSnapshots().get(0).routeEntries().get(0)
+                               .clusterSnapshot();
+            if (clusterSnapshot != null && clusterName.equals(clusterSnapshot.xdsResource().name())) {
+                lbRef.set(clusterSnapshot.loadBalancer());
+            }
+        };
+        root.addSnapshotWatcher(watcher);
+        await().untilAsserted(() -> assertThat(lbRef.get()).isNotNull());
+        return lbRef.get();
+    }
+}

--- a/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
@@ -146,6 +146,7 @@ message HealthCheck {
     // 200-only policy - 200 must be included explicitly as needed. Ranges follow half-open
     // semantics of :ref:`Int64Range <envoy_v3_api_msg_type.v3.Int64Range>`. The start and end of each
     // range are required. Only statuses in the range [100, 600) are allowed.
+    option (armeria.xds.supported.field) = 9;
     repeated type.v3.Int64Range expected_statuses = 9;
 
     // Specifies a list of HTTP response statuses considered retriable. If provided, responses in this range

--- a/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHealthCheckedEndpointGroupBuilder.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/client/endpoint/XdsHealthCheckedEndpointGroupBuilder.java
@@ -16,7 +16,9 @@
 
 package com.linecorp.armeria.xds.client.endpoint;
 
+import java.util.List;
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +39,7 @@ import io.envoyproxy.envoy.config.cluster.v3.Cluster;
 import io.envoyproxy.envoy.config.core.v3.HealthCheck.HttpHealthCheck;
 import io.envoyproxy.envoy.config.endpoint.v3.Endpoint.HealthCheckConfig;
 import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.type.v3.Int64Range;
 
 final class XdsHealthCheckedEndpointGroupBuilder
         extends AbstractHealthCheckedEndpointGroupBuilder<XdsHealthCheckedEndpointGroupBuilder> {
@@ -45,12 +48,14 @@ final class XdsHealthCheckedEndpointGroupBuilder
 
     private final Cluster cluster;
     private final HttpHealthCheck httpHealthCheck;
+    private final IntPredicate expectedStatuses;
 
     XdsHealthCheckedEndpointGroupBuilder(EndpointGroup delegate, Cluster cluster,
                                          HttpHealthCheck httpHealthCheck) {
         super(delegate);
         this.cluster = cluster;
         this.httpHealthCheck = httpHealthCheck;
+        expectedStatuses = toExpectedStatuses(httpHealthCheck);
     }
 
     @Override
@@ -68,7 +73,7 @@ final class XdsHealthCheckedEndpointGroupBuilder
             final DefaultHttpHealthChecker checker =
                     new DefaultHttpHealthChecker(ctx, endpoint(healthCheckConfig, ctx.originalEndpoint()),
                                                  path, httpMethod(httpHealthCheck) == HttpMethod.GET,
-                                                 protocol(cluster), host);
+                                                 protocol(cluster), host, expectedStatuses);
             checker.start();
             return checker;
         };
@@ -92,6 +97,22 @@ final class XdsHealthCheckedEndpointGroupBuilder
         } else {
             return SessionProtocol.HTTP;
         }
+    }
+
+    private static IntPredicate toExpectedStatuses(HttpHealthCheck httpHealthCheck) {
+        final List<Int64Range> ranges = httpHealthCheck.getExpectedStatusesList();
+        if (ranges.isEmpty()) {
+            // Envoy default: 200 only
+            return statusCode -> statusCode == 200;
+        }
+        return statusCode -> {
+            for (Int64Range range : ranges) {
+                if (statusCode >= range.getStart() && statusCode < range.getEnd()) {
+                    return true;
+                }
+            }
+            return false;
+        };
     }
 
     private static Endpoint endpoint(HealthCheckConfig healthCheckConfig, Endpoint endpoint) {


### PR DESCRIPTION
Motivation:

Armeria's xDS health checker currently hard-codes health as 2xx status responses. Envoy's `HttpHealthCheck.expected_statuses` field allows operators to define custom status code ranges that should be considered healthy (e.g., treating 404 as healthy for certain services). This field was previously ignored, causing health check mismatches when the xDS configuration relies on non-2xx statuses.

Modifications:

- Modified `DefaultHttpHealthChecker` to accept an `IntPredicate` for expected statuses instead of hard-coding 2xx as healthy. Refactored the status evaluation from a `switch` block to an `if-else` chain that checks informational, server error, and not-modified statuses first, then delegates to the predicate for health determination.
- Modified `XdsHealthCheckedEndpointGroupBuilder` to parse `expected_statuses` from `HttpHealthCheck` proto into an `IntPredicate` using half-open `Int64Range` semantics. When no ranges are configured, defaults to Envoy's behavior of treating only status 200 as healthy.
- Added `supported.field` proto annotation for `expected_statuses` in `health_check.proto`
- Added `ExpectedStatusesTest` integration test covering: custom ranges making non-2xx statuses healthy, default behavior without `expected_statuses`, and exclusive range semantics

Result:

- xDS health checks now respect `expected_statuses` ranges from the `HttpHealthCheck` configuration
- When `expected_statuses` is set, only status codes within the specified half-open ranges are considered healthy
- When `expected_statuses` is not set, the default behavior treats only 200 as healthy, consistent with Envoy
