### PR TITLE
Add version info to xDS proto apis and bootstrap node

### DIFF
--- a/xds-api/src/main/java/com/linecorp/armeria/xds/api/SupportedFieldValidator.java
+++ b/xds-api/src/main/java/com/linecorp/armeria/xds/api/SupportedFieldValidator.java
@@ -34,9 +34,8 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 
-import com.linecorp.armeria.xds.api.SupportedFieldProto.FieldSupport;
-
 import com.linecorp.armeria.common.annotation.UnstableApi;
+import com.linecorp.armeria.xds.api.SupportedFieldProto.FieldSupport;
 
 /**
  * Validates protobuf messages against the {@code (armeria.xds.supported.field)} and

--- a/xds-api/src/main/java/com/linecorp/armeria/xds/api/SupportedFieldValidator.java
+++ b/xds-api/src/main/java/com/linecorp/armeria/xds/api/SupportedFieldValidator.java
@@ -34,6 +34,8 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 
+import com.linecorp.armeria.xds.api.SupportedFieldProto.FieldSupport;
+
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
 /**
@@ -45,11 +47,17 @@ import com.linecorp.armeria.common.annotation.UnstableApi;
  * <p>Supported fields are annotated in the proto files, e.g.:
  * <pre>{@code
  * message Address {
- *   option (armeria.xds.supported.field) = 2;
+ *   option (armeria.xds.supported.field) = {
+ *     number: 2,
+ *     since: "1.39.0"
+ *   };
  *   string address = 2;
  *
  *   oneof port_specifier {
- *     option (armeria.xds.supported.oneof_field) = 3;
+ *     option (armeria.xds.supported.oneof_field) = {
+ *       number: 3,
+ *       since: "1.39.0"
+ *     };
  *     uint32 port_value = 3;
  *   }
  * }
@@ -170,10 +178,19 @@ public final class SupportedFieldValidator {
     }
 
     private static boolean unsupportedEnumValue(EnumValueDescriptor ev) {
-        final List<Integer> supportedValues =
+        final List<FieldSupport> supportedValues =
                 ev.getType().getOptions().getExtension(SupportedFieldProto.supported.enumValue);
         // If no enum values are annotated, treat as "no opinion" — skip validation.
-        return !supportedValues.isEmpty() && !supportedValues.contains(ev.getNumber());
+        if (supportedValues.isEmpty()) {
+            return false;
+        }
+        final int number = ev.getNumber();
+        for (FieldSupport fs : supportedValues) {
+            if (fs.getNumber() == number) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isGoogleApi(String pkg) {
@@ -182,11 +199,15 @@ public final class SupportedFieldValidator {
 
     private Set<FieldDescriptor> supportedFields(Descriptors.Descriptor descriptor) {
         return supportedFieldsCache.computeIfAbsent(descriptor, d -> {
-            final Set<Integer> supportedNumbers = new HashSet<>(
-                    d.getOptions().getExtension(SupportedFieldProto.supported.field));
+            final Set<Integer> supportedNumbers = new HashSet<>();
+            for (FieldSupport fs : d.getOptions().getExtension(SupportedFieldProto.supported.field)) {
+                supportedNumbers.add(fs.getNumber());
+            }
             for (Descriptors.OneofDescriptor oneof : d.getOneofs()) {
-                supportedNumbers.addAll(
-                        oneof.getOptions().getExtension(SupportedFieldProto.supported.oneofField));
+                for (FieldSupport fs : oneof.getOptions()
+                                             .getExtension(SupportedFieldProto.supported.oneofField)) {
+                    supportedNumbers.add(fs.getNumber());
+                }
             }
             final Set<FieldDescriptor> result = new HashSet<>();
             for (FieldDescriptor fd : d.getFields()) {

--- a/xds-api/src/main/proto/armeria/xds/athenz/athenz_access_token.proto
+++ b/xds-api/src/main/proto/armeria/xds/athenz/athenz_access_token.proto
@@ -17,9 +17,18 @@ import "armeria/xds/supported.proto";
 // Connection-level attributes (protocol/port/SNI/ALPN) are excluded because a
 // library data plane cannot supply them.
 enum WellKnownEndpointAttribute {
-  option (armeria.xds.supported.enum_value) = 1;
-  option (armeria.xds.supported.enum_value) = 2;
-  option (armeria.xds.supported.enum_value) = 3;
+  option (armeria.xds.supported.enum_value) = {
+    number: 1,
+    since: "1.41.0"
+  };
+  option (armeria.xds.supported.enum_value) = {
+    number: 2,
+    since: "1.41.0"
+  };
+  option (armeria.xds.supported.enum_value) = {
+    number: 3,
+    since: "1.41.0"
+  };
 
   WELL_KNOWN_ENDPOINT_ATTRIBUTE_UNSPECIFIED = 0;
   WELL_KNOWN_ENDPOINT_ATTRIBUTE_HOST = 1;          // :authority
@@ -31,10 +40,16 @@ enum WellKnownEndpointAttribute {
 message EndpointAttribute {
   oneof attribute {
     option (validate.required) = true;
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+    number: 1,
+    since: "1.41.0"
+  };
     WellKnownEndpointAttribute well_known = 1
     [(validate.rules).enum = {defined_only: true not_in: 0}];
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+    number: 2,
+    since: "1.41.0"
+  };
     // Implementation-specific attribute name, documented per syntax_version.
     string custom = 2 [(validate.rules).string = {min_len: 1}];
   }
@@ -43,27 +58,45 @@ message EndpointAttribute {
 // Placeholders: ${host|method|path}, ${custom.<name>},
 // ${match.<name>.<index>}; $$ is a literal $. Unknown or missing -> rule fails.
 message StringTemplate {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string template = 1 [(validate.rules).string = {min_len: 1}];
 }
 
 message MappingString {
   oneof string_specifier {
     option (validate.required) = true;
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+    number: 1,
+    since: "1.41.0"
+  };
     string literal = 1 [(validate.rules).string = {min_len: 1}];
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+    number: 2,
+    since: "1.41.0"
+  };
     StringTemplate template = 2 [(validate.rules).message = {required: true}];
   }
 }
 
 message EndpointAttributeMatch {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   // Capture namespace referenced from templates as ${match.<name>.<index>}.
   string name = 1;
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   EndpointAttribute attribute = 2 [(validate.rules).message = {required: true}];
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.41.0"
+  };
   envoy.type.matcher.v3.StringMatcher matcher = 3
   [(validate.rules).message = {required: true}];
 }
@@ -71,19 +104,34 @@ message EndpointAttributeMatch {
 // All conditions must match (empty = match all); rules are tried in order,
 // first match wins.
 message AssertionMappingRule {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string name = 1;
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   repeated EndpointAttributeMatch conditions = 2;
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.41.0"
+  };
   MappingString action = 3 [(validate.rules).message = {required: true}];
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+    number: 4,
+    since: "1.41.0"
+  };
   MappingString resource = 4 [(validate.rules).message = {required: true}];
 }
 
 // No matching rule, or a rule whose action/resource fails to resolve -> deny.
 message AssertionMapping {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   repeated AssertionMappingRule rules = 1
   [(validate.rules).repeated = {min_items: 1}];
 }
@@ -91,24 +139,42 @@ message AssertionMapping {
 // Outbound: token to acquire for a destination. Static per cluster; routing
 // selects the cluster, so there is no per-request mapping here.
 message AccessTokenTarget {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string target_domain = 1 [(validate.rules).string = {min_len: 1}];
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   // Roles included in the token scope; usually one.
   repeated string target_roles = 2
   [(validate.rules).repeated = {min_items: 1, items {string {min_len: 1}}}];
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.41.0"
+  };
   // Consumers reject versions they do not implement.
   uint32 syntax_version = 3 [(validate.rules).uint32 = {gte: 1}];
 }
 
 // Inbound: token evaluation for a listener.
 message AccessTokenConstraint {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string constraint_domain = 1 [(validate.rules).string = {min_len: 1}];
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   uint32 syntax_version = 2 [(validate.rules).uint32 = {gte: 1}];
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.41.0"
+  };
   // Optional explicit rules for (action, resource). When unset, the default
   // mapping applies: action = lower(method), resource = request path.
   AssertionMapping assertion_mapping = 3;

--- a/xds-api/src/main/proto/armeria/xds/athenz/athenz_filter_config.proto
+++ b/xds-api/src/main/proto/armeria/xds/athenz/athenz_filter_config.proto
@@ -10,16 +10,28 @@ import "armeria/xds/athenz/athenz_access_token.proto";
 
 // Outbound filter config: injects an Athenz access token into requests.
 message AccessTokenTargetConfig {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string zts_cluster_name = 1 [(validate.rules).string = {min_len: 1}];
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   jp.co.lycorp.ftd.athenz.v1.AccessTokenTarget access_token_target = 2 [(validate.rules).message = {required: true}];
 }
 
 // Inbound filter config: authorizes requests using Athenz access tokens.
 message AccessTokenConstraintConfig {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.41.0"
+  };
   string zts_cluster_name = 1 [(validate.rules).string = {min_len: 1}];
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.41.0"
+  };
   jp.co.lycorp.ftd.athenz.v1.AccessTokenConstraint access_token_constraint = 2 [(validate.rules).message = {required: true}];
 }

--- a/xds-api/src/main/proto/armeria/xds/kubernetes/kubernetes_cluster_config.proto
+++ b/xds-api/src/main/proto/armeria/xds/kubernetes/kubernetes_cluster_config.proto
@@ -11,31 +11,49 @@ import "envoy/extensions/transport_sockets/tls/v3/secret.proto";
 
 message KubernetesClusterConfig {
   // The Kubernetes Service name to watch for endpoints. (Required)
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.42.0"
+  };
   string service_name = 1 [(validate.rules).string = {min_len: 1}];
 
   // The Kubernetes namespace. If empty, uses the client's default namespace.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.42.0"
+  };
   string namespace = 2;
 
   // The port name to select. If empty, uses the first port.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.42.0"
+  };
   string port_name = 3;
 
   // Endpoint discovery mode. Default: POD.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+    number: 4,
+    since: "1.42.0"
+  };
   KubernetesEndpointMode mode = 4;
 
   // The Kubernetes API server URL (e.g. "https://kubernetes.default.svc").
   // If empty, uses the default from kubeconfig or in-cluster config.
-  option (armeria.xds.supported.field) = 5;
+  option (armeria.xds.supported.field) = {
+    number: 5,
+    since: "1.42.0"
+  };
   string api_server_url = 5;
 
   // SDS secret config for the bearer token to authenticate with the K8s API.
   // The secret must be a generic_secret whose value is the raw bearer token.
   // When the secret rotates, the KubernetesEndpointGroup is recreated.
   // If unset, uses the default KubernetesClient auth (kubeconfig/in-cluster SA token).
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+    number: 6,
+    since: "1.42.0"
+  };
   envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig credential = 6;
 }
 

--- a/xds-api/src/main/proto/armeria/xds/spring/spring_config_source.proto
+++ b/xds-api/src/main/proto/armeria/xds/spring/spring_config_source.proto
@@ -13,7 +13,10 @@ import "armeria/xds/supported.proto";
 // This message is packed into the ``typed_config`` field of a
 // ``custom_config_source`` in the bootstrap configuration.
 message SpringConfigSource {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.42.0"
+  };
   // The prefix prepended to resource names to form Spring property keys.
   // For example, with prefix ``armeria.xds.`` and resource name ``my-cluster``,
   // the property key becomes ``armeria.xds.my-cluster``.

--- a/xds-api/src/main/proto/armeria/xds/supported.proto
+++ b/xds-api/src/main/proto/armeria/xds/supported.proto
@@ -6,26 +6,29 @@ option java_outer_classname = "SupportedFieldProto";
 
 import "google/protobuf/descriptor.proto";
 
+message FieldSupport {
+  int32 number = 1;
+  string since = 2;
+}
+
 // Enclosing message so that option usage reads as
 // `(armeria.xds.supported.field)`, `(armeria.xds.supported.oneof_field)`,
 // and `(armeria.xds.supported.enum_value)`.
 message supported {
   extend google.protobuf.MessageOptions {
-    // Field numbers of supported fields in this message.
-    // Place each `option (armeria.xds.supported.field) = <field_number>;`
-    // directly above the corresponding field declaration.
-    repeated int32 field = 50000;
+    // Supported fields in this message.
+    // Place each annotation directly above the corresponding field declaration.
+    repeated FieldSupport field = 50000;
   }
 
   extend google.protobuf.OneofOptions {
-    // Field numbers of supported oneof members.
-    // Place each `option (armeria.xds.supported.oneof_field) = <field_number>;`
-    // directly above the corresponding field inside a oneof block.
-    repeated int32 oneof_field = 50000;
+    // Supported oneof members.
+    // Place each annotation directly above the corresponding field inside a oneof block.
+    repeated FieldSupport oneof_field = 50000;
   }
 
   extend google.protobuf.EnumOptions {
-    // Enum value numbers of supported values in this enum.
-    repeated int32 enum_value = 50000;
+    // Supported enum values.
+    repeated FieldSupport enum_value = 50000;
   }
 }

--- a/xds-api/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
+++ b/xds-api/src/main/proto/envoy/config/bootstrap/v3/bootstrap.proto
@@ -55,19 +55,28 @@ message Bootstrap {
 
     // Static :ref:`Listeners <envoy_v3_api_msg_config.listener.v3.Listener>`. These listeners are
     // available regardless of LDS configuration.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     repeated listener.v3.Listener listeners = 1;
 
     // If a network based configuration source is specified for :ref:`cds_config
     // <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.DynamicResources.cds_config>`, it's necessary
     // to have some initial cluster definitions available to allow Envoy to know
     // how to speak to the management server.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     repeated cluster.v3.Cluster clusters = 2;
 
     // These static secrets can be used by :ref:`SdsSecretConfig
     // <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.SdsSecretConfig>`
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     repeated envoy.extensions.transport_sockets.tls.v3.Secret secrets = 3;
   }
 
@@ -80,7 +89,10 @@ message Bootstrap {
 
     // All :ref:`Listeners <envoy_v3_api_msg_config.listener.v3.Listener>` are provided by a single
     // :ref:`LDS <arch_overview_dynamic_config_lds>` configuration source.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     core.v3.ConfigSource lds_config = 1;
 
     // ``xdstp://`` resource locator for listener collection.
@@ -90,7 +102,10 @@ message Bootstrap {
     // All post-bootstrap :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` definitions are
     // provided by a single :ref:`CDS <arch_overview_dynamic_config_cds>`
     // configuration source.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     core.v3.ConfigSource cds_config = 2;
 
     // ``xdstp://`` resource locator for cluster collection.
@@ -104,7 +119,10 @@ message Bootstrap {
     // :ref:`ConfigSources <envoy_v3_api_msg_config.core.v3.ConfigSource>` that have
     // the :ref:`ads <envoy_v3_api_field_config.core.v3.ConfigSource.ads>` field set will be
     // streamed on the ADS channel.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     core.v3.ApiConfigSource ads_config = 3;
   }
 
@@ -158,7 +176,10 @@ message Bootstrap {
 
   // Node identity to present to the management server and for instance
   // identification purposes (e.g. in generated headers).
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   core.v3.Node node = 1;
 
   // A list of :ref:`Node <envoy_v3_api_msg_config.core.v3.Node>` field names
@@ -196,16 +217,25 @@ message Bootstrap {
   repeated string node_context_params = 26;
 
   // Statically specified resources.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   StaticResources static_resources = 2;
 
   // xDS configuration sources.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   DynamicResources dynamic_resources = 3;
 
   // Configuration for the cluster manager which owns all upstream clusters
   // within the server.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   ClusterManager cluster_manager = 4;
 
   // Health discovery service config option.
@@ -524,7 +554,10 @@ message ClusterManager {
   // <envoy_v3_api_field_config.bootstrap.v3.Bootstrap.StaticResources.clusters>`. This is unrelated to
   // the :option:`--service-cluster` option which does not `affect zone aware
   // routing <https://github.com/envoyproxy/envoy/issues/774>`_.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string local_cluster_name = 1;
 
   // Optional global configuration for outlier detection.

--- a/xds-api/src/main/proto/envoy/config/cluster/v3/cluster.proto
+++ b/xds-api/src/main/proto/envoy/config/cluster/v3/cluster.proto
@@ -57,13 +57,19 @@ message Cluster {
   enum DiscoveryType {
     // Refer to the :ref:`static discovery type<arch_overview_service_discovery_types_static>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 0;
+    option (armeria.xds.supported.enum_value) = {
+        number: 0,
+        since: "1.39.0"
+    };
     STATIC = 0;
 
     // Refer to the :ref:`strict DNS discovery
     // type<arch_overview_service_discovery_types_strict_dns>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 1;
+    option (armeria.xds.supported.enum_value) = {
+        number: 1,
+        since: "1.39.0"
+    };
     STRICT_DNS = 1;
 
     // Refer to the :ref:`logical DNS discovery
@@ -73,7 +79,10 @@ message Cluster {
 
     // Refer to the :ref:`service discovery type<arch_overview_service_discovery_types_eds>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 3;
+    option (armeria.xds.supported.enum_value) = {
+        number: 3,
+        since: "1.39.0"
+    };
     EDS = 3;
 
     // Refer to the :ref:`original destination discovery
@@ -92,13 +101,19 @@ message Cluster {
     // Refer to the :ref:`round robin load balancing
     // policy<arch_overview_load_balancing_types_round_robin>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 0;
+    option (armeria.xds.supported.enum_value) = {
+        number: 0,
+        since: "1.39.0"
+    };
     ROUND_ROBIN = 0;
 
     // Refer to the :ref:`least request load balancing
     // policy<arch_overview_load_balancing_types_least_request>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 1;
+    option (armeria.xds.supported.enum_value) = {
+        number: 1,
+        since: "1.39.0"
+    };
     LEAST_REQUEST = 1;
 
     // Refer to the :ref:`ring hash load balancing
@@ -109,7 +124,10 @@ message Cluster {
     // Refer to the :ref:`random load balancing
     // policy<arch_overview_load_balancing_types_random>`
     // for an explanation.
-    option (armeria.xds.supported.enum_value) = 3;
+    option (armeria.xds.supported.enum_value) = {
+        number: 3,
+        since: "1.39.0"
+    };
     RANDOM = 3;
 
     // Refer to the :ref:`Maglev load balancing policy<arch_overview_load_balancing_types_maglev>`
@@ -175,7 +193,10 @@ message Cluster {
         "envoy.api.v2.Cluster.TransportSocketMatch";
 
     // The name of the match, used in stats generation.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string name = 1 [(validate.rules).string = {min_len: 1}];
 
     // Optional metadata match criteria.
@@ -183,12 +204,18 @@ message Cluster {
     // will use the transport socket configuration specified here.
     // The endpoint's metadata entry in ``envoy.transport_socket_match`` is used to match
     // against the values specified in this field.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     google.protobuf.Struct match = 2;
 
     // The configuration of the transport socket.
     // [#extension-category: envoy.transport_sockets.upstream]
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     core.v3.TransportSocket transport_socket = 3;
   }
 
@@ -198,13 +225,19 @@ message Cluster {
         "envoy.api.v2.Cluster.CustomClusterType";
 
     // The type of the cluster to instantiate. The name must match a supported cluster type.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.41.0"
+    };
     string name = 1 [(validate.rules).string = {min_len: 1}];
 
     // Cluster specific configuration which depends on the cluster being instantiated.
     // See the supported cluster for further documentation.
     // [#extension-category: envoy.clusters]
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.41.0"
+    };
     google.protobuf.Any typed_config = 2;
   }
 
@@ -214,13 +247,19 @@ message Cluster {
         "envoy.api.v2.Cluster.EdsClusterConfig";
 
     // Configuration for the source of EDS updates for this Cluster.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     core.v3.ConfigSource eds_config = 1;
 
     // Optional alternative to cluster name to present to EDS. This does not
     // have the same restrictions as cluster name, i.e. it may be arbitrary
     // length. This may be a xdstp:// URL.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     string service_name = 2;
   }
 
@@ -237,11 +276,20 @@ message Cluster {
     // etc). If DEFAULT_SUBSET is selected, load balancing is performed over the
     // endpoints matching the values from the default_subset field.
     enum LbSubsetFallbackPolicy {
-      option (armeria.xds.supported.enum_value) = 0;
+      option (armeria.xds.supported.enum_value) = {
+          number: 0,
+          since: "1.39.0"
+      };
       NO_FALLBACK = 0;
-      option (armeria.xds.supported.enum_value) = 1;
+      option (armeria.xds.supported.enum_value) = {
+          number: 1,
+          since: "1.39.0"
+      };
       ANY_ENDPOINT = 1;
-      option (armeria.xds.supported.enum_value) = 2;
+      option (armeria.xds.supported.enum_value) = {
+          number: 2,
+          since: "1.39.0"
+      };
       DEFAULT_SUBSET = 2;
     }
 
@@ -321,7 +369,10 @@ message Cluster {
       }
 
       // List of keys to match with the weighted cluster metadata.
-      option (armeria.xds.supported.field) = 1;
+      option (armeria.xds.supported.field) = {
+          number: 1,
+          since: "1.39.0"
+      };
       repeated string keys = 1;
 
       // Selects a mode of operation in which each subset has only one host. This mode uses the same rules for
@@ -355,7 +406,10 @@ message Cluster {
     // The behavior used when no endpoint subset matches the selected route's
     // metadata. The value defaults to
     // :ref:`NO_FALLBACK<envoy_v3_api_enum_value_config.cluster.v3.Cluster.LbSubsetConfig.LbSubsetFallbackPolicy.NO_FALLBACK>`.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     LbSubsetFallbackPolicy fallback_policy = 1 [(validate.rules).enum = {defined_only: true}];
 
     // Specifies the default subset of endpoints used during fallback if
@@ -382,7 +436,10 @@ message Cluster {
     // A subset is matched when the metadata from the selected route and
     // weighted cluster contains the same keys and values as the subset's
     // metadata. The same host may appear in multiple subsets.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     repeated LbSubsetSelector subset_selectors = 3;
 
     // If true, routing to subsets will take into account the localities and locality weights of the
@@ -432,7 +489,10 @@ message Cluster {
     // Represents the size of slow start window.
     // If set, the newly created host remains in slow start mode starting from its creation time
     // for the duration of slow start window.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     google.protobuf.Duration slow_start_window = 1;
 
     // This parameter controls the speed of traffic increase over the slow start window. Defaults to 1.0,
@@ -447,13 +507,19 @@ message Cluster {
     //
     // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
     // Once host exits slow start, time_factor and aggression no longer affect its weight.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     core.v3.RuntimeDouble aggression = 2;
 
     // Configures the minimum percentage of origin weight that avoids too small new weight,
     // which may cause endpoints in slow start mode receive no traffic in slow start window.
     // If not specified, the default is 10%.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     type.v3.Percent min_weight_percent = 3;
   }
 
@@ -461,7 +527,10 @@ message Cluster {
   message RoundRobinLbConfig {
     // Configuration for slow start mode.
     // If this configuration is not set, slow start will not be not enabled.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     SlowStartConfig slow_start_config = 1;
   }
 
@@ -501,7 +570,10 @@ message Cluster {
 
     // Configuration for slow start mode.
     // If this configuration is not set, slow start will not be not enabled.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     SlowStartConfig slow_start_config = 3;
   }
 
@@ -601,7 +673,10 @@ message Cluster {
       // if zone aware routing is configured. If not specified, the default is 100%.
       // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
       // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-      option (armeria.xds.supported.field) = 1;
+      option (armeria.xds.supported.field) = {
+          number: 1,
+          since: "1.39.0"
+      };
       type.v3.Percent routing_enabled = 1;
 
       // Configures minimum upstream cluster size required for zone aware routing
@@ -609,14 +684,20 @@ message Cluster {
       // even if zone aware routing is configured. If not specified, the default is 6.
       // * :ref:`runtime values <config_cluster_manager_cluster_runtime_zone_routing>`.
       // * :ref:`Zone aware routing support <arch_overview_load_balancing_zone_aware_routing>`.
-      option (armeria.xds.supported.field) = 2;
+      option (armeria.xds.supported.field) = {
+          number: 2,
+          since: "1.39.0"
+      };
       google.protobuf.UInt64Value min_cluster_size = 2;
 
       // If set to true, Envoy will not consider any hosts when the cluster is in :ref:`panic
       // mode<arch_overview_load_balancing_panic_threshold>`. Instead, the cluster will fail all
       // requests as if all hosts are unhealthy. This can help avoid potentially overwhelming a
       // failing service.
-      option (armeria.xds.supported.field) = 3;
+      option (armeria.xds.supported.field) = {
+          number: 3,
+          since: "1.39.0"
+      };
       bool fail_traffic_on_panic = 3;
     }
 
@@ -663,14 +744,23 @@ message Cluster {
     //
     // .. note::
     //   The specified percent will be truncated to the nearest 1%.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     type.v3.Percent healthy_panic_threshold = 1;
 
     oneof locality_config_specifier {
-      option (armeria.xds.supported.oneof_field) = 2;
+      option (armeria.xds.supported.oneof_field) = {
+          number: 2,
+          since: "1.39.0"
+      };
       ZoneAwareLbConfig zone_aware_lb_config = 2;
 
-      option (armeria.xds.supported.oneof_field) = 3;
+      option (armeria.xds.supported.oneof_field) = {
+          number: 3,
+          since: "1.39.0"
+      };
       LocalityWeightedLbConfig locality_weighted_lb_config = 3;
     }
 
@@ -718,7 +808,10 @@ message Cluster {
     // Specifies the base interval between refreshes. This parameter is required and must be greater
     // than zero and less than
     // :ref:`max_interval <envoy_v3_api_field_config.cluster.v3.Cluster.RefreshRate.max_interval>`.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     google.protobuf.Duration base_interval = 1 [(validate.rules).duration = {
       required: true
       gt {nanos: 1000000}
@@ -728,7 +821,10 @@ message Cluster {
     // greater than or equal to the
     // :ref:`base_interval <envoy_v3_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`  if set. The default
     // is 10 times the :ref:`base_interval <envoy_v3_api_field_config.cluster.v3.Cluster.RefreshRate.base_interval>`.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     google.protobuf.Duration max_interval = 2 [(validate.rules).duration = {gt {nanos: 1000000}}];
   }
 
@@ -845,7 +941,10 @@ message Cluster {
   // :ref:`transport socket match criteria <envoy_v3_api_field_config.core.v3.HealthCheck.transport_socket_match_criteria>` field.
   //
   // [#comment:TODO(incfly): add a detailed architecture doc on intended usage.]
-  option (armeria.xds.supported.field) = 43;
+  option (armeria.xds.supported.field) = {
+      number: 43,
+      since: "1.39.0"
+  };
   repeated TransportSocketMatch transport_socket_matches = 43;
 
   // Optional matcher that selects a transport socket from
@@ -888,7 +987,10 @@ message Cluster {
   // :ref:`statistics <config_cluster_manager_cluster_stats>` if :ref:`alt_stat_name
   // <envoy_v3_api_field_config.cluster.v3.Cluster.alt_stat_name>` is not provided.
   // Any ``:`` in the cluster name will be converted to ``_`` when emitting statistics.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // An optional alternative to the cluster name to be used for observability. This name is used
@@ -905,21 +1007,33 @@ message Cluster {
   oneof cluster_discovery_type {
     // The :ref:`service discovery type <arch_overview_service_discovery_types>`
     // to use for resolving the cluster.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     DiscoveryType type = 2 [(validate.rules).enum = {defined_only: true}];
 
     // The custom cluster type.
-    option (armeria.xds.supported.oneof_field) = 38;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 38,
+        since: "1.41.0"
+    };
     CustomClusterType cluster_type = 38;
   }
 
   // Configuration to use for EDS updates for the Cluster.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   EdsClusterConfig eds_cluster_config = 3;
 
   // The timeout for new network connections to hosts in the cluster.
   // If not set, a default value of 5s will be used.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   google.protobuf.Duration connect_timeout = 4 [(validate.rules).duration = {gt {}}];
 
   // Soft limit on size of the cluster’s connections read and write buffers. If
@@ -929,7 +1043,10 @@ message Cluster {
 
   // The :ref:`load balancer type <arch_overview_load_balancing_types>` to use
   // when picking a host in the cluster.
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   LbPolicy lb_policy = 6 [(validate.rules).enum = {defined_only: true}];
 
   // Setting this is required for specifying members of
@@ -943,14 +1060,20 @@ message Cluster {
   //   Setting this allows non-EDS cluster types to contain embedded EDS equivalent
   //   :ref:`endpoint assignments<envoy_v3_api_msg_config.endpoint.v3.ClusterLoadAssignment>`.
   //
-  option (armeria.xds.supported.field) = 33;
+  option (armeria.xds.supported.field) = {
+      number: 33,
+      since: "1.39.0"
+  };
   endpoint.v3.ClusterLoadAssignment load_assignment = 33;
 
   // Optional :ref:`active health checking <arch_overview_health_checking>`
   // configuration for the cluster. If no
   // configuration is specified no health checking will be done and all cluster
   // members will be considered healthy at all times.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   repeated core.v3.HealthCheck health_checks = 8;
 
   // Optional maximum requests for a single upstream connection. This parameter
@@ -1028,7 +1151,10 @@ message Cluster {
   // specific options.
   // [#next-major-version: make this a list of typed extensions.]
   // [#extension-category: envoy.upstream_options]
-  option (armeria.xds.supported.field) = 36;
+  option (armeria.xds.supported.field) = {
+      number: 36,
+      since: "1.41.0"
+  };
   map<string, google.protobuf.Any> typed_extension_protocol_options = 36;
 
   // If the DNS refresh rate is specified and the cluster type is either
@@ -1044,7 +1170,10 @@ message Cluster {
   // extension point and configuring it with :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.
   // If :ref:`cluster_type<envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type>` is configured with
   // :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`, this field will be ignored.
-  option (armeria.xds.supported.field) = 16;
+  option (armeria.xds.supported.field) = {
+      number: 16,
+      since: "1.39.0"
+  };
   google.protobuf.Duration dns_refresh_rate = 16 [
     deprecated = true,
     (validate.rules).duration = {gt {nanos: 1000000}},
@@ -1082,7 +1211,10 @@ message Cluster {
   // extension point and configuring it with :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.
   // If :ref:`cluster_type<envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type>` is configured with
   // :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`, this field will be ignored.
-  option (armeria.xds.supported.field) = 44;
+  option (armeria.xds.supported.field) = {
+      number: 44,
+      since: "1.39.0"
+  };
   RefreshRate dns_failure_refresh_rate = 44
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
@@ -1093,7 +1225,10 @@ message Cluster {
   // extension point and configuring it with :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`.
   // If :ref:`cluster_type<envoy_v3_api_field_config.cluster.v3.Cluster.cluster_type>` is configured with
   // :ref:`DnsCluster<envoy_v3_api_msg_extensions.clusters.dns.v3.DnsCluster>`, this field will be ignored.
-  option (armeria.xds.supported.field) = 39;
+  option (armeria.xds.supported.field) = {
+      number: 39,
+      since: "1.39.0"
+  };
   bool respect_dns_ttl = 39
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
@@ -1184,7 +1319,10 @@ message Cluster {
   core.v3.BindConfig upstream_bind_config = 21;
 
   // Configuration for load balancing subsetting.
-  option (armeria.xds.supported.field) = 22;
+  option (armeria.xds.supported.field) = {
+      number: 22,
+      since: "1.39.0"
+  };
   LbSubsetConfig lb_subset_config = 22;
 
   // Optional configuration for the load balancing algorithm selected by
@@ -1206,16 +1344,25 @@ message Cluster {
     OriginalDstLbConfig original_dst_lb_config = 34;
 
     // Optional configuration for the LeastRequest load balancing policy.
-    option (armeria.xds.supported.oneof_field) = 37;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 37,
+        since: "1.39.0"
+    };
     LeastRequestLbConfig least_request_lb_config = 37;
 
     // Optional configuration for the RoundRobin load balancing policy.
-    option (armeria.xds.supported.oneof_field) = 56;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 56,
+        since: "1.39.0"
+    };
     RoundRobinLbConfig round_robin_lb_config = 56;
   }
 
   // Common configuration for all load balancer implementations.
-  option (armeria.xds.supported.field) = 27;
+  option (armeria.xds.supported.field) = {
+      number: 27,
+      since: "1.39.0"
+  };
   CommonLbConfig common_lb_config = 27;
 
   // Optional custom transport socket implementation to use for upstream connections.
@@ -1223,7 +1370,10 @@ message Cluster {
   // :ref:`UpstreamTlsContexts <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.UpstreamTlsContext>` in the ``typed_config``.
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
-  option (armeria.xds.supported.field) = 24;
+  option (armeria.xds.supported.field) = {
+      number: 24,
+      since: "1.39.0"
+  };
   core.v3.TransportSocket transport_socket = 24;
 
   // The Metadata field can be used to provide additional information about the

--- a/xds-api/src/main/proto/envoy/config/core/v3/address.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/address.proto
@@ -29,7 +29,10 @@ message Pipe {
   // abstract namespace. The starting '@' is replaced by a null byte by Envoy.
   // Paths starting with '@' will result in an error in environments other than
   // Linux.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string path = 1 [(validate.rules).string = {min_len: 1}];
 
   // The mode for the Pipe. Not applicable for abstract sockets.
@@ -75,13 +78,19 @@ message SocketAddress {
   // address must be an IP (``STATIC`` or ``EDS`` clusters) or a hostname resolved by DNS
   // (``STRICT_DNS`` or ``LOGICAL_DNS`` clusters). Address resolution can be customized
   // via :ref:`resolver_name <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string address = 2 [(validate.rules).string = {min_len: 1}];
 
   oneof port_specifier {
     option (validate.required) = true;
 
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     uint32 port_value = 3 [(validate.rules).uint32 = {lte: 65535}];
 
     // This is only valid if :ref:`resolver_name
@@ -196,10 +205,16 @@ message Address {
   oneof address {
     option (validate.required) = true;
 
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     SocketAddress socket_address = 1;
 
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     Pipe pipe = 2;
 
     // Specifies a user-space address handled by :ref:`internal listeners

--- a/xds-api/src/main/proto/envoy/config/core/v3/base.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/base.proto
@@ -73,7 +73,10 @@ message Locality {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.Locality";
 
   // Region this :ref:`zone <envoy_v3_api_field_config.core.v3.Locality.zone>` belongs to.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string region = 1;
 
   // Defines the local service zone where Envoy is running. Though optional, it
@@ -84,13 +87,19 @@ message Locality {
   // <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html>`_
   // on AWS, `Zone <https://cloud.google.com/compute/docs/regions-zones/>`_ on
   // GCP, etc.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string zone = 2;
 
   // When used for locality of upstream hosts, this field further splits zone
   // into smaller chunks of sub-zones so they can be load balanced
   // independently.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   string sub_zone = 3;
 }
 
@@ -158,7 +167,10 @@ message Node {
   // <config_cluster_manager_cds>`, and :ref:`HTTP tracing
   // <arch_overview_tracing>`, either in this message or via
   // :option:`--service-node`.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   string id = 1;
 
   // Defines the local service cluster name where Envoy is running. Though
@@ -187,16 +199,27 @@ message Node {
   map<string, xds.core.v3.ContextParams> dynamic_parameters = 12;
 
   // Locality specifying where the Envoy instance is running.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   Locality locality = 4;
 
   // Free-form string that identifies the entity requesting config.
   // E.g. "envoy" or "grpc"
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.42.0"
+  };
   string user_agent_name = 6;
 
   oneof user_agent_version_type {
     // Free-form string that identifies the version of the entity requesting config.
     // E.g. "1.12.2" or "abcd1234", or "SpecialEnvoyBuild"
+    option (armeria.xds.supported.oneof_field) = {
+        number: 7,
+        since: "1.42.0"
+    };
     string user_agent_version = 7;
 
     // Structured version of the entity requesting config.
@@ -252,7 +275,10 @@ message Metadata {
   // :ref:`typed_filter_metadata <envoy_v3_api_field_config.core.v3.Metadata.typed_filter_metadata>`
   // fields are present in the metadata with same keys,
   // only ``typed_filter_metadata`` field will be parsed.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   map<string, google.protobuf.Struct> filter_metadata = 1
       [(validate.rules).map = {keys {string {min_len: 1}}}];
 
@@ -409,7 +435,10 @@ message HeaderValue {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.core.HeaderValue";
 
   // Header name.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string key = 1
       [(validate.rules).string =
            {min_len: 1 max_bytes: 16384 well_known_regex: HTTP_HEADER_NAME strict: false}];
@@ -421,7 +450,10 @@ message HeaderValue {
   // unknown header values are replaced with the empty string instead of ``-``.
   // Header value is encoded as string. This does not work for non-utf8 characters.
   // Only one of ``value`` or ``raw_value`` can be set.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string value = 2 [
     (validate.rules).string = {max_bytes: 16384 well_known_regex: HTTP_HEADER_VALUE strict: false},
     (udpa.annotations.field_migrate).oneof_promotion = "value_type"
@@ -502,7 +534,10 @@ message HeaderMap {
 // events inside this directory trigger the watch.
 message WatchedDirectory {
   // Directory path to watch.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string path = 1 [(validate.rules).string = {min_len: 1}];
 }
 
@@ -515,15 +550,24 @@ message DataSource {
     option (validate.required) = true;
 
     // Local filesystem data source.
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string filename = 1 [(validate.rules).string = {min_len: 1}];
 
     // Bytes inlined in the configuration.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     bytes inline_bytes = 2;
 
     // String inlined in the configuration.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     string inline_string = 3;
 
     // Environment variable data source.
@@ -633,7 +677,10 @@ message TransportSocket {
 
   reserved "config";
 
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   // The name of the transport socket to instantiate. The name must match a supported transport
   // socket implementation.
   string name = 1 [(validate.rules).string = {min_len: 1}];
@@ -641,7 +688,10 @@ message TransportSocket {
   // Implementation specific configuration which depends on the implementation being instantiated.
   // See the supported transport socket implementations for further documentation.
   oneof config_type {
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     google.protobuf.Any typed_config = 3;
   }
 }

--- a/xds-api/src/main/proto/envoy/config/core/v3/config_source.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/config_source.proto
@@ -30,14 +30,20 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // xDS API and non-xDS services version. This is used to describe both resource and transport
 // protocol versions (in distinct configuration fields).
 enum ApiVersion {
-  option (armeria.xds.supported.enum_value) = 0;
+  option (armeria.xds.supported.enum_value) = {
+      number: 0,
+      since: "1.39.0"
+  };
   // When not specified, we assume v3; it is the only supported version.
   AUTO = 0;
 
   // Use xDS v2 API. This is no longer supported.
   V2 = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version_enum) = "3.0"];
 
-  option (armeria.xds.supported.enum_value) = 2;
+  option (armeria.xds.supported.enum_value) = {
+      number: 2,
+      since: "1.39.0"
+  };
   // Use xDS v3 API.
   V3 = 2;
 }
@@ -60,36 +66,54 @@ message ApiConfigSource {
     // the v2 protos is used.
     REST = 1;
 
-    option (armeria.xds.supported.enum_value) = 2;
+    option (armeria.xds.supported.enum_value) = {
+        number: 2,
+        since: "1.39.0"
+    };
     // SotW gRPC service.
     GRPC = 2;
 
-    option (armeria.xds.supported.enum_value) = 3;
+    option (armeria.xds.supported.enum_value) = {
+        number: 3,
+        since: "1.39.0"
+    };
     // Using the delta xDS gRPC service, i.e. DeltaDiscovery{Request,Response}
     // rather than Discovery{Request,Response}. Rather than sending Envoy the entire state
     // with every update, the xDS server only sends what has changed since the last update.
     DELTA_GRPC = 3;
 
-    option (armeria.xds.supported.enum_value) = 5;
+    option (armeria.xds.supported.enum_value) = {
+        number: 5,
+        since: "1.39.0"
+    };
     // SotW xDS gRPC with ADS. All resources which resolve to this configuration source will be
     // multiplexed on a single connection to an ADS endpoint.
     // [#not-implemented-hide:]
     AGGREGATED_GRPC = 5;
 
-    option (armeria.xds.supported.enum_value) = 6;
+    option (armeria.xds.supported.enum_value) = {
+        number: 6,
+        since: "1.39.0"
+    };
     // Delta xDS gRPC with ADS. All resources which resolve to this configuration source will be
     // multiplexed on a single connection to an ADS endpoint.
     // [#not-implemented-hide:]
     AGGREGATED_DELTA_GRPC = 6;
   }
 
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   // API type (gRPC, REST, delta gRPC)
   ApiType api_type = 1 [(validate.rules).enum = {defined_only: true}];
 
   // API version for xDS transport protocol. This describes the xDS gRPC/REST
   // endpoint and version of [Delta]DiscoveryRequest/Response used on the wire.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   ApiVersion transport_api_version = 8 [(validate.rules).enum = {defined_only: true}];
 
   // Cluster names should be used only with REST. If > 1
@@ -104,7 +128,10 @@ message ApiConfigSource {
 
   // Multiple gRPC services be provided for GRPC. If > 1 cluster is defined,
   // services will be cycled through if any kind of failure occurs.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   repeated GrpcService grpc_services = 4;
 
   // For REST APIs, the delay between successive polls.
@@ -168,7 +195,10 @@ message RateLimitSettings {
 
 // Local filesystem path configuration source.
 message PathConfigSource {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   // Path on the filesystem to source and watch for configuration updates.
   // When sourcing configuration for a :ref:`secret <envoy_v3_api_msg_extensions.transport_sockets.tls.v3.Secret>`,
   // the certificate and key files are also watched for updates.
@@ -187,7 +217,10 @@ message PathConfigSource {
   //   this path. This is required in certain deployment scenarios. See below for more information.
   string path = 1 [(validate.rules).string = {min_len: 1}];
 
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   // If configured, this directory will be watched for *moves*. When an entry in this directory is
   // moved to, the ``path`` will be reloaded. This is required in certain deployment scenarios.
   //
@@ -227,16 +260,25 @@ message ConfigSource {
     string path = 1 [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
     // Local filesystem path configuration source.
-    option (armeria.xds.supported.oneof_field) = 8;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 8,
+        since: "1.39.0"
+    };
     PathConfigSource path_config_source = 8;
 
     // API configuration source.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     ApiConfigSource api_config_source = 2;
 
     // When set, ADS will be used to fetch resources. The ADS API configuration
     // source in the bootstrap configuration is used.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     AggregatedConfigSource ads = 3;
 
     // [#not-implemented-hide:]
@@ -250,7 +292,10 @@ message ConfigSource {
     // [#next-major-version: In xDS v3, consider replacing the ads field with this one, since
     // this field can implicitly mean to use the same stream in the case where the ConfigSource
     // is provided via ADS and the specified data can also be obtained via ADS.]
-    option (armeria.xds.supported.oneof_field) = 5;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 5,
+        since: "1.39.0"
+    };
     SelfConfigSource self = 5;
 
     // Armeria extension: a custom config source implementation resolved via
@@ -259,7 +304,10 @@ message ConfigSource {
     // (e.g. CentralDogma, etcd, Consul) without modifying the upstream proto
     // definition.
     // The large field number avoids conflicts with future upstream additions.
-    option (armeria.xds.supported.oneof_field) = 1000;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1000,
+        since: "1.39.0"
+    };
     TypedExtensionConfig custom_config_source = 1000;
   }
 
@@ -270,13 +318,19 @@ message ConfigSource {
   // when the xDS API subscription starts, and is disarmed on first config update or on error. 0
   // means no timeout - Envoy will wait indefinitely for the first xDS config (unless another
   // timeout applies). The default is 15s.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   google.protobuf.Duration initial_fetch_timeout = 4;
 
   // API version for xDS resources. This implies the type URLs that the client
   // will request for resources and the resource type that the client will in
   // turn expect to be delivered.
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   ApiVersion resource_api_version = 6 [(validate.rules).enum = {defined_only: true}];
 }
 

--- a/xds-api/src/main/proto/envoy/config/core/v3/extension.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/extension.proto
@@ -21,7 +21,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message TypedExtensionConfig {
   // The name of an extension. This is not used to select the extension, instead
   // it serves the role of an opaque identifier.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.40.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // The typed config for the extension. The type URL will be used to identify
@@ -30,6 +33,9 @@ message TypedExtensionConfig {
   // URL of ``TypedStruct`` will be utilized. See the
   // :ref:`extension configuration overview
   // <config_overview_extension_configuration>` for further details.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.40.0"
+  };
   google.protobuf.Any typed_config = 2 [(validate.rules).any = {required: true}];
 }

--- a/xds-api/src/main/proto/envoy/config/core/v3/grpc_service.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/grpc_service.proto
@@ -39,7 +39,10 @@ message GrpcService {
     // The name of the upstream gRPC cluster. SSL credentials will be supplied
     // in the :ref:`Cluster <envoy_v3_api_msg_config.cluster.v3.Cluster>` :ref:`transport_socket
     // <envoy_v3_api_field_config.cluster.v3.Cluster.transport_socket>`.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
 
     // The ``:authority`` header in the grpc request. If this field is not set, the authority header value will be ``cluster_name``.
@@ -323,7 +326,10 @@ message GrpcService {
     // Envoy's in-built gRPC client.
     // See the :ref:`gRPC services overview <arch_overview_grpc_services>`
     // documentation for discussion on gRPC client selection.
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     EnvoyGrpc envoy_grpc = 1;
 
     // `Google C++ gRPC client <https://github.com/grpc/grpc>`_
@@ -341,7 +347,10 @@ message GrpcService {
   // be injected. For more information, including details on header value syntax, see the
   // documentation on :ref:`custom request headers
   // <config_http_conn_man_headers_custom_request_headers>`.
-  option (armeria.xds.supported.field) = 5;
+  option (armeria.xds.supported.field) = {
+      number: 5,
+      since: "1.39.0"
+  };
   repeated HeaderValue initial_metadata = 5;
 
   // Optional default retry policy for RPCs or streams initiated toward this gRPC service.

--- a/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
+++ b/xds-api/src/main/proto/envoy/config/core/v3/health_check.proto
@@ -38,15 +38,24 @@ enum HealthStatus {
   // The health status is not known. This is interpreted by Envoy as ``HEALTHY``.
   UNKNOWN = 0;
 
-  option (armeria.xds.supported.enum_value) = 1;
+  option (armeria.xds.supported.enum_value) = {
+      number: 1,
+      since: "1.39.0"
+  };
   // Healthy.
   HEALTHY = 1;
 
-  option (armeria.xds.supported.enum_value) = 2;
+  option (armeria.xds.supported.enum_value) = {
+      number: 2,
+      since: "1.39.0"
+  };
   // Unhealthy.
   UNHEALTHY = 2;
 
-  option (armeria.xds.supported.enum_value) = 3;
+  option (armeria.xds.supported.enum_value) = {
+      number: 3,
+      since: "1.39.0"
+  };
   // Connection draining in progress. E.g.,
   // `<https://aws.amazon.com/blogs/aws/elb-connection-draining-remove-instances-from-service-with-care/>`_
   // or
@@ -58,7 +67,10 @@ enum HealthStatus {
   // ``UNHEALTHY``.
   TIMEOUT = 4;
 
-  option (armeria.xds.supported.enum_value) = 5;
+  option (armeria.xds.supported.enum_value) = {
+      number: 5,
+      since: "1.39.0"
+  };
   // Degraded.
   DEGRADED = 5;
 }
@@ -102,12 +114,18 @@ message HealthCheck {
     // left empty (default value), the name of the cluster this health check is associated
     // with will be used. The host header can be customized for a specific endpoint by setting the
     // :ref:`hostname <envoy_v3_api_field_config.endpoint.v3.Endpoint.HealthCheckConfig.hostname>` field.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string host = 1 [(validate.rules).string = {well_known_regex: HTTP_HEADER_VALUE}];
 
     // Specifies the HTTP path that will be requested during health checking. For example
     // ``/healthcheck``.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     string path = 2 [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_VALUE}];
 
     // HTTP specific payload to be sent as the request body during health checking.
@@ -174,7 +192,10 @@ message HealthCheck {
     // Request body payloads are supported for POST, PUT, PATCH, and OPTIONS methods only.
     // CONNECT method is disallowed because it is not appropriate for health check request.
     // If a non-200 response is expected by the method, it needs to be set in :ref:`expected_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.expected_statuses>`.
-    option (armeria.xds.supported.field) = 13;
+    option (armeria.xds.supported.field) = {
+        number: 13,
+        since: "1.39.0"
+    };
     RequestMethod method = 13 [(validate.rules).enum = {defined_only: true not_in: 6}];
   }
 
@@ -277,14 +298,20 @@ message HealthCheck {
 
   // The time to wait for a health check response. If the timeout is reached the
   // health check attempt will be considered a failure.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   google.protobuf.Duration timeout = 1 [(validate.rules).duration = {
     required: true
     gt {}
   }];
 
   // The interval between health checks.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   google.protobuf.Duration interval = 2 [(validate.rules).duration = {
     required: true
     gt {}
@@ -312,13 +339,19 @@ message HealthCheck {
   // :ref:`expected_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.expected_statuses>`
   // or :ref:`retriable_statuses <envoy_v3_api_field_config.core.v3.HealthCheck.HttpHealthCheck.retriable_statuses>`,
   // this threshold is ignored and the host is considered immediately unhealthy.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   google.protobuf.UInt32Value unhealthy_threshold = 4 [(validate.rules).message = {required: true}];
 
   // The number of healthy health checks required before a host is marked
   // healthy. Note that during startup, only a single successful health check is
   // required to mark a host healthy.
-  option (armeria.xds.supported.field) = 5;
+  option (armeria.xds.supported.field) = {
+      number: 5,
+      since: "1.39.0"
+  };
   google.protobuf.UInt32Value healthy_threshold = 5 [(validate.rules).message = {required: true}];
 
   // [#not-implemented-hide:] Non-serving port for health checking.
@@ -331,7 +364,10 @@ message HealthCheck {
     option (validate.required) = true;
 
     // HTTP health check.
-    option (armeria.xds.supported.oneof_field) = 8;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 8,
+        since: "1.39.0"
+    };
     HttpHealthCheck http_health_check = 8;
 
     // TCP health check.

--- a/xds-api/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
+++ b/xds-api/src/main/proto/envoy/config/endpoint/v3/endpoint.proto
@@ -100,7 +100,10 @@ message ClusterLoadAssignment {
     //
     // Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
     // :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     google.protobuf.UInt32Value overprovisioning_factor = 3 [(validate.rules).uint32 = {gt: 0}];
 
     // The max time until which the endpoints from this assignment can be used.
@@ -118,7 +121,10 @@ message ClusterLoadAssignment {
     // .. note::
     //   This is not currently implemented for
     //   :ref:`locality weighted load balancing <arch_overview_load_balancing_locality_weighted_lb>`.
-    option (armeria.xds.supported.field) = 6;
+    option (armeria.xds.supported.field) = {
+        number: 6,
+        since: "1.39.0"
+    };
     bool weighted_priority_health = 6;
   }
 
@@ -126,11 +132,17 @@ message ClusterLoadAssignment {
   // <envoy_v3_api_field_config.cluster.v3.Cluster.EdsClusterConfig.service_name>` value if specified
   // in the cluster :ref:`EdsClusterConfig
   // <envoy_v3_api_msg_config.cluster.v3.Cluster.EdsClusterConfig>`.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string cluster_name = 1 [(validate.rules).string = {min_len: 1}];
 
   // List of endpoints to load balance to.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated LocalityLbEndpoints endpoints = 2;
 
   // Map of named endpoints that can be referenced in LocalityLbEndpoints.
@@ -138,6 +150,9 @@ message ClusterLoadAssignment {
   map<string, Endpoint> named_endpoints = 5;
 
   // Load balancing policy settings.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   Policy policy = 4;
 }

--- a/xds-api/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
+++ b/xds-api/src/main/proto/envoy/config/endpoint/v3/endpoint_components.proto
@@ -40,7 +40,10 @@ message Endpoint {
     // as the host's serving address port. This provides an alternative health
     // check port. Setting this with a non-zero value allows an upstream host
     // to have different health check address port.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     uint32 port_value = 1 [(validate.rules).uint32 = {lte: 65535}];
 
     // By default, the host header for L7 health checks is controlled by cluster level configuration
@@ -48,7 +51,10 @@ message Endpoint {
     // :ref:`authority <envoy_v3_api_field_config.core.v3.HealthCheck.GrpcHealthCheck.authority>`). Setting this
     // to a non-empty value allows overriding the cluster level configuration for a specific
     // endpoint.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     string hostname = 2;
 
     // Optional alternative health check host address.
@@ -56,12 +62,18 @@ message Endpoint {
     // .. attention::
     //
     //   The form of the health check host address is expected to be a direct IP address.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     core.v3.Address address = 3;
 
     // Optional flag to control if perform active health check for this endpoint.
     // Active health check is enabled by default if there is a health checker.
-    option (armeria.xds.supported.field) = 4;
+    option (armeria.xds.supported.field) = {
+        number: 4,
+        since: "1.39.0"
+    };
     bool disable_active_health_check = 4;
   }
 
@@ -79,7 +91,10 @@ message Endpoint {
   //   specified :ref:`resolver <envoy_v3_api_field_config.core.v3.SocketAddress.resolver_name>`
   //   in the Address). For LOGICAL or STRICT DNS, it is expected to be hostname,
   //   and will be resolved via DNS.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   core.v3.Address address = 1;
 
   // The optional health check configuration is used as configuration for the
@@ -89,14 +104,20 @@ message Endpoint {
   //
   //   This takes into effect only for upstream clusters with
   //   :ref:`active health checking <arch_overview_health_checking>` enabled.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   HealthCheckConfig health_check_config = 2;
 
   // The hostname associated with this endpoint. This hostname is not used for routing or address
   // resolution. If provided, it will be associated with the endpoint, and can be used for features
   // that require a hostname, like
   // :ref:`auto_host_rewrite <envoy_v3_api_field_config.route.v3.RouteAction.auto_host_rewrite>`.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   string hostname = 3;
 
   // An ordered list of addresses that together with ``address`` comprise the
@@ -114,7 +135,10 @@ message LbEndpoint {
 
   // Upstream host identifier or a named reference.
   oneof host_identifier {
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     Endpoint endpoint = 1;
 
     // [#not-implemented-hide:]
@@ -122,7 +146,10 @@ message LbEndpoint {
   }
 
   // Optional health status when known and supplied by EDS server.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   core.v3.HealthStatus health_status = 2;
 
   // The endpoint metadata specifies values that may be used by the load
@@ -132,7 +159,10 @@ message LbEndpoint {
   // This may be matched against in a route's
   // :ref:`RouteAction <envoy_v3_api_msg_config.route.v3.RouteAction>` metadata_match field
   // to subset the endpoints considered in cluster load balancing.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   core.v3.Metadata metadata = 3;
 
   // The optional load balancing weight of the upstream host; at least 1.
@@ -144,7 +174,10 @@ message LbEndpoint {
   // LocalityLbEndpoints. If unspecified, will be treated as 1. The sum
   // of the weights of all endpoints in the endpoint's locality must not
   // exceed uint32_t maximal value (4294967295).
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   google.protobuf.UInt32Value load_balancing_weight = 4 [(validate.rules).uint32 = {gte: 1}];
 }
 
@@ -184,17 +217,26 @@ message LocalityLbEndpoints {
   }
 
   // Identifies location of where the upstream hosts run.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   core.v3.Locality locality = 1;
 
   // Metadata to provide additional information about the locality endpoints in aggregate.
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+      number: 9,
+      since: "1.39.0"
+  };
   core.v3.Metadata metadata = 9;
 
   // The group of endpoints belonging to the locality specified.
   // This is ignored if :ref:`leds_cluster_locality_config
   // <envoy_v3_api_field_config.endpoint.v3.LocalityLbEndpoints.leds_cluster_locality_config>` is set.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated LbEndpoint lb_endpoints = 2;
 
   oneof lb_config {
@@ -221,7 +263,10 @@ message LocalityLbEndpoints {
   // configured. These weights are ignored otherwise. If no weights are
   // specified when locality weighted load balancing is enabled, the locality is
   // assigned no load.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   google.protobuf.UInt32Value load_balancing_weight = 3 [(validate.rules).uint32 = {gte: 1}];
 
   // Optional: the priority for this LocalityLbEndpoints. If unspecified this will
@@ -233,7 +278,10 @@ message LocalityLbEndpoints {
   // next highest priority group. Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>`.
   //
   // Priorities should range from 0 (highest) to N (lowest) without skipping.
-  option (armeria.xds.supported.field) = 5;
+  option (armeria.xds.supported.field) = {
+      number: 5,
+      since: "1.39.0"
+  };
   uint32 priority = 5 [(validate.rules).uint32 = {lte: 128}];
 
   // Optional: Per locality proximity value which indicates how close this

--- a/xds-api/src/main/proto/envoy/config/listener/v3/api_listener.proto
+++ b/xds-api/src/main/proto/envoy/config/listener/v3/api_listener.proto
@@ -31,6 +31,9 @@ message ApiListener {
   // it would have caused circular dependencies for go protos: lds.proto depends on this file,
   // and http_connection_manager.proto depends on rds.proto, which is in the same directory as
   // lds.proto, so lds.proto cannot depend on this file.]
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   google.protobuf.Any api_listener = 1;
 }

--- a/xds-api/src/main/proto/envoy/config/listener/v3/listener.proto
+++ b/xds-api/src/main/proto/envoy/config/listener/v3/listener.proto
@@ -143,7 +143,10 @@ message Listener {
   // The unique name by which this listener is known. If no name is provided,
   // Envoy will allocate an internal UUID for the listener. If the listener is to be dynamically
   // updated or removed via :ref:`LDS <config_listeners_lds>` a unique name must be provided.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1;
 
   // The address that the listener should listen on. In general, the address must be unique, though
@@ -175,7 +178,10 @@ message Listener {
   //
   // Example using SNI for filter chain selection can be found in the
   // :ref:`FAQ entry <faq_how_to_setup_sni>`.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.41.0"
+  };
   repeated FilterChain filter_chains = 3;
 
   // Discover filter chains configurations by external service. Dynamic discovery of filter chains is allowed
@@ -211,7 +217,10 @@ message Listener {
 
   // The default filter chain if none of the filter chain matches. If no default filter chain is supplied,
   // the connection will be closed. The filter chain match is ignored in this field.
-  option (armeria.xds.supported.field) = 25;
+  option (armeria.xds.supported.field) = {
+      number: 25,
+      since: "1.41.0"
+  };
   FilterChain default_filter_chain = 25;
 
   // Soft limit on size of the listener’s new connection read and write buffers.
@@ -333,7 +342,10 @@ message Listener {
   // and the top-level Listener should essentially be a oneof that selects between the
   // socket listener and the various types of API listener. That way, a given Listener message
   // can structurally only contain the fields of the relevant type.]
-  option (armeria.xds.supported.field) = 19;
+  option (armeria.xds.supported.field) = {
+      number: 19,
+      since: "1.39.0"
+  };
   ApiListener api_listener = 19;
 
   // The listener's connection balancer configuration, currently only applicable to TCP listeners.

--- a/xds-api/src/main/proto/envoy/config/listener/v3/listener_components.proto
+++ b/xds-api/src/main/proto/envoy/config/listener/v3/listener_components.proto
@@ -35,11 +35,17 @@ message Filter {
   reserved "config";
 
   // The name of the filter configuration.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   oneof config_type {
-    option (armeria.xds.supported.oneof_field) = 4;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 4,
+        since: "1.41.0"
+    };
     // Filter specific configuration which depends on the filter being
     // instantiated. See the supported filters for further documentation.
     // [#extension-category: envoy.filters.network]
@@ -115,7 +121,10 @@ message FilterChainMatch {
 
   // Optional destination port to consider when use_original_dst is set on the
   // listener in determining a filter chain match.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.41.0"
+  };
   google.protobuf.UInt32Value destination_port = 8 [(validate.rules).uint32 = {lte: 65535 gte: 1}];
 
   // If non-empty, an IP address and prefix length to match addresses when the
@@ -164,7 +173,10 @@ message FilterChainMatch {
   //
   //   See the :ref:`FAQ entry <faq_how_to_setup_sni>` on how to configure SNI for more
   //   information.
-  option (armeria.xds.supported.field) = 11;
+  option (armeria.xds.supported.field) = {
+      number: 11,
+      since: "1.41.0"
+  };
   repeated string server_names = 11;
 
   // If non-empty, a transport protocol to consider when determining a filter chain match.
@@ -176,7 +188,10 @@ message FilterChainMatch {
   // * ``raw_buffer`` - default, used when no transport protocol is detected,
   // * ``tls`` - set by :ref:`envoy.filters.listener.tls_inspector <config_listener_filters_tls_inspector>`
   //   when TLS protocol is detected.
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+      number: 9,
+      since: "1.41.0"
+  };
   string transport_protocol = 9;
 
   // If non-empty, a list of application protocols (e.g. ALPN for TLS protocol) to consider when
@@ -198,7 +213,10 @@ message FilterChainMatch {
   //   However, the use of ALPN is pretty much limited to the HTTP/2 traffic on the Internet,
   //   and matching on values other than ``h2`` is going to lead to a lot of false negatives,
   //   unless all connecting clients are known to use ALPN.
-  option (armeria.xds.supported.field) = 10;
+  option (armeria.xds.supported.field) = {
+      number: 10,
+      since: "1.41.0"
+  };
   repeated string application_protocols = 10;
 }
 
@@ -213,7 +231,10 @@ message FilterChain {
   reserved "tls_context", "on_demand_configuration";
 
   // The criteria to use when matching a connection to this filter chain.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   FilterChainMatch filter_chain_match = 1;
 
   // A list of individual network filters that make up the filter chain for
@@ -226,7 +247,10 @@ message FilterChain {
   // to TCP, the onData() method will never be called. Therefore, network filters
   // for QUIC listeners should only expect to do work at the start of a new connection
   // (i.e. in onNewConnection()). HCM must be the last (or only) filter in the chain.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.41.0"
+  };
   repeated Filter filters = 3;
 
   // Whether the listener should expect a PROXY protocol V1 header on new
@@ -251,7 +275,10 @@ message FilterChain {
   // If no transport socket configuration is specified, new connections
   // will be set up with plaintext.
   // [#extension-category: envoy.transport_sockets.downstream]
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.41.0"
+  };
   core.v3.TransportSocket transport_socket = 6;
 
   // If present and nonzero, the amount of time to allow incoming connections to complete any

--- a/xds-api/src/main/proto/envoy/config/route/v3/route.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route.proto
@@ -32,11 +32,17 @@ message RouteConfiguration {
   // :ref:`route_config_name
   // <envoy_v3_api_field_extensions.filters.network.http_connection_manager.v3.Rds.route_config_name>` in
   // :ref:`envoy_v3_api_msg_extensions.filters.network.http_connection_manager.v3.Rds`.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1;
 
   // An array of virtual hosts that make up the route table.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated VirtualHost virtual_hosts = 2;
 
   // An array of virtual hosts will be dynamically loaded via the VHDS API.
@@ -136,7 +142,10 @@ message RouteConfiguration {
   // .. note::
   //     This option will not strip the port number (if any) contained in route config
   //     :ref:`envoy_v3_api_msg_config.route.v3.VirtualHost`.domains field.
-  option (armeria.xds.supported.field) = 14;
+  option (armeria.xds.supported.field) = {
+      number: 14,
+      since: "1.39.0"
+  };
   bool ignore_port_in_host_matching = 14;
 
   // Normally, virtual host matching is done using the :authority (or

--- a/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
+++ b/xds-api/src/main/proto/envoy/config/route/v3/route_components.proto
@@ -67,7 +67,10 @@ message VirtualHost {
 
   // The logical name of the virtual host. This is used when emitting certain
   // statistics but is not relevant for routing.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   // A list of domains (host/authority header) that will be matched to this
@@ -88,7 +91,10 @@ message VirtualHost {
   //   must be unique across all virtual hosts or the config will fail to load.
   //
   // Domains cannot contain control characters. This is validated by the well_known_regex HTTP_HEADER_VALUE.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated string domains = 2 [(validate.rules).repeated = {
     min_items: 1
     items {string {well_known_regex: HTTP_HEADER_VALUE strict: false}}
@@ -97,7 +103,10 @@ message VirtualHost {
   // The list of routes that will be matched, in order, for incoming requests.
   // The first route that matches will be used.
   // Only one of this and ``matcher`` can be specified.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   repeated Route routes = 3 [(udpa.annotations.field_migrate).oneof_promotion = "route_selection"];
 
   // The match tree to use when resolving route actions for incoming requests. Only one of this and ``routes``
@@ -166,7 +175,10 @@ message VirtualHost {
   // [#comment: An entry's value may be wrapped in a
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
-  option (armeria.xds.supported.field) = 15;
+  option (armeria.xds.supported.field) = {
+      number: 15,
+      since: "1.39.0"
+  };
   map<string, google.protobuf.Any> typed_per_filter_config = 15;
 
   // Decides whether the :ref:`x-envoy-attempt-count
@@ -200,7 +212,10 @@ message VirtualHost {
   // Indicates the retry policy for all routes in this virtual host. Note that setting a
   // route level entry will take precedence over this config and it'll be treated
   // independently (e.g., values are not inherited).
-  option (armeria.xds.supported.field) = 16;
+  option (armeria.xds.supported.field) = {
+      number: 16,
+      since: "1.39.0"
+  };
   RetryPolicy retry_policy = 16;
 
   // [#not-implemented-hide:]
@@ -294,18 +309,27 @@ message Route {
   reserved "per_filter_config";
 
   // Name for the route.
-  option (armeria.xds.supported.field) = 14;
+  option (armeria.xds.supported.field) = {
+      number: 14,
+      since: "1.39.0"
+  };
   string name = 14;
 
   // Route matching parameters.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   RouteMatch match = 1 [(validate.rules).message = {required: true}];
 
   oneof action {
     option (validate.required) = true;
 
     // Route request to some upstream cluster.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     RouteAction route = 2;
 
     // Return a redirect.
@@ -325,7 +349,10 @@ message Route {
     // without forwarding to an upstream host. This will be used in non-proxy
     // xDS clients like the gRPC server. It could also be used in the future
     // in Envoy for a filter that directly generates responses for requests.
-    option (armeria.xds.supported.oneof_field) = 18;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 18,
+        since: "1.41.0"
+    };
     NonForwardingAction non_forwarding_action = 18;
   }
 
@@ -347,7 +374,10 @@ message Route {
   // [#comment: An entry's value may be wrapped in a
   // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
   // message to specify additional options.]
-  option (armeria.xds.supported.field) = 13;
+  option (armeria.xds.supported.field) = {
+      number: 13,
+      since: "1.39.0"
+  };
   map<string, google.protobuf.Any> typed_per_filter_config = 13;
 
   // Specifies a set of headers that will be added to requests matching this
@@ -454,7 +484,10 @@ message WeightedCluster {
     // [#next-major-version: Need to add back the validation rule: (validate.rules).string = {min_len: 1}]
     // Name of the upstream cluster. The cluster must exist in the
     // :ref:`cluster manager configuration <config_cluster_manager>`.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.41.0"
+    };
     string name = 1 [(udpa.annotations.field_migrate).oneof_promotion = "cluster_specifier"];
 
     // Only one of ``name`` and ``cluster_header`` may be specified.
@@ -482,7 +515,10 @@ message WeightedCluster {
     // is determined by its weight. The sum of weights across all
     // entries in the clusters array must be greater than 0, and must not exceed
     // uint32_t maximal value (4294967295).
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.41.0"
+    };
     google.protobuf.UInt32Value weight = 2;
 
     // Optional endpoint metadata match criteria used by the subset load balancer. Only endpoints in
@@ -490,7 +526,10 @@ message WeightedCluster {
     // load balancing. Note that this will be merged with what's provided in
     // :ref:`RouteAction.metadata_match <envoy_v3_api_field_config.route.v3.RouteAction.metadata_match>`, with
     // values here taking precedence. The filter name should be specified as ``envoy.lb``.
-    option (armeria.xds.supported.field) = 3;
+    option (armeria.xds.supported.field) = {
+        number: 3,
+        since: "1.41.0"
+    };
     core.v3.Metadata metadata_match = 3;
 
     // Specifies a list of headers to be added to requests when this cluster is selected
@@ -533,7 +572,10 @@ message WeightedCluster {
     // [#comment: An entry's value may be wrapped in a
     // :ref:`FilterConfig<envoy_v3_api_msg_config.route.v3.FilterConfig>`
     // message to specify additional options.]
-    option (armeria.xds.supported.field) = 10;
+    option (armeria.xds.supported.field) = {
+        number: 10,
+        since: "1.41.0"
+    };
     map<string, google.protobuf.Any> typed_per_filter_config = 10;
 
     oneof host_rewrite_specifier {
@@ -545,7 +587,10 @@ message WeightedCluster {
   }
 
   // Specifies one or more upstream clusters associated with the route.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   repeated ClusterWeight clusters = 1 [(validate.rules).repeated = {min_items: 1}];
 
   // Specifies the total weight across all clusters. The sum of all cluster weights must equal this
@@ -640,12 +685,18 @@ message RouteMatch {
 
     // If specified, the route is a prefix rule meaning that the prefix must
     // match the beginning of the ``:path`` header.
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string prefix = 1;
 
     // If specified, the route is an exact path rule meaning that the path must
     // exactly match the ``:path`` header once the query string is removed.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     string path = 2;
 
     // If specified, the route is a regular expression rule meaning that the
@@ -660,7 +711,10 @@ message RouteMatch {
     // path_specifier entirely and just rely on a set of header matchers which can already match
     // on :path, etc. The issue with that is it is unclear how to generically deal with query string
     // stripping. This needs more thought.]
-    option (armeria.xds.supported.oneof_field) = 10;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 10,
+        since: "1.39.0"
+    };
     type.matcher.v3.RegexMatcher safe_regex = 10 [(validate.rules).message = {required: true}];
 
     // If this is used as the matcher, the matcher will only match CONNECT or CONNECT-UDP requests.
@@ -682,7 +736,10 @@ message RouteMatch {
     // but would not match ``/api/developer``
     //
     // Expect the value to not contain ``?`` or ``#`` and not to end in ``/``
-    option (armeria.xds.supported.oneof_field) = 14;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 14,
+        since: "1.39.0"
+    };
     string path_separated_prefix = 14 [(validate.rules).string = {pattern: "^[^?#]+[^?#/]$"}];
 
     // [#extension-category: envoy.path.match]
@@ -691,7 +748,10 @@ message RouteMatch {
 
   // Indicates that prefix/path matching should be case-sensitive. The default
   // is true. Ignored for safe_regex matching.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   google.protobuf.BoolValue case_sensitive = 4;
 
   // Indicates that the route should additionally match on a runtime key. Every time the route
@@ -717,7 +777,10 @@ message RouteMatch {
   // config. A match will happen if all the headers in the route are present in
   // the request with the same values (or based on presence if the value field
   // is not in the config).
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   repeated HeaderMatcher headers = 6;
 
   // Specifies a set of URL query parameters on which the route should
@@ -734,7 +797,10 @@ message RouteMatch {
   //    is used, the transcoded message fields may be different. The query parameters are
   //    URL-encoded, but the message fields are not. For example, if a query
   //    parameter is "foo%20bar", the message field will be "foo bar".
-  option (armeria.xds.supported.field) = 7;
+  option (armeria.xds.supported.field) = {
+      number: 7,
+      since: "1.39.0"
+  };
   repeated QueryParameterMatcher query_parameters = 7;
 
   // Specifies a set of cookies on which the route should match. The router parses the ``Cookie``
@@ -745,7 +811,10 @@ message RouteMatch {
   // If specified, only gRPC requests will be matched. The router will check
   // that the ``Content-Type`` header has ``application/grpc`` or one of the various
   // ``application/grpc+`` values.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   GrpcRouteMatchOptions grpc = 8;
 
   // If specified, the client tls context will be matched against the defined
@@ -1157,7 +1226,10 @@ message RouteAction {
 
     // Indicates the upstream cluster to which the request should be routed
     // to.
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string cluster = 1 [(validate.rules).string = {min_len: 1}];
 
     // Envoy will determine the cluster to route to by reading the value of the
@@ -1181,7 +1253,10 @@ message RouteAction {
     // assigned to each cluster. See
     // :ref:`traffic splitting <config_http_conn_man_route_table_traffic_splitting_split>`
     // for additional documentation.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.41.0"
+    };
     WeightedCluster weighted_clusters = 3;
 
     // Name of the cluster specifier plugin to use to determine the cluster for requests on this route.
@@ -1205,7 +1280,10 @@ message RouteAction {
   // for load balancing. If using :ref:`weighted_clusters
   // <envoy_v3_api_field_config.route.v3.RouteAction.weighted_clusters>`, metadata will be merged, with values
   // provided there taking precedence. The filter name should be specified as ``envoy.lb``.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.39.0"
+  };
   core.v3.Metadata metadata_match = 4;
 
   // Indicates that during forwarding, the matched prefix (or path) should be
@@ -1406,7 +1484,10 @@ message RouteAction {
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
   //   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
   //   :ref:`retry overview <arch_overview_http_routing_retry>`.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   google.protobuf.Duration timeout = 8;
 
   // Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
@@ -1461,7 +1542,10 @@ message RouteAction {
   // Indicates that the route has a retry policy. Note that if this is set,
   // it'll take precedence over the virtual host level retry policy entirely
   // (e.g., policies are not merged, the most internal one becomes the enforced policy).
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+      number: 9,
+      since: "1.39.0"
+  };
   RetryPolicy retry_policy = 9;
 
   // [#not-implemented-hide:]
@@ -1641,7 +1725,10 @@ message RetryPolicy {
     // than zero. Values less than 1 ms are rounded up to 1 ms.
     // See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion of Envoy's
     // back-off algorithm.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     google.protobuf.Duration base_interval = 1 [(validate.rules).duration = {
       required: true
       gt {}
@@ -1651,7 +1738,10 @@ message RetryPolicy {
     // greater than or equal to the ``base_interval`` if set. The default is 10 times the
     // ``base_interval``. See :ref:`config_http_filters_router_x-envoy-max-retries` for a discussion
     // of Envoy's back-off algorithm.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     google.protobuf.Duration max_interval = 2 [(validate.rules).duration = {gt {}}];
 
     // Specifies the exponential backoff factor that Envoy doesn't support. (2x is by default).
@@ -1664,7 +1754,10 @@ message RetryPolicy {
     // .. note::
     //
     //   If the header appears multiple times only the first value is used.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string name = 1
         [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
@@ -1720,7 +1813,10 @@ message RetryPolicy {
     // to match against the response. Headers are tried in order, and matched case
     // insensitive. The first header to be parsed successfully is used. If no headers
     // match the default exponential back-off is used instead.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     repeated ResetHeader reset_headers = 1 [(validate.rules).repeated = {min_items: 1}];
 
     // Specifies the maximum back off interval that Envoy will allow. If a reset
@@ -1728,20 +1824,29 @@ message RetryPolicy {
     // the next header will be tried.
     //
     // Defaults to 300 seconds.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     google.protobuf.Duration max_interval = 2 [(validate.rules).duration = {gt {}}];
   }
 
   // Specifies the conditions under which retry takes place. These are the same
   // conditions documented for :ref:`config_http_filters_router_x-envoy-retry-on` and
   // :ref:`config_http_filters_router_x-envoy-retry-grpc-on`.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string retry_on = 1;
 
   // Specifies the allowed number of retries. This parameter is optional and
   // defaults to 1. These are the same conditions documented for
   // :ref:`config_http_filters_router_x-envoy-max-retries`.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   google.protobuf.UInt32Value num_retries = 2
       [(udpa.annotations.field_migrate).rename = "max_retries"];
 
@@ -1756,7 +1861,10 @@ message RetryPolicy {
   //   Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
   //   retry policy, a request that times out will not be retried as the total timeout budget
   //   would have been exhausted.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   google.protobuf.Duration per_try_timeout = 3;
 
   // Specifies an upstream idle timeout per retry attempt (including the initial attempt). This
@@ -1802,7 +1910,10 @@ message RetryPolicy {
   int64 host_selection_retry_max_attempts = 6;
 
   // HTTP status codes that should trigger a retry in addition to those specified by retry_on.
-  option (armeria.xds.supported.field) = 7;
+  option (armeria.xds.supported.field) = {
+      number: 7,
+      since: "1.39.0"
+  };
   repeated uint32 retriable_status_codes = 7;
 
   // Specifies parameters that control exponential retry back off. This parameter is optional, in which case the
@@ -1810,7 +1921,10 @@ message RetryPolicy {
   // ``upstream.base_retry_backoff_ms`` runtime parameter. The default maximum interval is 10 times
   // the base interval. The documentation for :ref:`config_http_filters_router_x-envoy-max-retries`
   // describes Envoy's back-off algorithm.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   RetryBackOff retry_back_off = 8;
 
   // Specifies parameters that control a retry back-off strategy that is used
@@ -1820,17 +1934,26 @@ message RetryPolicy {
   // configured, this back-off strategy will be used instead of the
   // default exponential back off strategy (configured using ``retry_back_off``)
   // whenever a response includes the matching headers.
-  option (armeria.xds.supported.field) = 11;
+  option (armeria.xds.supported.field) = {
+      number: 11,
+      since: "1.39.0"
+  };
   RateLimitedRetryBackOff rate_limited_retry_back_off = 11;
 
   // HTTP response headers that trigger a retry if present in the response. A retry will be
   // triggered if any of the header matches match the upstream response headers.
   // The field is only consulted if 'retriable-headers' retry policy is active.
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+      number: 9,
+      since: "1.39.0"
+  };
   repeated HeaderMatcher retriable_headers = 9;
 
   // HTTP headers which must be present in the request for retries to be attempted.
-  option (armeria.xds.supported.field) = 10;
+  option (armeria.xds.supported.field) = {
+      number: 10,
+      since: "1.39.0"
+  };
   repeated HeaderMatcher retriable_request_headers = 10;
 }
 
@@ -2713,7 +2836,10 @@ message HeaderMatcher {
   reserved "regex_match";
 
   // Specifies the name of the header in the request.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1
       [(validate.rules).string = {min_len: 1 well_known_regex: HTTP_HEADER_NAME strict: false}];
 
@@ -2748,12 +2874,18 @@ message HeaderMatcher {
     //
     // * For range [-10,0), route will match for header value -1, but not for 0, ``somestring``, 10.9,
     //   ``-1somestring``
-    option (armeria.xds.supported.oneof_field) = 6;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 6,
+        since: "1.39.0"
+    };
     type.v3.Int64Range range_match = 6;
 
     // If specified as true, header match will be performed based on whether the header is in the
     // request. If specified as false, header match will be performed based on whether the header is absent.
-    option (armeria.xds.supported.oneof_field) = 7;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 7,
+        since: "1.39.0"
+    };
     bool present_match = 7;
 
     // If specified, header match will be performed based on the prefix of the header value.
@@ -2815,7 +2947,10 @@ message HeaderMatcher {
     ];
 
     // If specified, header match will be performed based on the string match of the header value.
-    option (armeria.xds.supported.oneof_field) = 13;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 13,
+        since: "1.39.0"
+    };
     type.matcher.v3.StringMatcher string_match = 13;
   }
 
@@ -2827,7 +2962,10 @@ message HeaderMatcher {
   //
   // * The regex ``\d{3}`` does not match the value ``1234``, so it will match when inverted.
   // * The range [-10,0) will match the value -1, so it will not match when inverted.
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.39.0"
+  };
   bool invert_match = 8;
 
   // If specified, for any header match rule, if the header match rule specified header
@@ -2858,7 +2996,10 @@ message HeaderMatcher {
   //   :ref:`treat_missing_header_as_empty <envoy_v3_api_field_config.route.v3.HeaderMatcher.treat_missing_header_as_empty>`
   //   is set to false; The "header4" header is not present.
   //   The match rule for "header4" will be ignored so it will not match.
-  option (armeria.xds.supported.field) = 14;
+  option (armeria.xds.supported.field) = {
+      number: 14,
+      since: "1.39.0"
+  };
   bool treat_missing_header_as_empty = 14;
 }
 
@@ -2875,16 +3016,25 @@ message QueryParameterMatcher {
 
   // Specifies the name of a key that must be present in the requested
   // ``path``'s query string.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1 max_bytes: 1024}];
 
   oneof query_parameter_match_specifier {
     // Specifies whether a query parameter value should match against a string.
-    option (armeria.xds.supported.oneof_field) = 5;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 5,
+        since: "1.39.0"
+    };
     type.matcher.v3.StringMatcher string_match = 5 [(validate.rules).message = {required: true}];
 
     // Specifies whether a query parameter should be present.
-    option (armeria.xds.supported.oneof_field) = 6;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 6,
+        since: "1.39.0"
+    };
     bool present_match = 6;
   }
 }

--- a/xds-api/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/common/fault/v3/fault.proto
@@ -52,7 +52,10 @@ message FaultDelay {
     // the JSON/YAML Duration mapping. For HTTP/Mongo, the specified
     // delay will be injected before a new request/operation.
     // This is required if type is FIXED.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.41.0"
+    };
     google.protobuf.Duration fixed_delay = 3 [(validate.rules).duration = {gt {}}];
 
     // Fault delays are controlled via an HTTP header (if applicable).
@@ -60,7 +63,10 @@ message FaultDelay {
   }
 
   // The percentage of operations/connections/requests on which the delay will be injected.
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.41.0"
+  };
   type.v3.FractionalPercent percentage = 4;
 }
 

--- a/xds-api/src/main/proto/envoy/extensions/filters/http/credential_injector/v3/credential_injector.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/http/credential_injector/v3/credential_injector.proto
@@ -72,7 +72,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message CredentialInjector {
   // Whether to overwrite the value or not if the injected headers already exist.
   // Value defaults to false.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.40.0"
+  };
   bool overwrite = 1;
 
   // Whether to send the request to upstream if the credential is not present or if the credential injection
@@ -81,11 +84,17 @@ message CredentialInjector {
   // By default, a request will fail with ``401 Unauthorized`` if the
   // credential is not present or the injection of the credential to the request fails.
   // If set to true, the request will be sent to upstream without the credential.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.40.0"
+  };
   bool allow_request_without_credential = 2;
 
   // The credential to inject into the proxied requests
   // [#extension-category: envoy.http.injected_credentials]
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.40.0"
+  };
   config.core.v3.TypedExtensionConfig credential = 3 [(validate.rules).message = {required: true}];
 }

--- a/xds-api/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/http/fault/v3/fault.proto
@@ -44,7 +44,10 @@ message FaultAbort {
     option (validate.required) = true;
 
     // HTTP status code to use to abort the HTTP request.
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.41.0"
+    };
     uint32 http_status = 2 [(validate.rules).uint32 = {lt: 600 gte: 200}];
 
     // gRPC status code to use to abort the gRPC request.
@@ -56,7 +59,10 @@ message FaultAbort {
 
   // The percentage of requests/operations/connections that will be aborted with the error code
   // provided.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.41.0"
+  };
   type.v3.FractionalPercent percentage = 3;
 }
 
@@ -67,12 +73,18 @@ message HTTPFault {
 
   // If specified, the filter will inject delays based on the values in the
   // object.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   common.fault.v3.FaultDelay delay = 1;
 
   // If specified, the filter will abort requests based on the values in
   // the object. At least ``abort`` or ``delay`` must be specified.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.41.0"
+  };
   FaultAbort abort = 2;
 
   // Specifies the name of the (destination) upstream cluster that the
@@ -89,7 +101,10 @@ message HTTPFault {
   // headers in the filter config. A match will happen if all the headers in the
   // config are present in the request with the same values (or based on
   // presence if the ``value`` field is not in the config).
-  option (armeria.xds.supported.field) = 4;
+  option (armeria.xds.supported.field) = {
+      number: 4,
+      since: "1.41.0"
+  };
   repeated config.route.v3.HeaderMatcher headers = 4;
 
   // Faults are injected for the specified list of downstream hosts. If this

--- a/xds-api/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/http/router/v3/router.proto
@@ -134,7 +134,10 @@ message Router {
   // upstream HTTP filters will not trigger retries, and local errors sent by
   // upstream HTTP filters will count as a final response if hedging is configured.
   // [#extension-category: envoy.filters.http.upstream]
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+      number: 8,
+      since: "1.41.0"
+  };
   repeated network.http_connection_manager.v3.HttpFilter upstream_http_filters = 8;
 
   // If set to true, Envoy will reject ``CONNECT`` requests that send data before

--- a/xds-api/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/xds-api/src/main/proto/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -450,18 +450,27 @@ message HttpConnectionManager {
   // The human readable prefix to use when emitting statistics for the
   // connection manager. See the :ref:`statistics documentation <config_http_conn_man_stats>` for
   // more information.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string stat_prefix = 2 [(validate.rules).string = {min_len: 1}];
 
   oneof route_specifier {
     option (validate.required) = true;
 
     // The connection manager’s route table will be dynamically loaded via the RDS API.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     Rds rds = 3;
 
     // The route table for the connection manager is static and is specified in this property.
-    option (armeria.xds.supported.oneof_field) = 4;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 4,
+        since: "1.39.0"
+    };
     config.route.v3.RouteConfiguration route_config = 4;
 
     // A route table will be dynamically assigned to each request based on request attributes
@@ -473,7 +482,10 @@ message HttpConnectionManager {
   // A list of individual HTTP filters that make up the filter chain for
   // requests made to the connection manager. :ref:`Order matters <arch_overview_http_filters_ordering>`
   // as the filters are processed sequentially as request events happen.
-  option (armeria.xds.supported.field) = 5;
+  option (armeria.xds.supported.field) = {
+      number: 5,
+      since: "1.39.0"
+  };
   repeated HttpFilter http_filters = 5;
 
   // Whether the connection manager manipulates the :ref:`config_http_conn_man_headers_user-agent`
@@ -1134,14 +1146,20 @@ message Rds {
       "envoy.config.filter.network.http_connection_manager.v2.Rds";
 
   // Configuration source specifier for RDS.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   config.core.v3.ConfigSource config_source = 1;
 
   // The name of the route configuration. This name will be passed to the RDS
   // API. This allows an Envoy configuration with multiple HTTP listeners (and
   // associated HTTP connection manager filters) to use different route
   // configurations.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string route_config_name = 2;
 }
 
@@ -1310,7 +1328,10 @@ message HttpFilter {
   reserved "config";
 
   // The name of the filter configuration. It also serves as a resource name in ExtensionConfigDS.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
   oneof config_type {
@@ -1321,7 +1342,10 @@ message HttpFilter {
     // :ref:`ExtensionWithMatcher <envoy_v3_api_msg_extensions.common.matching.v3.ExtensionWithMatcher>`
     // with the desired HTTP filter.
     // [#extension-category: envoy.filters.http]
-    option (armeria.xds.supported.oneof_field) = 4;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 4,
+        since: "1.39.0"
+    };
     google.protobuf.Any typed_config = 4;
 
     // Configuration source specifier for an extension configuration discovery service.
@@ -1338,7 +1362,10 @@ message HttpFilter {
   // If true, clients that do not support this filter may ignore the
   // filter but otherwise accept the config.
   // Otherwise, clients that do not support this filter must reject the config.
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   bool is_optional = 6;
 
   // If true, the filter is disabled by default and must be explicitly enabled by setting
@@ -1347,7 +1374,10 @@ message HttpFilter {
   // for more details.
   //
   // Terminal filters (e.g. ``envoy.filters.http.router``) cannot be marked as disabled.
-  option (armeria.xds.supported.field) = 7;
+  option (armeria.xds.supported.field) = {
+      number: 7,
+      since: "1.41.0"
+  };
   bool disabled = 7;
 }
 

--- a/xds-api/src/main/proto/envoy/extensions/http/injected_credentials/generic/v3/generic.proto
+++ b/xds-api/src/main/proto/envoy/extensions/http/injected_credentials/generic/v3/generic.proto
@@ -25,13 +25,19 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Generic {
   // The SDS configuration for the credential that will be injected to the specified HTTP request header.
   // It must be a generic secret.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.40.0"
+  };
   transport_sockets.tls.v3.SdsSecretConfig credential = 1
       [(validate.rules).message = {required: true}];
 
   // The header that will be injected to the HTTP request with the provided credential.
   // If not set, filter will default to: ``Authorization``
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.40.0"
+  };
   string header = 2
       [(validate.rules).string = {well_known_regex: HTTP_HEADER_NAME ignore_empty: true}];
 

--- a/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
+++ b/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/common.proto
@@ -219,7 +219,10 @@ message TlsCertificate {
   // parent directory for any file moves to support rotation. This currently
   // only applies to dynamic secrets, when the ``TlsCertificate`` is delivered via
   // SDS.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   config.core.v3.DataSource certificate_chain = 1;
 
   // The TLS private key.
@@ -227,7 +230,10 @@ message TlsCertificate {
   // If ``private_key`` is a filesystem path, a watch will be added to the parent
   // directory for any file moves to support rotation. This currently only
   // applies to dynamic secrets, when the ``TlsCertificate`` is delivered via SDS.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   config.core.v3.DataSource private_key = 2 [(udpa.annotations.sensitive) = true];
 
   // ``Pkcs12`` data containing TLS certificate, chain, and private key.
@@ -255,7 +261,10 @@ message TlsCertificate {
   // specified. This only applies when a ``TlsCertificate`` is delivered by SDS
   // with references to filesystem paths. See the :ref:`SDS key rotation
   // <sds_key_rotation>` documentation for further details.
-  option (armeria.xds.supported.field) = 7;
+  option (armeria.xds.supported.field) = {
+      number: 7,
+      since: "1.39.0"
+  };
   config.core.v3.WatchedDirectory watched_directory = 7;
 
   // BoringSSL private key method provider. This is an alternative to :ref:`private_key
@@ -270,7 +279,10 @@ message TlsCertificate {
 
   // The password to decrypt the TLS private key. If this field is not set, it is assumed that the
   // TLS private key is not password encrypted.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   config.core.v3.DataSource password = 3 [(udpa.annotations.sensitive) = true];
 
   // The OCSP response to be stapled with this certificate during the handshake.
@@ -339,19 +351,34 @@ message SubjectAltNameMatcher {
   // against.
   enum SanType {
     SAN_TYPE_UNSPECIFIED = 0;
-    option (armeria.xds.supported.enum_value) = 1;
+    option (armeria.xds.supported.enum_value) = {
+        number: 1,
+        since: "1.39.0"
+    };
     EMAIL = 1;
-    option (armeria.xds.supported.enum_value) = 2;
+    option (armeria.xds.supported.enum_value) = {
+        number: 2,
+        since: "1.39.0"
+    };
     DNS = 2;
-    option (armeria.xds.supported.enum_value) = 3;
+    option (armeria.xds.supported.enum_value) = {
+        number: 3,
+        since: "1.39.0"
+    };
     URI = 3;
-    option (armeria.xds.supported.enum_value) = 4;
+    option (armeria.xds.supported.enum_value) = {
+        number: 4,
+        since: "1.39.0"
+    };
     IP_ADDRESS = 4;
     OTHER_NAME = 5;
   }
 
   // Specification of type of SAN. Note that the default enum value is an invalid choice.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   SanType san_type = 1 [(validate.rules).enum = {defined_only: true not_in: 0}];
 
   // Matcher for SAN value.
@@ -370,7 +397,10 @@ message SubjectAltNameMatcher {
   //          * INTEGER/ENUMERATED: Validated against a string containing the integer value
   //          * NULL: Validated against an empty string
   //          * Other types: Validated directly against the string value
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   type.matcher.v3.StringMatcher matcher = 2 [(validate.rules).message = {required: true}];
 
   // OID Value which is required if OTHER_NAME SAN type is used.
@@ -440,7 +470,10 @@ message CertificateValidationContext {
   // of a full chain.
   //
   // If ``ca_certificate_provider_instance`` is set, it takes precedence over ``trusted_ca``.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   config.core.v3.DataSource trusted_ca = 1
       [(udpa.annotations.field_migrate).oneof_promotion = "ca_cert_source"];
 
@@ -455,7 +488,10 @@ message CertificateValidationContext {
   // If present, system root certs are used only if neither of the ``trusted_ca``
   // or ``ca_certificate_provider_instance`` fields are set.
   // [#not-implemented-hide:]
-  option (armeria.xds.supported.field) = 17;
+  option (armeria.xds.supported.field) = {
+      number: 17,
+      since: "1.39.0"
+  };
   SystemRootCerts system_root_certs = 17;
 
   // If specified, updates of a file-based ``trusted_ca`` source will be triggered
@@ -465,7 +501,10 @@ message CertificateValidationContext {
   // ``CertificateValidationContext`` is delivered by SDS with references to
   // filesystem paths. See the :ref:`SDS key rotation <sds_key_rotation>`
   // documentation for further details.
-  option (armeria.xds.supported.field) = 11;
+  option (armeria.xds.supported.field) = {
+      number: 11,
+      since: "1.39.0"
+  };
   config.core.v3.WatchedDirectory watched_directory = 11;
 
   // An optional list of base64-encoded SHA-256 hashes. If specified, Envoy will verify that the
@@ -498,7 +537,10 @@ message CertificateValidationContext {
   //   <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_hash>`,
   //   because SPKI is tied to a private key, so it doesn't change when the certificate
   //   is renewed using the same private key.
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+      number: 3,
+      since: "1.39.0"
+  };
   repeated string verify_certificate_spki = 3
       [(validate.rules).repeated = {items {string {min_len: 44 max_bytes: 44}}}];
 
@@ -528,7 +570,10 @@ message CertificateValidationContext {
   // :ref:`verify_certificate_spki
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.verify_certificate_spki>` are specified,
   // a hash matching value from either of the lists will result in the certificate being accepted.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated string verify_certificate_hash = 2
       [(validate.rules).repeated = {items {string {min_len: 64 max_bytes: 95}}}];
 
@@ -554,7 +599,10 @@ message CertificateValidationContext {
   //   Subject Alternative Names are easily spoofable and verifying only them is insecure,
   //   therefore this option must be used together with :ref:`trusted_ca
   //   <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  option (armeria.xds.supported.field) = 15;
+  option (armeria.xds.supported.field) = {
+      number: 15,
+      since: "1.39.0"
+  };
   repeated SubjectAltNameMatcher match_typed_subject_alt_names = 15;
 
   // This field is deprecated in favor of
@@ -563,7 +611,10 @@ message CertificateValidationContext {
   // Note that if both this field and :ref:`match_typed_subject_alt_names
   // <envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.match_typed_subject_alt_names>`
   // are specified, the former (deprecated field) is ignored.
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+      number: 9,
+      since: "1.39.0"
+  };
   repeated type.matcher.v3.StringMatcher match_subject_alt_names = 9
       [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 

--- a/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/secret.proto
+++ b/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/secret.proto
@@ -26,7 +26,10 @@ message GenericSecret {
 
   // Secret of generic type and is available to filters. It is expected
   // that only only one of secret and secrets is set.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.40.0"
+  };
   config.core.v3.DataSource secret = 1 [(udpa.annotations.sensitive) = true];
 
   // For cases where multiple associated secrets need to be distributed together. It is expected
@@ -40,10 +43,16 @@ message SdsSecretConfig {
   // Name by which the secret can be uniquely referred to. When both name and config are specified,
   // then secret can be fetched and/or reloaded via SDS. When only name is specified, then secret
   // will be loaded from static resources.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1 [(validate.rules).string = {min_len: 1}];
 
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   config.core.v3.ConfigSource sds_config = 2;
 }
 
@@ -52,19 +61,31 @@ message Secret {
   option (udpa.annotations.versioning).previous_message_type = "envoy.api.v2.auth.Secret";
 
   // Name (FQDN, UUID, SPKI, SHA256, etc.) by which the secret can be uniquely referred to.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   string name = 1;
 
   oneof type {
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     TlsCertificate tls_certificate = 2;
 
     TlsSessionTicketKeys session_ticket_keys = 3;
 
-    option (armeria.xds.supported.oneof_field) = 4;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 4,
+        since: "1.39.0"
+    };
     CertificateValidationContext validation_context = 4;
 
-    option (armeria.xds.supported.oneof_field) = 5;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 5,
+        since: "1.40.0"
+    };
     GenericSecret generic_secret = 5;
   }
 }

--- a/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
+++ b/xds-api/src/main/proto/envoy/extensions/transport_sockets/tls/v3/tls.proto
@@ -38,11 +38,17 @@ message UpstreamTlsContext {
   //
   //   Server certificate verification is not enabled by default. To enable verification, configure
   //   :ref:`trusted_ca<envoy_v3_api_field_extensions.transport_sockets.tls.v3.CertificateValidationContext.trusted_ca>`.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   CommonTlsContext common_tls_context = 1;
 
   // SNI string to use when creating TLS backend connections.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string sni = 2 [(validate.rules).string = {max_bytes: 255}];
 
   // If true, replaces the SNI for the connection with the hostname of the upstream host, if
@@ -108,12 +114,18 @@ message DownstreamTlsContext {
   }
 
   // Common TLS context settings.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   CommonTlsContext common_tls_context = 1;
 
   // If specified, Envoy will reject connections without a valid client
   // certificate.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.41.0"
+  };
   google.protobuf.BoolValue require_client_certificate = 2;
 
   // If specified, Envoy will reject connections without a valid and matching SNI.
@@ -250,13 +262,19 @@ message CommonTlsContext {
         "envoy.api.v2.auth.CommonTlsContext.CombinedCertificateValidationContext";
 
     // How to validate peer certificates.
-    option (armeria.xds.supported.field) = 1;
+    option (armeria.xds.supported.field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     CertificateValidationContext default_validation_context = 1
         [(validate.rules).message = {required: true}];
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    option (armeria.xds.supported.field) = 2;
+    option (armeria.xds.supported.field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     SdsSecretConfig validation_context_sds_secret_config = 2
         [(validate.rules).message = {required: true}];
 
@@ -284,7 +302,10 @@ message CommonTlsContext {
   //
   // If ``tls_certificate_provider_instance`` is set, this field is ignored.
   // If this field is set, ``tls_certificate_sds_secret_configs`` is ignored.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   repeated TlsCertificate tls_certificates = 2;
 
   // Configs for fetching TLS certificates via SDS API. Note SDS API allows certificates to be
@@ -295,7 +316,10 @@ message CommonTlsContext {
   //
   // If ``tls_certificates`` or ``tls_certificate_provider_instance`` are set, this field
   // is ignored.
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   repeated SdsSecretConfig tls_certificate_sds_secret_configs = 6;
 
   // Certificate provider instance for fetching TLS certs.
@@ -325,12 +349,18 @@ message CommonTlsContext {
 
   oneof validation_context_type {
     // How to validate peer certificates.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     CertificateValidationContext validation_context = 3;
 
     // Config for fetching validation context via SDS API. Note SDS API allows certificates to be
     // fetched/refreshed over the network asynchronously with respect to the TLS handshake.
-    option (armeria.xds.supported.oneof_field) = 7;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 7,
+        since: "1.39.0"
+    };
     SdsSecretConfig validation_context_sds_secret_config = 7;
 
     // Combines the default ``CertificateValidationContext`` with the SDS-provided dynamic context for certificate
@@ -344,7 +374,10 @@ message CommonTlsContext {
     // * **Boolean Fields:** Boolean fields are combined using a logical OR operation.
     //
     // The resulting ``CertificateValidationContext`` is used to perform certificate validation.
-    option (armeria.xds.supported.oneof_field) = 8;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 8,
+        since: "1.39.0"
+    };
     CombinedCertificateValidationContext combined_validation_context = 8;
 
     // Certificate provider for fetching validation context.

--- a/xds-api/src/main/proto/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
+++ b/xds-api/src/main/proto/envoy/extensions/upstreams/http/v3/http_protocol_options.proto
@@ -71,10 +71,16 @@ message HttpProtocolOptions {
     oneof protocol_config {
       option (validate.required) = true;
 
-      option (armeria.xds.supported.oneof_field) = 1;
+      option (armeria.xds.supported.oneof_field) = {
+          number: 1,
+          since: "1.41.0"
+      };
       config.core.v3.Http1ProtocolOptions http_protocol_options = 1;
 
-      option (armeria.xds.supported.oneof_field) = 2;
+      option (armeria.xds.supported.oneof_field) = {
+          number: 2,
+          since: "1.41.0"
+      };
       config.core.v3.Http2ProtocolOptions http2_protocol_options = 2;
 
       // .. warning::
@@ -153,7 +159,10 @@ message HttpProtocolOptions {
     option (validate.required) = true;
 
     // To explicitly configure either HTTP/1 or HTTP/2 (but not both!) use ``explicit_http_config``.
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.41.0"
+    };
     ExplicitHttpConfig explicit_http_config = 3;
 
     // This allows switching on protocol based on what protocol the downstream
@@ -161,7 +170,10 @@ message HttpProtocolOptions {
     UseDownstreamHttpConfig use_downstream_protocol_config = 4;
 
     // This allows switching on protocol based on ALPN
-    option (armeria.xds.supported.oneof_field) = 5;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 5,
+        since: "1.41.0"
+    };
     AutoHttpConfig auto_config = 5;
   }
 

--- a/xds-api/src/main/proto/envoy/type/matcher/v3/regex.proto
+++ b/xds-api/src/main/proto/envoy/type/matcher/v3/regex.proto
@@ -64,7 +64,10 @@ message RegexMatcher {
 
   // The regex match string. The string must be supported by the configured engine. The regex is matched
   // against the full string, not as a partial match.
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   string regex = 2 [(validate.rules).string = {min_len: 1}];
 }
 

--- a/xds-api/src/main/proto/envoy/type/matcher/v3/string.proto
+++ b/xds-api/src/main/proto/envoy/type/matcher/v3/string.proto
@@ -36,7 +36,10 @@ message StringMatcher {
     // Examples:
     //
     // * ``abc`` only matches the value ``abc``.
-    option (armeria.xds.supported.oneof_field) = 1;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 1,
+        since: "1.39.0"
+    };
     string exact = 1;
 
     // The input string must have the prefix specified here.
@@ -48,7 +51,10 @@ message StringMatcher {
     // Examples:
     //
     // * ``abc`` matches the value ``abc.xyz``
-    option (armeria.xds.supported.oneof_field) = 2;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 2,
+        since: "1.39.0"
+    };
     string prefix = 2 [(validate.rules).string = {min_len: 1}];
 
     // The input string must have the suffix specified here.
@@ -60,11 +66,17 @@ message StringMatcher {
     // Examples:
     //
     // * ``abc`` matches the value ``xyz.abc``
-    option (armeria.xds.supported.oneof_field) = 3;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 3,
+        since: "1.39.0"
+    };
     string suffix = 3 [(validate.rules).string = {min_len: 1}];
 
     // The input string must match the regular expression specified here.
-    option (armeria.xds.supported.oneof_field) = 5;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 5,
+        since: "1.39.0"
+    };
     RegexMatcher safe_regex = 5 [(validate.rules).message = {required: true}];
 
     // The input string must have the substring specified here.
@@ -76,7 +88,10 @@ message StringMatcher {
     // Examples:
     //
     // * ``abc`` matches the value ``xyz.abc.def``
-    option (armeria.xds.supported.oneof_field) = 7;
+    option (armeria.xds.supported.oneof_field) = {
+        number: 7,
+        since: "1.39.0"
+    };
     string contains = 7 [(validate.rules).string = {min_len: 1}];
 
     // Use an extension as the matcher type.
@@ -88,7 +103,10 @@ message StringMatcher {
   // has no effect for the ``safe_regex`` match.
   // For example, the matcher ``data`` will match both input string ``Data`` and ``data`` if this option
   // is set to ``true``.
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+      number: 6,
+      since: "1.39.0"
+  };
   bool ignore_case = 6;
 }
 

--- a/xds-api/src/main/proto/envoy/type/v3/percent.proto
+++ b/xds-api/src/main/proto/envoy/type/v3/percent.proto
@@ -20,7 +20,10 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 message Percent {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.Percent";
 
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   double value = 1 [(validate.rules).double = {lte: 100.0 gte: 0.0}];
 }
 
@@ -52,11 +55,17 @@ message FractionalPercent {
   }
 
   // Specifies the numerator. Defaults to 0.
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.41.0"
+  };
   uint32 numerator = 1;
 
   // Specifies the denominator. If the denominator specified is less than the numerator, the final
   // fractional percentage is capped at 1 (100%).
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.41.0"
+  };
   DenominatorType denominator = 2 [(validate.rules).enum = {defined_only: true}];
 }

--- a/xds-api/src/main/proto/envoy/type/v3/range.proto
+++ b/xds-api/src/main/proto/envoy/type/v3/range.proto
@@ -20,11 +20,17 @@ message Int64Range {
   option (udpa.annotations.versioning).previous_message_type = "envoy.type.Int64Range";
 
   // start of the range (inclusive)
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+      number: 1,
+      since: "1.39.0"
+  };
   int64 start = 1;
 
   // end of the range (exclusive)
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+      number: 2,
+      since: "1.39.0"
+  };
   int64 end = 2;
 }
 

--- a/xds-api/src/test/proto/armeria/xds/testing/test_supported.proto
+++ b/xds-api/src/test/proto/armeria/xds/testing/test_supported.proto
@@ -10,34 +10,64 @@ import "google/protobuf/wrappers.proto";
 import "google/protobuf/duration.proto";
 
 message TestCluster {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.39.0"
+  };
   string name = 1;
-  option (armeria.xds.supported.field) = 2;
+  option (armeria.xds.supported.field) = {
+    number: 2,
+    since: "1.39.0"
+  };
   TestDiscoveryType type = 2;
-  option (armeria.xds.supported.field) = 3;
+  option (armeria.xds.supported.field) = {
+    number: 3,
+    since: "1.39.0"
+  };
   TestEdsConfig eds_config = 3;
   string unsupported_field = 4;
   TestOutlierDetection outlier_detection = 5;
-  option (armeria.xds.supported.field) = 6;
+  option (armeria.xds.supported.field) = {
+    number: 6,
+    since: "1.39.0"
+  };
   google.protobuf.Any typed_config = 6;
-  option (armeria.xds.supported.field) = 7;
+  option (armeria.xds.supported.field) = {
+    number: 7,
+    since: "1.39.0"
+  };
   google.protobuf.UInt32Value max_requests = 7;
-  option (armeria.xds.supported.field) = 8;
+  option (armeria.xds.supported.field) = {
+    number: 8,
+    since: "1.39.0"
+  };
   google.protobuf.Duration timeout = 8;
-  option (armeria.xds.supported.field) = 9;
+  option (armeria.xds.supported.field) = {
+    number: 9,
+    since: "1.39.0"
+  };
   map<string, TestDiscoveryType> type_map = 9;
 }
 
 enum TestDiscoveryType {
-  option (armeria.xds.supported.enum_value) = 0;
+  option (armeria.xds.supported.enum_value) = {
+    number: 0,
+    since: "1.39.0"
+  };
   STATIC = 0;
-  option (armeria.xds.supported.enum_value) = 1;
+  option (armeria.xds.supported.enum_value) = {
+    number: 1,
+    since: "1.39.0"
+  };
   EDS = 1;
   LOGICAL_DNS = 2;
 }
 
 message TestEdsConfig {
-  option (armeria.xds.supported.field) = 1;
+  option (armeria.xds.supported.field) = {
+    number: 1,
+    since: "1.39.0"
+  };
   string service_name = 1;
   string unsupported_nested = 2;
 }

--- a/xds/src/main/java/com/linecorp/armeria/xds/ControlPlaneClientManager.java
+++ b/xds/src/main/java/com/linecorp/armeria/xds/ControlPlaneClientManager.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.Version;
 import com.linecorp.armeria.xds.configsource.SotwConfigSourceSubscriptionFactory;
 import com.linecorp.armeria.xds.filter.FactoryContext;
 import com.linecorp.armeria.xds.stream.SnapshotStream;
@@ -49,7 +50,7 @@ final class ControlPlaneClientManager implements SafeCloseable {
                               ConfigSourceMapper configSourceMapper,
                               XdsExtensionRegistry extensionRegistry,
                               SnapshotWatcher<Object> defaultWatcher) {
-        bootstrapNode = bootstrap.getNode();
+        bootstrapNode = populateUserAgent(bootstrap.getNode());
         this.eventLoop = eventLoop;
         this.bootstrapClusters = bootstrapClusters;
         this.configSourceMapper = configSourceMapper;
@@ -130,6 +131,19 @@ final class ControlPlaneClientManager implements SafeCloseable {
             default:
                 return null;
         }
+    }
+
+    private static Node populateUserAgent(Node node) {
+        if (!node.getUserAgentName().isEmpty()) {
+            return node;
+        }
+        final Node.Builder builder = node.toBuilder()
+                                         .setUserAgentName("armeria");
+        final String version = Version.get("armeria-core").artifactVersion();
+        if (!"unknown".equals(version)) {
+            builder.setUserAgentVersion(version);
+        }
+        return builder.build();
     }
 
     Map<ConfigSource, ConfigSourceHandler> clientMap() {


### PR DESCRIPTION
Motivation:

The `supported.field`, `supported.oneof_field`, and `supported.enum_value` proto annotations currently use bare `int32` values, which record *which* fields Armeria supports but not *when* support was added. This makes it difficult for users and control plane operators to determine the minimum Armeria version required for a given xDS feature.

Additionally, Armeria's xDS client does not identify itself to the control plane — the `user_agent_name` and `user_agent_version` fields in the bootstrap `Node` message are left empty.

Modifications:

- Introduced a `FieldSupport` message in `supported.proto` with `number` (int32) and `since` (string) fields, replacing the raw `int32` for all three annotation types.
- Transformed all existing annotations across 36 proto files (29 envoy, 4 armeria, 1 test, 1 supported.proto, 1 Java file) to the new multiline `FieldSupport` format with the appropriate `since` version.
- Updated `SupportedFieldValidator` to extract `getNumber()` from `FieldSupport` entries instead of using raw integers.
- Populated the bootstrap `Node` with `user_agent_name: "armeria"` and `user_agent_version` (from `Version.get("armeria-core")`) in `ControlPlaneClientManager`, respecting user-provided values.
- Added `supported.field` annotations for `Node.user_agent_name` (field 6) and `supported.oneof_field` for `Node.user_agent_version` (field 7) in `base.proto`.

Result:

- Every `supported.*` annotation now carries a `since` version, making it possible to determine the minimum Armeria version for each supported xDS field.
- Armeria's xDS client now identifies itself via `user_agent_name`/`user_agent_version` in the bootstrap Node, allowing control planes to identify the client implementation and version.
