### PR TITLE
Add xDS retry backoff multiplier support

### DIFF
--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -1656,7 +1656,7 @@ message RetryPolicy {
 
     // Specifies the exponential backoff factor that Envoy doesn't support. (2x is by default).
     option (armeria.xds.supported.field) = 1000;
-    google.protobuf.UInt32Value exponential_backoff_factor = 1000;
+    google.protobuf.UInt32Value exponential_backoff_factor = 1000 [(validate.rules).uint32 = {gt: 1}];
   }
 
   message ResetHeader {

--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -1655,6 +1655,7 @@ message RetryPolicy {
     google.protobuf.Duration max_interval = 2 [(validate.rules).duration = {gt {}}];
 
     // Specifies the exponential backoff factor that Envoy doesn't support. (2x is by default).
+    option (armeria.xds.supported.field) = 1000;
     google.protobuf.UInt32Value exponential_backoff_factor = 1000;
   }
 

--- a/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
@@ -273,9 +273,13 @@ final class RetryStateFactory {
                     XdsCommonUtil.durationToMillis(retryBackOff.getBaseInterval(), 25);
             final long maxIntervalMillis =
                     XdsCommonUtil.durationToMillis(retryBackOff.getMaxInterval(), baseIntervalMillis * 10);
+            final double multiplier = retryBackOff.hasExponentialBackoffFactor()
+                                      ? retryBackOff.getExponentialBackoffFactor().getValue()
+                                      : 2.0;
             final Backoff defaultBackoff = Backoff.builderForExponential()
                                                   .initialDelayMillis(baseIntervalMillis)
                                                   .maxDelayMillis(maxIntervalMillis)
+                                                  .multiplier(multiplier)
                                                   .jitter(0, 0.5)
                                                   .build();
             backoff = new DelegatingBackoff(defaultBackoff);

--- a/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/RetryStateFactory.java
@@ -191,7 +191,7 @@ final class RetryStateFactory {
                     ImmutableList.builderWithExpectedSize(expectedSize);
             for (String headerName : splitHeaderNames) {
                 builder.add(XdsHeaderMatcher.of(HeaderMatcher.newBuilder()
-                                                               .setName(headerName.trim()).build()));
+                                                             .setName(headerName.trim()).build()));
             }
             builder.addAll(retriableResponseHeaderMatchers);
             retriableResponseHeaderMatchers = builder.build();
@@ -273,9 +273,8 @@ final class RetryStateFactory {
                     XdsCommonUtil.durationToMillis(retryBackOff.getBaseInterval(), 25);
             final long maxIntervalMillis =
                     XdsCommonUtil.durationToMillis(retryBackOff.getMaxInterval(), baseIntervalMillis * 10);
-            final double multiplier = retryBackOff.hasExponentialBackoffFactor()
-                                      ? retryBackOff.getExponentialBackoffFactor().getValue()
-                                      : 2.0;
+            final double multiplier =
+                    XdsCommonUtil.uint32ValueToInt(retryBackOff.getExponentialBackoffFactor(), 2);
             final Backoff defaultBackoff = Backoff.builderForExponential()
                                                   .initialDelayMillis(baseIntervalMillis)
                                                   .maxDelayMillis(maxIntervalMillis)


### PR DESCRIPTION
Motivation:

Armeria's xDS retry policy uses a hard-coded 2x exponential backoff multiplier. The `RetryBackOff.exponential_backoff_factor` field (custom extension field 1000) allows configuring a different multiplier, but it was previously ignored.

Modifications:

- Modified `RetryStateFactory` to read `exponential_backoff_factor` from the `RetryBackOff` proto and pass it to `Backoff.builderForExponential().multiplier()`. Defaults to 2.0 when not set.
- Added `supported.field` proto annotation for `exponential_backoff_factor` in `route_components.proto`

Result:

- The xDS retry backoff multiplier is now configurable via `exponential_backoff_factor`
- When not set, the default 2x multiplier is preserved
