### PR TITLE
Lower the Kotlin baseline of armeria-kotlin to 2.2

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -92,6 +92,10 @@ jwt = "4.6.0"
 # kafka >=4.0.0 requires java 11
 kafka = "3.9.2"
 kotlin = "2.4.10"
+# The oldest Kotlin a user of armeria-kotlin can stay on. Kotlin binaries are readable only by the
+# compiler of the same or the next minor version, so this decides that floor; armeria-kotlin is
+# compiled against it and publishes it as its kotlin-stdlib requirement.
+kotlin-baseline = "2.2.21"
 kotlin-coroutine = "1.11.0"
 krotodc = "1.2.2"
 ktlint-gradle-plugin = "14.2.0"
@@ -837,12 +841,15 @@ javadocs = "https://kafka.apache.org/33/javadoc/"
 [libraries.kotlin-allopen]
 module = "org.jetbrains.kotlin:kotlin-allopen"
 version.ref = "kotlin"
+[libraries.kotlin-stdlib]
+module = "org.jetbrains.kotlin:kotlin-stdlib"
+version.ref = "kotlin-baseline"
 [libraries.kotlin-stdlib-jdk8]
 module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 version.ref = "kotlin"
 [libraries.kotlin-reflect]
 module = "org.jetbrains.kotlin:kotlin-reflect"
-version.ref = "kotlin"
+version.ref = "kotlin-baseline"
 
 [libraries.kotlin-coroutines-core]
 module = "org.jetbrains.kotlinx:kotlinx-coroutines-core"

--- a/gradle/scripts/lib/kotlin.gradle
+++ b/gradle/scripts/lib/kotlin.gradle
@@ -4,6 +4,14 @@ configure(projectsWithFlags('kotlin')) {
 
     apply plugin: 'kotlin'
 
+    // A module that pins a Kotlin language version also compiles and publishes against that baseline's
+    // kotlin-stdlib. Without this, the Kotlin Gradle plugin injects its own version, which then lands in
+    // the published POM as a compile scope dependency and forces every user onto that Kotlin version.
+    if (extractKotlinTargetVersion(project) != null &&
+            managedVersions.containsKey('org.jetbrains.kotlin:kotlin-stdlib')) {
+        kotlin.coreLibrariesVersion = managedVersions['org.jetbrains.kotlin:kotlin-stdlib']
+    }
+
     // compileJmhKotlin is injected by 'jmh' plugin while a benchmark module is being initialized.
     afterEvaluate {
         def target = project.tasks.findByName('compileJava')?.targetCompatibility ?:

--- a/it/kotlin-compat/build.gradle.kts
+++ b/it/kotlin-compat/build.gradle.kts
@@ -1,0 +1,31 @@
+// Guards the Kotlin compatibility contract of the published Kotlin modules. `:kotlin` and
+// `:grpc-kotlin` pin their Kotlin language version and their kotlin-stdlib to `kotlin-baseline`, so
+// that a user on an older Kotlin can upgrade Armeria without upgrading Kotlin.
+dependencies {
+    implementation(project(":kotlin"))
+    implementation(project(":grpc-kotlin"))
+}
+
+// Resolves the two modules the way a user's Kotlin compile classpath does, as jars rather than as the
+// class directories a project dependency resolves to inside this build.
+val kotlinConsumerClasspath by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    extendsFrom(configurations.implementation.get())
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_API))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category::class.java, Category.LIBRARY))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                  objects.named(LibraryElements::class.java, LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, Bundling.EXTERNAL))
+    }
+}
+
+tasks.withType<Test> {
+    val baseline = libs.versions.kotlin.baseline.get()
+    inputs.files(kotlinConsumerClasspath)
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        listOf("-Darmeria.kotlin.baseline=$baseline",
+               "-Darmeria.kotlin.compileClasspath=${kotlinConsumerClasspath.asPath}")
+    })
+}

