### PR TITLE
Abort retried requests not reaching the wire

### DIFF
--- a/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
+++ b/core/src/main/java/com/linecorp/armeria/client/retry/RetryingClient.java
@@ -478,6 +478,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
     private static void completeLogIfBytesNotTransferred(AggregatedHttpResponse response,
                                                          ClientRequestContext ctx) {
         if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_FIRST_BYTES_TRANSFERRED_TIME)) {
+            final HttpRequest req = ctx.request();
+            if (req != null) {
+                req.abort();
+            }
             final RequestLogBuilder logBuilder = ctx.logBuilder();
             logBuilder.endRequest();
             logBuilder.responseHeaders(response.headers());
@@ -492,6 +496,10 @@ public final class RetryingClient extends AbstractRetryingClient<HttpRequest, Ht
             HttpResponse response, @Nullable ResponseHeaders headers, ClientRequestContext ctx,
             @Nullable Throwable responseCause) {
         if (!ctx.log().isAvailable(RequestLogProperty.REQUEST_FIRST_BYTES_TRANSFERRED_TIME)) {
+            final HttpRequest req = ctx.request();
+            if (req != null) {
+                req.abort();
+            }
             final RequestLogBuilder logBuilder = ctx.logBuilder();
             if (responseCause != null) {
                 logBuilder.endRequest(responseCause);

--- a/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientRequestLeakTest.java
+++ b/core/src/test/java/com/linecorp/armeria/client/retry/RetryingClientRequestLeakTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.client.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * Verifies that {@link RetryingClient} releases the duplicated request's pooled content
+ * when a decorator short-circuits without consuming the request body.
+ */
+class RetryingClientRequestLeakTest {
+
+    @RegisterExtension
+    static final ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service("/", (ctx, req) -> HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE));
+        }
+    };
+
+    @Test
+    void shouldReleaseRequestBodyWhenDecoratorShortCircuits() {
+        final AtomicInteger attemptCount = new AtomicInteger();
+        final ByteBuf sentinel = ByteBufAllocator.DEFAULT.buffer().writeBytes("test-body".getBytes());
+        assertThat(sentinel.refCnt()).isEqualTo(1);
+
+        final WebClient client =
+                WebClient.builder(server.httpUri())
+                         .decorator((delegate, ctx, req) -> {
+                             attemptCount.incrementAndGet();
+                             return HttpResponse.of(HttpStatus.SERVICE_UNAVAILABLE);
+                         })
+                         .decorator(RetryingClient.newDecorator(
+                                 RetryRule.builder()
+                                          .onServerErrorStatus()
+                                          .thenBackoff(Backoff.withoutDelay()), 3))
+                         .build();
+
+        final AggregatedHttpResponse res = client.post("/", HttpData.wrap(sentinel)).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(attemptCount.get()).isEqualTo(3);
+
+        // The sentinel ByteBuf should have been fully released.
+        assertThat(sentinel.refCnt()).isZero();
+    }
+}


### PR DESCRIPTION
Motivation:

When `RetryingClient` retries a request, it creates a duplicate of the original request via `HttpRequestDuplicator.duplicate()` for each attempt. The duplicator buffers the original body signals in a shared queue, and each child stream creates a `RETAINED_DUPLICATE` of pooled `ByteBuf`s upon delivery. If a downstream decorator short-circuits by returning a response without consuming the request body, the duplicated request stream is never drained.

`RetryingClient` passes `tryCompleteLog = false` to `ClientUtil`, bypassing the normal `ctx.cancel()` → `req.abort()` cleanup path. Its own `completeLogIfBytesNotTransferred` method completed the log but did not abort the unconsumed request, leaving the retained `ByteBuf` references leaked.

Modifications:

- In both overloads of `RetryingClient.completeLogIfBytesNotTransferred`, abort the derived context's request when the request was never written to the wire. If a downstream consumer actually needed the body, it would have subscribed to or aggregated the request stream already. Aborting an unconsumed request is safe cleanup.
- Added `RetryingClientRequestLeakTest` that verifies a pooled `ByteBuf` is fully released after retries when a decorator short-circuits without consuming the request body.

Result:

- Pooled request body `ByteBuf`s are no longer leaked when `RetryingClient` retries and the request is not consumed by downstream decorators.
- No behavioral change for users who consume the request body normally.