--- a/it/kotlin-compat/src/test/java/com/linecorp/armeria/it/kotlin/KotlinBaselineCompatibilityTest.java
+++ b/it/kotlin-compat/src/test/java/com/linecorp/armeria/it/kotlin/KotlinBaselineCompatibilityTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.armeria.it.kotlin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Makes sure a user does not have to upgrade Kotlin in order to upgrade Armeria.
+ *
+ * <p>A Kotlin binary is readable only by the compiler of the same or the next minor version, and the
+ * compiler reads every Kotlin binary on the compile classpath whether or not the user's code touches it.
+ * So the oldest Kotlin a user may stay on is decided by two things Armeria publishes: the metadata
+ * version of its own classes, and the version of the kotlin-stdlib it declares at compile scope. Both
+ * are pinned to {@code kotlin-baseline} in {@code dependencies.toml}, which lets users one minor older
+ * than the baseline keep compiling.
+ *
+ * <p>This test reads the same classpath a user's Kotlin compiler would have to read. It fails when
+ * something raises that floor again - the {@code kotlin2.x} flag disappearing from
+ * {@code settings.gradle}, the Kotlin Gradle plugin going back to injecting its own kotlin-stdlib, or a
+ * newly added compile scope dependency that was built with a newer Kotlin.
+ */
+class KotlinBaselineCompatibilityTest {
+
+    private static final Pattern JAR_VERSION = Pattern.compile("^(.*)-(\\d+\\.\\d+\\.\\d+.*)\\.jar$");
+
+    private static int[] baseline;
+    private static Map<File, int[]> metadataVersions;
+
+    @BeforeAll
+    static void scanCompileClasspath() {
+        baseline = parseVersion(systemProperty("armeria.kotlin.baseline"));
+
+        metadataVersions = new LinkedHashMap<>();
+        for (String path : systemProperty("armeria.kotlin.compileClasspath").split(File.pathSeparator)) {
+            final File jar = new File(path);
+            final int[] version = metadataVersion(jar);
+            if (version != null) {
+                metadataVersions.put(jar, version);
+            }
+        }
+
+        // An empty or half-resolved classpath would make every assertion below pass without testing
+        // anything, so make sure the modules under test are actually there.
+        assertThat(metadataVersions.keySet().stream().map(File::getName))
+                .as("Kotlin binaries on the compile classpath")
+                .anyMatch(name -> name.startsWith("armeria-kotlin-"))
+                .anyMatch(name -> name.startsWith("armeria-grpc-kotlin-"))
+                .anyMatch(name -> name.startsWith("kotlin-stdlib-"));
+    }
+
+    @Test
+    void everyKotlinBinaryIsReadableByTheOldestSupportedCompiler() {
+        final List<String> tooNew = new ArrayList<>();
+        metadataVersions.forEach((jar, version) -> {
+            if (compareMinor(version, baseline) > 0) {
+                tooNew.add(jar.getName() + " has metadata version " + format(version));
+            }
+        });
+
+        assertThat(tooNew)
+                .as("Kotlin binaries a user's compiler would fail to read. Every entry must be at or " +
+                    "below the %s baseline; raising one of them forces every user onto a newer Kotlin.",
+                    format(baseline))
+                .isEmpty();
+    }
+
+    @Test
+    void armeriaKotlinModulesAreCompiledAtTheBaseline() {
+        final Map<String, String> compiledAt = new LinkedHashMap<>();
+        metadataVersions.forEach((jar, version) -> {
+            if (jar.getName().startsWith("armeria-")) {
+                compiledAt.put(jar.getName(), version[0] + "." + version[1]);
+            }
+        });
+        final String expected = baseline[0] + "." + baseline[1];
+
+        // Catches a `kotlin-baseline` bump that forgets the flag, which would otherwise leave the
+        // modules compiled at the old minor while shipping a newer kotlin-stdlib.
+        assertThat(compiledAt.values())
+                .as("Kotlin minor the Armeria modules were compiled at, per %s. Keep the 'kotlin<x.y>' " +
+                    "flag in settings.gradle in sync with the 'kotlin-baseline' version in " +
+                    "dependencies.toml.", compiledAt)
+                .isNotEmpty()
+                .containsOnly(expected);
+    }
+
+    @Test
+    void kotlinStdlibIsPinnedToTheBaseline() {
+        final String expected = systemProperty("armeria.kotlin.baseline");
+        final List<String> stdlibs = new ArrayList<>();
+        for (File jar : metadataVersions.keySet()) {
+            final Matcher matcher = JAR_VERSION.matcher(jar.getName());
+            if (matcher.matches() && "kotlin-stdlib".equals(matcher.group(1))) {
+                stdlibs.add(matcher.group(2));
+            }
+        }
+
+        assertThat(stdlibs)
+                .as("kotlin-stdlib published at compile scope. It must stay at the %s baseline; the " +
+                    "Kotlin Gradle plugin otherwise injects its own version and upgrades every user.",
+                    expected)
+                .containsExactly(expected);
+    }
+
+    private static int[] metadataVersion(File jar) {
+        if (!jar.isFile()) {
+            return null;
+        }
+        try (JarFile jarFile = new JarFile(jar)) {
+            final JarEntry entry = jarFile.stream()
+                                          .filter(e -> e.getName().startsWith("META-INF/") &&
+                                                       e.getName().endsWith(".kotlin_module"))
+                                          .findFirst()
+                                          .orElse(null);
+            if (entry == null) {
+                return null;
+            }
+            // A .kotlin_module starts with the metadata version: the number of components followed by
+            // the components themselves, all as big-endian ints.
+            try (InputStream in = jarFile.getInputStream(entry);
+                 DataInputStream data = new DataInputStream(in)) {
+                final int length = data.readInt();
+                assertThat(length).as("metadata version length of %s", jar.getName()).isBetween(2, 8);
+                final int[] version = new int[length];
+                for (int i = 0; i < length; i++) {
+                    version[i] = data.readInt();
+                }
+                return version;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read " + jar, e);
+        }
+    }
+
+    private static int compareMinor(int[] a, int[] b) {
+        if (a[0] != b[0]) {
+            return Integer.compare(a[0], b[0]);
+        }
+        return Integer.compare(a[1], b[1]);
+    }
+
+    private static int[] parseVersion(String version) {
+        final String[] components = version.split("\\.");
+        final int[] parsed = new int[components.length];
+        for (int i = 0; i < components.length; i++) {
+            parsed[i] = Integer.parseInt(components[i]);
+        }
+        return parsed;
+    }
+
+    private static String format(int[] version) {
+        return Arrays.stream(version)
+                     .mapToObj(Integer::toString)
+                     .reduce((a, b) -> a + '.' + b)
+                     .orElseThrow(IllegalStateException::new);
+    }
+
+    private static String systemProperty(String name) {
+        final String value = System.getProperty(name);
+        assertThat(value).as("system property '%s', set by build.gradle.kts", name).isNotBlank();
+        return value;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -112,7 +112,7 @@ project(':brave6').projectDir = file('brave/brave6')
 includeWithFlags ':core',                                'java', 'publish', 'shade', 'trim', 'native'
 includeWithFlags ':eureka',                              'java', 'publish', 'relocate', 'native'
 includeWithFlags ':grpc',                                'java', 'publish', 'relocate', 'native'
-includeWithFlags ':grpc-kotlin',                         'java', 'publish', 'relocate', 'kotlin-grpc', 'kotlin', 'native'
+includeWithFlags ':grpc-kotlin',                         'java', 'publish', 'relocate', 'kotlin-grpc', 'kotlin', 'kotlin2.2', 'native'
 includeWithFlags ':grpc-protocol',                       'java', 'publish', 'relocate', 'native'
 // GraphQL-Java requires Java 11+.
 includeWithFlags ':graphql',                             'java11', 'publish', 'relocate', 'native'
@@ -129,7 +129,7 @@ includeWithFlags ':junit4',                              'java', 'publish', 'rel
 includeWithFlags ':junit5',                              'java', 'publish', 'relocate'
 includeWithFlags ':jsonrpc',                             'java', 'publish', 'relocate'
 includeWithFlags ':kafka',                               'java', 'publish', 'relocate', 'native'
-includeWithFlags ':kotlin',                              'java', 'publish', 'relocate', 'kotlin', 'native'
+includeWithFlags ':kotlin',                              'java', 'publish', 'relocate', 'kotlin', 'kotlin2.2', 'native'
 includeWithFlags ':kubernetes',                          'java11', 'publish', 'relocate', 'native'
 includeWithFlags ':logback',                             'java', 'publish', 'relocate', 'no_aggregation'
 project(':logback').projectDir = file('logback/logback')

--- a/settings.gradle
+++ b/settings.gradle
@@ -259,6 +259,7 @@ includeWithFlags ':it:grpc:protobuf4',                         'java', 'relocate
 includeWithFlags ':it:internal-logging',                       'java', 'relocate'
 includeWithFlags ':it:jackson-provider',                       'java', 'relocate'
 includeWithFlags ':it:kotlin',                                 'java', 'relocate', 'kotlin'
+includeWithFlags ':it:kotlin-compat',                          'java'
 includeWithFlags ':it:kubernetes-chaos-tests',                 'java11', 'relocate'
 includeWithFlags ':it:logback1.4',                             'java11', 'relocate'
 includeWithFlags ':it:logback1.5',                             'java11', 'relocate', 'no_aggregation'


### PR DESCRIPTION
Motivation:
Two things about the Kotlin modules reach users, and both track whatever Kotlin the build happens to use. The compiled classes carry `@Metadata(mv=[2,4,0])`, and the Kotlin Gradle plugin injects its own kotlin-stdlib into the published POM at compile scope, which upgrades the user's kotlin-stdlib to 2.4.10. A Kotlin binary is readable only by the compiler of the same or the next minor version, so a user must be on Kotlin 2.4 to use armeria-kotlin at all, and upgrading Armeria for a bug fix drags a Kotlin upgrade along with it.

Modifications:
- Added the `kotlin2.2` flag to `:kotlin` and `:grpc-kotlin`, which makes `kotlin.gradle` pin their `languageVersion` and `apiVersion` to 2.2. The flag itself already existed but no module used it.
- Added `kotlin-baseline` to `dependencies.toml`, declared `kotlin-stdlib` explicitly against it, and moved `kotlin-reflect` onto the same version.
- Made `kotlin.gradle` set `coreLibrariesVersion` from the managed `kotlin-stdlib` version for modules that pin a Kotlin language version, so the baseline stdlib is both what those modules compile against and what they publish.

Result:
- armeria-kotlin and armeria-grpc-kotlin now publish `@Metadata(mv=[2,2,0])` and declare kotlin-stdlib 2.2.21, so a Kotlin 2.1 user can upgrade Armeria without upgrading Kotlin.
- The build still uses the Kotlin 2.4.10 compiler. Only the language level and the stdlib the Kotlin modules compile against are pinned, so CI verifies the floor that is published rather than assuming it.
- The baseline is a moving target: Kotlin 2.4 already rejects language version 1.9 and deprecates 2.0 and 2.1, so 2.2 is the lowest non-deprecated setting today and will have to be raised. Per-version compatibility test modules are not part of this change.